### PR TITLE
Roll out stable 38.20230527.3.0, testing 38.20230609.2.1, next 38.20230609.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,105 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-05-31T18:52:48Z",
-        "generator": "fedora-coreos-stream-generator v0.2.12-3-gd40c776"
+        "last-modified": "2023-06-14T03:09:01Z",
+        "generator": "fedora-coreos-stream-generator v0.2.13"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "cde760e766d38b9cd401a8c2853bbb7a959adce18d7ad7e926c2ef69cc9236db",
-                                "uncompressed-sha256": "47645ee05c2fc031899f39b877120a383ebdb8897c899be86a256c85397f638b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3604e766a3e6edc4ae8a101da8aecb4bb73e08197302a76a43c19a6aadc12a9b",
+                                "uncompressed-sha256": "80aa19f76cbd7d6dcb0c79d6e9e1cbe88e88c594c6b4d28404cc2f76876b2a18"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ee47c8b416907f5990204780eee99efddf919bc76e0f67e7a00d273685451c61",
-                                "uncompressed-sha256": "e5bff3ecc825a88ec97a29d4a13280a9fc31ce4d3b5eed6380f4a8ecb2c536f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7cc240d0ab6f5f66a0d8b80bf9f92cbfbda68605655d31bae199da249a7d08a4",
+                                "uncompressed-sha256": "45719dba032fa221641ff5372f90d72c3eb1bad320451663c7c4c55c651aaee4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4d456e6c4d9f9286fc38664b8d3f0f13d052d3e13d75e7f09903c296c4894ba1",
-                                "uncompressed-sha256": "308e8628c76b9e2cc2155fb3746ba7ce9ae262331e92721e1710efff10167969"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "154f006a302dad5f8203e993bc567c722e93a59ca8024e31c784dffe5cdb0022",
+                                "uncompressed-sha256": "adb64569a478c6c65f4adc180548c074b311e1518f77c995e0ed86b85031fefe"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live.aarch64.iso.sig",
-                                "sha256": "3fe57b5685997c3d495cd7053228276c0a5d56621214d37eafa9f6b574c6ca4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live.aarch64.iso.sig",
+                                "sha256": "2c47f8cf8df7c26ed6f99ae28f593f8d1dc6f2303f22626d6f1803e19a102def"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-kernel-aarch64.sig",
-                                "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-kernel-aarch64.sig",
+                                "sha256": "78314fcdfa709fe01923fd6da19ce6cadb570e868d50ebb7445042f6914c1a3a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "991d92fece7535d281eea8699b93d21d11c5104c004c875bf4cbe0a06b93f11d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "722815f196a59957a613063da33c7b60587c80d1c3e5a2e72e586398d4c0b72f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "3cc72fddcb8b0232f0eea0df5aeeb2c16c9d9f3814ddb88f37c74d2d070bf353"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6c5d5ed087a4a91871460478761d2aec3d5c33a59da18a6de243a1cb52f7fb22"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "9c4d8160b8fa38ce1b3d460265a42a30ccbd9188d0b4cab8c875f358ce5aa5c3",
-                                "uncompressed-sha256": "6a0ffc5da7fdb1fd24fac7e67f2de245436aa745c9647f2c28ad6b04a5ab40f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "96447dd2e5dae5abb02c607fc3722d67273d5bb73134b2cf03e9cd382ba98211",
+                                "uncompressed-sha256": "eb03c0d95f1df95dd1c82a2d6a63b7aece2c6fa5fd9b3c7d93a960d41a9f75a3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "99682e304979cf85d13b5c0e8106c0178a4f062a6cffe844a9169565f0a09bb9",
-                                "uncompressed-sha256": "f44bb9ad3c9d8913d75ac4f7734ec94da9d6b72b7d7d039932f83b6366e6b8fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1d2fd70e45fbc55868b528f75183b0b07eaf67a8d80a9e3bbae0895ed131e6bf",
+                                "uncompressed-sha256": "017655f75c452a86bccec43560ba5aeb802173b45656a4db643b41901402dc2c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/aarch64/fedora-coreos-38.20230527.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5e3b9bf22d001f7b94b11ec10d0ead757f13012cbcca57e7f1c0d45fce275467",
-                                "uncompressed-sha256": "cfa7dfae62ebad68acbb55e1a1404a8513a274fa641925ea930e8e926428de47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "56db1ef090c8bce5ed05fdd11fdbe587f7b703ae667542aa650ae27c61f361eb",
+                                "uncompressed-sha256": "49ab51578123bff764c3fb52a4f2c53a345008f41db5c10d2811cfdb059b0b87"
                             }
                         }
                     }
@@ -109,195 +109,284 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-03ccb527b6c9d024c"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-042cb8c0ada43f6ff"
                         },
                         "ap-east-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f49d0a547b8e782b"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0a025b2c1d447d49b"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0cb1ee73859691134"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0696f376ad14932aa"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-045491a933c1f06f9"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-07e8c8c2d5bd66cc6"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0749717e091e09f40"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0d1bbbf33cfeaa4bd"
                         },
                         "ap-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-033556953537bdd43"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0f54dd8a8fe5a4c81"
                         },
                         "ap-south-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0cf4a1376552c2b70"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-04b7ac6af784f5a2b"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0b49fc20f85a26409"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0bd2dde75af42e7a5"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0e13830b2f55d7f83"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0135fcf4060a23e05"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-01c7ca17f46f0257a"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0140a82aa009bd96f"
                         },
                         "ca-central-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f996ddd45edb71fe"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0c934af0cae7c2373"
                         },
                         "eu-central-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0624ad6581bb743dd"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-07e081b9ff6568e92"
                         },
                         "eu-central-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-024ed1c408bac9344"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0eb2bc73e3b6de98d"
                         },
                         "eu-north-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0e96fd0db14e57769"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-09cd9098dd2e2a8d0"
                         },
                         "eu-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-023c8db196329b843"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-093a032f008515e92"
                         },
                         "eu-south-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0c23fe64fae467c9d"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-007b7089d42ee2a0b"
                         },
                         "eu-west-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f508360a921a5ef1"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0c521ff4e1fdb700f"
                         },
                         "eu-west-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-003cb85e5c68783e8"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-03673d8766d6a86d5"
                         },
                         "eu-west-3": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0df98374b2647a52d"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-05b97fb911a39688b"
                         },
                         "me-central-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-02222b85d101e434f"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-092575f9f355816c7"
                         },
                         "me-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-06e63d77e83ba83ca"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0976b71e64eb464af"
                         },
                         "sa-east-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0760806476c066b79"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0736698da3bc50c3d"
                         },
                         "us-east-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f4d9c5620c476e3c"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0de68f3ce48de7fd0"
                         },
                         "us-east-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0a382de98b70f420e"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-01a79d18177163174"
                         },
                         "us-west-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0624801ff6c422056"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-088cebf2442fc4894"
                         },
                         "us-west-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0176872a2cc7d5c13"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-02b2dfdfab4fd2c2f"
                         }
                     }
                 }
             }
         },
-        "s390x": {
+        "ppc64le": {
             "artifacts": {
-                "ibmcloud": {
-                    "release": "38.20230527.1.1",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "beb4aac983dc1c76a2be1d5775338601060ed6bbc0e5f02c730419ab01a4f72c",
-                                "uncompressed-sha256": "5fa810098797decad2b402b23b3567d0fb29ed0b998fb7e94ef15e9bb3ed9209"
-                            }
-                        }
-                    }
-                },
                 "metal": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3b8c43cb66165e1a75cf683168044fa63250f97d7e15cc301a513aece22bd6d5",
