### PR TITLE
Roll out stable 38.20230609.3.0, testing 38.20230625.2.0, next 38.20230625.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,105 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-06-14T03:09:01Z",
+        "last-modified": "2023-06-27T18:05:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.13"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3604e766a3e6edc4ae8a101da8aecb4bb73e08197302a76a43c19a6aadc12a9b",
-                                "uncompressed-sha256": "80aa19f76cbd7d6dcb0c79d6e9e1cbe88e88c594c6b4d28404cc2f76876b2a18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "324c40ba39f5d78f048d90b50ae0a408bfe3e937d267d9d6928206dce70a9b4b",
+                                "uncompressed-sha256": "647dc52c040f29efccbf74d9b90345ed5a506cf96700d753a67f096a866d36b9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7cc240d0ab6f5f66a0d8b80bf9f92cbfbda68605655d31bae199da249a7d08a4",
-                                "uncompressed-sha256": "45719dba032fa221641ff5372f90d72c3eb1bad320451663c7c4c55c651aaee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "2795f59d4904d55948d2f1e549aaad5f48e6b17b82470b003274c367fc97e846",
+                                "uncompressed-sha256": "fcecc092b761d1906312ace422df1e31e7cedc53cb692afb605d3b0cf58bb654"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "38.20230625.1.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "43f6cac2efba20350624bdde4846d0c88a750799b31ba5f6dd089159be537898",
+                                "uncompressed-sha256": "ea5373547a526ef41a15bc731be49349f84804231c195130d26da5d4517226b2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "154f006a302dad5f8203e993bc567c722e93a59ca8024e31c784dffe5cdb0022",
-                                "uncompressed-sha256": "adb64569a478c6c65f4adc180548c074b311e1518f77c995e0ed86b85031fefe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3d3b919f5efd29cd3b5b44660e90f913af1b6ccd38328253695f86eeb7a3607c",
+                                "uncompressed-sha256": "54c28ffbf470da348cbb8c8f39ef9d25936c4f59c81a444f2c8fad91dec3d312"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live.aarch64.iso.sig",
-                                "sha256": "2c47f8cf8df7c26ed6f99ae28f593f8d1dc6f2303f22626d6f1803e19a102def"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live.aarch64.iso.sig",
+                                "sha256": "84368b232f18f6a732656e37ac13a603ea3402b85635296033689ac25a36593d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-kernel-aarch64.sig",
-                                "sha256": "78314fcdfa709fe01923fd6da19ce6cadb570e868d50ebb7445042f6914c1a3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-kernel-aarch64.sig",
+                                "sha256": "76761feda014f26804e68539d69f3906a3572539369f646f4497456af9ede553"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "722815f196a59957a613063da33c7b60587c80d1c3e5a2e72e586398d4c0b72f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1056df032bbf6a0809302c91a5c8ac1278e4c1d679995b6f11d6c4534c7ca35b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6c5d5ed087a4a91871460478761d2aec3d5c33a59da18a6de243a1cb52f7fb22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "e130f72747105bc5da83b70239adaa62b6bd8f1728c8c7cb5f7272a16f3312c3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "96447dd2e5dae5abb02c607fc3722d67273d5bb73134b2cf03e9cd382ba98211",
-                                "uncompressed-sha256": "eb03c0d95f1df95dd1c82a2d6a63b7aece2c6fa5fd9b3c7d93a960d41a9f75a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "dc9136f5cf56dfe8690712602dbb7f6f772f0085420532c62172ef6182a09b12",
+                                "uncompressed-sha256": "e35989e9e19ecb115fab385973b8108156f889f566efcf54ace6c46dd7305e8c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1d2fd70e45fbc55868b528f75183b0b07eaf67a8d80a9e3bbae0895ed131e6bf",
-                                "uncompressed-sha256": "017655f75c452a86bccec43560ba5aeb802173b45656a4db643b41901402dc2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b0451804f9130e069384fc2b81cd31ad76120e9b7c10c39f049e19a7e3c0cb70",
+                                "uncompressed-sha256": "9b231bd6b4122f623c3c1523a6d8fbaf032325a9657faf8cd0876c499dc4ab83"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/aarch64/fedora-coreos-38.20230609.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "56db1ef090c8bce5ed05fdd11fdbe587f7b703ae667542aa650ae27c61f361eb",
-                                "uncompressed-sha256": "49ab51578123bff764c3fb52a4f2c53a345008f41db5c10d2811cfdb059b0b87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1846024dea3b64e68ac6145ce75b4987bd4860a7759b44c9e4e4944b8a70b423",
+                                "uncompressed-sha256": "c57d62c339fe754931e927cc15d2a261966045805fdc9ad11092528975d0d962"
                             }
                         }
                     }
@@ -109,195 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-042cb8c0ada43f6ff"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-014b11c04682ecd83"
                         },
                         "ap-east-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0a025b2c1d447d49b"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-06defcfc23c2ca1bc"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0696f376ad14932aa"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0a8703fe17572583f"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-07e8c8c2d5bd66cc6"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-01bc9af314908e199"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0d1bbbf33cfeaa4bd"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0b0276eebbe8ad91d"
                         },
                         "ap-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0f54dd8a8fe5a4c81"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-09c3889e2ab2d1180"
                         },
                         "ap-south-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-04b7ac6af784f5a2b"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-01e90f666d2c2df33"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0bd2dde75af42e7a5"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-072b455faa1fed94b"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0135fcf4060a23e05"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-071e009ea4427a5ce"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0140a82aa009bd96f"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0fdb65ddcbb768a0f"
                         },
                         "ca-central-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0c934af0cae7c2373"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0f6cc139ca6b1f5fb"
                         },
                         "eu-central-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-07e081b9ff6568e92"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-09bc7ba33c57352b2"
                         },
                         "eu-central-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0eb2bc73e3b6de98d"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-06df1ac5a12d6bf5f"
                         },
                         "eu-north-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-09cd9098dd2e2a8d0"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-06f49056783b13ead"
                         },
                         "eu-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-093a032f008515e92"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0100eaaa40f96ae0e"
                         },
                         "eu-south-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-007b7089d42ee2a0b"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0bd7cc160bcf06391"
                         },
                         "eu-west-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0c521ff4e1fdb700f"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-01b113a50797863e1"
                         },
                         "eu-west-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-03673d8766d6a86d5"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0d5d082907fb7385f"
                         },
                         "eu-west-3": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-05b97fb911a39688b"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-009b8f05a8578b36f"
                         },
                         "me-central-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-092575f9f355816c7"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0ee25e9a850962c29"
                         },
                         "me-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0976b71e64eb464af"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-06b77e2d223951a1c"
                         },
                         "sa-east-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0736698da3bc50c3d"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-032a3ebdeb9dde120"
                         },
                         "us-east-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0de68f3ce48de7fd0"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0dfef69ffa2fd554a"
                         },
                         "us-east-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-01a79d18177163174"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-05aca547f241494f2"
                         },
                         "us-west-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-088cebf2442fc4894"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-051ec8e44303e6292"
                         },
                         "us-west-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-02b2dfdfab4fd2c2f"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-00fb85a01e801b2c6"
                         }
                     }
+                },
+                "gcp": {
+                    "release": "38.20230625.1.0",
+                    "project": "fedora-coreos-cloud",
+                    "family": "fedora-coreos-next-arm64",
+                    "name": "fedora-coreos-38-20230625-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6bd1abf741f8e617312c15c02d81f699ebbfeeafabf0abbd067aab6b4ba52b0c",
-                                "uncompressed-sha256": "921d1e93c04976acb9ac7f823861c087e8cbf523fa1067a161733c4ed968e8c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "80ec14c905e6f86de66f715d74055ae845d8897ee591537acebe4fe09d05990b",
+                                "uncompressed-sha256": "832cee20ab7b0c02616309d1ce74098411fec1837afcc463f1a26f1c91f87e45"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live.ppc64le.iso.sig",
-                                "sha256": "f16627f401c9866ccfd9d0e5d2fdf90cee9bbbada4a0906cfbacd9d996bd5e1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live.ppc64le.iso.sig",
+                                "sha256": "6f69b6bd2b5dab6744b99fe2fb85921a0805c064b3d17a0afb74105a4b9c4787"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "d3c459c1fcfc267b775fb916a1f9d0f84afc64485ec1c484b96ea5909e796307"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "f0e3495fdc3d80eda9e8642a248686ad5d1a15d841a99252c11f7043f2323a37"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b02c1abb17cf64d54435e1b2b80b2c0424721664c33c587294c40cb1c1f0a600"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "40ed40c569b75d96657b2c6b5c93d18a2dcff4bccb60358c809e57290d3137fa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "54bf1ec23be4fe01f621e5a353183e94575a099c480a7e9a1545e28667fdc31f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1a18537422801e4777bc3712cc4e28543bf668f18270aa9ddbda800842642ba8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "d66987684ad933dff763cb7dea8a34d91fd21a5bb0eaeafb1c1747e0d540129e",
-                                "uncompressed-sha256": "517fd5e90e923b0f3efb06c5b706abd1436fbf4a234847190b6780392c89b90b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "35ef200e91590e5169971957ebd542fb36932d3649e2748c94a85a8927321e63",
+                                "uncompressed-sha256": "e03b91e76bcce5fe8efe40fc679876e2036145ada1e925ab07ac00c7b55f8cf1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2b3a844f1e737d8d75f184ad09f1be72c2757642d581ece847d18926eff4ab32",
-                                "uncompressed-sha256": "c484b9bdbc7adc1962a5e08a775f3bd313894adb99a9df1aa608df97b731b6d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a240d5b3d322f73f8d19b3b2b60882e59bdfd992f664e7c558ea3cec45cdf4d3",
+                                "uncompressed-sha256": "326ee375d6859e08c0758a30dda8ba7fa7aaf04d960ee579a455a89f7fa8a3e1"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4119c417b3299020b45e621df33ae0e34fde4b1ae3ffe93c6761cab0993990f0",
-                                "uncompressed-sha256": "76fe4f4b39de1aafad63317c234fed6edaafed9a9eb00730ff9641ccd1a89c0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "7c386d98ed7dc48e103b2f12ddc63b34602e2cadb7888e94aa82ab40971f7c8f",
+                                "uncompressed-sha256": "78b52d8b9c8ad20c860efd93cf4301c9c5b604c80ea92bbe6c026f9a510fc187"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/ppc64le/fedora-coreos-38.20230609.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "59ea15d1afd90f9eb31e23c96f99234cf2beb23d654e02f2f40a346d588b60b5",
-                                "uncompressed-sha256": "90b8ebdeb59f947d123164af981f6049184daf1821c27b665bd717b438c984f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c3fd060765e1e6e6141d17a1eed0864cee69c62218afcd7eca1f2ed53bbc10fb",
+                                "uncompressed-sha256": "efbcb7a1e4836735d9fe0ac9cb9323d69b9a2d79e458adcd2f89ec15c7d859e6"
                             }
                         }
                     }
