### PR TITLE
Roll out stable 38.20230625.3.0, testing 38.20230709.2.0, next 38.20230709.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-06-27T18:05:13Z",
-        "generator": "fedora-coreos-stream-generator v0.2.13"
+        "last-modified": "2023-07-11T20:42:13Z",
+        "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "324c40ba39f5d78f048d90b50ae0a408bfe3e937d267d9d6928206dce70a9b4b",
-                                "uncompressed-sha256": "647dc52c040f29efccbf74d9b90345ed5a506cf96700d753a67f096a866d36b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "25ae22a663d7cccf9c4f98cd9f76203d5f21cfd9ee84177528a526a232b1a874",
+                                "uncompressed-sha256": "e005c2b87939080248a8acd5a5ecb0352b82e08170b1b64e654da77efde416a7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2795f59d4904d55948d2f1e549aaad5f48e6b17b82470b003274c367fc97e846",
-                                "uncompressed-sha256": "fcecc092b761d1906312ace422df1e31e7cedc53cb692afb605d3b0cf58bb654"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1f599e11328184b8a6551a80a4ff833e3ed86f420a92f010f3b4ce9715f9b15d",
+                                "uncompressed-sha256": "4ad4e86e1d9a71a31eae324a7c9deffb7c09b3dddc1f90c49f78e74a1f77c178"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "43f6cac2efba20350624bdde4846d0c88a750799b31ba5f6dd089159be537898",
-                                "uncompressed-sha256": "ea5373547a526ef41a15bc731be49349f84804231c195130d26da5d4517226b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "168551c8f1a9bff9197fb98f615ef248b59841601a7b0bdacaacca741c45818f",
+                                "uncompressed-sha256": "0bdcfb2fcdff6d7cafdf64a37979712cec319f67be149aa729c2216a7309c1a3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3d3b919f5efd29cd3b5b44660e90f913af1b6ccd38328253695f86eeb7a3607c",
-                                "uncompressed-sha256": "54c28ffbf470da348cbb8c8f39ef9d25936c4f59c81a444f2c8fad91dec3d312"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2fe6dc30baa0287ed9e1d4af25f59441740e3abca4e6a8f716c495817f1736de",
+                                "uncompressed-sha256": "13a1baf827e47b8c82869a0e13ac1be62f5892b987da56995ae98f9dc988ebb8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live.aarch64.iso.sig",
-                                "sha256": "84368b232f18f6a732656e37ac13a603ea3402b85635296033689ac25a36593d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live.aarch64.iso.sig",
+                                "sha256": "d66c53f62e5013b9ee13050cd8bce435ecca22c1dcf824c7575e80076592ad40"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-kernel-aarch64.sig",
-                                "sha256": "76761feda014f26804e68539d69f3906a3572539369f646f4497456af9ede553"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-kernel-aarch64.sig",
+                                "sha256": "c7fbb56fc10168a448f0ee5eb04cab81a23d31957ce9eed9bd4a1c987c61106a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1056df032bbf6a0809302c91a5c8ac1278e4c1d679995b6f11d6c4534c7ca35b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "b3f6e6476d7b3364839ebf722fc627739012db570638526be7e434b4ebab14bc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "e130f72747105bc5da83b70239adaa62b6bd8f1728c8c7cb5f7272a16f3312c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "d06e3d3799f27584ad831fb038acbfb19c2ae562caa5e6ce24ab45f8dd0414c2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "dc9136f5cf56dfe8690712602dbb7f6f772f0085420532c62172ef6182a09b12",
-                                "uncompressed-sha256": "e35989e9e19ecb115fab385973b8108156f889f566efcf54ace6c46dd7305e8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "187c798e0337ea3f01ae3e3ec2bcab3ed925a7dea2230bbe5f7dad055f100c5c",
+                                "uncompressed-sha256": "b649b69a8dcdbdd8b3cbb56150597af07ddc0d16e49305e81388b36123bcdc49"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b0451804f9130e069384fc2b81cd31ad76120e9b7c10c39f049e19a7e3c0cb70",
-                                "uncompressed-sha256": "9b231bd6b4122f623c3c1523a6d8fbaf032325a9657faf8cd0876c499dc4ab83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "06fe20faae05a4685522bfb8e2dde2eb4fc7cf827c5ddd4359ecc82c8bac5c8c",
+                                "uncompressed-sha256": "915ad6a30c69d605a99e166072f308cc795ed5efab9994c3b8be9fe533e20a1c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/aarch64/fedora-coreos-38.20230625.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1846024dea3b64e68ac6145ce75b4987bd4860a7759b44c9e4e4944b8a70b423",
-                                "uncompressed-sha256": "c57d62c339fe754931e927cc15d2a261966045805fdc9ad11092528975d0d962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b7aeba89c59187ecdf7c4df778cf2d5c709468517f678fd1f7bdcf528590e14f",
+                                "uncompressed-sha256": "4bf48005b16047f8174ad54f2519493b0a468a8390de2fd10dba722102415b7e"
                             }
                         }
                     }
@@ -122,201 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-014b11c04682ecd83"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0d10802e61c9e2491"
                         },
                         "ap-east-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-06defcfc23c2ca1bc"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-00c316a4d58fadfb9"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0a8703fe17572583f"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-076027dbd83ed3744"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-01bc9af314908e199"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-014e8889eec02ca3a"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0b0276eebbe8ad91d"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0639c6b7121409bb5"
                         },
                         "ap-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-09c3889e2ab2d1180"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-08def278586bb38a5"
                         },
                         "ap-south-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-01e90f666d2c2df33"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-03751c852a5344ad5"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-072b455faa1fed94b"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0c922c8569973610d"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-071e009ea4427a5ce"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-01fc24ccc0945353c"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0fdb65ddcbb768a0f"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0ec6fac4249d8ef1a"
                         },
                         "ca-central-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0f6cc139ca6b1f5fb"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0c4f070e8327fc33a"
                         },
                         "eu-central-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-09bc7ba33c57352b2"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0a12a05cc59302fe1"
                         },
                         "eu-central-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-06df1ac5a12d6bf5f"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-099689c56c53c5431"
                         },
                         "eu-north-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-06f49056783b13ead"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0608c4f3c0c52aeac"
                         },
                         "eu-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0100eaaa40f96ae0e"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-06854cc98e4bd17d8"
                         },
                         "eu-south-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0bd7cc160bcf06391"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-07f9315b699a79d58"
                         },
                         "eu-west-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-01b113a50797863e1"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0697f288012f27bcb"
                         },
                         "eu-west-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0d5d082907fb7385f"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0753729a897251e17"
                         },
                         "eu-west-3": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-009b8f05a8578b36f"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-07fbb464b6f9762cd"
                         },
                         "me-central-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0ee25e9a850962c29"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0c605569bb3399f93"
                         },
                         "me-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-06b77e2d223951a1c"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-098fc0628c4597ac2"
                         },
                         "sa-east-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-032a3ebdeb9dde120"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0691206a1e9be4845"
                         },
                         "us-east-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0dfef69ffa2fd554a"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-02f3732ab3ca00326"
                         },
                         "us-east-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-05aca547f241494f2"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-02d3ce66d278b67d3"
                         },
                         "us-west-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-051ec8e44303e6292"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0ed01179be45b0646"
                         },
                         "us-west-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-00fb85a01e801b2c6"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-02f6dd55fd7ad4e19"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-38-20230625-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230709-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "80ec14c905e6f86de66f715d74055ae845d8897ee591537acebe4fe09d05990b",
-                                "uncompressed-sha256": "832cee20ab7b0c02616309d1ce74098411fec1837afcc463f1a26f1c91f87e45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8053f87940c50daa8710f6b0f559c3f5ec465dc7d0c2f3478f7ad53b204a2b2b",
+                                "uncompressed-sha256": "7cf41efb5f872eef6d2bc146cf68c6ce6407fe4b5ddbe007ff7edfe2c535b856"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live.ppc64le.iso.sig",
-                                "sha256": "6f69b6bd2b5dab6744b99fe2fb85921a0805c064b3d17a0afb74105a4b9c4787"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live.ppc64le.iso.sig",
+                                "sha256": "98d924b757e86696ec13321ddbca1492eac2cdf8a58c7aebb5904e2303de9f98"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "f0e3495fdc3d80eda9e8642a248686ad5d1a15d841a99252c11f7043f2323a37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-kernel-ppc64le.sig",
+                                "sha256": "fe2b37977e0d98b4742d7fabf60d53cc8ad5c32e6d8f5351c067294c47c08aaa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "40ed40c569b75d96657b2c6b5c93d18a2dcff4bccb60358c809e57290d3137fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ff952f5c95ab2dcbe857ffb147be073e5dca2dc7a5cad7d131cbb4051d8f8186"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1a18537422801e4777bc3712cc4e28543bf668f18270aa9ddbda800842642ba8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "bd39e4fe52983b062b8494d38efb2ce8afc9daf86278bd6112447b75c8f7a493"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "35ef200e91590e5169971957ebd542fb36932d3649e2748c94a85a8927321e63",
-                                "uncompressed-sha256": "e03b91e76bcce5fe8efe40fc679876e2036145ada1e925ab07ac00c7b55f8cf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "fbd82f922c69c326f4541bde2342d8da5ee1904e99f0b6d770e06ef420245f86",
+                                "uncompressed-sha256": "02ffbf22d98e51e374332b83d4427f9e438aac79f6f02f6285917caf7019dc4b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a240d5b3d322f73f8d19b3b2b60882e59bdfd992f664e7c558ea3cec45cdf4d3",
-                                "uncompressed-sha256": "326ee375d6859e08c0758a30dda8ba7fa7aaf04d960ee579a455a89f7fa8a3e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "c813dfd06d773429451c604cb68fccbd0d05f052d19d14da8f65771afeed20d8",
+                                "uncompressed-sha256": "bbdfbe3078712a5b073b3d130938c0d65d84f858c3f748b59c54109621c01034"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "7c386d98ed7dc48e103b2f12ddc63b34602e2cadb7888e94aa82ab40971f7c8f",
-                                "uncompressed-sha256": "78b52d8b9c8ad20c860efd93cf4301c9c5b604c80ea92bbe6c026f9a510fc187"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "aae8ef8445e79a50116f9704c2bdb428df542237a25080a4eec7955ed3be74da",
+                                "uncompressed-sha256": "960eb3a87acd593b93250c9ef732e113fc921b7e92225d5ba023a618ee0c2ed1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/ppc64le/fedora-coreos-38.20230625.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c3fd060765e1e6e6141d17a1eed0864cee69c62218afcd7eca1f2ed53bbc10fb",
-                                "uncompressed-sha256": "efbcb7a1e4836735d9fe0ac9cb9323d69b9a2d79e458adcd2f89ec15c7d859e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "646fa4c59a160bb3f06745cb0897fb7f2f53f0e2cef40e873e5133693789da55",
+                                "uncompressed-sha256": "031e23582dfeea1e57b283935d987f8cd9bdad53aeaba92f0e0db3da5c347401"
                             }
                         }
                     }