-                                "uncompressed-sha256": "598130776bce1e2d82f41e77b4ab2c30fe426fbd763d6d4903f5501e8d960faa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6bd1abf741f8e617312c15c02d81f699ebbfeeafabf0abbd067aab6b4ba52b0c",
+                                "uncompressed-sha256": "921d1e93c04976acb9ac7f823861c087e8cbf523fa1067a161733c4ed968e8c9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live.s390x.iso.sig",
-                                "sha256": "7286a9cc862c5e26b09d1b69a97f735d1c812a89c0fea381f6892b46db51027c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live.ppc64le.iso.sig",
+                                "sha256": "f16627f401c9866ccfd9d0e5d2fdf90cee9bbbada4a0906cfbacd9d996bd5e1e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-kernel-s390x.sig",
-                                "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "d3c459c1fcfc267b775fb916a1f9d0f84afc64485ec1c484b96ea5909e796307"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "b717fda439fed4b05ba66c884469b6486e844e99017fde321b18b14e160f5431"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b02c1abb17cf64d54435e1b2b80b2c0424721664c33c587294c40cb1c1f0a600"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "ff4387931e4d5537aa14d2e73e544dc4591ce4dfff58c74f78b3195a145a1fc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "54bf1ec23be4fe01f621e5a353183e94575a099c480a7e9a1545e28667fdc31f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "03152ba9dd24c040efbb593d5bbceadaeba63a44634102e82c77d37b89fcfaad",
-                                "uncompressed-sha256": "2c938cdf60c5c5a9dbe3b4d95f3f6495180290d1c6ba4063743bc755bb42a31c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "d66987684ad933dff763cb7dea8a34d91fd21a5bb0eaeafb1c1747e0d540129e",
+                                "uncompressed-sha256": "517fd5e90e923b0f3efb06c5b706abd1436fbf4a234847190b6780392c89b90b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8e972190ee56330b3404e8702f7cd7604617ec83ce40b20369e926efde8e0250",
-                                "uncompressed-sha256": "d7b9525ffc4d85ca68319c5961d78d1430e49c4cdfde07a55be8a0e6921c80a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2b3a844f1e737d8d75f184ad09f1be72c2757642d581ece847d18926eff4ab32",
+                                "uncompressed-sha256": "c484b9bdbc7adc1962a5e08a775f3bd313894adb99a9df1aa608df97b731b6d6"
+                            }
+                        }
+                    }
+                },
+                "powervs": {
+                    "release": "38.20230609.1.0",
+                    "formats": {
+                        "ova.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "4119c417b3299020b45e621df33ae0e34fde4b1ae3ffe93c6761cab0993990f0",
+                                "uncompressed-sha256": "76fe4f4b39de1aafad63317c234fed6edaafed9a9eb00730ff9641ccd1a89c0a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/s390x/fedora-coreos-38.20230527.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "792cbdf55f9b7556be8ce30dfcfa2845f22d86cc2d8430fb22db7cbf4e98cd15",
-                                "uncompressed-sha256": "fb0f2e59afbddc0258f5802f3a01c2fdbeb1773b94f17072a80cf6421d2450c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "59ea15d1afd90f9eb31e23c96f99234cf2beb23d654e02f2f40a346d588b60b5",
+                                "uncompressed-sha256": "90b8ebdeb59f947d123164af981f6049184daf1821c27b665bd717b438c984f8"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "s390x": {
+            "artifacts": {
+                "ibmcloud": {
+                    "release": "38.20230609.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0d35cfe99b3675f1c6d6682cc7d5dd61e19dff4c07e8e37b235297eae688d093",
+                                "uncompressed-sha256": "23c7219e7b4dcda2a25cbb53d86cf32e7cd234e72b7222693b9dd4f7a4ebcb42"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "38.20230609.1.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "74c1b106fa4f929008b0bc45207bb48955379afdfdf9ad37d32e21d60c98d88f",
+                                "uncompressed-sha256": "bba8d8f6d2b7f7cc920ce061c31c3a26e8bd2053c53ca29e67f4445cb9933ba8"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live.s390x.iso.sig",
+                                "sha256": "5fd611c5f1a6cc154659b9339b5539a0912a1fef15e37b9d65f277b92b5db71b"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-kernel-s390x.sig",
+                                "sha256": "317165aa952d53852e2d6c54ab52c1431be23ffa4f7c983021b9000f9caf8463"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "42be78c5163a5516e1f1e41f480ec501371b9f7b20c6090d8bba66c9b7a8925e"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e065ebda5220ccfbdd256f80d517b5aa9d8e523b761a5d5d7e88c6071a534611"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "71915f55bbac3eafc0b499aff2bf669b67e3072e3b43817402e4b8175e56f668",
+                                "uncompressed-sha256": "490527a87705d7e246265d9dd0848a00766bdf058ff3b4a1fa07deb8d5050755"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "38.20230609.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "37cb7e3408cf25902aa62726a7b1f6b1610154554fde6052b4957cc8cf2f9ec3",
+                                "uncompressed-sha256": "9a968109f5bc5d9965806421d7ea9f47c6879d18a3fff29fdccf43e49e15bd6f"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "38.20230609.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "88350e999bbbbecbabb139a19bd6e392f6a29cbcbb184bb2843c6152887f2c9d",
+                                "uncompressed-sha256": "d428d1da4edefbcdc4807f0afa279baeb96afcaae8f5d988e32e229904953e4b"
                             }
                         }
                     }
@@ -308,237 +397,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "84f0bd77b58f0606e6627f1035404444ec52786ace61fb4734d67885ef6cefe9",
-                                "uncompressed-sha256": "dc41d050b5a68ae477101e70ca7d6bf81e9bda1989f38ccaff9e4d80a0d6cd3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "247465cc64223a31db1d547cd6b38d88edabec67cc404cfb624e42b75e4d8c0f",
+                                "uncompressed-sha256": "cc36542b6258f285d9d080445edce662db334500e062699ce1dd36e48faf8d99"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f12f92afb0a41e8187210d729372eee617f75a6ebfb622ba57b351d64afe59a3",
-                                "uncompressed-sha256": "fcebf93cb8962b73b000dc03f05714f55306d43c74b3103f0882eaee06767501"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "be09236b51c48de437b9869d4d22d5407f6c40de4901a928627f79d2d5ef8a55",
+                                "uncompressed-sha256": "462fc015e1cfb8090ea766166095fb07cf3f9a3282a9c00b368eaac1764bb2db"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "463476852e39448c8cd5176771e551e48cb6a39f2fab9924019d25a2a4b46f13",
-                                "uncompressed-sha256": "607d572b5afa9708fc6aba29222de826af5e4d8898ad677bd1bdc9e5403224a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b053a90c30e483a7b361842d87724e9bdfab58df42b65f07a8643887e2a7e937",
+                                "uncompressed-sha256": "64b1cda6a515e278a7c71d87996a19dcbafca1c21b9920e25a27f0b9aa174ad8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5d46693ae9d4822910779b61182bf0ab3999a97a0337b73325cd1d9e2c3c911f",
-                                "uncompressed-sha256": "39c47bb4c01b5919d30b8db026346b5a21a406733c334741150308d178c2f4b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d49dfa5db21afb04875a1c619a28abdad5b2d873a773c29f97175535f25e7ea5",
+                                "uncompressed-sha256": "e3cecb2c31fa999885a1b5b3f18c5e9c5d374b9667dd3b3a2d566270bb15d648"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d935627cdc3cd0049f60cad043b89861fb4890a9693f9d97af8b5922a6221eb6",
-                                "uncompressed-sha256": "46f1567bf48294afeab1d5e9dfbe8d05b7d7e5fe4fcd04e0258793895283fb0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "36105ce392477b85ef65d587c7920002c12dae6621a8aec0059c2644fb0bae68",
+                                "uncompressed-sha256": "aa94778918a6cdc0359102134895c7f0d5e3a486de91d81703907c8d1171b46e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e31db2de21058bc6aeab495ff3cf3e21502595d0974fd3d4ecd01a7ae326d1ca",
-                                "uncompressed-sha256": "490fffdc4fcb503e4904abfd10c798196f5e74a5753eb6d6eca827baa35d112c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "05cfe9320d5e1bde720d826730d347964ece5bdbc76ff08b14af98055ca75194",
+                                "uncompressed-sha256": "31d8cae588b77a45dce3c2e1f1022f0f50ab1466eb1f63e5e612b53c685ad893"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2b46d8206c07cd11ed1d06f8e8c2266e7b191fda75dc909cb873f7fb752a1b0e",
-                                "uncompressed-sha256": "6576d316ca7e649d321cf297981ce28845dbcb35c7f858b404a5d159af8cb942"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5c9d687b4396eae188d1c2991f01f88443f2dc85c9a723bb679cbea45881ae41",
+                                "uncompressed-sha256": "98ad9e7b68f9283ae4d286e6e36a95c434b6bdec15926d9b4cd8680035f4b5c1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "472d9a5dd9de102b3d9d01b65d678d298886204b9c9b095148b7e7a1278a2b76",
-                                "uncompressed-sha256": "cb79f19fad0a77453e4b00f6d443e9ce53e306e5b96399ce4c334aea8c181c7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c978269ed4e591c9ca5b419a0eaf99c08b5acddfae68e3a67d0feecfe21af097",
+                                "uncompressed-sha256": "be004712e02c98b20bc378d5dd37b252dffde8a278c5a9d977d46c84fc2b47d2"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5cddbc6ce8d52c534cb0720af59b8be2807118f7ed26df933405439fd8daa36b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2bad4a617b5de905470df8f34009c706b4e9c3438df4e0de0f24b9195ad4ddce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a4b85c746a1faa8c71980b56aeb1fe75a11b53671ee34a4099d8d888236e0f38",
-                                "uncompressed-sha256": "38e6cf2db13164826eacf8b99ca1178dbe222b31f0471159cff1554996dc298d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "99f847f972f6f317bd429cba7215fb522eec75b2337a086d53c42190a4485b35",
+                                "uncompressed-sha256": "1a7b2c278c81c4acc0d5939ad3e43c6cccdfbd18497cacb919186938dc3bf632"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live.x86_64.iso.sig",
-                                "sha256": "f89198c7782c39882a22ea65303e66e4d87168c54dc61b26e92a0209559aea0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live.x86_64.iso.sig",
+                                "sha256": "7d1aa573909ead372d1c35e0475fd863b878ae253ed7b9e7e7a0a429a2a1f3c2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-kernel-x86_64.sig",
-                                "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d8e5ff16a69a032c0e47df0c2fa97e724bf58deb49ea5881855574728fa96cd2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b2c6cbe3fd622c92a64fe03ce4af398da2037701bf892d204e14ed6842d5d4a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "717c8acaecec9659a03051419d9e6e20c56c3e3881ea3565ac08ad3ab4f4f060"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b307631f700b68e2257fcde708a7733467d4ce6594b93e968ce7d8d14e1675ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "188e3a0c5f7f671f00e604ced9374cbeedd3d0f71fc5ddbc947e80ad45756797"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "3cb76c5feaffbfb0187d1a98db95f3113c079127300851dbf6dd079bda83d6a5",
-                                "uncompressed-sha256": "f5e75f5b0331c4bc508143cdb3439cea884e3090a8e2cdf719afb45fca67f68a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8644eda2ada60545f704ebee12cdea3c2bae9f14cd853f065d067c954d4b1315",
+                                "uncompressed-sha256": "2e663161135a4b895f7ac2a74dfe7beefd8ce641860f058dd9b758ecd03bcfd0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "47de795a14366c77cb47f7dacfb748e63d5b22f6230c6fe45d9457a9e1036d5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b2012d3a39d4d4c7626ae8c4057410de7ec516fed9800e5547f473c8ef6a93e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d6f598eb03d5a22fb6500dd5f22d0f03dc3a172f7e0e069c58b02df27e7c7c10",
-                                "uncompressed-sha256": "b92a1414b08bf520d12b0473ecd832dbdc99927d201a8ae5b84709c940f2dfe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "995d6a43518a37d8a460e194ba3fc589aee19da45a5f5abc8d11621cdbb37fbf",
+                                "uncompressed-sha256": "7204a851ffefc0b5bd6c6665e079f9d94965d0db32369b926ae787e05e34c88a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8338080f6869d0e566a91182b755ab01863e1bcc912d492ec861d78058248edd",
-                                "uncompressed-sha256": "b3b3db0e0acd4513a21dd779e3ddab1aaca1afc9e595eabbc661e014f23a0f58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e10ecadae99cd81cf5d56be205f8f07b002dd3f33f26a2b057c1d8ead7f50fc4",
+                                "uncompressed-sha256": "07f161d6fd72ea3a7df3f99e81f9f9c994c4caa4256fb73cc1c545d12d33381f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "8a5f740f8771d7734ed53deeb22a5248435db2c3404df8d6dd78af3b3d700466"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "3b939a986a5d5084b30428e2b6bc43094931812d753d73df952805423a82ab21"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "bb1dc5924f172b240cfd33a34af5141dea681ed63eef77ccfcc810ae826e379b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "9628918b6448b6165cfd6f39342a6ff53f1bbf4c0bb6baeb234a50e096faf2db"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230527.1.1/x86_64/fedora-coreos-38.20230527.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1c4e85bbcf6b723f83610db3503bddb4fa832e4a576620d2dbe286440d8b9a42",
-                                "uncompressed-sha256": "d80fe6aebc80b6dc7125b73dd0f2ac39ae4d3b59de67ea78576473f80295077e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d7c80cdc9c88cf4088d98f3a187a393646a032bb4acc81ae6dfcf4726d464160",
+                                "uncompressed-sha256": "ee4bfc005022ec3449239aa2cb78e69d6501394eefcaaea02d24a4b6f0cfcd6c"
                             }
                         }
                     }