@@ -308,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0d35cfe99b3675f1c6d6682cc7d5dd61e19dff4c07e8e37b235297eae688d093",
-                                "uncompressed-sha256": "23c7219e7b4dcda2a25cbb53d86cf32e7cd234e72b7222693b9dd4f7a4ebcb42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "854b2609af3b0e398fd3ce5b50a495a9466ee5b3d3b61efaa9086cee6d5bccbf",
+                                "uncompressed-sha256": "f689216bfcb6d04628ead78b53b6a66e046ad9163806fe50db07d84049754228"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "74c1b106fa4f929008b0bc45207bb48955379afdfdf9ad37d32e21d60c98d88f",
-                                "uncompressed-sha256": "bba8d8f6d2b7f7cc920ce061c31c3a26e8bd2053c53ca29e67f4445cb9933ba8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b6f9f1e9827196a2c945801570ad057e3698f582b98d347ad87a07566199cb3a",
+                                "uncompressed-sha256": "1202055de1ffa4d175128e2198fb8b9bc446ec0d52b5e74a8737d6c0f2b9ef86"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live.s390x.iso.sig",
-                                "sha256": "5fd611c5f1a6cc154659b9339b5539a0912a1fef15e37b9d65f277b92b5db71b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live.s390x.iso.sig",
+                                "sha256": "cfcdf411d8a58a6fa12b8faf5cff6a7792e7944da3e69cea0e8c386cc43352ff"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-kernel-s390x.sig",
-                                "sha256": "317165aa952d53852e2d6c54ab52c1431be23ffa4f7c983021b9000f9caf8463"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-kernel-s390x.sig",
+                                "sha256": "975e859bd56ef68e78e05af715c5ff167edff175f7987f67ee513ff8c3fdd68f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "42be78c5163a5516e1f1e41f480ec501371b9f7b20c6090d8bba66c9b7a8925e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a1ac6a77fffb8a0ca4a6076253f5235f1a35429849802150848dad87d502fa98"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e065ebda5220ccfbdd256f80d517b5aa9d8e523b761a5d5d7e88c6071a534611"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "2634544189b5e2763cf70e2cc91fcac8adb9fe5e5b5e19199612062bc27fb9d8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "71915f55bbac3eafc0b499aff2bf669b67e3072e3b43817402e4b8175e56f668",
-                                "uncompressed-sha256": "490527a87705d7e246265d9dd0848a00766bdf058ff3b4a1fa07deb8d5050755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e17b137e6629963c1727cab7628f66f9125508cd8bc7363b915f44eefa96fdee",
+                                "uncompressed-sha256": "3e3d11c049bdca4d3e65fad940aea23a5cc27390aa6cc67bb260a907600dc79f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "37cb7e3408cf25902aa62726a7b1f6b1610154554fde6052b4957cc8cf2f9ec3",
-                                "uncompressed-sha256": "9a968109f5bc5d9965806421d7ea9f47c6879d18a3fff29fdccf43e49e15bd6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "87a3738c8575365916a0bb3395500976e45e83c123557d01acea5566903561a6",
+                                "uncompressed-sha256": "9d3b53200810e00b0abd7a856ae8bc64b407f67e29dc54d5395a38a7beff0047"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/s390x/fedora-coreos-38.20230609.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "88350e999bbbbecbabb139a19bd6e392f6a29cbcbb184bb2843c6152887f2c9d",
-                                "uncompressed-sha256": "d428d1da4edefbcdc4807f0afa279baeb96afcaae8f5d988e32e229904953e4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "53ca3fd3164ccc5e7855a67e470f84aa6862344806ecff5a871010eb18c049a8",
+                                "uncompressed-sha256": "7415f0792264cefd994f214c9799a2cf1cabaddc14ec930c5b1830db8ce6e27b"
                             }
                         }
                     }