@@ -327,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "854b2609af3b0e398fd3ce5b50a495a9466ee5b3d3b61efaa9086cee6d5bccbf",
-                                "uncompressed-sha256": "f689216bfcb6d04628ead78b53b6a66e046ad9163806fe50db07d84049754228"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d63e2b8ad3220ea04583e9e0fe272d0be61c1632b573351d5713a39089fa3a3b",
+                                "uncompressed-sha256": "bf466c3d56d7268ac6cbd7d2d4e489d2273b1463e1d30deb40dd267fd4c40f43"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b6f9f1e9827196a2c945801570ad057e3698f582b98d347ad87a07566199cb3a",
-                                "uncompressed-sha256": "1202055de1ffa4d175128e2198fb8b9bc446ec0d52b5e74a8737d6c0f2b9ef86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "09e23d4be96bed94f1b3f466275e25b2cecdb6b2a1a10bbf7feef1664e4bf675",
+                                "uncompressed-sha256": "e6ffdfd026ee7f13281de72d4a644e02c93d029b8fd07dec7f6af9529ab9d392"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live.s390x.iso.sig",
-                                "sha256": "cfcdf411d8a58a6fa12b8faf5cff6a7792e7944da3e69cea0e8c386cc43352ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live.s390x.iso.sig",
+                                "sha256": "d4b064531908f14c694b5e4ecf4fa9847f7440b9a50402edf3dfdc803bdf874c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-kernel-s390x.sig",
-                                "sha256": "975e859bd56ef68e78e05af715c5ff167edff175f7987f67ee513ff8c3fdd68f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-kernel-s390x.sig",
+                                "sha256": "3e6ea6448e01968e71b7604c81cb8fcd9eaa793ead0d7b41b1ee63a992ca7cb2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a1ac6a77fffb8a0ca4a6076253f5235f1a35429849802150848dad87d502fa98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f64f19c0af44e1f07c6168aabf95d59287889ecfd2219c08fa26c50635b04699"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "2634544189b5e2763cf70e2cc91fcac8adb9fe5e5b5e19199612062bc27fb9d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "4491319525a632d0bc7c7e1c56216a81e0d43c354b3c9b8ab90a68ec6ba267b2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e17b137e6629963c1727cab7628f66f9125508cd8bc7363b915f44eefa96fdee",
-                                "uncompressed-sha256": "3e3d11c049bdca4d3e65fad940aea23a5cc27390aa6cc67bb260a907600dc79f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "02e146cbec6eeb4cbfb457f0f0f1ba063cd71b3f4e3871e8adce0a52792c723c",
+                                "uncompressed-sha256": "b616f65917fdd79e069adfc50db551bbe35f084c9459b744876e616b55bf9579"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "87a3738c8575365916a0bb3395500976e45e83c123557d01acea5566903561a6",
-                                "uncompressed-sha256": "9d3b53200810e00b0abd7a856ae8bc64b407f67e29dc54d5395a38a7beff0047"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2dea2affc4aab4ae9f64fd36d6b0a7766756e5d89f28e9a17116e576fc2282a9",
+                                "uncompressed-sha256": "2fdb352f54bf4233b0861ec8c7552861d8a7634ed89e5448bd7811930faa058c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/s390x/fedora-coreos-38.20230625.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "53ca3fd3164ccc5e7855a67e470f84aa6862344806ecff5a871010eb18c049a8",
-                                "uncompressed-sha256": "7415f0792264cefd994f214c9799a2cf1cabaddc14ec930c5b1830db8ce6e27b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "875bb9c945a7d062cbde2943c744d561682bc9e1554720708fe015ed5a2f2a09",
+                                "uncompressed-sha256": "93b9fb7a3db365b5e95f00dcd3e549156f76fd6ea6b3e2c7484e0c3e731ca1ca"
                             }
                         }
                     }
@@ -416,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "548cb7c463531f92d9203b564ce745849009939fbc6a9b88f7b40087c3ae9703",
-                                "uncompressed-sha256": "40fd560c2e7ccc83e049364676e4ab760533aee7706a971a92c06c04b8b57bc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1a442f393d3415e2deaf3d423c9ae6428cdf059cfc705a0ebe57486043d5e6c9",
+                                "uncompressed-sha256": "546a12526b6a03786f87dc0d649556ef94347e060bb6a558a7585416214c2005"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a82b32aa0745eba84989a2be6f53084664f17cec018365a012530f70dd4b64bd",
-                                "uncompressed-sha256": "cf9b9dd0f7b5978cad371a008c94d0953da5425300abbd22936a27606cc87062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e6e9f3693c773ce1311bf33c6998205ff3c7536df3e2186edfa69ad20a31224a",
+                                "uncompressed-sha256": "d66ac6c0336b42574ac19df521cc05358f1213a1e9df799d6fdf505c18b6541e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7c01be8ddd1992eac5dd89853b375a863b23ff6f927d4f597d17a23bb7b5c5f5",
-                                "uncompressed-sha256": "79a4439dab96b14550ea0e52d9384a864020726081915b0cba18e33c94cca591"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1c3de2970a332333e3aa9aaaad05352e76fae0241a2d9962c3e8da5f7cd8f89a",
+                                "uncompressed-sha256": "7a298a6c2d0321a257b8b6367b657694dd82d3cc8db838765f87a459af5d8e1e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fa24679f223be9dbbdf2e64c81a570fc6fd52e4fcac71b24250e3e4fb4853583",
-                                "uncompressed-sha256": "bd9c4f88750a2f64f451b8dba2da9f6aec6d0407178e084b4fe90d635862b6af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7bba7bbc05627176c31dba1e38495d5fadadd814e2cddec321ad4db139e5f2a3",
+                                "uncompressed-sha256": "2caddaa45da19b5e864d9d1b4eb2be299db081ef482c868f4f6e3a32baeb063d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c8ebeca5dbf9c68df3f82d6f10c7c8e9126dcea29a8ef64ed46a01f798bee486",
-                                "uncompressed-sha256": "3bd8e1fb162217e7eaf8e479ddd0066c546a365e1edfc3957d764a243e3b81f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "52aaf30edb3282d96519108473b7485eff90e97aed812bddd1ec76bce9242f60",
+                                "uncompressed-sha256": "54bf27fb8e481dfc46aa189824270daee03a048071702602d530810849743f89"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1fd215668c0fa2ab2b5e7215c84750eb76a75f7e4f0fb9e6ba8d42c8c523004d",
-                                "uncompressed-sha256": "27e88c72e67de53772e351470f680dd62c28b21973e842727e4281d09a2be786"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0e1530651c68a930a5c5488e5aa2b44f1bc59140093d3becf8efaa301763d84d",
+                                "uncompressed-sha256": "5e5d5a80862af9c22aabbdbce41af70f4fcd6d60d9c9b82526cf25b55a1bdf04"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "04d5df65c94ef4b9740b9b6890948e944fa4d02da9be43bacea54bca7127e3ff",
-                                "uncompressed-sha256": "d4853de27de11bcb4b194a662b02b03076bca06290e69f34aea2e5b0c6de9699"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7275882373f85fbfcb6c65b665a00637e1fcec8e8147ee7b1a414125b17a9ef1",
+                                "uncompressed-sha256": "77ab3ccb3541a666dd49167186f0225a875f6896d33fd162fffd3ae125947f18"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ae05140d911dba18816ee148489f409ee162c67f8b508ebb400784b4aad64933",
-                                "uncompressed-sha256": "863cfe9c425011a043b2bc588c8739108c453db5e88e5249cc48d04b5311dd4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e3623258d5832e1c74329d39925b77c825a6c9eb6ea5214237d204c51e60f63b",
+                                "uncompressed-sha256": "58331000ff44fe923c88e40707cfaebd45f9638952993db2ae54558ad9a0cb9f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "8ec86c11df09c8e082ad5f800250a71d4fcd6436477c1eae583975dd70e6d9ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "9bd52021fd8b53642e25964688f54db7c9c8da82201861a55cda7ddd0f7b1482"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cedc7246c72c3d77af7e3884acb3403add7b73439e66370b66a33549208d3f29",
-                                "uncompressed-sha256": "84fb62befe547d203e7e180494f4ff2831ebc1f0eddcbb76460b5e8424da5213"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ea42367c788cde2e2e9bf2d8467c817e45a34baf9ea145f2416cf1a2321daa76",
+                                "uncompressed-sha256": "dafeab33970ba5b6e5927e3683ba737a9114cf7905a7eeb2ed2a8bb3ba1008b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live.x86_64.iso.sig",
-                                "sha256": "b9e2a9e6b37396acaa1a71ac6ac5f1dab35939abf83c06400462b08177869369"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live.x86_64.iso.sig",
+                                "sha256": "79368e1609c6393b26ceb3722274b00583519a682f63590d65627b884d98a932"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-kernel-x86_64.sig",
-                                "sha256": "6da41b956f8aaa6e456e6eae6be356f0c8c5000de6f25c60316ec863e1823bf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-kernel-x86_64.sig",
+                                "sha256": "47f50ceeb55185dfc29728d34fa939be712599bfa222e033e976ded9cb2fa938"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3106e5c118640b8dd964d09858fc799d40d7019c9c50dd97bd5a1023afc4b036"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "2110a86a5b2cfdba9c3399ca6ab090bb6593c6ce48e332ee886d3022aae9b83f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2eeef941371b186018de56338333eaef404706c6c201a537aa29e6c6c19e91b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "0b4348c4184f4778c319a4c557aea950866881ea482c4ed43ca18554fc434ab2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "bcc07261e90ebf28bccd02dd066fe38d3c34892450dba834c20d4f7fab822a0d",
-                                "uncompressed-sha256": "9db5ec9b5f4aa6482c84531a30a63685382e5b83d0d884b2f92af951598e8ff9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "cf41d7e61af494b8515791075a0bf572022a893d86e610d3ca3772f5cc9022b6",
+                                "uncompressed-sha256": "ab57449744dbbdf841a4295cb2ec78aa0aea7a78c0e65fe5ca1e57d94c3d97eb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4876c58709fb22c9ac41b30b5d60612e0d8df5ddeadc3386cf3a2a5234726eed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "477d30be10cd360f3a0f56604fb650b3285cd0a88887eb54f94fa8d3672e8dc0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3f13e8480b4e57b6e3a4eb43684100556d4d026ffaa288e8d0e7467061cc0be8",
-                                "uncompressed-sha256": "c77bfb3848bbd24b1d31d2046bb098b9d3f3821f4fbec6ebdd7861e37e9b6a93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8419e227b8c12a1278a04f65ad5b41ddb60abb4dcc61f139048da31213f13cd8",
+                                "uncompressed-sha256": "17d2c7880ebd61b6a88642fc6def1d2f41b0c2627c245c9f2d9ff03550788bcf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d3a22c25030719dca120b6eb0aa9bfae91856167433d14775761ac1cc3c2c472",
-                                "uncompressed-sha256": "c56e7f439063fea16358831f8a8e624db796465085b4b591dcd3227c4147d7a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8aefa313ba2df4f84d1667a64d643b703dbf10d00e1bba2ea37692eabb3c0563",
+                                "uncompressed-sha256": "6666801c9a234f650605a84502c3bbaff8cdb2a414d48aed7415f56fb77bbb37"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "e5d0f038cb3274e28001862f6dc0ee5fcbf2e56b2ab41117927a682efb6089d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "857779221b381a0d7ac310e09260bc866436af2f6448a822732e39250bcd1205"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "7718523d4b59f1d64007bc571a4e287d6fff6771767913d5d0f01362ceaab523"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "80d21b9ec6154255fd906b9b55a04efc3f7e2e3f600d753125ecdfa03f413250"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230625.1.0/x86_64/fedora-coreos-38.20230625.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1a680e4bfd1d4015f1681958088de59f509cbf45ba80ba2371eab27825f240bb",
-                                "uncompressed-sha256": "e682fe423b5a569e0f36a7190c4985dbd7007ef864a6be7981087b56c3edf409"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "688bc3b8253d1780af3d3946eeee600efa5e4388a0d79b36af11009958db1a2f",
+                                "uncompressed-sha256": "91d936ab0e25ddc0439b81ee7862b7cf7f4eb33ca66bb9c6b492132b062c2bb7"
                             }
                         }
                     }