@@ -548,121 +637,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0cd8c11bb6a342132"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0d75664a8e3522f1e"
                         },
                         "ap-east-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-00db7d06472476f26"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0d17ba8415bc399fa"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-07679d8ab3d187c0b"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0682668d8ad3cf774"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f1ee435056dc80f6"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-02e4b3027a49844e7"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0cba67d17a2fcdd84"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-026dd4502ddbb9ac3"
                         },
                         "ap-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-04b834ddc1d722c7a"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-079d65af45e82b8d8"
                         },
                         "ap-south-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0960152487b99a766"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-019ef698fd69a538b"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-02ec9bb7c4ec28290"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0e1d6af922b067e4b"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0d93f34cf20c0c3a6"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0d4a1c3cfeede73f6"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0fda19fdffde7cdb2"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-04b07a5842e09dee6"
                         },
                         "ca-central-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f7e944163a412df8"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0b595b0f73189dac1"
                         },
                         "eu-central-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0f3e2a393ef263403"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0d1998e0cd07cf9fc"
                         },
                         "eu-central-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-03ff8d9f8516b7544"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-009497da1a208b4d4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-085f993c7c79622b0"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0eb2959f338d35437"
                         },
                         "eu-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-01af7420e9a557e39"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-03ce6fd25fdf409f2"
                         },
                         "eu-south-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-04aa9b20a211af4f4"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-09b91b0fda8d8112a"
                         },
                         "eu-west-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-07bc0d9603295a1a3"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-01acd4e9a5c8a5386"
                         },
                         "eu-west-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-06c5b1bf10d980590"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-05c13a081f269be70"
                         },
                         "eu-west-3": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0cd3562f778216b08"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-08c85cce1dc1d11b4"
                         },
                         "me-central-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-084a7ace2939cf8d3"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0a9d35c542f844ad4"
                         },
                         "me-south-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0fa72b381bc7ed043"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0e5d33f6f2b34c09d"
                         },
                         "sa-east-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-06b77cc4f080dc59a"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-081732df2488d07a7"
                         },
                         "us-east-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-05f5f3cc554895598"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-02944daa82870f97e"
                         },
                         "us-east-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-03ae04c49cf7c16d5"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0e0e61917a7fe9aef"
                         },
                         "us-west-1": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0a9f9896fc1cf7dfa"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0b90f27eb7e66c173"
                         },
                         "us-west-2": {
-                            "release": "38.20230527.1.1",
-                            "image": "ami-0870f8c97b74a04ca"
+                            "release": "38.20230609.1.0",
+                            "image": "ami-0f83d9c7df6e8c70f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230527-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230609-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230527.1.1",
+                    "release": "38.20230609.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e7b62ad1ebe6df765f28415f99afa782278644c9e329f0bd49e3dc7e68ff4c8d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b5f79afc683277b7398a5a34c99da197a485268a9981c94a2e1f347b7bc25670"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,105 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-05-31T18:52:44Z",
-        "generator": "fedora-coreos-stream-generator v0.2.12-3-gd40c776"
+        "last-modified": "2023-06-14T03:08:59Z",
+        "generator": "fedora-coreos-stream-generator v0.2.13"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3ed2a7ef9297a008ace2a993c291bde00f6147b1a748226e71b71d687d397c26",
-                                "uncompressed-sha256": "92ae2f332b576082abf1684548c6bb526d89e88838d8db920341970c48e20e93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8b8fc1196037cd8bf5e9d054007a2db719fc3786752a24e24f1622d4be0ddecd",
+                                "uncompressed-sha256": "c919354c930ae10a271ef5efab26a127b5f24fc5624ccf9ae3ae9cb72c598a93"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "04854bd6dbac7c18777a9abd41c25e77e1fc02e936bbdd6bc3b5365866e00358",
-                                "uncompressed-sha256": "bba5a0f7e85217c03d53bc4fcf736cbb2e469a59420deaf48fd9c4a044f25014"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a09877f4ded8cf2effb92da95df3d62297210b521aa28fdf199651942131399a",
+                                "uncompressed-sha256": "f01315d06c1a9a348bee7ab6b4a571407a093d8d4d5105303aa0c2938f5b455c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "57ba29e2a3061493459748b79aef060b4afdf45f20cc5ee358cafae63a09a6df",
-                                "uncompressed-sha256": "f15af69ed221fc7cfd2f88d0f172f2da70c2838a6a5e22aa65879a0e1919c28b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "65e90c5732b3583f49f5e383c413e6f43f9eeb0c966b8da2462a91461dbfac19",
+                                "uncompressed-sha256": "c94bcb92652f9e2707cf1601c732553056d25549e9dca9acc61d808371a93f46"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live.aarch64.iso.sig",
-                                "sha256": "c863ae564a8bee8b6cefaf5569a56206b5028c0e22291bc5b49dd044852fe563"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live.aarch64.iso.sig",
+                                "sha256": "29fea16238d378735b3a8f54a2486c883c4616fd1a998e75681f32541894a4fe"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-kernel-aarch64.sig",
                                 "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "56fcd31b1dd1405292989eaac2076b8829af2ad390b121c1eece564e6b887dd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ce6652224fe101e3544bcf1256603e801deab89d9cced28824dd9c5a3c97234a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5fa752faf845f88cd0018d44c4116688341ab56d969f3ef4fa398a2e94978ab3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "eb15f9ca7d94ee217554a7c7809d4d02032efaf6160971aad3a0d4110e8baee8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f33b632fe68b7df9a47d39afd3d172d9e3d432b91c7e5a348c4df6f5261b76e7",
-                                "uncompressed-sha256": "04be12889fd9acc7499975072f76fa976cdaf36725275db5f61d41e0d47ba62f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "52bac1fbae009604fe3c69f91fc2c500fe6cf5b58e516ccb2122a5a7c759e85b",
+                                "uncompressed-sha256": "e4520e6dffae2d31d14ba6608c16b258d25720f39cbb31524e0fd85bee0e3b55"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "11cea1199d7233125c7e33f42fd2cd6e65b2aa8f87d7f50642193d03d8bfb822",
-                                "uncompressed-sha256": "b5d0bb2145917b727e7cce7c186c29d5dd99ac21d629bf5baaee0b4eb0554760"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "172a65a24a3d0ac5eaebe00745604ea190eaaf8b378aedba4e4ad93fa83d5308",
+                                "uncompressed-sha256": "6711a9b6715b1fe5360076003635eb16135b93c2d4318dfcea81d0419d134767"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/aarch64/fedora-coreos-38.20230514.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9eada4a8b301e8db6f4e19d8bb22ae4f289a5ff8d0e4674a399cf62a0ad43ced",
-                                "uncompressed-sha256": "333e03567aa6b8f3af5a45009fc14434ff0d686c9fa22679dae12c152b120246"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c8cadc11030bdcc8beef930ea90fc21e58775ebc6407f95486d165e60b6f58aa",
+                                "uncompressed-sha256": "abfbfbbc2d635cd86074cbe871dc8446ecf6b71480c8481b4123f65658b10106"
                             }
                         }
                     }