@@ -397,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "247465cc64223a31db1d547cd6b38d88edabec67cc404cfb624e42b75e4d8c0f",
-                                "uncompressed-sha256": "cc36542b6258f285d9d080445edce662db334500e062699ce1dd36e48faf8d99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "548cb7c463531f92d9203b564ce745849009939fbc6a9b88f7b40087c3ae9703",
+                                "uncompressed-sha256": "40fd560c2e7ccc83e049364676e4ab760533aee7706a971a92c06c04b8b57bc8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "be09236b51c48de437b9869d4d22d5407f6c40de4901a928627f79d2d5ef8a55",
-                                "uncompressed-sha256": "462fc015e1cfb8090ea766166095fb07cf3f9a3282a9c00b368eaac1764bb2db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a82b32aa0745eba84989a2be6f53084664f17cec018365a012530f70dd4b64bd",
+                                "uncompressed-sha256": "cf9b9dd0f7b5978cad371a008c94d0953da5425300abbd22936a27606cc87062"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b053a90c30e483a7b361842d87724e9bdfab58df42b65f07a8643887e2a7e937",
-                                "uncompressed-sha256": "64b1cda6a515e278a7c71d87996a19dcbafca1c21b9920e25a27f0b9aa174ad8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7c01be8ddd1992eac5dd89853b375a863b23ff6f927d4f597d17a23bb7b5c5f5",
+                                "uncompressed-sha256": "79a4439dab96b14550ea0e52d9384a864020726081915b0cba18e33c94cca591"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d49dfa5db21afb04875a1c619a28abdad5b2d873a773c29f97175535f25e7ea5",
-                                "uncompressed-sha256": "e3cecb2c31fa999885a1b5b3f18c5e9c5d374b9667dd3b3a2d566270bb15d648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "fa24679f223be9dbbdf2e64c81a570fc6fd52e4fcac71b24250e3e4fb4853583",
+                                "uncompressed-sha256": "bd9c4f88750a2f64f451b8dba2da9f6aec6d0407178e084b4fe90d635862b6af"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "36105ce392477b85ef65d587c7920002c12dae6621a8aec0059c2644fb0bae68",
-                                "uncompressed-sha256": "aa94778918a6cdc0359102134895c7f0d5e3a486de91d81703907c8d1171b46e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c8ebeca5dbf9c68df3f82d6f10c7c8e9126dcea29a8ef64ed46a01f798bee486",
+                                "uncompressed-sha256": "3bd8e1fb162217e7eaf8e479ddd0066c546a365e1edfc3957d764a243e3b81f8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "05cfe9320d5e1bde720d826730d347964ece5bdbc76ff08b14af98055ca75194",
-                                "uncompressed-sha256": "31d8cae588b77a45dce3c2e1f1022f0f50ab1466eb1f63e5e612b53c685ad893"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1fd215668c0fa2ab2b5e7215c84750eb76a75f7e4f0fb9e6ba8d42c8c523004d",
+                                "uncompressed-sha256": "27e88c72e67de53772e351470f680dd62c28b21973e842727e4281d09a2be786"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5c9d687b4396eae188d1c2991f01f88443f2dc85c9a723bb679cbea45881ae41",
-                                "uncompressed-sha256": "98ad9e7b68f9283ae4d286e6e36a95c434b6bdec15926d9b4cd8680035f4b5c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "04d5df65c94ef4b9740b9b6890948e944fa4d02da9be43bacea54bca7127e3ff",
+                                "uncompressed-sha256": "d4853de27de11bcb4b194a662b02b03076bca06290e69f34aea2e5b0c6de9699"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c978269ed4e591c9ca5b419a0eaf99c08b5acddfae68e3a67d0feecfe21af097",
-                                "uncompressed-sha256": "be004712e02c98b20bc378d5dd37b252dffde8a278c5a9d977d46c84fc2b47d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ae05140d911dba18816ee148489f409ee162c67f8b508ebb400784b4aad64933",
+                                "uncompressed-sha256": "863cfe9c425011a043b2bc588c8739108c453db5e88e5249cc48d04b5311dd4c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2bad4a617b5de905470df8f34009c706b4e9c3438df4e0de0f24b9195ad4ddce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "8ec86c11df09c8e082ad5f800250a71d4fcd6436477c1eae583975dd70e6d9ef"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "99f847f972f6f317bd429cba7215fb522eec75b2337a086d53c42190a4485b35",
-                                "uncompressed-sha256": "1a7b2c278c81c4acc0d5939ad3e43c6cccdfbd18497cacb919186938dc3bf632"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cedc7246c72c3d77af7e3884acb3403add7b73439e66370b66a33549208d3f29",
+                                "uncompressed-sha256": "84fb62befe547d203e7e180494f4ff2831ebc1f0eddcbb76460b5e8424da5213"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live.x86_64.iso.sig",
-                                "sha256": "7d1aa573909ead372d1c35e0475fd863b878ae253ed7b9e7e7a0a429a2a1f3c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live.x86_64.iso.sig",
+                                "sha256": "b9e2a9e6b37396acaa1a71ac6ac5f1dab35939abf83c06400462b08177869369"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-kernel-x86_64.sig",
-                                "sha256": "d8e5ff16a69a032c0e47df0c2fa97e724bf58deb49ea5881855574728fa96cd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-kernel-x86_64.sig",
+                                "sha256": "6da41b956f8aaa6e456e6eae6be356f0c8c5000de6f25c60316ec863e1823bf9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "717c8acaecec9659a03051419d9e6e20c56c3e3881ea3565ac08ad3ab4f4f060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3106e5c118640b8dd964d09858fc799d40d7019c9c50dd97bd5a1023afc4b036"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "188e3a0c5f7f671f00e604ced9374cbeedd3d0f71fc5ddbc947e80ad45756797"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "2eeef941371b186018de56338333eaef404706c6c201a537aa29e6c6c19e91b1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "8644eda2ada60545f704ebee12cdea3c2bae9f14cd853f065d067c954d4b1315",
-                                "uncompressed-sha256": "2e663161135a4b895f7ac2a74dfe7beefd8ce641860f058dd9b758ecd03bcfd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "bcc07261e90ebf28bccd02dd066fe38d3c34892450dba834c20d4f7fab822a0d",
+                                "uncompressed-sha256": "9db5ec9b5f4aa6482c84531a30a63685382e5b83d0d884b2f92af951598e8ff9"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b2012d3a39d4d4c7626ae8c4057410de7ec516fed9800e5547f473c8ef6a93e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4876c58709fb22c9ac41b30b5d60612e0d8df5ddeadc3386cf3a2a5234726eed"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "995d6a43518a37d8a460e194ba3fc589aee19da45a5f5abc8d11621cdbb37fbf",
-                                "uncompressed-sha256": "7204a851ffefc0b5bd6c6665e079f9d94965d0db32369b926ae787e05e34c88a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3f13e8480b4e57b6e3a4eb43684100556d4d026ffaa288e8d0e7467061cc0be8",
+                                "uncompressed-sha256": "c77bfb3848bbd24b1d31d2046bb098b9d3f3821f4fbec6ebdd7861e37e9b6a93"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e10ecadae99cd81cf5d56be205f8f07b002dd3f33f26a2b057c1d8ead7f50fc4",
-                                "uncompressed-sha256": "07f161d6fd72ea3a7df3f99e81f9f9c994c4caa4256fb73cc1c545d12d33381f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d3a22c25030719dca120b6eb0aa9bfae91856167433d14775761ac1cc3c2c472",
+                                "uncompressed-sha256": "c56e7f439063fea16358831f8a8e624db796465085b4b591dcd3227c4147d7a6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "3b939a986a5d5084b30428e2b6bc43094931812d753d73df952805423a82ab21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "e5d0f038cb3274e28001862f6dc0ee5fcbf2e56b2ab41117927a682efb6089d8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "9628918b6448b6165cfd6f39342a6ff53f1bbf4c0bb6baeb234a50e096faf2db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "7718523d4b59f1d64007bc571a4e287d6fff6771767913d5d0f01362ceaab523"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230609.1.0/x86_64/fedora-coreos-38.20230609.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d7c80cdc9c88cf4088d98f3a187a393646a032bb4acc81ae6dfcf4726d464160",
-                                "uncompressed-sha256": "ee4bfc005022ec3449239aa2cb78e69d6501394eefcaaea02d24a4b6f0cfcd6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1a680e4bfd1d4015f1681958088de59f509cbf45ba80ba2371eab27825f240bb",
+                                "uncompressed-sha256": "e682fe423b5a569e0f36a7190c4985dbd7007ef864a6be7981087b56c3edf409"
                             }
                         }
                     }
@@ -637,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0d75664a8e3522f1e"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-02298e385548b0a99"
                         },
                         "ap-east-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0d17ba8415bc399fa"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0577a8c5a4f1701a8"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0682668d8ad3cf774"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0fddec8f39838dbdc"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-02e4b3027a49844e7"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-02655f93f60431d23"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-026dd4502ddbb9ac3"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0db3ebe981ec60855"
                         },
                         "ap-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-079d65af45e82b8d8"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0173e6036b7fbb4ea"
                         },
                         "ap-south-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-019ef698fd69a538b"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0112df0ad97145a03"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0e1d6af922b067e4b"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0933113078f3fac45"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0d4a1c3cfeede73f6"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0e66b3ad7356ecd01"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-04b07a5842e09dee6"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-09d6bd7f8ba88e8df"
                         },
                         "ca-central-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0b595b0f73189dac1"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0457be4580869ac58"
                         },
                         "eu-central-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0d1998e0cd07cf9fc"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0b1d93680e5da03b4"
                         },
                         "eu-central-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-009497da1a208b4d4"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0e315a0a2e7849871"
                         },
                         "eu-north-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0eb2959f338d35437"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-01c4567ef43433f7d"
                         },
                         "eu-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-03ce6fd25fdf409f2"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-073c0657450c0fa71"
                         },
                         "eu-south-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-09b91b0fda8d8112a"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0065423d45c313c24"
                         },
                         "eu-west-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-01acd4e9a5c8a5386"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-00eb9a6e74e97e1a2"
                         },
                         "eu-west-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-05c13a081f269be70"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0bc41926691de9a0d"
                         },
                         "eu-west-3": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-08c85cce1dc1d11b4"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-09c31eb627416497e"
                         },
                         "me-central-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0a9d35c542f844ad4"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0c0748b4d13327e9c"
                         },
                         "me-south-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0e5d33f6f2b34c09d"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0e479368edb77751f"
                         },
                         "sa-east-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-081732df2488d07a7"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0670150e4af3d8c22"
                         },
                         "us-east-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-02944daa82870f97e"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-066aed4bb4096d6cc"
                         },
                         "us-east-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0e0e61917a7fe9aef"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-01343bf60a7621d8e"
                         },
                         "us-west-1": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0b90f27eb7e66c173"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0f0ef33d5c99f5510"
                         },
                         "us-west-2": {
-                            "release": "38.20230609.1.0",
-                            "image": "ami-0f83d9c7df6e8c70f"
+                            "release": "38.20230625.1.0",
+                            "image": "ami-0ab194ccaf9b0f3f6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230609-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230625-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230609.1.0",
+                    "release": "38.20230625.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b5f79afc683277b7398a5a34c99da197a485268a9981c94a2e1f347b7bc25670"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c1a38c327119d1d58ea30cdc00c3278e85436a22fef856ef03da016f27cb313e"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,105 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-06-14T03:08:59Z",
+        "last-modified": "2023-06-27T18:05:10Z",
         "generator": "fedora-coreos-stream-generator v0.2.13"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8b8fc1196037cd8bf5e9d054007a2db719fc3786752a24e24f1622d4be0ddecd",
-                                "uncompressed-sha256": "c919354c930ae10a271ef5efab26a127b5f24fc5624ccf9ae3ae9cb72c598a93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c7c52d602d73edfe79cb6557b4de4d90b4f88ef45d2b2e185851de7442cc6e35",
+                                "uncompressed-sha256": "a14734aa2dd6df77f9ae22750dca4b3a14199f10230e81214f4467d154b0c09a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a09877f4ded8cf2effb92da95df3d62297210b521aa28fdf199651942131399a",
-                                "uncompressed-sha256": "f01315d06c1a9a348bee7ab6b4a571407a093d8d4d5105303aa0c2938f5b455c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "41f1cdb48cd5c9daad14b6a8b1a6a57913ed78a33d0f8f3e9ca7f2bbda3af340",
+                                "uncompressed-sha256": "7b950ab98568608b387936bca145543a05902526dbef6f09539ed56ce5216287"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "38.20230609.3.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "b5b3bf15a241162ba2f47b00ad903c41e156d84a085847e05804c645d4a2302e",
+                                "uncompressed-sha256": "e91c14e18083cf0fd19b82484eef64e5997e49dfae6cfdea19698e4fd0f61d80"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "65e90c5732b3583f49f5e383c413e6f43f9eeb0c966b8da2462a91461dbfac19",
-                                "uncompressed-sha256": "c94bcb92652f9e2707cf1601c732553056d25549e9dca9acc61d808371a93f46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5f5b9ce7807fdae3f076e4c4cf5ed0a8c8793bbbee2de401051f2b053cbdeb49",
+                                "uncompressed-sha256": "bbcbc24119c07d7f11c7d6474b40a1723a97e4cbf73903e87e40c7c0b033d8af"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live.aarch64.iso.sig",
-                                "sha256": "29fea16238d378735b3a8f54a2486c883c4616fd1a998e75681f32541894a4fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live.aarch64.iso.sig",
+                                "sha256": "3bb1263b094c4b279dedc20ea0631f464dc880d3d4539089f0d7430614654c9f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-kernel-aarch64.sig",
-                                "sha256": "3220992101cc232cb4531063ab6a0e99b704f389d76cd65eee23c0c8fb02d3a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-kernel-aarch64.sig",
+                                "sha256": "78314fcdfa709fe01923fd6da19ce6cadb570e868d50ebb7445042f6914c1a3a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ce6652224fe101e3544bcf1256603e801deab89d9cced28824dd9c5a3c97234a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a87cdc09639736a3826200f88a92c7f73b21dce41218b4fbc1def31eba8f3e94"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "eb15f9ca7d94ee217554a7c7809d4d02032efaf6160971aad3a0d4110e8baee8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5db9d28aa7bfc04954d42e68509c31eb87343dd8a1a768407218faf275a7b226"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "52bac1fbae009604fe3c69f91fc2c500fe6cf5b58e516ccb2122a5a7c759e85b",
-                                "uncompressed-sha256": "e4520e6dffae2d31d14ba6608c16b258d25720f39cbb31524e0fd85bee0e3b55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ed4fccb7e1efd41e8acf952f69eefa67d60d2f21134fa4164a2675dffbba235c",
+                                "uncompressed-sha256": "4cf388031f37105eedb449ed3f649a9d84c5b1dba19cca0fd30f6a123393f3eb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "172a65a24a3d0ac5eaebe00745604ea190eaaf8b378aedba4e4ad93fa83d5308",
-                                "uncompressed-sha256": "6711a9b6715b1fe5360076003635eb16135b93c2d4318dfcea81d0419d134767"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6245b839f22a9ebf3ab684b8b1119c12af947ca05807f1fd36a9ce67505a0b01",
+                                "uncompressed-sha256": "1ca478ca5cebfc94950d76014d12a48bfd72df1c4f0cae23cccc1b92f6ddfe9c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/aarch64/fedora-coreos-38.20230527.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c8cadc11030bdcc8beef930ea90fc21e58775ebc6407f95486d165e60b6f58aa",
-                                "uncompressed-sha256": "abfbfbbc2d635cd86074cbe871dc8446ecf6b71480c8481b4123f65658b10106"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0410362c212df040096933738607e56027005deb1c4a3eae417079180aaadc65",
+                                "uncompressed-sha256": "ab04cc58bff46622dd433ff9e6cd13c9b5a266925b4986bd0d25d13bb417fa3c"
                             }
                         }
                     }