@@ -656,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-02298e385548b0a99"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0c6681dce77df2647"
                         },
                         "ap-east-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0577a8c5a4f1701a8"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-06a775ca016fa90cd"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0fddec8f39838dbdc"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0bccda3c60763e73c"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-02655f93f60431d23"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0be2fa72b366f06c2"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0db3ebe981ec60855"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0d3ef7ee60ba06c3c"
                         },
                         "ap-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0173e6036b7fbb4ea"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-073c2d785211b7274"
                         },
                         "ap-south-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0112df0ad97145a03"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0e377813e2380f29a"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0933113078f3fac45"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-04dbb20278cbc48b2"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0e66b3ad7356ecd01"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-089c678754f27cb8a"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-09d6bd7f8ba88e8df"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-04f80e92d2be37dcd"
                         },
                         "ca-central-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0457be4580869ac58"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0a1dad4ee3c88e470"
                         },
                         "eu-central-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0b1d93680e5da03b4"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0270a2fd7d9f4fa0d"
                         },
                         "eu-central-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0e315a0a2e7849871"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-02bacca15606d2fbb"
                         },
                         "eu-north-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-01c4567ef43433f7d"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-03ccdfe8b8ce7cb7e"
                         },
                         "eu-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-073c0657450c0fa71"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0ade1a3e128021a8e"
                         },
                         "eu-south-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0065423d45c313c24"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-07f3fa6be6e42fa52"
                         },
                         "eu-west-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-00eb9a6e74e97e1a2"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0b9c3488acf18f8cf"
                         },
                         "eu-west-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0bc41926691de9a0d"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0fb57de41b892c051"
                         },
                         "eu-west-3": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-09c31eb627416497e"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-00bf6895aa5cd2d99"
                         },
                         "me-central-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0c0748b4d13327e9c"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-0113799f03cd4f8f5"
                         },
                         "me-south-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0e479368edb77751f"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-04c38ebda442c165d"
                         },
                         "sa-east-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0670150e4af3d8c22"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-01d97659c4ce653b4"
                         },
                         "us-east-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-066aed4bb4096d6cc"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-08b6c3aa41b7f2170"
                         },
                         "us-east-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-01343bf60a7621d8e"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-04a11dc81038e0d19"
                         },
                         "us-west-1": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0f0ef33d5c99f5510"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-08f5cb792efdac033"
                         },
                         "us-west-2": {
-                            "release": "38.20230625.1.0",
-                            "image": "ami-0ab194ccaf9b0f3f6"
+                            "release": "38.20230709.1.1",
+                            "image": "ami-08253611dfdeeac13"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230625-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230709-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230625.1.0",
+                    "release": "38.20230709.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c1a38c327119d1d58ea30cdc00c3278e85436a22fef856ef03da016f27cb313e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:47e355fe49b0a54f3e1b466dd174215149834be90cca736cad78212c871cd749"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-06-27T18:05:10Z",
-        "generator": "fedora-coreos-stream-generator v0.2.13"
+        "last-modified": "2023-07-11T20:42:11Z",
+        "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c7c52d602d73edfe79cb6557b4de4d90b4f88ef45d2b2e185851de7442cc6e35",
-                                "uncompressed-sha256": "a14734aa2dd6df77f9ae22750dca4b3a14199f10230e81214f4467d154b0c09a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "51e7fd86d8f061e49378350e233bd7d2a465cd476acdd0f2ce408fac4112020d",
+                                "uncompressed-sha256": "0c5563b5e25015739d4d55be344adfd723deeb23e1735b5693ca57f772e44b1b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "41f1cdb48cd5c9daad14b6a8b1a6a57913ed78a33d0f8f3e9ca7f2bbda3af340",
-                                "uncompressed-sha256": "7b950ab98568608b387936bca145543a05902526dbef6f09539ed56ce5216287"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d636a08771d969b7d69baba7d781361cd36008aa6ab125c05a2e8c186cf9f5e9",
+                                "uncompressed-sha256": "66d333ee0cc8979c4e7836fc82ab0d448a10b698b93f87484321eaea7d548e48"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "b5b3bf15a241162ba2f47b00ad903c41e156d84a085847e05804c645d4a2302e",
-                                "uncompressed-sha256": "e91c14e18083cf0fd19b82484eef64e5997e49dfae6cfdea19698e4fd0f61d80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "148a086715e18c446f2deaa305e65026130a4892a89756d4c84428cbedb55d81",
+                                "uncompressed-sha256": "15c13e80a713efb4765bc1650fcc6d89de7ff604ae7384175c4f37066b9867f6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5f5b9ce7807fdae3f076e4c4cf5ed0a8c8793bbbee2de401051f2b053cbdeb49",
-                                "uncompressed-sha256": "bbcbc24119c07d7f11c7d6474b40a1723a97e4cbf73903e87e40c7c0b033d8af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ee03100f04254aa309f3d1ab06c33f74af033d3ec5efd08ed5bb1377d080bf30",
+                                "uncompressed-sha256": "87a4da8ab87055f0f834eb35fabad15ed7de5ae8ef10dcb0221c808061d6cfe9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live.aarch64.iso.sig",
-                                "sha256": "3bb1263b094c4b279dedc20ea0631f464dc880d3d4539089f0d7430614654c9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live.aarch64.iso.sig",
+                                "sha256": "6985c8b34cd359c60070caf6d73a6088a3e1f5b9c51dac71cc8da6e9a6d913e2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-kernel-aarch64.sig",
-                                "sha256": "78314fcdfa709fe01923fd6da19ce6cadb570e868d50ebb7445042f6914c1a3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-kernel-aarch64.sig",
+                                "sha256": "76761feda014f26804e68539d69f3906a3572539369f646f4497456af9ede553"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a87cdc09639736a3826200f88a92c7f73b21dce41218b4fbc1def31eba8f3e94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ed55c85c068a2cb4114f47dbcd47167cfbc62f4914d6d08b01a376d21d4d3c80"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5db9d28aa7bfc04954d42e68509c31eb87343dd8a1a768407218faf275a7b226"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0081fc1d6c2db04bec96cb3711ce7735e3a4955acc61a92bc8566189d0a51811"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ed4fccb7e1efd41e8acf952f69eefa67d60d2f21134fa4164a2675dffbba235c",
-                                "uncompressed-sha256": "4cf388031f37105eedb449ed3f649a9d84c5b1dba19cca0fd30f6a123393f3eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0493d47a4f1e98120cbfb7507ed1dd6137ea1d07305eb9225b4804044c06c79b",
+                                "uncompressed-sha256": "d0a4dda1cff18ad5204152dc578e76719078822b5e693d417603b16a31a7b597"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6245b839f22a9ebf3ab684b8b1119c12af947ca05807f1fd36a9ce67505a0b01",
-                                "uncompressed-sha256": "1ca478ca5cebfc94950d76014d12a48bfd72df1c4f0cae23cccc1b92f6ddfe9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "029fb8f53d9bbfb58f58c89afa1ae4e72967738908d298804b43778dc9ac168e",
+                                "uncompressed-sha256": "c2b1880e255e5411505ff8b113935405b23330a05d259f5025e5fef7ebcf7c4f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/aarch64/fedora-coreos-38.20230609.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0410362c212df040096933738607e56027005deb1c4a3eae417079180aaadc65",
-                                "uncompressed-sha256": "ab04cc58bff46622dd433ff9e6cd13c9b5a266925b4986bd0d25d13bb417fa3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f40ace486d2f75b686c879ef09a0842223222062640e84492b20d38da4eec5a3",
+                                "uncompressed-sha256": "79242ddd409488dc4a4a30434ed8dc49f44f0c8b466a07cb689e2beaf2e0c285"
                             }
                         }
                     }