@@ -109,108 +109,108 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-059bdbc0560c02fbe"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-08ba99a4c2fbe6343"
                         },
                         "ap-east-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-029449553daa44611"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0560a1da5c62325c8"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0e54b39858e0a6bf7"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0df9ecf2a542a98b0"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0115b8e36ede73127"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-008cd9dae5ff09f4e"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0f85cc7b6449033f8"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-00464da7a213b4b22"
                         },
                         "ap-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0963dbda260e7dab5"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-005e2585c9845edd3"
                         },
                         "ap-south-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-09417cbb0654dd06e"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-040dc3b270cdc66b6"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0e7ac1ec150c1f2ef"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0f7c20af29b77533d"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-01157b35360b43f24"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0f84b05c41a80a0e7"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0b16570dd4efd1213"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0a21c8d6c65a9dba0"
                         },
                         "ca-central-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-06402829ee92e1bcd"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-00e7b40bb4d5984f6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0902c1b597bcc58e2"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0e5ae8cb9dede191c"
                         },
                         "eu-central-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-08063b3820c0b227a"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0375f497efa6740ae"
                         },
                         "eu-north-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-002a7deb3b0ca195f"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0aaa3ff834e0c9de0"
                         },
                         "eu-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-039be789042383e36"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0d79206ed49379d9e"
                         },
                         "eu-south-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0e131f4050ddf4a6e"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0090791030d31a17b"
                         },
                         "eu-west-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0bf8f61edc7bde703"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-05bd3121060346a07"
                         },
                         "eu-west-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-029fd536153edd69a"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0a74465536bd7177a"
                         },
                         "eu-west-3": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0275058a8a5043410"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0ff81f03c41dabf1a"
                         },
                         "me-central-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0c830c0dbb94ae3d5"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-088751b464e89eae4"
                         },
                         "me-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-024cfa496438a095a"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-00dfd9b0bbe6c1be1"
                         },
                         "sa-east-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-066e8e04a04bfb64e"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0d6ba40251fc16e26"
                         },
                         "us-east-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-07aded6c65aaf9c00"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-07b0020ac9ff8f472"
                         },
                         "us-east-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-014d108bc6b7c7d87"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-00c0dd024859b5655"
                         },
                         "us-west-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-034d3563e4b2a95d7"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-013814ced554f33d3"
                         },
                         "us-west-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-00d1431a6b9945e80"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-03ac079d40d780c6b"
                         }
                     }
                 }
@@ -219,85 +219,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a49e5cba317e81144d8b0c9b1915b5ea47cb242f54beb8f6215ce5314aebf87c",
-                                "uncompressed-sha256": "d4211ac1de16e047a254c7a902b811a97f011b777fe0e70226c747a96f4a8469"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d334a4b464d30b2bb6033a1766e752df10867b3bb3dd15e455b42c347556751b",
+                                "uncompressed-sha256": "ab5a337e51b6493ce4c83a295d623d6a7a87454bdb15859bd66a4d283cabf61d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "66269a2ae64b85b6b69a47c3d5d85a1c9959818c0d645c6ff8ffd14aa3b3c895",
-                                "uncompressed-sha256": "ff0e391597b780610627aa6f4022d2019c253b07551f08b412acc6ae737fe3df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5d16c6bf77c21a6c3415b2d867fa1e16d120c798146bcf76cb2c8c38b2c39f99",
+                                "uncompressed-sha256": "5ed9656ba6d0b46dc57798d9fa88794950cb3455ba43555f1eedb64dd5d2d222"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live.s390x.iso.sig",
-                                "sha256": "4ecf13f615f986eca5143740000b30b8a0cb8d84ce754c5d060bbbf74a1350b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live.s390x.iso.sig",
+                                "sha256": "c4162f7ec91f7686e13f76c3bb7497ff35d3e0991905d46a2e4041a6596e2def"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-kernel-s390x.sig",
                                 "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "5f0585c5b976acddcebebaad9d9a4e9ad80e3a579cdc21e32082060cf617c702"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "6f7c47d440c0978bda667871abf03aa845b78680aa4d35fe355e3a35c358140c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "253a35a7203b695865802812e7c68746fbc00c8c58373c28cc1f644aad9293ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "d29538472c1fae51dac4108f093c36b5946b686865469cc49260a9827a6f771e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "af85f0b5794c7e3351418c2e6637b8af21fc6f9bbfc44ddc99d0b4ccee26596f",
-                                "uncompressed-sha256": "e2b882378fd4c9aa8be7364468a985dbcefead332cf47a4324725864dfc9fa81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c85fac758fafac7a62f1c2dcfaaf2d6cf628be85dcb45a776c093acc6ffa3fc0",
+                                "uncompressed-sha256": "8b2a4a3717eed51301b7ad5ef369edfb51f12450aaaee2ee2bf40ccc37fda52a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b4e38ae11632ff591fd4f9fb2a57643a6f4aceda1e39c315a4b077d3cf2b1f77",
-                                "uncompressed-sha256": "8a87a71c241caf49dd899516556245c8fbec414a2b7ad640c735737ee44e7eaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "68972ff896a7ba45fa491bf26d9be2da495c6f39e1dbee3b472d025569cd5775",
+                                "uncompressed-sha256": "b773eeb98005b537230d518c77e7f7936291c8de7612f43a1b0893a6e68b1873"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/s390x/fedora-coreos-38.20230514.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "949e77844d226ef13b4587ae05d5b255a97ad1fe555187cbc265e89532a6fa51",
-                                "uncompressed-sha256": "50e5ba9d44d2a7e8f4859d0672956e81d87350e3889fa42f6d3307059ae88759"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d35ed21bcd981cbb64fec689136636f24957cd2371656918c2b543be7cb12bba",
+                                "uncompressed-sha256": "4994e687d9e14557d366a2b56bf675c25ed07660db9c58631d0e9fcbc4411d8e"
                             }
                         }
                     }