@@ -109,195 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-08ba99a4c2fbe6343"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-066084551ad7c5ba6"
                         },
                         "ap-east-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0560a1da5c62325c8"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-07895c7047f8a0e78"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0df9ecf2a542a98b0"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0b8f59618899914eb"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-008cd9dae5ff09f4e"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0477f74a91ee0d8db"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-00464da7a213b4b22"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-099f2d71bce1b66bb"
                         },
                         "ap-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-005e2585c9845edd3"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0dbe34841f2354f99"
                         },
                         "ap-south-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-040dc3b270cdc66b6"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0fdf93bf53db62a20"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0f7c20af29b77533d"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0befe398d5b3a8937"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0f84b05c41a80a0e7"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-06ea2891d57fcbf39"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0a21c8d6c65a9dba0"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-06fe5e906cb26d5b4"
                         },
                         "ca-central-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-00e7b40bb4d5984f6"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-03d54c7c117e534d3"
                         },
                         "eu-central-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0e5ae8cb9dede191c"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-037a2ed830de30afe"
                         },
                         "eu-central-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0375f497efa6740ae"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-038f4d1892115f504"
                         },
                         "eu-north-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0aaa3ff834e0c9de0"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-01f3034e32d4e311a"
                         },
                         "eu-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0d79206ed49379d9e"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0250da658122e8f15"
                         },
                         "eu-south-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0090791030d31a17b"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0fa453857ecbf78c0"
                         },
                         "eu-west-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-05bd3121060346a07"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0fadfdf82b427ed59"
                         },
                         "eu-west-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0a74465536bd7177a"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-00421627a17084464"
                         },
                         "eu-west-3": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0ff81f03c41dabf1a"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-02df146c5360d5c49"
                         },
                         "me-central-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-088751b464e89eae4"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-00822be4932100ebf"
                         },
                         "me-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-00dfd9b0bbe6c1be1"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-082fd77fac5725bbc"
                         },
                         "sa-east-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0d6ba40251fc16e26"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0a1ca75627a2f07ca"
                         },
                         "us-east-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-07b0020ac9ff8f472"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0783dccd7b8d2c1fb"
                         },
                         "us-east-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-00c0dd024859b5655"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-016654791c8c8bc2e"
                         },
                         "us-west-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-013814ced554f33d3"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0349ef5f9c1c55f13"
                         },
                         "us-west-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-03ac079d40d780c6b"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-00ebee68141c737df"
                         }
                     }
+                },
+                "gcp": {
+                    "release": "38.20230609.3.0",
+                    "project": "fedora-coreos-cloud",
+                    "family": "fedora-coreos-stable-arm64",
+                    "name": "fedora-coreos-38-20230609-3-0-gcp-aarch64"
                 }
             }
         },
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d334a4b464d30b2bb6033a1766e752df10867b3bb3dd15e455b42c347556751b",
-                                "uncompressed-sha256": "ab5a337e51b6493ce4c83a295d623d6a7a87454bdb15859bd66a4d283cabf61d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8d37c34650898b672961284202a835a2371899aece24c3c382d7d177b519a651",
+                                "uncompressed-sha256": "0126f6210352797969be92fa1d6e69a8e13cba0e3243de879526803e43bc8853"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5d16c6bf77c21a6c3415b2d867fa1e16d120c798146bcf76cb2c8c38b2c39f99",
-                                "uncompressed-sha256": "5ed9656ba6d0b46dc57798d9fa88794950cb3455ba43555f1eedb64dd5d2d222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ef019f5164487097f50dc9d3980ac6b62e71ba6b1299160f98969b557d04cd1c",
+                                "uncompressed-sha256": "2a0efd8cd508d26cd72ec428502d5079740e3d725da60a04401de1c7e6e281f4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live.s390x.iso.sig",
-                                "sha256": "c4162f7ec91f7686e13f76c3bb7497ff35d3e0991905d46a2e4041a6596e2def"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live.s390x.iso.sig",
+                                "sha256": "b6bc28ed0a8c4060bfa0cd70794c4c6d40052e2bf675c878e05a60aaca653633"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-kernel-s390x.sig",
-                                "sha256": "f364e3ec3e2945dcbc12d89bb45baf1cea8efae09bb22e79e4e989936dec6da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-kernel-s390x.sig",
+                                "sha256": "317165aa952d53852e2d6c54ab52c1431be23ffa4f7c983021b9000f9caf8463"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "6f7c47d440c0978bda667871abf03aa845b78680aa4d35fe355e3a35c358140c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f4be62fbaf177c1500910cc189a7d87765a252730d8cf226bcb5e58c40f0daea"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d29538472c1fae51dac4108f093c36b5946b686865469cc49260a9827a6f771e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "479a7867d83d93f40f226ee2e0105834119150b752738b22c5cfa8d12ad2223e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "c85fac758fafac7a62f1c2dcfaaf2d6cf628be85dcb45a776c093acc6ffa3fc0",
-                                "uncompressed-sha256": "8b2a4a3717eed51301b7ad5ef369edfb51f12450aaaee2ee2bf40ccc37fda52a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d2334d505b46178ddffa069faa1e114dab9dc613dc5eb5382c292070bc424a26",
+                                "uncompressed-sha256": "83b7f30d98d9849418311f0dc55a5873519f5320bf47ac8153e066871fcf95e4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "68972ff896a7ba45fa491bf26d9be2da495c6f39e1dbee3b472d025569cd5775",
-                                "uncompressed-sha256": "b773eeb98005b537230d518c77e7f7936291c8de7612f43a1b0893a6e68b1873"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3049090ea2ebd6380086c086733680bbc54021bcc329003edf8e3316563e18af",
+                                "uncompressed-sha256": "4ac43284cfe7bf49baede874e6f71cc45c378984c267bdd50184e8d11759dc42"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/s390x/fedora-coreos-38.20230527.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d35ed21bcd981cbb64fec689136636f24957cd2371656918c2b543be7cb12bba",
-                                "uncompressed-sha256": "4994e687d9e14557d366a2b56bf675c25ed07660db9c58631d0e9fcbc4411d8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8a22dd3a590fdf3cadb58df0adecfbaf0d072ba4fd4a0f3b89c66d7a139c600f",
+                                "uncompressed-sha256": "ab7eaff097093e856bd1ff9d528c9976b1926e80f43cfc8eeea90e97fd74e3a2"
                             }
                         }
                     }