@@ -122,201 +122,290 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-066084551ad7c5ba6"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-01f7c00e5795f1813"
                         },
                         "ap-east-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-07895c7047f8a0e78"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0f4e4852bc092754a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0b8f59618899914eb"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0fc515b952c5f53f0"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0477f74a91ee0d8db"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0d4a5c2ae8b33d81c"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-099f2d71bce1b66bb"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-09e3031f33b5f76a2"
                         },
                         "ap-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0dbe34841f2354f99"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-05a75e773fc4f43de"
                         },
                         "ap-south-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0fdf93bf53db62a20"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0b29f5818f615ef6d"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0befe398d5b3a8937"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-09a544a1bdd906f71"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-06ea2891d57fcbf39"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0258425926248f642"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-06fe5e906cb26d5b4"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-02082360a089d9112"
                         },
                         "ca-central-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-03d54c7c117e534d3"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0122b01e6164270d8"
                         },
                         "eu-central-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-037a2ed830de30afe"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0e4c1216385f64182"
                         },
                         "eu-central-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-038f4d1892115f504"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0d859e8901b4d59c1"
                         },
                         "eu-north-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-01f3034e32d4e311a"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-01ef2b44d89267219"
                         },
                         "eu-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0250da658122e8f15"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0ae8b86410081f5d0"
                         },
                         "eu-south-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0fa453857ecbf78c0"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0662ec28fbd54e465"
                         },
                         "eu-west-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0fadfdf82b427ed59"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-02794e669ea2e2c3d"
                         },
                         "eu-west-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-00421627a17084464"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0f3b1ac63f7736519"
                         },
                         "eu-west-3": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-02df146c5360d5c49"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0d97a4167f65abbcf"
                         },
                         "me-central-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-00822be4932100ebf"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0a924a6ce80af08d4"
                         },
                         "me-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-082fd77fac5725bbc"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-099100e99f02b72c4"
                         },
                         "sa-east-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0a1ca75627a2f07ca"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-08a16ec7e0e606f63"
                         },
                         "us-east-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0783dccd7b8d2c1fb"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-03777816913e8e8a6"
                         },
                         "us-east-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-016654791c8c8bc2e"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-082637480ae288e56"
                         },
                         "us-west-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0349ef5f9c1c55f13"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0b619c21b51650a8f"
                         },
                         "us-west-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-00ebee68141c737df"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0c4e16efb57452a60"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230609-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230625-3-0-gcp-aarch64"
                 }
             }
         },
-        "s390x": {
+        "ppc64le": {
             "artifacts": {
-                "ibmcloud": {
-                    "release": "38.20230609.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8d37c34650898b672961284202a835a2371899aece24c3c382d7d177b519a651",
-                                "uncompressed-sha256": "0126f6210352797969be92fa1d6e69a8e13cba0e3243de879526803e43bc8853"
-                            }
-                        }
-                    }
-                },
                 "metal": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ef019f5164487097f50dc9d3980ac6b62e71ba6b1299160f98969b557d04cd1c",