@@ -308,237 +308,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ac31f14defc39c391e5f06d9bd526689c3514f511d0bb15813165d8d7f8c26c4",
-                                "uncompressed-sha256": "b16a7d48546f5e23bbcc749b002f8852f7460e9e4b4d9c845135a770966e2537"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "608175c1d9d1aa273298497f6eb838355e37dd04c0e3b475885cc5e03217ed31",
+                                "uncompressed-sha256": "d83e57c8478aab6810d94189d25a2bee253abff38ea8cd070e624c096a84829d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "91bb24522f58fa1ed1482d1a4fe2ea04b9e0235006afa0a5c1e9043611c6bb96",
-                                "uncompressed-sha256": "b7f804c2435eb6309b32fc0f70ef483995b1158b4444956ff83f56833b1d2579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b6bfff500c968f92a2023821cf5b3b12695bd6e58f35fbcd71a22c2fcc5ef384",
+                                "uncompressed-sha256": "0848cc511f8268203ee7c6baf7a91addd67c0ac609ccbde11fd74a1d45537f1b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b3b0f94fff809d1786a6daadf27c4189f64c996e445e812862ac1e11127fef8d",
-                                "uncompressed-sha256": "3b949e7b83acbaf774a5914f6092878fa4c8fedf41aaf688909b250a5407b9f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7c869df92cf63b9092ccb6742ff643d881ae7bea49ecc82c60f6f42a49fbc316",
+                                "uncompressed-sha256": "c53eb44c3758fda8868efe9f2ee9d42ba64f7dfd5d22fb1ab252a0de205674b8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "78b379ca5b2da3b74ea634078d53ec3f5f278af95522a683d7e936217908ad0a",
-                                "uncompressed-sha256": "c63af56ee16464acd6557dd05e9b619ebd3869c885c9b40dd5d4b4d958f6e817"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "fbc6e043d52ebb140334ccfe8a2f2b89a187a5f7cb65a614a1c517acecc1ce3a",
+                                "uncompressed-sha256": "261c50edd01484d6c47a41d491cfd9968e342026c8da92f9ffedd80561baf21b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9a8d098bc38da32b41a10ea66cce6d1f94cac25e38f10b865923396b52cf64bf",
-                                "uncompressed-sha256": "debc9319c086f15e9571d9e85e037bbe8b0ab9dbec98c3ec1f515ee348b3a251"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "96c2bec4debe6edcb2074bc0db20c11cff867204ab5da260bd14e678e65bb9f0",
+                                "uncompressed-sha256": "c3bd51b65a099e77d55343f2648e276e172233cc2f2eb8d0693bc715d12c3356"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a466de146d100847e3802d6da98960743f1f1549cdb64230820538365a197117",
-                                "uncompressed-sha256": "bee6e2fa21c32354adb5d303305914bca0350b7565320ccb657f1121e838a671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8c4315460926642e11abef3ece20334c921640342e04495ccb7d4d13e2015fc2",
+                                "uncompressed-sha256": "7291307e85652ff3ad1ab1fd647d88bd1583ad77e414581318489b6d13300dcb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "51462c8bd9f2ea3417880ee20d667460aca404f1b3b5c28eca560bce088adc07",
-                                "uncompressed-sha256": "4f911a342689a6d3405c67a482013fc643f18395db2dee189e8695423460acd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "650b4e750a40579c51d2f391b128a909e82cb9f6f0aedcaf80904fe0ebbfb3db",
+                                "uncompressed-sha256": "6ae0cd0234e2160ddc9d1971efc8145cd36c47d050bab0d664537f1bd6da9730"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5c52da2532836fa4a11ffcd55e437d9fa9c36b62edec5e49f9f7b905c981f892",
-                                "uncompressed-sha256": "3a444ccfe2ef2fe5eae2138d5af8a2ec8788021b21bc59ec0930a8232424fbd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0685d1e67d54675176f5c2ea14c21fe1d807638bb36ee038cada536380bd3de0",
+                                "uncompressed-sha256": "0aba88f736fa277497d6754a80a824c238b508e17092d94e177b6ad703b608bd"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c5bc0e2e5dcaf06cdf7cddcfa9c11395adddbb310adeb7e5ec28ed66bf3aaccf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2927c7c2d8dacf1c617728657681ed3f502922788ad2a826c2bdca7ec9aec0d2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "72f874694e94f11f45a3cc450cf412ffbc27106865872bb972576f67464c360b",
-                                "uncompressed-sha256": "4fa6cb6cda63e6bf443cd19ad480689e9d9fc8733ccede9b0e670302339252b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "04dc5d4221be7d0409a7113309d44f7b7bc05dec86e02a8e3c0d879233e2ab33",
+                                "uncompressed-sha256": "9bdaf19d3f8da7851e50a1073d8713b369e5f1efdf2127e19ed2601ab4848eff"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live.x86_64.iso.sig",
-                                "sha256": "70cac41c33979bbc9b371b1acfb2f05a8ec77d359e0b484b739b6ac86d3406f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live.x86_64.iso.sig",
+                                "sha256": "4eedad401224cdeb8221aa07daf7478988498ed758483ecc8722efbd4e1200eb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-kernel-x86_64.sig",
                                 "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b16e1f72e0a3ca5bc59e9ea4d6f10f3ff361fe888c56b309fbbc8eac010f41f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "62a0ba5c141b423ad0b8a794795b5e5a5ec4cfcb6a37f7cdab6a1119933d27b5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "07a9baf95e9bae4c091db0d420ccb1104c91ced091c2f71363fdb5c87a9d1b99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3f205ca246b0fa524f4cdf00926bffd0d44883af83834a215d09366d161c8651"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2447bb309ba399483bafeebb1b509ba23a6d865088fcfdec0816904e811f9f98",
-                                "uncompressed-sha256": "dcf522524b478611259393d5c9dc4f180c35dc5811c6a4b8e08632325f907ec5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "2af1e7d5653ef86e934e0422eb68e25f253c2518a40ec0c6d12ccd9d37155542",
+                                "uncompressed-sha256": "e1ef4253bc07a1995868cc8c92a6868f2eda32b855bf41ce02eeca667cf6ca9b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "dd47470967f310b3f370c33a074483ba3d46b0a7e6e98e12dabce949f154c335"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ba681e99d6148be04f93224589b2fb07956bfa202426c76989fe32501a7dfb94"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4ceb2e1c86181d02722646f5ca3362852cca2825f195646fc5e83af3dd3a8342",
-                                "uncompressed-sha256": "1558783e5fc3faafae47e58fbe11b611fd020aaabf9fc34890c4e6e7b05f36d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "12a9fd05b03cc6c71be38961e87d945ca2a983bd5a066be1df28e261891b3bd9",
+                                "uncompressed-sha256": "632134337c6f983fb0350aa6611c0725b4f7b9353a5295dee3d871b09b4a4e35"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d5a0ff08fa31c6128ce77aa9ec888c68520da2740d55d17cb5a2ad722aa89857",
-                                "uncompressed-sha256": "12458901d0e66d01ad2239d7ff0bcb2af32bfbdb747a5c1f40dffac6336f7e7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1a1f808ce39a95a2b8dc2d116d93eaa3e737c5018ef7f8a4bf4c386833d35519",
+                                "uncompressed-sha256": "5121ac66a9c9c8cceeb43f896afc9465ace9a8972ddd2f6926c1d62e6442f407"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "310a2e17e8dc513e931df9fbdc3dd5ae361ab09b927d40a10b5b46b35a4a68ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "57ce6e0813fea48d981d19b76c99dd13ad30194049d25b8f4968ede853288da0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "bdf82329f793e1bfcacba1ac02fac55272437b1bacc26c1363795a10d0eb2b1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "710ae30ce2ce0112ce16a92a9b89c54d8e8bb5270f20bf4f6b2754e7ed54931a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230514.3.0/x86_64/fedora-coreos-38.20230514.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8e99faaa23b2d310b7e954d5812f25c3ac572b8111d11c8fb9ab4c12ddbc572f",
-                                "uncompressed-sha256": "b1d9f454a08788fd6f24846feaaaa5a0c0d8c2d4b321306b07001c0293491a5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "60b2e7d37b7dcb2a1162fc31db0f083b610627cb56ef747f52303c2cf4b864ed",
+                                "uncompressed-sha256": "71d95ee1584213abc550874c1c012e5787ecd8cc7f7df7e74a16d7693dababe7"
                             }
                         }
                     }