@@ -308,237 +327,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "608175c1d9d1aa273298497f6eb838355e37dd04c0e3b475885cc5e03217ed31",
-                                "uncompressed-sha256": "d83e57c8478aab6810d94189d25a2bee253abff38ea8cd070e624c096a84829d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a5a12cb1ede5947ee03581cfcfabbc01dd36fe70ebc06888186d7e55d7c33545",
+                                "uncompressed-sha256": "bc6843093f04726bf3ca59da88988599ebde7a13d0120527680445d74baaa637"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b6bfff500c968f92a2023821cf5b3b12695bd6e58f35fbcd71a22c2fcc5ef384",
-                                "uncompressed-sha256": "0848cc511f8268203ee7c6baf7a91addd67c0ac609ccbde11fd74a1d45537f1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4b904aead15f537a2bbcb558771e1e439f492896157ff50ea9faaa7a842bc653",
+                                "uncompressed-sha256": "68c36c5f3595483d1f314133c46fe6226c5b2033515020d6a752fee976e8e3b4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7c869df92cf63b9092ccb6742ff643d881ae7bea49ecc82c60f6f42a49fbc316",
-                                "uncompressed-sha256": "c53eb44c3758fda8868efe9f2ee9d42ba64f7dfd5d22fb1ab252a0de205674b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e81e9721a0c00a9c249d130f4ef9a9daa8abafc26fa1ab157fdf26825e1b6b4d",
+                                "uncompressed-sha256": "0632efaee111cb1f4c858a5b62cb80fd8ec619e28129735aa0270869229ff0a3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fbc6e043d52ebb140334ccfe8a2f2b89a187a5f7cb65a614a1c517acecc1ce3a",
-                                "uncompressed-sha256": "261c50edd01484d6c47a41d491cfd9968e342026c8da92f9ffedd80561baf21b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f85183f79943c3278a27de0483015232e70b5b586e6aed145f996a1a58578983",
+                                "uncompressed-sha256": "e94affbe2383945e567bff1b90dae87f4c0c9d66cff54619b9b8064f7de790aa"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "96c2bec4debe6edcb2074bc0db20c11cff867204ab5da260bd14e678e65bb9f0",
-                                "uncompressed-sha256": "c3bd51b65a099e77d55343f2648e276e172233cc2f2eb8d0693bc715d12c3356"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c3497717f1485fe652b3bce0dc1a16e493d95763f97ed5ed3f3ddd9f5ccaba79",
+                                "uncompressed-sha256": "4655dadc5a437554569f7ec30883735a757ab1013619c646ceab4bc795ec4428"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8c4315460926642e11abef3ece20334c921640342e04495ccb7d4d13e2015fc2",
-                                "uncompressed-sha256": "7291307e85652ff3ad1ab1fd647d88bd1583ad77e414581318489b6d13300dcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7bdf5bcec6376c2840310b261f71715a8ced3d35f8cb179fd824f686edf2c86f",
+                                "uncompressed-sha256": "9023230223e8bc56d90784da78c62c03c9f3470a2eb3da350f21f9b6da1d44b8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "650b4e750a40579c51d2f391b128a909e82cb9f6f0aedcaf80904fe0ebbfb3db",
-                                "uncompressed-sha256": "6ae0cd0234e2160ddc9d1971efc8145cd36c47d050bab0d664537f1bd6da9730"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7db9f41ec23f1736e202df6225353be1ee660df9d83e1a2e235ca42406310e8b",
+                                "uncompressed-sha256": "39634c143cd3b7960bb3e5e0ec7d4acdbe918c22be1f9bfeab158afc3a44a6e9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0685d1e67d54675176f5c2ea14c21fe1d807638bb36ee038cada536380bd3de0",
-                                "uncompressed-sha256": "0aba88f736fa277497d6754a80a824c238b508e17092d94e177b6ad703b608bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9b974bfbdac9b723f273a082554c9b05084c96dab7c1511fb31dd6df9e8edbb3",
+                                "uncompressed-sha256": "2a25a4d8bb2d4c8f67b100ee3e10d6b984c00a7ae74791a342ef986a1dd9dc70"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2927c7c2d8dacf1c617728657681ed3f502922788ad2a826c2bdca7ec9aec0d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "8b25f48c093bb39a0445d7d75517634ab7600df86221613f7897751d6a0cfb7a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "04dc5d4221be7d0409a7113309d44f7b7bc05dec86e02a8e3c0d879233e2ab33",
-                                "uncompressed-sha256": "9bdaf19d3f8da7851e50a1073d8713b369e5f1efdf2127e19ed2601ab4848eff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f17b2ae0b2d7e366baa25a15e68567be5b4fb9bb15c7ba6180638049075afa76",
+                                "uncompressed-sha256": "5a6d2707ec680c1226baea55b021308121131e7854d268dbc5b5dcc891c89056"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live.x86_64.iso.sig",
-                                "sha256": "4eedad401224cdeb8221aa07daf7478988498ed758483ecc8722efbd4e1200eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live.x86_64.iso.sig",
+                                "sha256": "20f855b03d32eab84a20d8c1314f25cd470c01d06ee3c9fe6157d108a3d4e94e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-kernel-x86_64.sig",
-                                "sha256": "1caa067a5593e432c61db22864d09519219f7d926280e50817bd33fd609ce2eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-kernel-x86_64.sig",
+                                "sha256": "d8e5ff16a69a032c0e47df0c2fa97e724bf58deb49ea5881855574728fa96cd2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "62a0ba5c141b423ad0b8a794795b5e5a5ec4cfcb6a37f7cdab6a1119933d27b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0417ec15eedca23f54e240107e2723c2228da9ef9306a97d8d0b9b57f0d24911"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3f205ca246b0fa524f4cdf00926bffd0d44883af83834a215d09366d161c8651"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "40630e7af3bccb2f4a9eecc532de67eb28f4ed654b48dc9d003a867280cd842c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2af1e7d5653ef86e934e0422eb68e25f253c2518a40ec0c6d12ccd9d37155542",
-                                "uncompressed-sha256": "e1ef4253bc07a1995868cc8c92a6868f2eda32b855bf41ce02eeca667cf6ca9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e14822b642fd24e2ac9bc88039ab8dbbd0951a1e5c5861677b2619229d08a683",
+                                "uncompressed-sha256": "e3e107d77113f7be68d856f7060f517b7c3e9ee514585e80119a56ece766d763"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ba681e99d6148be04f93224589b2fb07956bfa202426c76989fe32501a7dfb94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "205da8b6eb99991f418ddb439f246b6a4c1b701ade03b7c21d78c0ebfe25d853"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "12a9fd05b03cc6c71be38961e87d945ca2a983bd5a066be1df28e261891b3bd9",
-                                "uncompressed-sha256": "632134337c6f983fb0350aa6611c0725b4f7b9353a5295dee3d871b09b4a4e35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e38a079c6f1b7fafa0a4d5901b8386c4894e272ac911585fef0591de25a6ab9d",
+                                "uncompressed-sha256": "8984082bfbd870749d69cc2849423b9d30b1c60f5fc7653537c79d16fec63d8a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1a1f808ce39a95a2b8dc2d116d93eaa3e737c5018ef7f8a4bf4c386833d35519",
-                                "uncompressed-sha256": "5121ac66a9c9c8cceeb43f896afc9465ace9a8972ddd2f6926c1d62e6442f407"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2c039e778505f608ff78b8ba02d497780ee95182f477dbd939ddd335ece29326",
+                                "uncompressed-sha256": "67983bcc7a669b046f55303438c56c58044019d3ded2f3e3104d7c69f303a018"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "57ce6e0813fea48d981d19b76c99dd13ad30194049d25b8f4968ede853288da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7706cb4e2a2877246d950c2cb866dd0ed37c0f612124d006aaaabce9249804cc"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "710ae30ce2ce0112ce16a92a9b89c54d8e8bb5270f20bf4f6b2754e7ed54931a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "70c8ca28cfa95cc72a7e91d681397f0b4b0cdf890b859c7cee7fc700a8ceac04"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230527.3.0/x86_64/fedora-coreos-38.20230527.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "60b2e7d37b7dcb2a1162fc31db0f083b610627cb56ef747f52303c2cf4b864ed",
-                                "uncompressed-sha256": "71d95ee1584213abc550874c1c012e5787ecd8cc7f7df7e74a16d7693dababe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9569fbfaaacc9b4f3f08480f5b276313b84ea00fcdd59203cb1921e93758a564",
+                                "uncompressed-sha256": "510abc4a62445dbd1596503bd8fb772ad155d006524e021e4fb77e3d1ef10099"
                             }
                         }
                     }