-                                "uncompressed-sha256": "2a0efd8cd508d26cd72ec428502d5079740e3d725da60a04401de1c7e6e281f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "ed967f68a75618712b8f93b0cfa9595797c4421ddac3470a9ab52c80db656bdf",
+                                "uncompressed-sha256": "15187188965c5f947e4ad47bfee4d94a45dba0cc6bfa812d20edf59b72968975"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live.s390x.iso.sig",
-                                "sha256": "b6bc28ed0a8c4060bfa0cd70794c4c6d40052e2bf675c878e05a60aaca653633"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live.ppc64le.iso.sig",
+                                "sha256": "3c82e4273feb0314ba4e0c7e326a3ca4ce0cb193ad077337b9e778349a097e19"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-kernel-s390x.sig",
-                                "sha256": "317165aa952d53852e2d6c54ab52c1431be23ffa4f7c983021b9000f9caf8463"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "f0e3495fdc3d80eda9e8642a248686ad5d1a15d841a99252c11f7043f2323a37"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f4be62fbaf177c1500910cc189a7d87765a252730d8cf226bcb5e58c40f0daea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b7a459d0f05501794a911622c404bdff1b1ad21ce18a4385260d99c4b1063bbf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "479a7867d83d93f40f226ee2e0105834119150b752738b22c5cfa8d12ad2223e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "530e448edc81bb465a9e9621432b33efea0e1f12b58a54c550581ba96678b083"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d2334d505b46178ddffa069faa1e114dab9dc613dc5eb5382c292070bc424a26",
-                                "uncompressed-sha256": "83b7f30d98d9849418311f0dc55a5873519f5320bf47ac8153e066871fcf95e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6a2b10a5ce74fabd5acb37c49f5fac76ce8c586ebe38b29274803a32aac3b482",
+                                "uncompressed-sha256": "9211490f16bd7d983e23c138ab5362da315f783c7b45e7c372e1084b18178873"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3049090ea2ebd6380086c086733680bbc54021bcc329003edf8e3316563e18af",
-                                "uncompressed-sha256": "4ac43284cfe7bf49baede874e6f71cc45c378984c267bdd50184e8d11759dc42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "382a69fd8fe8749a53f8349c66bf4d9dfefe03ce885005bb3adfa66dedffea0c",
+                                "uncompressed-sha256": "51b65ed8398c042f40aaaed1528ceee98ee347780c87f81b684883cdb7ddd54d"
+                            }
+                        }
+                    }
+                },
+                "powervs": {
+                    "release": "38.20230625.3.0",
+                    "formats": {
+                        "ova.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9d9a7de3d2648bd2e5633983139eb05e29b93fc67dec2b9671f39205d58e5a30",
+                                "uncompressed-sha256": "1d30c0925c1364b9eff56f54d738c8aa371a6754e7afafc336e13d8515575425"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/s390x/fedora-coreos-38.20230609.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8a22dd3a590fdf3cadb58df0adecfbaf0d072ba4fd4a0f3b89c66d7a139c600f",
-                                "uncompressed-sha256": "ab7eaff097093e856bd1ff9d528c9976b1926e80f43cfc8eeea90e97fd74e3a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7fe5c6a29af7ba7471371154450fe4ac797ab42d90302a91d5daa30f7719dd34",
+                                "uncompressed-sha256": "6d29a4e3bb967fa3eb2cd1696f3ed2ede83ef8926f0700eea93a9544fd85146b"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {}
+        },
+        "s390x": {
+            "artifacts": {
+                "ibmcloud": {
+                    "release": "38.20230625.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5aac3b3ed85e3ac53af130c6750cc4848e0682d201651347439dfc95ef559763",
+                                "uncompressed-sha256": "b25df86719abadcb5445b126727378e26e3612bb6a8a5a930a1bf840f7db542d"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "38.20230625.3.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "613e4aa86c64e29fec75dafd42081e4b7338e38e7e1d065b9744eef1cba7acc9",
+                                "uncompressed-sha256": "fa425c6735d6aabc4b2411289241370fdb77525745e8c0b09be6ec9996f564ea"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live.s390x.iso.sig",
+                                "sha256": "8827df17434f63bf65e636e5ec4b90df5796a9bf854db2694cfa407d300cb3ed"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-kernel-s390x.sig",
+                                "sha256": "975e859bd56ef68e78e05af715c5ff167edff175f7987f67ee513ff8c3fdd68f"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "6882683dc9dc4118ab8a10bebb38a25a05e93c9d1d9847b6a6eae31c7b2773ac"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "8319b5fe4523b0e0d4c64c2fc1630b09c773874133aedcb2e4814f563eca4da4"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "50098c68166f8908ebd1844721ae68623f62f63883afafa22fb58cdecc509f51",
+                                "uncompressed-sha256": "3d104dbd620a389b0af668285ee013fcaa8210cc2bcc0169bc31923312cacbeb"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "38.20230625.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "796745d4f85f61ad1b2c027b6ebf10d57aab370a54de604ff4fd509bdbcc037f",
+                                "uncompressed-sha256": "c5738e0d17b17209edb5ecd4b474b7c205d51c9e642c0c9caf8d1456f49892bd"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "38.20230625.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3e533bd24b72845e23846ede4b43c1619b457ca49260b4ad4af026eb9d238758",
+                                "uncompressed-sha256": "2db3a36a67c142d11606b1c98ec4f9d1e27c31e2c80d277392b00423cf6a2371"
                             }
                         }
                     }
@@ -327,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a5a12cb1ede5947ee03581cfcfabbc01dd36fe70ebc06888186d7e55d7c33545",
-                                "uncompressed-sha256": "bc6843093f04726bf3ca59da88988599ebde7a13d0120527680445d74baaa637"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "878a3313e1c18270ecde111802b1d85b822ed678c62297a1097b2003a91261b2",
+                                "uncompressed-sha256": "de589de41479541eb3084a086db2a1e17aa060bcdccab1b820a89ebdb0b08064"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4b904aead15f537a2bbcb558771e1e439f492896157ff50ea9faaa7a842bc653",
-                                "uncompressed-sha256": "68c36c5f3595483d1f314133c46fe6226c5b2033515020d6a752fee976e8e3b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9ec2904940f1502131f93bf62d331339040bb3a840cb2744940e1f931c9289d4",
+                                "uncompressed-sha256": "a90fac165be7e9fa32e7c9572e63e46e0d20eb0deacfbb286f5aab737cba1ba0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e81e9721a0c00a9c249d130f4ef9a9daa8abafc26fa1ab157fdf26825e1b6b4d",
-                                "uncompressed-sha256": "0632efaee111cb1f4c858a5b62cb80fd8ec619e28129735aa0270869229ff0a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4c2cea7301093bde854a9331df54f2767f369c70d1c325ced2d5579b1551a0a2",
+                                "uncompressed-sha256": "f0e85cdebb1e8ad65bc5f0c124d8653de64fcd89e7f18f4ecf85a7676c207b5f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f85183f79943c3278a27de0483015232e70b5b586e6aed145f996a1a58578983",
-                                "uncompressed-sha256": "e94affbe2383945e567bff1b90dae87f4c0c9d66cff54619b9b8064f7de790aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a6efcdd15b3604d127e152f5c418fe86627b379243cb3195680abc8017c2aaa9",
+                                "uncompressed-sha256": "57e2a4a42c889e5304c91307fab02d461ae9647cb59a701647220d544f16c261"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c3497717f1485fe652b3bce0dc1a16e493d95763f97ed5ed3f3ddd9f5ccaba79",
-                                "uncompressed-sha256": "4655dadc5a437554569f7ec30883735a757ab1013619c646ceab4bc795ec4428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "0c60f29aee6fd3994cfd8aec1398f2450419157c095516f3a2eefa944730addd",
+                                "uncompressed-sha256": "505508dcb9bc61dd8099b69bf17978f2f5e456788944bf03ceb55459a2653dbe"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7bdf5bcec6376c2840310b261f71715a8ced3d35f8cb179fd824f686edf2c86f",
-                                "uncompressed-sha256": "9023230223e8bc56d90784da78c62c03c9f3470a2eb3da350f21f9b6da1d44b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "147516d337cf5cfec062bdf4440565170d6c3fb40e1a9152665627ac76c1f3f8",
+                                "uncompressed-sha256": "47c4dd32c4ab600b261c5e60bff222574cf18f9aae1cc608de430839511a8977"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7db9f41ec23f1736e202df6225353be1ee660df9d83e1a2e235ca42406310e8b",
-                                "uncompressed-sha256": "39634c143cd3b7960bb3e5e0ec7d4acdbe918c22be1f9bfeab158afc3a44a6e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a95553657d65e074a82a579b3572480ae7d6c9b0f7e33ac5ca2cb6ef6cf2e771",
+                                "uncompressed-sha256": "e81529a15241ab69c167230063158fd1ede782955c3c85500a50c54c51880ef8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9b974bfbdac9b723f273a082554c9b05084c96dab7c1511fb31dd6df9e8edbb3",
-                                "uncompressed-sha256": "2a25a4d8bb2d4c8f67b100ee3e10d6b984c00a7ae74791a342ef986a1dd9dc70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7e003646479d5b43f6ef0851f420ae4715954a9d0773bf6feea38a1e5d972e1e",
+                                "uncompressed-sha256": "0f31b2611b87427b73c207c9a2a9c8d53abfef528cc4b614e5f4826d21abc9f1"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "8b25f48c093bb39a0445d7d75517634ab7600df86221613f7897751d6a0cfb7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "40861d453771e094748a41d52c86f55f637383b9b4ecb9783efb11c59b375393"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f17b2ae0b2d7e366baa25a15e68567be5b4fb9bb15c7ba6180638049075afa76",
-                                "uncompressed-sha256": "5a6d2707ec680c1226baea55b021308121131e7854d268dbc5b5dcc891c89056"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "43e33d6125136be7d430770d6ad35d5aa3e0fc45ba458887bb32835a279e68fa",
+                                "uncompressed-sha256": "6be2328c2345615c1ca136b83e37581964d1a4612045ee63f2c5c3a9b09a746b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live.x86_64.iso.sig",
-                                "sha256": "20f855b03d32eab84a20d8c1314f25cd470c01d06ee3c9fe6157d108a3d4e94e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live.x86_64.iso.sig",
+                                "sha256": "9ba1f05947a34bee54b08cf3411f41964ae98b1f5f5a4c01e4ce6539089b4d3a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-kernel-x86_64.sig",
-                                "sha256": "d8e5ff16a69a032c0e47df0c2fa97e724bf58deb49ea5881855574728fa96cd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-kernel-x86_64.sig",
+                                "sha256": "6da41b956f8aaa6e456e6eae6be356f0c8c5000de6f25c60316ec863e1823bf9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0417ec15eedca23f54e240107e2723c2228da9ef9306a97d8d0b9b57f0d24911"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e5cefadb005956e1675c547e926f68527000c18c8b8c4310217d7e3c9b76dbac"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "40630e7af3bccb2f4a9eecc532de67eb28f4ed654b48dc9d003a867280cd842c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ced45e534009c1675130914243abd7603b352f59deb61af1877bf189347e8073"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e14822b642fd24e2ac9bc88039ab8dbbd0951a1e5c5861677b2619229d08a683",
-                                "uncompressed-sha256": "e3e107d77113f7be68d856f7060f517b7c3e9ee514585e80119a56ece766d763"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ecdb57caf5a32326e62dc576d75cce31e5b3ae201e4022dd6300cb21daae6474",
+                                "uncompressed-sha256": "c93026b3b9faca045037ff72d3c550f1d5986f6e0b032eec09c1e8e0f40cf36c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "205da8b6eb99991f418ddb439f246b6a4c1b701ade03b7c21d78c0ebfe25d853"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c7aa1e213bae2975e65db718e190e4c88b4a9416c221f2396513c16b04ac0535"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e38a079c6f1b7fafa0a4d5901b8386c4894e272ac911585fef0591de25a6ab9d",
-                                "uncompressed-sha256": "8984082bfbd870749d69cc2849423b9d30b1c60f5fc7653537c79d16fec63d8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "85788f8a7ee75904b01b3f61cfe69c6a9bcdd3bbb4e1e35a397783542c306744",
+                                "uncompressed-sha256": "b07b84fbe8ebf98079b725a3ef98c464bd89fbdbcd6b5df8d095a5002b5ecfea"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2c039e778505f608ff78b8ba02d497780ee95182f477dbd939ddd335ece29326",
-                                "uncompressed-sha256": "67983bcc7a669b046f55303438c56c58044019d3ded2f3e3104d7c69f303a018"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "96b587d1c6cb71306f275395988ec4a5feac7f1a5bd6b74c1f50fb25e5c6aac8",
+                                "uncompressed-sha256": "86af114d870a7bd15dcb5a44c1e8758d0ff32418cab4b92312e9882d5d938ccf"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7706cb4e2a2877246d950c2cb866dd0ed37c0f612124d006aaaabce9249804cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "2ad09f2412840d368f49e35fe419247fd561d47209ab0380cb42672bb8d6d878"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "70c8ca28cfa95cc72a7e91d681397f0b4b0cdf890b859c7cee7fc700a8ceac04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "a62fc2a50973b08721982a0240192b71256aed8c2906aa399a45f081fbef2ad2"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230609.3.0/x86_64/fedora-coreos-38.20230609.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9569fbfaaacc9b4f3f08480f5b276313b84ea00fcdd59203cb1921e93758a564",
-                                "uncompressed-sha256": "510abc4a62445dbd1596503bd8fb772ad155d006524e021e4fb77e3d1ef10099"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "78889c3f4cb792a02629b61c6e2afbaf07ab7d962e583b5f3f57bac894d381c2",
+                                "uncompressed-sha256": "97d43e4b35b9e799e58e725fafc25436d834c3547588bf87dbefae58de4db1a8"
                             }
                         }
                     }