@@ -548,121 +548,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-024af2479f15f50bb"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0e16dca09327aa2f7"
                         },
                         "ap-east-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-02801ec91fd412d47"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-01fe10e7344834082"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0251515bbc4aa2c1a"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0c5d0212aaab1bece"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0a618bf825108eef0"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-06af7aaf66c936f6a"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-06bf33e960a9bcb2d"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0c7392cb8a360d3af"
                         },
                         "ap-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0a351593d6f68f2ac"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0d7036e806fb61b11"
                         },
                         "ap-south-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-01b2bf2f612a925ae"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-079a041816a1a23fc"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0ffa52a55088c8f58"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0b6e40cdef29097e7"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-056d5af6fd2d64dd3"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-02378d2770fe5e30e"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-09a3c9ead405983be"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0a03fa94b1e92a8e4"
                         },
                         "ca-central-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0f160a93120d3ec65"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0ce19e0215f7cc25c"
                         },
                         "eu-central-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-016a79745fc97446a"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0c48d4cad9af8650c"
                         },
                         "eu-central-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0d520ea9e61b1f715"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0b2f12e2f9faf08c3"
                         },
                         "eu-north-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-08b4e31db859f2a35"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0951631ed4ca44107"
                         },
                         "eu-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0a47a4a1f88bd94ef"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-09d3313ae6b96abeb"
                         },
                         "eu-south-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-06e1d73df658d9f38"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0d890dbde17ddacd3"
                         },
                         "eu-west-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0f9c6bddf8b8adde7"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-081aa93705df3ed05"
                         },
                         "eu-west-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-068b595f0f83eef43"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-016f220089afd5e89"
                         },
                         "eu-west-3": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-01b3217c9b5d60790"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0afda6cb1453e1437"
                         },
                         "me-central-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0d72a2c16d732638a"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0f378ca4613fdda3b"
                         },
                         "me-south-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0a961427609cf7339"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0a9335881dcf28ae3"
                         },
                         "sa-east-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-056764656bd9ed7af"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0d5a0ef51ec8a8fea"
                         },
                         "us-east-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0f6f48394ee0124eb"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-01da231f2c9405cbd"
                         },
                         "us-east-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-0a7cabdd2ae611882"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-02ab92e36bf09f0b4"
                         },
                         "us-west-1": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-078aedec233f6d9f6"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0a3ebde2774b3d0fa"
                         },
                         "us-west-2": {
-                            "release": "38.20230514.3.0",
-                            "image": "ami-053378fc6ecc003e4"
+                            "release": "38.20230527.3.0",
+                            "image": "ami-0e09a55cd8269326f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230514-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230527-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230514.3.0",
+                    "release": "38.20230527.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8bd5f282df05fa9c999a9f41a9374bfbc70cd86850c139c4941649f842cb4354"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a356606dc8363be78e116dec37e584b977f603352115ab06fb38e6fbcfe97eff"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,105 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-05-31T18:52:46Z",
-        "generator": "fedora-coreos-stream-generator v0.2.12-3-gd40c776"
+        "last-modified": "2023-06-14T03:09:00Z",
+        "generator": "fedora-coreos-stream-generator v0.2.13"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "44cf859a5b9e9c0a233c4927f1ae7cd19271b8d09d1b439e090929bf735ba895",
-                                "uncompressed-sha256": "e5b0df4d6d294533f327053c97909927cfe447a54cac6ba32ead5b2c82fe31e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5a3c726f533c1714c6749f06cd0d50c72302e4980c545482e7f18f176773d52c",
+                                "uncompressed-sha256": "aba2e0b030a42071fe94ed7d420c4e680d79077a8b5fc6ee05f6425a06ab4a01"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7e659437736975f0ea8c71653b0298d61e8f3ebecc416419d2dd3bd06188cfdd",
-                                "uncompressed-sha256": "4720ee4102e768439a68e4066ac7515b0847a54d235e0a23a2b0343aabf5ab8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c7fe3a2385dc2519c1ae4880f4d2476a9ba044c61de87fb65ecc314986b97e88",
+                                "uncompressed-sha256": "2077e4918b6a9948df4ff13609edf2d9f81d1270a6aa4b40973adefd65bdf2fa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4c16bc8cf52f5e91cea5255d486fd61e79e53a7da92780327575e79e03b32653",
-                                "uncompressed-sha256": "41187c0b2e067022247a57bf8da5a3f22226eea38a2ee39501f4238e49951c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3c2aa9f22c225369dccb82dfb25f5ab5e4c5c98c4f890bf89e0e3eaf02926b52",
+                                "uncompressed-sha256": "2b1f1b61b54da3f3bac353c50afa6d9434220a5a8e7c496a8b18e1d0456370f8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live.aarch64.iso.sig",
-                                "sha256": "670e8e933c638f6884f7e0f9ca7e3d677a42f479f8102ed66da4ca759de2284f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live.aarch64.iso.sig",
+                                "sha256": "23dc93b2e50a9a20d2e3cec46a13179471615fa66c1d9bb5e24b2c824f755829"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-kernel-aarch64.sig",
-                                "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-kernel-aarch64.sig",
+                                "sha256": "78314fcdfa709fe01923fd6da19ce6cadb570e868d50ebb7445042f6914c1a3a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "fdfe605c980ca15c30a1a547593ce4a45a5ad10e3e67a8aad1461cd0341dcc56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "b506e7d954926e27debcfd0c981e2dac081272b684053e28ddaa5f69c9247e26"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "bbc17fb18e04295ed9f9bf9f476a81c73f6ca6f5b48921dfd5579fe64af1998a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "a8f02fde59022e4540ff8716bcae212c0b473dc704c72735d06576249e5f4bd8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "69db829dee9753f855a51857b5be5875017e1e39712aff5b63a1ff55941cc55d",
-                                "uncompressed-sha256": "a0ec2fe51efc80ec4d7362fd39f796202e96023b2748b9e5f7efe4475b4c233c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "a521871eb9f0041d609fe8006cdcd1e29643cac8b9cd9d3c34bf449fd68567ca",
+                                "uncompressed-sha256": "6e6e7a47fd92219db6069fc324ebe1563b2a3b37195256f3d001d2e24025a1c3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8d774992547d567d2e74a419ba717f10f5c4671f36ab62b4cfb09d0e0ec980d7",
-                                "uncompressed-sha256": "7be2fa7bbff45e1f8007f5bd501f2f0353cd1bd45fd5cf8aa6db3c3cf3d9170a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8b322818bd098f2d98e2ed280839c8483c12dac2422ea862ae15aa29f1f0afdd",
+                                "uncompressed-sha256": "4fa76625b76e4d6c21ecd994af097ebd29d2002403bed100f62a1253a9479046"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/aarch64/fedora-coreos-38.20230527.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "3dbd0f68e23138d529e1a3c9b8c4f4d5a2ad09e52751e89fc3464c08ae909326",
-                                "uncompressed-sha256": "c74b503252f31a9cd2db3d1b6325389cb08f9ee336473b868a088c57936c3e30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1d711eb67e0781face729cb68aadf1cf79b54e83d4c9c63ba4f9214b479e854f",
+                                "uncompressed-sha256": "0f9b6de27c143b0ba1be33deba53bdcfa7233e60adcc8fd517a1f0cc1a07df83"
                             }
                         }
                     }
@@ -109,195 +109,284 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-09ef483d679451ad5"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-071a510747df0db65"
                         },
                         "ap-east-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-08d3d4f6ed1b2fa75"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-009cacf11d2bd17c7"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-06f847a484b599a16"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0805f870801a7bbe2"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0d79be11bece47e38"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-04df5e0979ef1a01d"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0ede1a9e499c0ba7b"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-08a23cad3be630e0c"
                         },
                         "ap-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-076db453d40eff6c4"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-09ed9ff216bc5844d"
                         },
                         "ap-south-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-081241ae5bcfbdeb9"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-07e48c7e250518e61"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0f2d20640391e474a"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-08cd32ae145ff00fd"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-00a3c0149e40e0aad"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0924a1beb8e244e38"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0d60dd6affbc90930"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-04963ab5ada4e7715"
                         },
                         "ca-central-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0849e30ecea7f6b64"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0e18c3c5d61bfc3c7"
                         },
                         "eu-central-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0e09c4da81b011372"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-08a5a10931dfcf768"
                         },
                         "eu-central-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0cc89e8e0075ac268"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-02b0df03c09f25290"
                         },
                         "eu-north-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0f3a6af48945f0811"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0e8f21a5f495de4a3"
                         },
                         "eu-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-06f364698fbf9bb1c"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0d1762ab18d1af78a"
                         },
                         "eu-south-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-05d71b77fe99c8404"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0824271e8b96f0ede"
                         },
                         "eu-west-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-099e332cf519e8104"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-08dd58a1b827b42a1"
                         },
                         "eu-west-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-027b90acfa4b0b0cb"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0fb79051c432f0dc0"
                         },
                         "eu-west-3": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-06167e0279c307b02"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-08d3f3ff15f431ac4"
                         },
                         "me-central-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0e5fe316bbf515669"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-03add7fad102c8771"
                         },
                         "me-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-011fdb05c83f3f71b"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-04284661ec47196a8"
                         },
                         "sa-east-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-03c3f44a86e0a015a"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-06b643e8b9a77943c"
                         },
                         "us-east-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-08fc0fe1876ec492a"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-06a0310942aefd7dd"
                         },
                         "us-east-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-06b0d71629cb010ca"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0a41150d24d93661c"
                         },
                         "us-west-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0a85afdab2fb851a7"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-082531c030be231de"
                         },
                         "us-west-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0f28a6cd26ff69996"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0da5882c3e0fd2049"
                         }
                     }
                 }
             }
         },
-        "s390x": {
+        "ppc64le": {
             "artifacts": {
-                "ibmcloud": {
-                    "release": "38.20230527.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "aa6df63e63ebb8b0ab113dff911f486a6c4904cb66ea7d305a0794f3cec8a9c2",
-                                "uncompressed-sha256": "95ee4d42eb397f966919b980e0aa2b7740c756240ac5777161d6d5fcc2407ea5"
-                            }
-                        }
-                    }
-                },
                 "metal": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3ef870cad27ee72f249dd691b5c72727d1505531425048dbbf4a8c0449ae7758",