@@ -548,121 +567,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0e16dca09327aa2f7"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-046b6d6c86e079aeb"
                         },
                         "ap-east-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-01fe10e7344834082"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0e97b843054ce2f6b"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0c5d0212aaab1bece"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0d4a10634b3c73ee3"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-06af7aaf66c936f6a"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0e1178e21adbac720"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0c7392cb8a360d3af"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-05b37df1ca9d804ec"
                         },
                         "ap-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0d7036e806fb61b11"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0fadfe9ee6b0a61cd"
                         },
                         "ap-south-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-079a041816a1a23fc"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0d1cccfa83f3029f8"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0b6e40cdef29097e7"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-01e50aae81e95e311"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-02378d2770fe5e30e"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0fc1569f357a1ff52"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0a03fa94b1e92a8e4"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0ea57ba803eb4a5b0"
                         },
                         "ca-central-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0ce19e0215f7cc25c"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0bbd1f82275f123b5"
                         },
                         "eu-central-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0c48d4cad9af8650c"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0e5b6b5478e1ccf66"
                         },
                         "eu-central-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0b2f12e2f9faf08c3"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-07825f554d378fce4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0951631ed4ca44107"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-02ed572e5c082f952"
                         },
                         "eu-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-09d3313ae6b96abeb"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-03d5602ecadc1ccd1"
                         },
                         "eu-south-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0d890dbde17ddacd3"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-094be97688c56b030"
                         },
                         "eu-west-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-081aa93705df3ed05"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-039ac547c62b76eeb"
                         },
                         "eu-west-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-016f220089afd5e89"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0e6f90dec0bfac67c"
                         },
                         "eu-west-3": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0afda6cb1453e1437"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0b2205aae3edb84b0"
                         },
                         "me-central-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0f378ca4613fdda3b"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-019becb66cdde193c"
                         },
                         "me-south-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0a9335881dcf28ae3"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0f819b6793b9d8622"
                         },
                         "sa-east-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0d5a0ef51ec8a8fea"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-02b3aaffc64e3e59e"
                         },
                         "us-east-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-01da231f2c9405cbd"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-010beab39a4739a92"
                         },
                         "us-east-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-02ab92e36bf09f0b4"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-0a4e646f84e62be3e"
                         },
                         "us-west-1": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0a3ebde2774b3d0fa"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-09901f6bc82bcd4bf"
                         },
                         "us-west-2": {
-                            "release": "38.20230527.3.0",
-                            "image": "ami-0e09a55cd8269326f"
+                            "release": "38.20230609.3.0",
+                            "image": "ami-006e9be2de9257e9d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230527-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230609-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230527.3.0",
+                    "release": "38.20230609.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a356606dc8363be78e116dec37e584b977f603352115ab06fb38e6fbcfe97eff"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0d91265abb70fe5f0c95991b47f19aaf3eee12fe2b5548fa698bf7ce96100cb5"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,105 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-06-14T03:09:00Z",
+        "last-modified": "2023-06-27T18:05:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.13"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5a3c726f533c1714c6749f06cd0d50c72302e4980c545482e7f18f176773d52c",
-                                "uncompressed-sha256": "aba2e0b030a42071fe94ed7d420c4e680d79077a8b5fc6ee05f6425a06ab4a01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "de73ed8e5a3e08644b4d3f657b15480e6f28887c1a8a9b2654c6fbe277f15531",
+                                "uncompressed-sha256": "3d9fbdbd9b4fbb09cc5d06722bb56045463f5a74c1da8dca0492f3830dc2cefd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c7fe3a2385dc2519c1ae4880f4d2476a9ba044c61de87fb65ecc314986b97e88",
-                                "uncompressed-sha256": "2077e4918b6a9948df4ff13609edf2d9f81d1270a6aa4b40973adefd65bdf2fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8336a432f2f97d276faad87186d244683c1971759960d5221d89a3d215bd4a4c",
+                                "uncompressed-sha256": "1a518889cbc530249c8e98f848addadfec75572b659b86e6f635a57edf62acd0"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "38.20230625.2.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "1bf8bf00f864c9c5a84a9eecc6e130a46f478dad34e67df8b2d43ace3b9a7f45",
+                                "uncompressed-sha256": "4c3f5b1d4b801bd6c792454b4a82b8cd1067e8c3c70f0b7a885198254166aa1a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3c2aa9f22c225369dccb82dfb25f5ab5e4c5c98c4f890bf89e0e3eaf02926b52",
-                                "uncompressed-sha256": "2b1f1b61b54da3f3bac353c50afa6d9434220a5a8e7c496a8b18e1d0456370f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "17627dffdaabac7fd496959928d745a03038eb894cd984a42a84951bba64e52d",
+                                "uncompressed-sha256": "b10117e083da2fd15d6090df4c5f5927d8e74951be507bb5f7719bb3a3bd1f99"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live.aarch64.iso.sig",
-                                "sha256": "23dc93b2e50a9a20d2e3cec46a13179471615fa66c1d9bb5e24b2c824f755829"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live.aarch64.iso.sig",
+                                "sha256": "a37b9f63333f884aaed7eaa2b746eda3437f62ff5a932eb32892cf9cd62efb25"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-kernel-aarch64.sig",
-                                "sha256": "78314fcdfa709fe01923fd6da19ce6cadb570e868d50ebb7445042f6914c1a3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-kernel-aarch64.sig",
+                                "sha256": "76761feda014f26804e68539d69f3906a3572539369f646f4497456af9ede553"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "b506e7d954926e27debcfd0c981e2dac081272b684053e28ddaa5f69c9247e26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "db2f8cb406453db99e1b8505db6bb62839ec2b4b53945411690f9ec6c8ddd2e9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a8f02fde59022e4540ff8716bcae212c0b473dc704c72735d06576249e5f4bd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "961da91d06fa4785af5ab2e97b48f4ceec0d653770858d9affe29d0627fcca83"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "a521871eb9f0041d609fe8006cdcd1e29643cac8b9cd9d3c34bf449fd68567ca",
-                                "uncompressed-sha256": "6e6e7a47fd92219db6069fc324ebe1563b2a3b37195256f3d001d2e24025a1c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9973d93678c5afc3f6d2894a6f3696a241629e0f61f44861fc63a6c623c33017",
+                                "uncompressed-sha256": "b50c5c021ddeff563a5080f54be251d596be9ca50ce87b437a0726bd63bfd90d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8b322818bd098f2d98e2ed280839c8483c12dac2422ea862ae15aa29f1f0afdd",
-                                "uncompressed-sha256": "4fa76625b76e4d6c21ecd994af097ebd29d2002403bed100f62a1253a9479046"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7ed279b530afcfdba7f73209d344a803c560f2c118a58a9e108469e7fad25fc6",
+                                "uncompressed-sha256": "952332ec6082916426c9ebd949d15af9a9308a9b5d0c18391e33db47e942a28d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/aarch64/fedora-coreos-38.20230609.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1d711eb67e0781face729cb68aadf1cf79b54e83d4c9c63ba4f9214b479e854f",
-                                "uncompressed-sha256": "0f9b6de27c143b0ba1be33deba53bdcfa7233e60adcc8fd517a1f0cc1a07df83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5d7adf5c5c4a424e6c95c4836b36d9296cb8d8ef11ab37fbc29b9b1bc3395058",
+                                "uncompressed-sha256": "2c1599a6136d1b26765fea2b29dd62532750e67bfada33ba9752e95001ee4bab"
                             }
                         }
                     }
@@ -109,195 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-071a510747df0db65"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-073a5cc7798db7edf"
                         },
                         "ap-east-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-009cacf11d2bd17c7"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-00c00be9375ca39e0"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0805f870801a7bbe2"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0670d56ed461f5f51"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-04df5e0979ef1a01d"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0f482e8a9147f1d95"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-08a23cad3be630e0c"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0707f8b8eece03e8a"
                         },
                         "ap-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-09ed9ff216bc5844d"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0d345693fd1eec891"
                         },
                         "ap-south-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-07e48c7e250518e61"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0338a0076d393b6cf"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-08cd32ae145ff00fd"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0ac8aef35380b5983"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0924a1beb8e244e38"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0acfa7d19833bf3c9"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-04963ab5ada4e7715"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-084a4a3afa6461e4c"
                         },
                         "ca-central-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0e18c3c5d61bfc3c7"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0620f9ab20f5fc60f"
                         },
                         "eu-central-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-08a5a10931dfcf768"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0711396eccdcfdf13"
                         },
                         "eu-central-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-02b0df03c09f25290"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-03eeaf9f41e3970d4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0e8f21a5f495de4a3"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-07fc51f2b93a05ffd"
                         },
                         "eu-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0d1762ab18d1af78a"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0355b29889e7ec386"
                         },
                         "eu-south-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0824271e8b96f0ede"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-02305e645d2737fc7"
                         },
                         "eu-west-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-08dd58a1b827b42a1"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0cd35df3c1f8da0a3"
                         },
                         "eu-west-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0fb79051c432f0dc0"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-05b690df240680dae"
                         },
                         "eu-west-3": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-08d3f3ff15f431ac4"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-00c2c5c4fca7cb3b9"
                         },
                         "me-central-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-03add7fad102c8771"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0285ffee277f4b85e"
                         },
                         "me-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-04284661ec47196a8"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0ca996da7f273afa3"
                         },
                         "sa-east-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-06b643e8b9a77943c"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-01182318e151d4990"
                         },
                         "us-east-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-06a0310942aefd7dd"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0bfee0bf41048a311"
                         },
                         "us-east-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0a41150d24d93661c"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-035209b61d6effb03"
                         },
                         "us-west-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-082531c030be231de"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-04191ca4e27cbaea8"
                         },
                         "us-west-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0da5882c3e0fd2049"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-04e74488de8c2fd7a"
                         }
                     }