@@ -567,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-046b6d6c86e079aeb"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0ced9fd4cc692736a"
                         },
                         "ap-east-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0e97b843054ce2f6b"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-07e2a9712557e2e65"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0d4a10634b3c73ee3"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-048b7bc42ed92417b"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0e1178e21adbac720"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0bb5b8b4f22d417c2"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-05b37df1ca9d804ec"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-027c437721bbf807b"
                         },
                         "ap-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0fadfe9ee6b0a61cd"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-02edabd4aacf124cc"
                         },
                         "ap-south-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0d1cccfa83f3029f8"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0ddc19a3b5a95db5c"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-01e50aae81e95e311"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-04ce6814f20131aa2"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0fc1569f357a1ff52"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0c72fb95d1b40f98b"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0ea57ba803eb4a5b0"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0cbe0d2501a313147"
                         },
                         "ca-central-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0bbd1f82275f123b5"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0c03791278c6a078c"
                         },
                         "eu-central-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0e5b6b5478e1ccf66"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-059bb9e317761101a"
                         },
                         "eu-central-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-07825f554d378fce4"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-01c12597c2b42f9f0"
                         },
                         "eu-north-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-02ed572e5c082f952"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-09aafd4f74eb15648"
                         },
                         "eu-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-03d5602ecadc1ccd1"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-018ad7bd7045e63d2"
                         },
                         "eu-south-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-094be97688c56b030"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-05833185c4cfb6b3d"
                         },
                         "eu-west-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-039ac547c62b76eeb"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0f047c181a4fa1f86"
                         },
                         "eu-west-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0e6f90dec0bfac67c"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-0a526d65b798bb9dc"
                         },
                         "eu-west-3": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0b2205aae3edb84b0"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-08225414d335978a9"
                         },
                         "me-central-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-019becb66cdde193c"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-05223533929966193"
                         },
                         "me-south-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0f819b6793b9d8622"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-089125938ff3bff82"
                         },
                         "sa-east-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-02b3aaffc64e3e59e"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-07b01ae7ad6a2ebbf"
                         },
                         "us-east-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-010beab39a4739a92"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-04bf330fc88571ad6"
                         },
                         "us-east-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-0a4e646f84e62be3e"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-07358bdd48a3cb72f"
                         },
                         "us-west-1": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-09901f6bc82bcd4bf"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-05d0a47fc2de0a4af"
                         },
                         "us-west-2": {
-                            "release": "38.20230609.3.0",
-                            "image": "ami-006e9be2de9257e9d"
+                            "release": "38.20230625.3.0",
+                            "image": "ami-09e00edcd5c39ad7f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230609-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230625-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230609.3.0",
+                    "release": "38.20230625.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0d91265abb70fe5f0c95991b47f19aaf3eee12fe2b5548fa698bf7ce96100cb5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ce6a92a122f5f5107da2fcb596098cdd7309d9f20cc4dd6cdc07e5a27c60eb18"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-06-27T18:05:12Z",
-        "generator": "fedora-coreos-stream-generator v0.2.13"
+        "last-modified": "2023-07-11T20:42:13Z",
+        "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "de73ed8e5a3e08644b4d3f657b15480e6f28887c1a8a9b2654c6fbe277f15531",
-                                "uncompressed-sha256": "3d9fbdbd9b4fbb09cc5d06722bb56045463f5a74c1da8dca0492f3830dc2cefd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2fb2d843438aa0254c01bfd9213df225532b88b5449af6ef05d5eb06c5902a56",
+                                "uncompressed-sha256": "11b5bbf15528fc9fc646680e296d825b51c509ae20be86e65eab4992344b7228"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8336a432f2f97d276faad87186d244683c1971759960d5221d89a3d215bd4a4c",
-                                "uncompressed-sha256": "1a518889cbc530249c8e98f848addadfec75572b659b86e6f635a57edf62acd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ba24e29c7d5e742f6d3ac3e0177fede3cf4ff89e661a8c8f9f1aaca95c9b0af4",
+                                "uncompressed-sha256": "ef70800223c62fad9e90428deaac3acc5f9d0557191bd7e5814befc0fb46378d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1bf8bf00f864c9c5a84a9eecc6e130a46f478dad34e67df8b2d43ace3b9a7f45",
-                                "uncompressed-sha256": "4c3f5b1d4b801bd6c792454b4a82b8cd1067e8c3c70f0b7a885198254166aa1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "1088a36fd906751e9b8ce899fbee9c42d1b33465545517b4c104ea734b44c0b6",
+                                "uncompressed-sha256": "570e250334c8a63f5a286e5d2763c84eefe52723cda40df7fe1829314ddceb62"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "17627dffdaabac7fd496959928d745a03038eb894cd984a42a84951bba64e52d",
-                                "uncompressed-sha256": "b10117e083da2fd15d6090df4c5f5927d8e74951be507bb5f7719bb3a3bd1f99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "9a3e0355cf6e360ff729f5c8f37f78ef7d061b2914e805ab8d4b86f33aa0acbe",
+                                "uncompressed-sha256": "c5a8576990391a6c9c4bd67c5905ff0ec7084b285deedbe2c10e62124eb5f714"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live.aarch64.iso.sig",
-                                "sha256": "a37b9f63333f884aaed7eaa2b746eda3437f62ff5a932eb32892cf9cd62efb25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live.aarch64.iso.sig",
+                                "sha256": "d0e1a026e747d489dad8e60b06b124b7f91f00f003e0a5e2eda89648cc776505"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-kernel-aarch64.sig",
-                                "sha256": "76761feda014f26804e68539d69f3906a3572539369f646f4497456af9ede553"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-kernel-aarch64.sig",
+                                "sha256": "c7fbb56fc10168a448f0ee5eb04cab81a23d31957ce9eed9bd4a1c987c61106a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "db2f8cb406453db99e1b8505db6bb62839ec2b4b53945411690f9ec6c8ddd2e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ff8cfb9e44568298d243f40a98427faf30078896780210aa99e242fd182c9d8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "961da91d06fa4785af5ab2e97b48f4ceec0d653770858d9affe29d0627fcca83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "40766fdab99f41597c0d614b9cc6489c3412b452b19f980a0e468ce3d3521656"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9973d93678c5afc3f6d2894a6f3696a241629e0f61f44861fc63a6c623c33017",
-                                "uncompressed-sha256": "b50c5c021ddeff563a5080f54be251d596be9ca50ce87b437a0726bd63bfd90d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7cb6aa0957df32ca49c524f9a156314db3a4d7b233a94e718c620bca19136ab8",
+                                "uncompressed-sha256": "f5da78927082ec7eb897b735c9a7fc6be9b53094e712fd0e75b00f8dd8cc1061"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7ed279b530afcfdba7f73209d344a803c560f2c118a58a9e108469e7fad25fc6",
-                                "uncompressed-sha256": "952332ec6082916426c9ebd949d15af9a9308a9b5d0c18391e33db47e942a28d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c03a48f2090739486e42673378e6c935dc9b03fc143ea71745391a11ee155426",
+                                "uncompressed-sha256": "751324bceb878e2b98bf04cdae7fcab4d16f18b3c312dfd091e2cf8ece49c587"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/aarch64/fedora-coreos-38.20230625.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5d7adf5c5c4a424e6c95c4836b36d9296cb8d8ef11ab37fbc29b9b1bc3395058",
-                                "uncompressed-sha256": "2c1599a6136d1b26765fea2b29dd62532750e67bfada33ba9752e95001ee4bab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e54f863b1532c65873a8e332689939edbc5b324bd6c4eaa63d2e9f1fb2de9bd2",
+                                "uncompressed-sha256": "90511cece6795cc6596117e3512370288f09f7edb5a13bc2e2324d068e72df3d"
                             }
                         }
                     }
@@ -122,201 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-073a5cc7798db7edf"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-06af10f49c6835b29"
                         },
                         "ap-east-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-00c00be9375ca39e0"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0bcf486b9602e2e14"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0670d56ed461f5f51"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0892a65944c26936f"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0f482e8a9147f1d95"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0e9e1f66cdc176940"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0707f8b8eece03e8a"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-01de684000c808371"
                         },
                         "ap-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0d345693fd1eec891"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-07081840bd56b5bf6"
                         },
                         "ap-south-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0338a0076d393b6cf"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0e785d41df6e0edee"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0ac8aef35380b5983"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-052e3c0da354ca3ab"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0acfa7d19833bf3c9"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0cc1cd71cd89ace12"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-084a4a3afa6461e4c"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-06b11d1f3525820e2"
                         },
                         "ca-central-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0620f9ab20f5fc60f"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-09deb4c3d35303401"
                         },
                         "eu-central-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0711396eccdcfdf13"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0a1b4fc6b0bb1816c"
                         },
                         "eu-central-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-03eeaf9f41e3970d4"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0ae9ec6dcef0c5087"
                         },
                         "eu-north-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-07fc51f2b93a05ffd"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0da773f666e105a62"
                         },
                         "eu-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0355b29889e7ec386"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0d4f8024abde08a58"
                         },
                         "eu-south-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-02305e645d2737fc7"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-09866fcc54aac97ed"
                         },
                         "eu-west-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0cd35df3c1f8da0a3"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0372e5a78ecc389b2"
                         },
                         "eu-west-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-05b690df240680dae"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-08e0e457c4208ceb5"
                         },
                         "eu-west-3": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-00c2c5c4fca7cb3b9"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-06eba7efc5f763640"
                         },
                         "me-central-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0285ffee277f4b85e"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0166267d9094eb32d"
                         },
                         "me-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0ca996da7f273afa3"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0d10490cf11360602"
                         },
                         "sa-east-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-01182318e151d4990"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0ea6cbd199d9bdf97"
                         },
                         "us-east-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0bfee0bf41048a311"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0394c0b298094dbe4"
                         },
                         "us-east-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-035209b61d6effb03"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0ff3a427c553c471e"
                         },
                         "us-west-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-04191ca4e27cbaea8"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-04a26ba53d31cb253"
                         },
                         "us-west-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-04e74488de8c2fd7a"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0db6b075ac341fbea"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20230625-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230709-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "0794440303dc8f7386145d17dc8c17c064dc8493906fe2ffa494bce3e557b6c5",