-                                "uncompressed-sha256": "730ca6f551e255cbff0f01fde6f8e22147a3bc29ba9176a3f1d91a11ded17819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a17c13b700e16904c50cbd09a6cd4078dc1c9fe0a534d653233c80baadb7056d",
+                                "uncompressed-sha256": "396702a021de3212850be6e7ca422944e1265034fc375b921accc5f0426fce37"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live.s390x.iso.sig",
-                                "sha256": "a72f6a9cdabf6ba6d1b755f42143ca98e9fbfef7151bde48e7ea64d845a7050c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live.ppc64le.iso.sig",
+                                "sha256": "95ec7f7d28f3812f4cc911560d85274b9df71223406b24f446be9c3b2e2ce0cb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-kernel-s390x.sig",
-                                "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-kernel-ppc64le.sig",
+                                "sha256": "d3c459c1fcfc267b775fb916a1f9d0f84afc64485ec1c484b96ea5909e796307"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "d64e73fdb248046104c9cdf005a54842692a6bf00a4136532fc994c9e2573103"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "70190f472e98b72023e6a82428fbae85d9cf001bd5386bf2dced2d4399efef09"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "083272d344c7102a7be0d304abf14ebcbe083443378f30ae6bf1623efb04056b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0ef6872d853df2a42538233d1f7e744fb58723e6c605dabb4b4c019dab4dda36"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1105c4a283a677a8a7050412026568b3c0ef5a36a18127bc73816347724d3094",
-                                "uncompressed-sha256": "d99fd9d4d0ab4ad61d01eca65fe598e3a99b2829361148b1621bf7e7dc8b7d9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "390e5437de519d4fb2ec85fff3db25a8326b5310a1961ba1dfa18b6c947069d8",
+                                "uncompressed-sha256": "0d32afbbb36d94bbf8cab4bac7915627d1dcf051baefde056ac5f6fa44b7cb5d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2274bf2debb94f90e564286227fb0e2ae3b71c92ae442805cb6e2234f1ab5070",
-                                "uncompressed-sha256": "ed5aa433ae253f9a3810b1c92e42ef0d3cf853aef158fdfabdc3fa6d5c3036b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9d1f87d88419770423ce39119efd44f8f6ccdbace074b0a23154283f05a25f4b",
+                                "uncompressed-sha256": "4544effab71f97f2964191b65b5970669d9c589de811c458aeacd45fa5e4eae7"
+                            }
+                        }
+                    }
+                },
+                "powervs": {
+                    "release": "38.20230609.2.1",
+                    "formats": {
+                        "ova.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2fd9984906b775db7a666a16a7c925b5169fddd1e6f9a91c6816b3ddede22c2f",
+                                "uncompressed-sha256": "f5d9a713b5b6bc1225ec4de37b995cd8026428b3f656e2d8c3b003ace0043d13"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/s390x/fedora-coreos-38.20230527.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "46eea1f0064d14527dc3e2c145f6b9a8e3f8254807e92abf93a0bf384adc3b0d",
-                                "uncompressed-sha256": "1fc9f3a1103b449f5cc46aba84b975e3501c156af9597ce55fb7e030d6b99531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "fbca020a10e017ebd05cea199ab3d5caca8d898aa55ddb33c69e8565ea3bd712",
+                                "uncompressed-sha256": "b103e7b3c8ee8092d90b4fe6b68e9d679529952d3917ba4e99a6beff765b6fba"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "s390x": {
+            "artifacts": {
+                "ibmcloud": {
+                    "release": "38.20230609.2.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7e6a195135ea8715ed3c590f0a8225178b3511630a1f523ce151d5e7a9b429ca",
+                                "uncompressed-sha256": "7182a37996dea5e9b467b774cea096131d670fe07fd74d1e1b640a3dcb649897"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "38.20230609.2.1",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8550bba10a7022b635089bf1361b0b077bd6a91eb361db3a149b6f5058c1ae8b",
+                                "uncompressed-sha256": "cec062be1df59f32193b1ffa37a1484826e1d75fec0f70505f4ae49fe6604f45"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live.s390x.iso.sig",
+                                "sha256": "e4b4faf11732074bdd0b1ad449060a0bc21aa7b4c2887759e3c3cbd872398f3d"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-kernel-s390x.sig",
+                                "sha256": "317165aa952d53852e2d6c54ab52c1431be23ffa4f7c983021b9000f9caf8463"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "252e54bf9e40a9938d06cb507847396d44799a748cb2b16900be92f0d59ef433"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "a0cdecf47e939bcfdcad2ae4cb69a6cba610addde0c307b19c7f9feedb0edcfb"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "da622cd126c494dd2142d19dde85326859e3e3d53f18cffe89ecd2b541bde1bb",
+                                "uncompressed-sha256": "8f016bd5e6202195da64cd988fbb9559defb56f97efd2fbcd3d5dd7800d6b627"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "38.20230609.2.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6cb430feb90d93de89a62aff7807a4a94d3feedd5301596f8740a8aa62c1cc36",
+                                "uncompressed-sha256": "a002e278c7a03ae31c9dc0da602fa8a7affb98bc9c4d813bee026112c9096a79"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "38.20230609.2.1",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "df0d745f00889291ce919ccccb40277ffdb38f2d1589a9d541db19de4d290de0",
+                                "uncompressed-sha256": "34a65342553ed7a2cfa7ab968ff345791e7d566a42e832f1becaac0f17cedd41"
                             }
                         }
                     }
@@ -308,237 +397,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "abf5f858527a9df9517f65cc80acb3dfde6c8fd0dc5fc82d1c5234fd244747ff",
-                                "uncompressed-sha256": "e7c25ba975da65db4d017b9094824637fbf58f8f9636836f0db6f47c98f9de54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f50270a1f9029f7d274f30db3cd8c31b9956ad0ffbbae586305f327f59158b70",
+                                "uncompressed-sha256": "007f30766ded18f59871c84a972f46fc9eee74877608c490426b80c1712b232d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0553a4b8cd92b08111182a990d75cd0b1b9d1bb1ee926aa5d9702a779cd8c5aa",
-                                "uncompressed-sha256": "28378a08558b7f02ecc31e95074be3a1fa6be10808027e1f2a23c7210873d7bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "261168557a55de9401d39f24623762954eecab5ed24ac26589fd1853238e072a",
+                                "uncompressed-sha256": "996352d16671a1f371581e9501c7c003fecd3aba8a87bad5c7805f15b8a0566a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "968f8017560aa616d40c259a504b06f8d432ffd25fe858a3501778d62d9fd1b3",
-                                "uncompressed-sha256": "435b9038938f214acf0bf7b56078660f559080fbf4d0c6db7ef830abd9a2fdba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1f7682e4650889a35abae6dfd3a8bbedfc171c1d8d2bf8c7c4b1a927e96fbb90",
+                                "uncompressed-sha256": "9d13d667534ffbe3b66d0b6aa75673a49e9764c12b8b594ac62f7a7cc40c5c63"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "693b6d33a79e39bc878eb21c7764bce045fd74514c05029b4a88e32dfd2226a9",
-                                "uncompressed-sha256": "be39a01d67f854d2c788266afec8f1a2e59045f1a921fccfc3480fc1316e2832"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f5f5e7b0c472698115b49b086ecb6340bfe274025aad2d5f97c6a510ae95599d",
+                                "uncompressed-sha256": "1d4536f98d6f91c42bcc48c43aa5f3f96e7a4280836a04f5b088e2ff40887d0f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "212c1e80d959f936186fd6cf2a23cfc029ca6ffafde203b3f87b283ed280c97e",
-                                "uncompressed-sha256": "0160482530413473b1b2dc6d6571bdd7cd1d6e29e5ad4b3e9aea5b06c0743872"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1af6a5e5e5bbd322ed364b1efdd3ae389b2b3e28ff6cb6e27b424ad8738e65af",
+                                "uncompressed-sha256": "c967aa54f360ee80e93175b182570a4197ffc1cd0cbf0c16ae78fc8c2f929728"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "105f6996bc0a3ff69b441bf6e414d565c352150a8c48ff423f8667e5761c470d",
-                                "uncompressed-sha256": "dce0019f1379109bb79488611dcc1ac07e629bebf127210aaf995d3796cb0f38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b115a00cc5fe96cea893588e8f760edf33f46bbc18b23c4096e930a1881fd758",
+                                "uncompressed-sha256": "e1996e226774d9e9b92664e89b77d19bd6512217e6e3315dc96cdf04965dda06"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fb991a63c282519f45232bc461eaff67bb10dd5532f2fda8383d0597cb70d4b8",
-                                "uncompressed-sha256": "4ad9b0cca42b461fc5397f06cdeaca8c6370c1950acbfa54140bc998db453536"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b9af14145489e1bcb3b055b646ca27eb894e1baa15adc8430364ba133a94d7ee",
+                                "uncompressed-sha256": "b5130a9387237ddd40e455a2a960cfad416c5bcf1660826eb2125f1459659386"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c469c6781f007be73a1969099dda0fe67675710e0b3b1f4ba5a362fe3acba8cf",
-                                "uncompressed-sha256": "1e0849541651ac980be2b07f0c9ecb8efa80173bc3cb122679950117e5a928fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1e9a16767f1b9b89d4a64502a3c50b889c80340dcaf8a43ae437621d4e9153aa",
+                                "uncompressed-sha256": "10579d4a671c1d62679208907f2fb5fc9ef4b1ba92ec4edf3fbb6ed951783438"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ce16b20497ecc210f9ed4b2facef44ae0b157f561aa663b4df03cdbf4dc536dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a799918b87fd7a76c0f1ab3d3bb9317d6d6a32806e9471f6b32118e8cc163f90"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1312ae92d66073e1dff2030224f12f49dc8c4e1dbb51b45f33c06b493dceeae3",
-                                "uncompressed-sha256": "9e3bb9a9bd6755edef78c243566ba2ab8a2f37492ecc9f767d548d922f6ac8d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6d066ef7d01b81b04d586d923456b504bc8339692eddf82494f00ab617e8865a",
+                                "uncompressed-sha256": "8863233e30aff215746b7960adc74c2ee6c15264ae95382d347a51081cb327ec"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live.x86_64.iso.sig",
-                                "sha256": "8e25a6dcddd3c8ebe9e56497602c1969f9ff71f0180b254afdca5e3e0daeb758"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live.x86_64.iso.sig",
+                                "sha256": "a40cf13fac493911377037f247cc766cb68d6f4d5eda844709d8ca30cbb8efbc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-kernel-x86_64.sig",
-                                "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-kernel-x86_64.sig",
+                                "sha256": "d8e5ff16a69a032c0e47df0c2fa97e724bf58deb49ea5881855574728fa96cd2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e2903ac671c377cc0dd069b6cb70b8c84140db9cacd86f4eca77584abbfe729c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "09966ee504d4765308549199c7d26c8d3972bca7bcdb31cedea13beb8061e4e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "eb9b87e17ed963e019bc0aa7af69a17ddfbc3bf309873fa878f5ef14bfc9b18d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "3e9b4089622368a5e4a334b90ef39e89b0e8f22a2a31203b346c6ba69e653531"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f4145ff353d49d5cbd528763baab05c813b082b005eff2f43766fa5f27900df9",
-                                "uncompressed-sha256": "57a08eece86f05239cfa24646a7cd2637cca946e8878e2ae2aacf68fdb3da273"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "de7ea5aac51a3cb17d64214fd1b7f97bed659746d17dd06b52c5b41c70c2b44d",
+                                "uncompressed-sha256": "26a90ab8fa445ea35aa3ca486e28b39409f497b955e238d7eed1c502e1a59339"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1870db419ae64869da1cc2efd6f4cc487b20aa2ba20d0e31d4c6571e3563e916"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "15955b2ec30b1efe684afbf0b0b5cb8bab3cb6be37d61decd7804b329883989a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "cec24904f797a55b8ec6d7ca0b5f5fd4bb6e3845400ffad6fed2a3619f32466d",
-                                "uncompressed-sha256": "661c36d24614033a914f203d1171eb22a24aa8a946b1cd74a4dfde2a59a785c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "551950c9c68daf8131f5c023971cacb01de2792caf53310649c8103090b0d2c1",
+                                "uncompressed-sha256": "bbfed4f137387e5cb53d7697403108483b12a15f1ef709da41f6c81f4d95e11f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "01c2b97e8f8a3e6edadcfb024dfd3993152429f39c737eb86aab6e72030ed0a2",
-                                "uncompressed-sha256": "c9f5030f8a2e8d4e856696e7efce6a91126ef0a0173c5512d6267328729e5dc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "da84b9bd623a24ecb1a58fde24bfd351b3a62cf476ff42ac9873d0b1c611af8b",
+                                "uncompressed-sha256": "611715a356fe4e2f1e1661494405e6cae8d245757d3808b0a6bd41a1be9dff09"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "496d5092682def040e7204d8d8cdc730abd72ce8d80312eb6112bf528f8fcffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "59101d5d77cb885a0a0b33af6c35d9477ad20fe4438000e1db9d07877dc30ef9"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "10b22273bec7d36cd0b68ff73ab62c0c054997e82b23272475d7f709bd76a7f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "886b7c129fcca9fb41e751941df825a120afe4135e067533a3f1fc5fb9a44c1d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230527.2.0/x86_64/fedora-coreos-38.20230527.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e67a04ebe423bd355ff18c5e0711ddb72b3ae2567d9b20be70e616167ebab1f5",
-                                "uncompressed-sha256": "59a9de94bf6c16ef1558676b8cb51183e124afa095fbb8bfc2b0bc978da1c0fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "05f1307f557ba2786dcafaf58970623f2b11ae8abbcbb7a8f1f4e4fb082c1213",
+                                "uncompressed-sha256": "198a90f1572a046fdb46d53b6e989ff3612445ef2f60f026d229ea2fb7303556"
                             }
                         }
                     }