+                },
+                "gcp": {
+                    "release": "38.20230625.2.0",
+                    "project": "fedora-coreos-cloud",
+                    "family": "fedora-coreos-testing-arm64",
+                    "name": "fedora-coreos-38-20230625-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a17c13b700e16904c50cbd09a6cd4078dc1c9fe0a534d653233c80baadb7056d",
-                                "uncompressed-sha256": "396702a021de3212850be6e7ca422944e1265034fc375b921accc5f0426fce37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0794440303dc8f7386145d17dc8c17c064dc8493906fe2ffa494bce3e557b6c5",
+                                "uncompressed-sha256": "03f54bbdee58f3c9bfa5c63065f1b8d2ea695c8d4b8ee81866b07aa9e39c1c42"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live.ppc64le.iso.sig",
-                                "sha256": "95ec7f7d28f3812f4cc911560d85274b9df71223406b24f446be9c3b2e2ce0cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live.ppc64le.iso.sig",
+                                "sha256": "64360720e8cb762a283ff5dfe25968ea7b516c1cb5ab346f12e9788496c5c814"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-kernel-ppc64le.sig",
-                                "sha256": "d3c459c1fcfc267b775fb916a1f9d0f84afc64485ec1c484b96ea5909e796307"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "f0e3495fdc3d80eda9e8642a248686ad5d1a15d841a99252c11f7043f2323a37"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "70190f472e98b72023e6a82428fbae85d9cf001bd5386bf2dced2d4399efef09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e5d96b76f8cde2d91f5acbee08d3dd45d6e5a105ca74eccda989df1717ba3657"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0ef6872d853df2a42538233d1f7e744fb58723e6c605dabb4b4c019dab4dda36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "fcb550213946148fa8ed3f72800004e5b80aa4f46e02309e741cc76682cfef8f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "390e5437de519d4fb2ec85fff3db25a8326b5310a1961ba1dfa18b6c947069d8",
-                                "uncompressed-sha256": "0d32afbbb36d94bbf8cab4bac7915627d1dcf051baefde056ac5f6fa44b7cb5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "58597a9c551b03bf7d81d6a49a340ff58db27fad5ce585fcd5e73bae7f64565a",
+                                "uncompressed-sha256": "700884daad2ecfb8962286372bd9ac28f158da673ab6ff27ed7eca4ddc83ad7a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9d1f87d88419770423ce39119efd44f8f6ccdbace074b0a23154283f05a25f4b",
-                                "uncompressed-sha256": "4544effab71f97f2964191b65b5970669d9c589de811c458aeacd45fa5e4eae7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "21eac7f44f5b47205ea9e229530e0e7e6d9390f5e2ec3d53c594c4cfdfdb72fe",
+                                "uncompressed-sha256": "7e1439360647422cc9950c22cea50057ffb9812d94b63324559f0079f4905b24"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2fd9984906b775db7a666a16a7c925b5169fddd1e6f9a91c6816b3ddede22c2f",
-                                "uncompressed-sha256": "f5d9a713b5b6bc1225ec4de37b995cd8026428b3f656e2d8c3b003ace0043d13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "0f71c2abc9684813bb86d9eaeb346e80e19ca8a15819e1ba16685c45290e564a",
+                                "uncompressed-sha256": "219cc6ff3989112cdb13ece7c4196ffae5b24bf951af135e938df95914c728f4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/ppc64le/fedora-coreos-38.20230609.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "fbca020a10e017ebd05cea199ab3d5caca8d898aa55ddb33c69e8565ea3bd712",
-                                "uncompressed-sha256": "b103e7b3c8ee8092d90b4fe6b68e9d679529952d3917ba4e99a6beff765b6fba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f67813edc7fea3b3a1ee8cbc9f7977bcd16066738dc8c6cdd6a4df5f2ab168e0",
+                                "uncompressed-sha256": "d42bd267b1b3d2adf833452dd8a301c11a2ecc7abebe48c4279a07dad229dc44"
                             }
                         }
                     }
@@ -308,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7e6a195135ea8715ed3c590f0a8225178b3511630a1f523ce151d5e7a9b429ca",
-                                "uncompressed-sha256": "7182a37996dea5e9b467b774cea096131d670fe07fd74d1e1b640a3dcb649897"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ac47d9ec6b421b541d256032abaf4780083ecc733d5fcac16b5b20bf929b2bca",
+                                "uncompressed-sha256": "8c2448ffe10960c3ba0b84a7b604d254fb98c8139d7af254eb6028e86d4f26d1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8550bba10a7022b635089bf1361b0b077bd6a91eb361db3a149b6f5058c1ae8b",
-                                "uncompressed-sha256": "cec062be1df59f32193b1ffa37a1484826e1d75fec0f70505f4ae49fe6604f45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "af5c7f6ab8117ca68abf4be36d8e110327e6b94f1378f511db948d588fbf8607",
+                                "uncompressed-sha256": "9663434e451dc6461959a69f2a655c17c73483c2fd750e2a60cbe683468c8fdd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live.s390x.iso.sig",
-                                "sha256": "e4b4faf11732074bdd0b1ad449060a0bc21aa7b4c2887759e3c3cbd872398f3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live.s390x.iso.sig",
+                                "sha256": "ca03b999b1aae88f2fef72fe93577fd65751f19af3deaa4f14ec8a2ba9ccb670"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-kernel-s390x.sig",
-                                "sha256": "317165aa952d53852e2d6c54ab52c1431be23ffa4f7c983021b9000f9caf8463"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-kernel-s390x.sig",
+                                "sha256": "975e859bd56ef68e78e05af715c5ff167edff175f7987f67ee513ff8c3fdd68f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "252e54bf9e40a9938d06cb507847396d44799a748cb2b16900be92f0d59ef433"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "51af6bb9cf3cc983c1973438b64a5c78009670e59e02724b6b43fbef779458fd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "a0cdecf47e939bcfdcad2ae4cb69a6cba610addde0c307b19c7f9feedb0edcfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c1f7285db4dfc19fbc267a3c1ba2f6f8190b69e98dc7833167f7e81bd9db043f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "da622cd126c494dd2142d19dde85326859e3e3d53f18cffe89ecd2b541bde1bb",
-                                "uncompressed-sha256": "8f016bd5e6202195da64cd988fbb9559defb56f97efd2fbcd3d5dd7800d6b627"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "950130152a43cf725bc1c6e912e6c1099e686f6f421671c664a52fe5994d75e3",
+                                "uncompressed-sha256": "ae23ded885dba5ead62f277a613ff7d1cd11f2060cbbcc438a7e02e7ac3e5667"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6cb430feb90d93de89a62aff7807a4a94d3feedd5301596f8740a8aa62c1cc36",
-                                "uncompressed-sha256": "a002e278c7a03ae31c9dc0da602fa8a7affb98bc9c4d813bee026112c9096a79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b57f3eea8c81e85d940aebc7236c3bdf47b592925a52ecd98a63e6e0048e3bf5",
+                                "uncompressed-sha256": "17fce11c714b5fa60799e1d04f1f3154fe69dba05dabdf6eebaac83007b118b2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/s390x/fedora-coreos-38.20230609.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "df0d745f00889291ce919ccccb40277ffdb38f2d1589a9d541db19de4d290de0",
-                                "uncompressed-sha256": "34a65342553ed7a2cfa7ab968ff345791e7d566a42e832f1becaac0f17cedd41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "92795eaeada4e4b3dff037a709e8e2a2b2baf4d587c06e0fb15319a7e693214f",
+                                "uncompressed-sha256": "9169d5ff39d1f949d3853eb8a991c41cfd1be1382bc59eea0c7901924ac0ef9a"
                             }
                         }
                     }