-                                "uncompressed-sha256": "03f54bbdee58f3c9bfa5c63065f1b8d2ea695c8d4b8ee81866b07aa9e39c1c42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3697a238981c7e011a8b13f367a52fa3771378859ce2ef8a021ff516aa99c864",
+                                "uncompressed-sha256": "0cad77f4a4719e1d4eb2e8aafad1cc628c07e26b003c2b4cb96f0dcd098bd9c4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live.ppc64le.iso.sig",
-                                "sha256": "64360720e8cb762a283ff5dfe25968ea7b516c1cb5ab346f12e9788496c5c814"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live.ppc64le.iso.sig",
+                                "sha256": "2a8d80d1665f5e69e77d9bbfb70c6295b0eb37846701db415e373b2a9bb8034c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "f0e3495fdc3d80eda9e8642a248686ad5d1a15d841a99252c11f7043f2323a37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "fe2b37977e0d98b4742d7fabf60d53cc8ad5c32e6d8f5351c067294c47c08aaa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e5d96b76f8cde2d91f5acbee08d3dd45d6e5a105ca74eccda989df1717ba3657"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "4350e5e626eb7e0d19a78019070d6e140c02b1654dc9481ba5f07b033a08bb42"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "fcb550213946148fa8ed3f72800004e5b80aa4f46e02309e741cc76682cfef8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "6b5cc34ae8d25622c855c69728d8c8e5a2ddee822c404cba68c055fa4fc25d92"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "58597a9c551b03bf7d81d6a49a340ff58db27fad5ce585fcd5e73bae7f64565a",
-                                "uncompressed-sha256": "700884daad2ecfb8962286372bd9ac28f158da673ab6ff27ed7eca4ddc83ad7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3ae1c1d4df31bce88e0f7b518f826efac41f0b681efa0226a25cc672325b3610",
+                                "uncompressed-sha256": "b0bf5a5b15c8ab6457781ab952ea760fbf53ea121638b8060487d9836d7960bc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "21eac7f44f5b47205ea9e229530e0e7e6d9390f5e2ec3d53c594c4cfdfdb72fe",
-                                "uncompressed-sha256": "7e1439360647422cc9950c22cea50057ffb9812d94b63324559f0079f4905b24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e09f34e907146f29d32b9b9d29ad12ff53c1da61cc654f965041a90f8fa27dc3",
+                                "uncompressed-sha256": "d3d03df828a9b673574785c72c61b088965c532243bc95d5a56e9e76a4f9dcf0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0f71c2abc9684813bb86d9eaeb346e80e19ca8a15819e1ba16685c45290e564a",
-                                "uncompressed-sha256": "219cc6ff3989112cdb13ece7c4196ffae5b24bf951af135e938df95914c728f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "034068c3bb871ba963b517b5819d86ea4dce57348c7cba180fdeb5741cb982e3",
+                                "uncompressed-sha256": "163ee797fcc71d0e824cb72e30960d9e1228d74698568192896e123cf8a090a0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/ppc64le/fedora-coreos-38.20230625.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f67813edc7fea3b3a1ee8cbc9f7977bcd16066738dc8c6cdd6a4df5f2ab168e0",
-                                "uncompressed-sha256": "d42bd267b1b3d2adf833452dd8a301c11a2ecc7abebe48c4279a07dad229dc44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4031fb45227a663cf607583a9cc12561d425573ae27593f06376dd7676976106",
+                                "uncompressed-sha256": "cc7e5465947d12c0bbe36498371986fe82d97d9cc3e0d9c4b95fc667acbf3b28"
                             }
                         }
                     }
@@ -327,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ac47d9ec6b421b541d256032abaf4780083ecc733d5fcac16b5b20bf929b2bca",
-                                "uncompressed-sha256": "8c2448ffe10960c3ba0b84a7b604d254fb98c8139d7af254eb6028e86d4f26d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7e9d1abaaa2e2aa364c67ba8dd270c4ce23de1c5da599a6584a76926577cd8cb",
+                                "uncompressed-sha256": "da9245c73e4a4a6d4d334eb6b0e6918eb27e38c08f28ad068bf6256edc57d30f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "af5c7f6ab8117ca68abf4be36d8e110327e6b94f1378f511db948d588fbf8607",
-                                "uncompressed-sha256": "9663434e451dc6461959a69f2a655c17c73483c2fd750e2a60cbe683468c8fdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "bc3d4e16185f902ec66a38a94f521a97d3edc71d91eddc4285f19f473fe7f7a3",
+                                "uncompressed-sha256": "33c82ecb2de4562e10c71da40873da7ef8000d4091f25c8b3678297d577a9f9b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live.s390x.iso.sig",
-                                "sha256": "ca03b999b1aae88f2fef72fe93577fd65751f19af3deaa4f14ec8a2ba9ccb670"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live.s390x.iso.sig",
+                                "sha256": "4e430936dccb185b3ed9abf2902616676fddfde84b6dd973c805eb2e376de4c8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-kernel-s390x.sig",
-                                "sha256": "975e859bd56ef68e78e05af715c5ff167edff175f7987f67ee513ff8c3fdd68f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-kernel-s390x.sig",
+                                "sha256": "3e6ea6448e01968e71b7604c81cb8fcd9eaa793ead0d7b41b1ee63a992ca7cb2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "51af6bb9cf3cc983c1973438b64a5c78009670e59e02724b6b43fbef779458fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d6627a80a7857e93db0b28571e0baeebf9ac22db1446f9219b0b6918b7749116"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c1f7285db4dfc19fbc267a3c1ba2f6f8190b69e98dc7833167f7e81bd9db043f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "37b88c91ac1b851418c3ef4b55e4a1065bb78c97a6c4947a734326f04cc0bd18"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "950130152a43cf725bc1c6e912e6c1099e686f6f421671c664a52fe5994d75e3",
-                                "uncompressed-sha256": "ae23ded885dba5ead62f277a613ff7d1cd11f2060cbbcc438a7e02e7ac3e5667"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "18e73c3f3dae222a3b7a14fee53c92e59d6a2d21b41c1697fb04e8830bf541e0",
+                                "uncompressed-sha256": "ddb084e3ce558b3c7f25712c4f46b5011c6f8d4d51d4d1cdfbdbb7e4d754f62e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b57f3eea8c81e85d940aebc7236c3bdf47b592925a52ecd98a63e6e0048e3bf5",
-                                "uncompressed-sha256": "17fce11c714b5fa60799e1d04f1f3154fe69dba05dabdf6eebaac83007b118b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "47df1455ba89f27e010a8f82a0c4db52a19c6cf7d06394b3f4e1556c65b7e130",
+                                "uncompressed-sha256": "736ad0911be39de6653a2812e2599cd26cc3e8b7e42a7a72876cdb18180055f0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/s390x/fedora-coreos-38.20230625.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "92795eaeada4e4b3dff037a709e8e2a2b2baf4d587c06e0fb15319a7e693214f",
-                                "uncompressed-sha256": "9169d5ff39d1f949d3853eb8a991c41cfd1be1382bc59eea0c7901924ac0ef9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9d314ad58c42f249513ebb3c194d875f8a278dc62463e9f77a3bc0c338373dda",
+                                "uncompressed-sha256": "f57ecf85c4f3a58b96072d1c383df2b353d4418e87d8503a469ad4b75f1f1bc5"
                             }
                         }
                     }