@@ -548,121 +637,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-008943ea01cf78492"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-06c475d0097aa30a4"
                         },
                         "ap-east-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0e87b5b74dbd48b26"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-00d4c62971920986d"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-03a5fb9ff8f72e589"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-012af74a777ac8129"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-04121deb15fbbbf31"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-071d1136983e377ac"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0df4026f7ffc4633e"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-034915ae2f13e4835"
                         },
                         "ap-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0d181a978ee68bf14"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-03c21d9b722d64948"
                         },
                         "ap-south-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0b91d941a499cdcfd"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-01aecdd8e49b33eaa"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-08f40b50e7850a7c8"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-067c568a6f3f759ff"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0ad393c6337628e55"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-02df1fb98cb0d5597"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0c2c6562f862de28b"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-00ef194e3bf3dba94"
                         },
                         "ca-central-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-08f3fe3ae2a24f060"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0b16289dc20d5ae17"
                         },
                         "eu-central-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0ea13f9eba1f175fd"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0a1e6e375c731f3dd"
                         },
                         "eu-central-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0e1d89258ecb3831a"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0a3a68eb003fba02b"
                         },
                         "eu-north-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0d368a5f66e39a6c6"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-04046473cb4a4692f"
                         },
                         "eu-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0fef050d3e4db1ee9"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-05f84d8053bdee0c9"
                         },
                         "eu-south-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-01f11a116d5a81c20"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0ee56e84644af19d8"
                         },
                         "eu-west-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-05f11eccc31e071ab"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-042b8e3ce9b7445c2"
                         },
                         "eu-west-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-09f4655cb4418cf55"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-01af3d918cda0bb18"
                         },
                         "eu-west-3": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-01d18499aff3122d0"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-09c4a2597d0a65940"
                         },
                         "me-central-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-05ecb2147a31285af"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0cfd6ec1ee8fe1a60"
                         },
                         "me-south-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-054810c99bb0ae72d"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-055f6d8ea4da830ba"
                         },
                         "sa-east-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-088eeaf90d3d4dda8"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-051723c81431fc230"
                         },
                         "us-east-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-025a766db24f32047"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0be1774d984bf225a"
                         },
                         "us-east-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-00479421f394bfc6d"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-097e298aee54a25bd"
                         },
                         "us-west-1": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0fc975fb7a0cb1678"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-0bf9722acfcfa5924"
                         },
                         "us-west-2": {
-                            "release": "38.20230527.2.0",
-                            "image": "ami-0e77264d0a94324b7"
+                            "release": "38.20230609.2.1",
+                            "image": "ami-03fb2447cf4272c09"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230527-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230609-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230527.2.0",
+                    "release": "38.20230609.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a5d944c4c642f13184c646edc220c81d3293f7c5dfc96e30689bbd94e32e267e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bcae531e8d29ce98d4b6fc66c75b43378ad146bed077b9d5be9664eea924cc9f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-05-31T18:52:49Z"
+    "last-modified": "2023-06-14T03:09:02Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230514.1.0",
+      "version": "38.20230527.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230527.1.1",
+      "version": "38.20230609.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1685628000,
+          "start_epoch": 1686751200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-05-31T18:52:45Z"
+    "last-modified": "2023-06-14T03:09:00Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230430.3.1",
+      "version": "38.20230514.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230514.3.0",
+      "version": "38.20230527.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1685628000,
+          "start_epoch": 1686751200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-05-31T18:52:47Z"
+    "last-modified": "2023-06-14T03:09:01Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230514.2.0",
+      "version": "38.20230527.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230527.2.0",
+      "version": "38.20230609.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1685628000,
+          "start_epoch": 1686751200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).