@@ -397,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f50270a1f9029f7d274f30db3cd8c31b9956ad0ffbbae586305f327f59158b70",
-                                "uncompressed-sha256": "007f30766ded18f59871c84a972f46fc9eee74877608c490426b80c1712b232d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2f9e7e11522ab8d1ade4b98dee1ddf80780120d9ce75d5dbe226984803fba496",
+                                "uncompressed-sha256": "cb9ea2cae18053f7ccc5857bdd1028805296a828a14f130bbc3028ce4c701545"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "261168557a55de9401d39f24623762954eecab5ed24ac26589fd1853238e072a",
-                                "uncompressed-sha256": "996352d16671a1f371581e9501c7c003fecd3aba8a87bad5c7805f15b8a0566a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f613251ac289aaafeb8585c7e4df8c9f200eca58e0faaf8be8f5374ccb925920",
+                                "uncompressed-sha256": "fcfc90b232fab20318256fd79b7352162a089fc9e8d8b2f6b1804c207eb3fbce"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1f7682e4650889a35abae6dfd3a8bbedfc171c1d8d2bf8c7c4b1a927e96fbb90",
-                                "uncompressed-sha256": "9d13d667534ffbe3b66d0b6aa75673a49e9764c12b8b594ac62f7a7cc40c5c63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "32f68f258f284577b93ad48fb3e04427711a2b6036f6425bdc1aa5dbb1d911ec",
+                                "uncompressed-sha256": "90de35f73f20da3eef33cd92a80d32d67aefe0764f5a1de9c2f88505d95b5db7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f5f5e7b0c472698115b49b086ecb6340bfe274025aad2d5f97c6a510ae95599d",
-                                "uncompressed-sha256": "1d4536f98d6f91c42bcc48c43aa5f3f96e7a4280836a04f5b088e2ff40887d0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f61e5f438164859ac73f96d37cf2b0d4a9f16dd9a3fb494d69a7b23ae0790f38",
+                                "uncompressed-sha256": "d8243afdcc2aebfb79685c6f8c2bc640f8dcdea5450dae129f3a2fb480a492ee"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1af6a5e5e5bbd322ed364b1efdd3ae389b2b3e28ff6cb6e27b424ad8738e65af",
-                                "uncompressed-sha256": "c967aa54f360ee80e93175b182570a4197ffc1cd0cbf0c16ae78fc8c2f929728"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "016c342a8bfaff0d6d9da78bffeca1c174b2527894acfecb95953078866e393d",
+                                "uncompressed-sha256": "d3c04b5fd96767fbc8521f74074b97b8d4dd982b33be25d3bc99734f4a5de354"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b115a00cc5fe96cea893588e8f760edf33f46bbc18b23c4096e930a1881fd758",
-                                "uncompressed-sha256": "e1996e226774d9e9b92664e89b77d19bd6512217e6e3315dc96cdf04965dda06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d88761bd38b65a0800914f1c6eeb6ae1d95758f898472dcc2c9acd13a9f8318c",
+                                "uncompressed-sha256": "53c911c7cf7194271c77a8ccd2faf621c0b3b0104545d0e942828061342c79f8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b9af14145489e1bcb3b055b646ca27eb894e1baa15adc8430364ba133a94d7ee",
-                                "uncompressed-sha256": "b5130a9387237ddd40e455a2a960cfad416c5bcf1660826eb2125f1459659386"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "03402f7f148df7203904297519b645c31244eff6d20e47b7dd961ecc27cfebfb",
+                                "uncompressed-sha256": "ce847d948facc6e2488342c998c84cb2a7ee7f818297c3e7628545d2c49301d7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1e9a16767f1b9b89d4a64502a3c50b889c80340dcaf8a43ae437621d4e9153aa",
-                                "uncompressed-sha256": "10579d4a671c1d62679208907f2fb5fc9ef4b1ba92ec4edf3fbb6ed951783438"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "fd9aac774d8661f8fca0095154dec6a3b59377a97a3dd9b6c27522acc96c9731",
+                                "uncompressed-sha256": "0b3a2f0f06739014c3ce2f72d9cb38b61af314ee56d31d26a6f6e1ed6268144a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a799918b87fd7a76c0f1ab3d3bb9317d6d6a32806e9471f6b32118e8cc163f90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5831c7fd609fd3dd06919637107afb5f47c54a7b1a6ed0bd5f69a4aa87ac0d78"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6d066ef7d01b81b04d586d923456b504bc8339692eddf82494f00ab617e8865a",
-                                "uncompressed-sha256": "8863233e30aff215746b7960adc74c2ee6c15264ae95382d347a51081cb327ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cb166a974451a1a7b02a9c7bc1d85b22629a803ad43129506befcb4a045f078c",
+                                "uncompressed-sha256": "d90978da7b6de5e64e74bff4208c7df5788b815ba144c11f876810aa80096d27"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live.x86_64.iso.sig",
-                                "sha256": "a40cf13fac493911377037f247cc766cb68d6f4d5eda844709d8ca30cbb8efbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live.x86_64.iso.sig",
+                                "sha256": "4b31c25ce9266240f4677e552edee187543a8162f6099b8005dc8b984b33e567"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-kernel-x86_64.sig",
-                                "sha256": "d8e5ff16a69a032c0e47df0c2fa97e724bf58deb49ea5881855574728fa96cd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-kernel-x86_64.sig",
+                                "sha256": "6da41b956f8aaa6e456e6eae6be356f0c8c5000de6f25c60316ec863e1823bf9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "09966ee504d4765308549199c7d26c8d3972bca7bcdb31cedea13beb8061e4e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "55939aee4b595143506b97fd74c0f7a52774197e702df8c40a5e60036ba8d387"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "3e9b4089622368a5e4a334b90ef39e89b0e8f22a2a31203b346c6ba69e653531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8af17c63861ee0d6b6fec6ba8ba9ddd807c8527afdd111ec9f45821b1b233521"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "de7ea5aac51a3cb17d64214fd1b7f97bed659746d17dd06b52c5b41c70c2b44d",
-                                "uncompressed-sha256": "26a90ab8fa445ea35aa3ca486e28b39409f497b955e238d7eed1c502e1a59339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "18efaa24c0216c8c4c9de2cafc058bdcbb3872e3e932dddc685d206a6633e74f",
+                                "uncompressed-sha256": "d27d575ead9914652b1ab9491c98350649f510cba6bee0215a7bcf9e1f9740d1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "15955b2ec30b1efe684afbf0b0b5cb8bab3cb6be37d61decd7804b329883989a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "fcda989287132f1e88eda06e2dcb7cfaf07ff9f29a8503f0e6957febbea6765b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "551950c9c68daf8131f5c023971cacb01de2792caf53310649c8103090b0d2c1",
-                                "uncompressed-sha256": "bbfed4f137387e5cb53d7697403108483b12a15f1ef709da41f6c81f4d95e11f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bd7fdcf84988dba7d0302e187eee7e680b6b6d10d037d248527cc2cfd06df285",
+                                "uncompressed-sha256": "b436004edf4a10ff6db0b5a9ddcf60f5b9f063ad52a92f5f62a9c7094775d0cc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "da84b9bd623a24ecb1a58fde24bfd351b3a62cf476ff42ac9873d0b1c611af8b",
-                                "uncompressed-sha256": "611715a356fe4e2f1e1661494405e6cae8d245757d3808b0a6bd41a1be9dff09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d6b5c9d34f47020c67ca85389fb7e78c2e070415609cc430a8464afcbbfc6232",
+                                "uncompressed-sha256": "46a0d3730fce50e0a7644b67c9747019e5cea077cb76bc3eca7f20d051ef140e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "59101d5d77cb885a0a0b33af6c35d9477ad20fe4438000e1db9d07877dc30ef9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "3a44893aa8176c703a25de90dac37b8838b99ec6d5278349468084d21df3c618"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "886b7c129fcca9fb41e751941df825a120afe4135e067533a3f1fc5fb9a44c1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "202866278317c4b3128b6f21d8b259b37c6bbec894ee31af76702fc86361de63"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230609.2.1/x86_64/fedora-coreos-38.20230609.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "05f1307f557ba2786dcafaf58970623f2b11ae8abbcbb7a8f1f4e4fb082c1213",
-                                "uncompressed-sha256": "198a90f1572a046fdb46d53b6e989ff3612445ef2f60f026d229ea2fb7303556"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c20cdd31c2b3259b1abccb73018655fb3cf98af1a5aa3d066add1c6fc36718ce",
+                                "uncompressed-sha256": "421cd7027f5219106bce76600630ddd646120d0be24d0ff949e11c921763732f"
                             }
                         }
                     }
@@ -637,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-06c475d0097aa30a4"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0896fdc87ed7a6ce8"
                         },
                         "ap-east-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-00d4c62971920986d"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0b6d890074f2d45b5"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-012af74a777ac8129"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-09ecef619ec1af1aa"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-071d1136983e377ac"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-02642138178da6e10"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-034915ae2f13e4835"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-00d20da18a8f3a077"
                         },
                         "ap-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-03c21d9b722d64948"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-03ceb9badfc235d64"
                         },
                         "ap-south-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-01aecdd8e49b33eaa"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-095ee177737b2c4d3"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-067c568a6f3f759ff"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-03ee24975532fea55"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-02df1fb98cb0d5597"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-06784101d043ea285"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-00ef194e3bf3dba94"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-04f49349a4c23a525"
                         },
                         "ca-central-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0b16289dc20d5ae17"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-03f80a6ac2c600a48"
                         },
                         "eu-central-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0a1e6e375c731f3dd"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-070b087b395981883"
                         },
                         "eu-central-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0a3a68eb003fba02b"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-09f8b9b609e5283a4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-04046473cb4a4692f"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0e18e7c032f63c186"
                         },
                         "eu-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-05f84d8053bdee0c9"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-048340e60f6de7790"
                         },
                         "eu-south-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0ee56e84644af19d8"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0351c7e7ac3db2b6b"
                         },
                         "eu-west-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-042b8e3ce9b7445c2"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0f15decca1b505380"
                         },
                         "eu-west-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-01af3d918cda0bb18"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0feed208dd28c6e08"
                         },
                         "eu-west-3": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-09c4a2597d0a65940"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-020c72aa039218736"
                         },
                         "me-central-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0cfd6ec1ee8fe1a60"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-053b655acb7a8bd59"
                         },
                         "me-south-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-055f6d8ea4da830ba"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-06178d6db3616f761"
                         },
                         "sa-east-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-051723c81431fc230"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-03ecf36fd059908f7"
                         },
                         "us-east-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0be1774d984bf225a"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0ad5b70293092d4c5"
                         },
                         "us-east-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-097e298aee54a25bd"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-026fafbe0d14233ac"
                         },
                         "us-west-1": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-0bf9722acfcfa5924"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0e0f6a6d036c83b28"
                         },
                         "us-west-2": {
-                            "release": "38.20230609.2.1",
-                            "image": "ami-03fb2447cf4272c09"
+                            "release": "38.20230625.2.0",
+                            "image": "ami-0a51e3ca987e9c253"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230609-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230625-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230609.2.1",
+                    "release": "38.20230625.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bcae531e8d29ce98d4b6fc66c75b43378ad146bed077b9d5be9664eea924cc9f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:804afe67406718e5e69a5f3dd977057c4b9fb7ac603316f528a0d6bfbbd7cd38"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-06-14T03:09:02Z"
+    "last-modified": "2023-06-27T18:05:13Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230527.1.1",
+      "version": "38.20230609.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230609.1.0",
+      "version": "38.20230625.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1686751200,
+          "start_epoch": 1687890600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-06-14T03:09:00Z"
+    "last-modified": "2023-06-27T18:05:11Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230514.3.0",
+      "version": "38.20230527.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230527.3.0",
+      "version": "38.20230609.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1686751200,
+          "start_epoch": 1687890600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-06-14T03:09:01Z"
+    "last-modified": "2023-06-27T18:05:12Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230527.2.0",
+      "version": "38.20230609.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230609.2.1",
+      "version": "38.20230625.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1686751200,
+          "start_epoch": 1687890600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).