@@ -416,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2f9e7e11522ab8d1ade4b98dee1ddf80780120d9ce75d5dbe226984803fba496",
-                                "uncompressed-sha256": "cb9ea2cae18053f7ccc5857bdd1028805296a828a14f130bbc3028ce4c701545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "bdb1507fcdd14eaf6840b4fbf9bb3ba1efadd0d7ffdf88cfde50e8c86493b335",
+                                "uncompressed-sha256": "175cbd22aacc7316b088be0822c2d44af9fbe5203d605e01988531f8ad4892af"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f613251ac289aaafeb8585c7e4df8c9f200eca58e0faaf8be8f5374ccb925920",
-                                "uncompressed-sha256": "fcfc90b232fab20318256fd79b7352162a089fc9e8d8b2f6b1804c207eb3fbce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d0e0ad15192524f6c9ffe02793c7a4e7f3b3894928e6520d2bf393fc4decaca7",
+                                "uncompressed-sha256": "c59dfd7280e65413b776cb98e7035c9f4c2d9bfeaf6d7ce3b4c97840b098e789"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "32f68f258f284577b93ad48fb3e04427711a2b6036f6425bdc1aa5dbb1d911ec",
-                                "uncompressed-sha256": "90de35f73f20da3eef33cd92a80d32d67aefe0764f5a1de9c2f88505d95b5db7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "03a392f987a91c3a7fe85296b0989b807f89d02e96e79f5b6990bbbdb19d769a",
+                                "uncompressed-sha256": "732db2b7e506f6a8edc42313ad84289c3c8aa7bf82d407b80753fa0f9131adc3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f61e5f438164859ac73f96d37cf2b0d4a9f16dd9a3fb494d69a7b23ae0790f38",
-                                "uncompressed-sha256": "d8243afdcc2aebfb79685c6f8c2bc640f8dcdea5450dae129f3a2fb480a492ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7347728735d256c398560d6b7068239578931db26d0c735cf9f2f5a5dd6c3725",
+                                "uncompressed-sha256": "2d112df55ba5ca6e50f7239f9cefcaf5e454e1cf8488013513fcdc63d7e40365"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "016c342a8bfaff0d6d9da78bffeca1c174b2527894acfecb95953078866e393d",
-                                "uncompressed-sha256": "d3c04b5fd96767fbc8521f74074b97b8d4dd982b33be25d3bc99734f4a5de354"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "780bea2a0a935956cb4bb22f2080779434ce79919a91e7bf27fb0f6fecc314e2",
+                                "uncompressed-sha256": "74b2ee58a2d74824d27007368d3aea7870a448a0367bf4d78d413d06099dff26"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d88761bd38b65a0800914f1c6eeb6ae1d95758f898472dcc2c9acd13a9f8318c",
-                                "uncompressed-sha256": "53c911c7cf7194271c77a8ccd2faf621c0b3b0104545d0e942828061342c79f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a68272a03c0bf581e36a64825bcfdf4959a82a6bd06c73bfd56c211e06953760",
+                                "uncompressed-sha256": "994189d3d3fbff1f9793a6243e9b014f3dd493fc840c5c4802d3c7c51fb24b93"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "03402f7f148df7203904297519b645c31244eff6d20e47b7dd961ecc27cfebfb",
-                                "uncompressed-sha256": "ce847d948facc6e2488342c998c84cb2a7ee7f818297c3e7628545d2c49301d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2004425fb8a328d79b9e1a4a1be5ad123dc42daa04505b419245d0f6e6f25819",
+                                "uncompressed-sha256": "58e0065c7051e1b9e88f4ace64913faf4d5400e3ab30d7ceb1e304cd46c5e158"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "fd9aac774d8661f8fca0095154dec6a3b59377a97a3dd9b6c27522acc96c9731",
-                                "uncompressed-sha256": "0b3a2f0f06739014c3ce2f72d9cb38b61af314ee56d31d26a6f6e1ed6268144a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "afab407672e1d58b420d542941e4b2062f554b9c9b4ddc75c9a93c967f3fb22f",
+                                "uncompressed-sha256": "82ce4fafe2115e4f235116ed2c09fa239f62dfc98f2d636f973833c0c4e7fa0d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5831c7fd609fd3dd06919637107afb5f47c54a7b1a6ed0bd5f69a4aa87ac0d78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "73bf347532b3b2cfb18a7bcee77ec088911d22cb565d04f0a02849bf6b070348"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cb166a974451a1a7b02a9c7bc1d85b22629a803ad43129506befcb4a045f078c",
-                                "uncompressed-sha256": "d90978da7b6de5e64e74bff4208c7df5788b815ba144c11f876810aa80096d27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "611109cdd1c26dbe34752d8f6d5b8b8536eec7ca0b5630c5356e4f0b7102a123",
+                                "uncompressed-sha256": "64cdc38cde4d37339824cbf5046e060f9717c108ddd5d7210133bd601674703c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live.x86_64.iso.sig",
-                                "sha256": "4b31c25ce9266240f4677e552edee187543a8162f6099b8005dc8b984b33e567"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live.x86_64.iso.sig",
+                                "sha256": "898851c3119590925bdc6e9b41ed6b5a5878c9f78cf57846cb0f0dcebc9b384b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-kernel-x86_64.sig",
-                                "sha256": "6da41b956f8aaa6e456e6eae6be356f0c8c5000de6f25c60316ec863e1823bf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-kernel-x86_64.sig",
+                                "sha256": "47f50ceeb55185dfc29728d34fa939be712599bfa222e033e976ded9cb2fa938"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "55939aee4b595143506b97fd74c0f7a52774197e702df8c40a5e60036ba8d387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "2589fe21e29827593c223f6bb294e963ba253789431a6985e8c080bd9c74016e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "8af17c63861ee0d6b6fec6ba8ba9ddd807c8527afdd111ec9f45821b1b233521"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6f931f22f169b07136cd9cd46aa7b753e478e2765f97ab837a0371f5b9052e65"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "18efaa24c0216c8c4c9de2cafc058bdcbb3872e3e932dddc685d206a6633e74f",
-                                "uncompressed-sha256": "d27d575ead9914652b1ab9491c98350649f510cba6bee0215a7bcf9e1f9740d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1c9e0a039d69130e98ba146f7ee2669b50319dffd50ea6130be685d4440651de",
+                                "uncompressed-sha256": "fbcdcbbdd785c94f69601b3d87d8e771f90c7c9c768fc48079ce57d33932c002"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fcda989287132f1e88eda06e2dcb7cfaf07ff9f29a8503f0e6957febbea6765b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9c54aec6636ee690450ba38a7070c9eb7a0df9753c22f5d9caf5b46eebf69ef5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bd7fdcf84988dba7d0302e187eee7e680b6b6d10d037d248527cc2cfd06df285",
-                                "uncompressed-sha256": "b436004edf4a10ff6db0b5a9ddcf60f5b9f063ad52a92f5f62a9c7094775d0cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9dabcd47b035201ef13ff79252f805598dad4f4c77ad0447aac60050deccf05e",
+                                "uncompressed-sha256": "4064e2b8e474847de3e18cfb460f2b6b9719c840993e9b27d7bed5ce2f4ffb17"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d6b5c9d34f47020c67ca85389fb7e78c2e070415609cc430a8464afcbbfc6232",
-                                "uncompressed-sha256": "46a0d3730fce50e0a7644b67c9747019e5cea077cb76bc3eca7f20d051ef140e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e425e5b60c52415068797460f2ee456b1eb4cc209a1e0e0b3cda453667873a89",
+                                "uncompressed-sha256": "cac94a7cf00d903e060a3cb964cbf8eec06620a126f63f0017b26f35717179de"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "3a44893aa8176c703a25de90dac37b8838b99ec6d5278349468084d21df3c618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "6e4b36fa698d052e431fb0b412b7bd561569f9b95740d6dbf168bde6c68c6b68"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "202866278317c4b3128b6f21d8b259b37c6bbec894ee31af76702fc86361de63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "8eefd3964b09c10fac883de7f8d3aefbe801be23c370f6a33432d4b4e4f2b223"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230625.2.0/x86_64/fedora-coreos-38.20230625.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c20cdd31c2b3259b1abccb73018655fb3cf98af1a5aa3d066add1c6fc36718ce",
-                                "uncompressed-sha256": "421cd7027f5219106bce76600630ddd646120d0be24d0ff949e11c921763732f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "78421b4b79d3a56b0aa2676790f78b55f5d46ae441bd0e3eee5b6869735cac97",
+                                "uncompressed-sha256": "3737e731ea8d447e98eb813576a0d224d72aafe1b724a5f232b9384e6550cdb4"
                             }
                         }
                     }
@@ -656,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0896fdc87ed7a6ce8"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-08939c3c317159b24"
                         },
                         "ap-east-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0b6d890074f2d45b5"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0b057a5366e602692"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-09ecef619ec1af1aa"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-00d681546a59ef4ef"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-02642138178da6e10"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-044040e3f17c21a2c"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-00d20da18a8f3a077"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-05c2cd6c272a46882"
                         },
                         "ap-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-03ceb9badfc235d64"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-027469d05af0f50f4"
                         },
                         "ap-south-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-095ee177737b2c4d3"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-07254bea6448f68a6"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-03ee24975532fea55"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-04b0c6c434915e2d2"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-06784101d043ea285"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0fed346a5de701eb2"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-04f49349a4c23a525"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-07efc9b5c25768777"
                         },
                         "ca-central-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-03f80a6ac2c600a48"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0caa178cdecf3b52b"
                         },
                         "eu-central-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-070b087b395981883"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0daea999aefd3c1c1"
                         },
                         "eu-central-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-09f8b9b609e5283a4"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-045d92a7e7adabbb2"
                         },
                         "eu-north-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0e18e7c032f63c186"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0475597aec418cc84"
                         },
                         "eu-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-048340e60f6de7790"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0cc35cc5a5f360141"
                         },
                         "eu-south-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0351c7e7ac3db2b6b"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0d959ceb19fc13873"
                         },
                         "eu-west-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0f15decca1b505380"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-05a4cee94085be36e"
                         },
                         "eu-west-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0feed208dd28c6e08"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-08eaf44470690aabd"
                         },
                         "eu-west-3": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-020c72aa039218736"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-06b701fdd982cfba1"
                         },
                         "me-central-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-053b655acb7a8bd59"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-08aed2bcb9a38be43"
                         },
                         "me-south-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-06178d6db3616f761"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0778ceb6d9df2d212"
                         },
                         "sa-east-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-03ecf36fd059908f7"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-028491997a9826f2c"
                         },
                         "us-east-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0ad5b70293092d4c5"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0ebd689498ee36f75"
                         },
                         "us-east-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-026fafbe0d14233ac"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-03b575b8501da47df"
                         },
                         "us-west-1": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0e0f6a6d036c83b28"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0c2e69c261af78ebd"
                         },
                         "us-west-2": {
-                            "release": "38.20230625.2.0",
-                            "image": "ami-0a51e3ca987e9c253"
+                            "release": "38.20230709.2.0",
+                            "image": "ami-0f5ddb53b71a6039e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230625-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230709-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230625.2.0",
+                    "release": "38.20230709.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:804afe67406718e5e69a5f3dd977057c4b9fb7ac603316f528a0d6bfbbd7cd38"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:91786b35b1c200123ce594c26572d5e90305b4166fbb43feb773586ae606aa8d"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-06-27T18:05:13Z"
+    "last-modified": "2023-07-11T20:42:14Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230609.1.0",
+      "version": "38.20230625.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230625.1.0",
+      "version": "38.20230709.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1687890600,
+          "start_epoch": 1689170400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-06-27T18:05:11Z"
+    "last-modified": "2023-07-11T20:42:12Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230527.3.0",
+      "version": "38.20230609.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230609.3.0",
+      "version": "38.20230625.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1687890600,
+          "start_epoch": 1689170400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-06-27T18:05:12Z"
+    "last-modified": "2023-07-11T20:42:13Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230609.2.1",
+      "version": "38.20230625.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230625.2.0",
+      "version": "38.20230709.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1687890600,
+          "start_epoch": 1689170400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).