### PR TITLE
Roll out stable 38.20230709.3.0, testing 38.20230722.2.1, next 38.20230722.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-07-11T20:42:13Z",
+        "last-modified": "2023-07-25T18:00:05Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "25ae22a663d7cccf9c4f98cd9f76203d5f21cfd9ee84177528a526a232b1a874",
-                                "uncompressed-sha256": "e005c2b87939080248a8acd5a5ecb0352b82e08170b1b64e654da77efde416a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ab7e267998451213b01da83143bc43dcf348041c75dea7157a1054134788bec3",
+                                "uncompressed-sha256": "86e5b587eb45340c3caf80e64125fdaa00163af8a0a1b9b40372e67d80261dce"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1f599e11328184b8a6551a80a4ff833e3ed86f420a92f010f3b4ce9715f9b15d",
-                                "uncompressed-sha256": "4ad4e86e1d9a71a31eae324a7c9deffb7c09b3dddc1f90c49f78e74a1f77c178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "6c639358942f26e9faab13ecb8f5567a5c0748996bbe0397e8104cc94383cd34",
+                                "uncompressed-sha256": "fda82601ac1df6f07876aab3c909de3dbf470bd530e64c1af74bde957c80d3e7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "168551c8f1a9bff9197fb98f615ef248b59841601a7b0bdacaacca741c45818f",
-                                "uncompressed-sha256": "0bdcfb2fcdff6d7cafdf64a37979712cec319f67be149aa729c2216a7309c1a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c2a9aef77b88de4dfb65b5b413fc7017a641e476e4785fd179c4e827520b7a2f",
+                                "uncompressed-sha256": "fb24ae1ae1d17e99352f550c62b6d3ba098e49aa1ddca6c9ea1f5c15dee902e3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2fe6dc30baa0287ed9e1d4af25f59441740e3abca4e6a8f716c495817f1736de",
-                                "uncompressed-sha256": "13a1baf827e47b8c82869a0e13ac1be62f5892b987da56995ae98f9dc988ebb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f0af2c7a3f4ca7359368f09e17c014614144e88c526835643951df7d7c4c95cb",
+                                "uncompressed-sha256": "fb3d6c1abf271f94defa0e8a4e9f641cca805f98dd06dc82305e2f7a18857317"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live.aarch64.iso.sig",
-                                "sha256": "d66c53f62e5013b9ee13050cd8bce435ecca22c1dcf824c7575e80076592ad40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live.aarch64.iso.sig",
+                                "sha256": "f4d96bb01f7ea00e97f964877fabc0d82905b34c09731c36514292ce1234b808"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-kernel-aarch64.sig",
-                                "sha256": "c7fbb56fc10168a448f0ee5eb04cab81a23d31957ce9eed9bd4a1c987c61106a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-kernel-aarch64.sig",
+                                "sha256": "94784d5835a4cd49de420d4a04368cfe9433eec5a2da488481261457a1dce000"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "b3f6e6476d7b3364839ebf722fc627739012db570638526be7e434b4ebab14bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "90d074f10ca2c1417041895ceb745b9614beafb9ac9626bf68113a2a02a174ba"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "d06e3d3799f27584ad831fb038acbfb19c2ae562caa5e6ce24ab45f8dd0414c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f1689028b4acc28cb93eb502b437da66c4553b4449377c58e10ea940e666f967"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "187c798e0337ea3f01ae3e3ec2bcab3ed925a7dea2230bbe5f7dad055f100c5c",
-                                "uncompressed-sha256": "b649b69a8dcdbdd8b3cbb56150597af07ddc0d16e49305e81388b36123bcdc49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2fa2547ce00ab8f455dbd1c1ea6f4926dab5fa4268b3711e844ac94f5a332a56",
+                                "uncompressed-sha256": "81a4e8fecc84fb5576afbc6b8a67dadcc4e0240a9436619eca599c92969e78eb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "06fe20faae05a4685522bfb8e2dde2eb4fc7cf827c5ddd4359ecc82c8bac5c8c",
-                                "uncompressed-sha256": "915ad6a30c69d605a99e166072f308cc795ed5efab9994c3b8be9fe533e20a1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c7625d73266b00ca2fa0c2e1db2ea464f0a68a77372d10b53d938a282d137262",
+                                "uncompressed-sha256": "5ea4d8d70e2522dbf16579d742e590537c9a5f47f99d805292d4cbb9a025a822"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/aarch64/fedora-coreos-38.20230709.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b7aeba89c59187ecdf7c4df778cf2d5c709468517f678fd1f7bdcf528590e14f",
-                                "uncompressed-sha256": "4bf48005b16047f8174ad54f2519493b0a468a8390de2fd10dba722102415b7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f365bb9f25972ae65d05e5e8de73e4abb5f972161c9aaf570bf83e48de2c25ec",
+                                "uncompressed-sha256": "eb085ce1b1278474ff2f3ebbd8b5ded9ddd5c68b42d8e2b002808eea4e25325e"
                             }
                         }
                     }
@@ -122,201 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0d10802e61c9e2491"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0a80ce8c8190c47f6"
                         },
                         "ap-east-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-00c316a4d58fadfb9"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0adbd833bbea29ad5"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-076027dbd83ed3744"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0404c1e86f5ce44fe"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-014e8889eec02ca3a"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-05ec727e85165a833"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0639c6b7121409bb5"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0ed025f291e9ef0a9"
                         },
                         "ap-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-08def278586bb38a5"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-007204aad18a7d1ff"
                         },
                         "ap-south-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-03751c852a5344ad5"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-02c2c451572d3ab4e"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0c922c8569973610d"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0035785afedb3f4c5"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-01fc24ccc0945353c"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-06b1e2e726175ce24"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0ec6fac4249d8ef1a"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0259c9220fe727fc4"
                         },
                         "ca-central-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0c4f070e8327fc33a"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-08af8b9c13e7a4b16"
                         },
                         "eu-central-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0a12a05cc59302fe1"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-02d293f43b3c57bed"
                         },
                         "eu-central-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-099689c56c53c5431"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-076e7254c98b356e4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0608c4f3c0c52aeac"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0c425e599dac35cf7"
                         },
                         "eu-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-06854cc98e4bd17d8"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-007ddf0a17cf28866"
                         },
                         "eu-south-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-07f9315b699a79d58"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-00dafc336b3ab76c5"
                         },
                         "eu-west-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0697f288012f27bcb"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-013dc23bc5189a98e"
                         },
                         "eu-west-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0753729a897251e17"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0cba69f4a20c295a0"
                         },
                         "eu-west-3": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-07fbb464b6f9762cd"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0690a3b3e0b196864"
                         },
                         "me-central-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0c605569bb3399f93"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0ce1b1e6aabff6a91"
                         },
                         "me-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-098fc0628c4597ac2"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-06cef37bd29441f5c"
                         },
                         "sa-east-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0691206a1e9be4845"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-055b6d91f10e46210"
                         },
                         "us-east-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-02f3732ab3ca00326"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0dbdc5b0825543a72"
                         },
                         "us-east-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-02d3ce66d278b67d3"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0c98d7e14ab768ad6"
                         },
                         "us-west-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0ed01179be45b0646"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0b4577fc26dfa0a41"
                         },
                         "us-west-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-02f6dd55fd7ad4e19"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0b7a4b195d6170318"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-38-20230709-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230722-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "8053f87940c50daa8710f6b0f559c3f5ec465dc7d0c2f3478f7ad53b204a2b2b",
-                                "uncompressed-sha256": "7cf41efb5f872eef6d2bc146cf68c6ce6407fe4b5ddbe007ff7edfe2c535b856"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f53b29a4a6386187e2945e40a326894c2949f1d7cfe1c9393ab910ff6eef319a",
+                                "uncompressed-sha256": "6efc18fc3f813b811093fa105384f7f2621f8b0d23446047303443aaaf8594d6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live.ppc64le.iso.sig",
-                                "sha256": "98d924b757e86696ec13321ddbca1492eac2cdf8a58c7aebb5904e2303de9f98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live.ppc64le.iso.sig",
+                                "sha256": "1a9bc89c6af8ac39c4e7aa503c69f78108ccc5bc09e063efbfa58c8c30ab414d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "fe2b37977e0d98b4742d7fabf60d53cc8ad5c32e6d8f5351c067294c47c08aaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ff952f5c95ab2dcbe857ffb147be073e5dca2dc7a5cad7d131cbb4051d8f8186"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f6c216fafa87db76197ee5ed42c2d28198bb0c1d8e0a02f281df4e11d5902122"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "bd39e4fe52983b062b8494d38efb2ce8afc9daf86278bd6112447b75c8f7a493"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "6ba6e6118c47526fdf4a80b9177480947ad1b988f54eeb29eb6007edcf8abcb8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "fbd82f922c69c326f4541bde2342d8da5ee1904e99f0b6d770e06ef420245f86",
-                                "uncompressed-sha256": "02ffbf22d98e51e374332b83d4427f9e438aac79f6f02f6285917caf7019dc4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "f4475e8a6a394c2b8b1711f2350b065c26fb1e0df65b9c304926bb60777ca1d8",
+                                "uncompressed-sha256": "06088ff50ed6ddb05a5b88a6ed9f79287a1eeea1efccfb384aed96f4d3814b28"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "c813dfd06d773429451c604cb68fccbd0d05f052d19d14da8f65771afeed20d8",
-                                "uncompressed-sha256": "bbdfbe3078712a5b073b3d130938c0d65d84f858c3f748b59c54109621c01034"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "bccf5533bae5c2ec94b42bf995a772add3edf20a3450d76fb9d8fe8a18bf2536",
+                                "uncompressed-sha256": "f7ed190daca7976a19022d07da49afca2637aca21f83bc1f77d8ebd310c7f968"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "aae8ef8445e79a50116f9704c2bdb428df542237a25080a4eec7955ed3be74da",
-                                "uncompressed-sha256": "960eb3a87acd593b93250c9ef732e113fc921b7e92225d5ba023a618ee0c2ed1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f06092e03bd2ba2ee10a21935bdbbfc67715b46415a1aab07cbb2acb317e6789",
+                                "uncompressed-sha256": "8f594f5a065c70c523f01cd7e89e12f6d6151a71eab4efb82b29ba5813736f1c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/ppc64le/fedora-coreos-38.20230709.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "646fa4c59a160bb3f06745cb0897fb7f2f53f0e2cef40e873e5133693789da55",
-                                "uncompressed-sha256": "031e23582dfeea1e57b283935d987f8cd9bdad53aeaba92f0e0db3da5c347401"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "72ec0805d019e8654c32cfa2c69fc98ab1192c85e274d37414d725d3ba59ad7f",
+                                "uncompressed-sha256": "5fb45550dfb7e5b4fc4dd96ae18d62818e82801a215ece7333bd4416c7a4197a"
                             }
                         }
                     }
@@ -327,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d63e2b8ad3220ea04583e9e0fe272d0be61c1632b573351d5713a39089fa3a3b",
-                                "uncompressed-sha256": "bf466c3d56d7268ac6cbd7d2d4e489d2273b1463e1d30deb40dd267fd4c40f43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7fd2fe4b2fe1bc2e4696c752bb9eb026dc044d046a880856a533748b7ace1907",
+                                "uncompressed-sha256": "8c5182a8da3179a4f108513cfcea7c46309e9b21dabab60230411bcf62fd7686"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "09e23d4be96bed94f1b3f466275e25b2cecdb6b2a1a10bbf7feef1664e4bf675",
-                                "uncompressed-sha256": "e6ffdfd026ee7f13281de72d4a644e02c93d029b8fd07dec7f6af9529ab9d392"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "376d62826fdc885ce32e719f3da2b91514273021b649611a2886b87b00e7cbb7",
+                                "uncompressed-sha256": "121991221828c43e294d22434ba5f2c002e5591dd4b3ea7736ffac34665b7aa4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live.s390x.iso.sig",
-                                "sha256": "d4b064531908f14c694b5e4ecf4fa9847f7440b9a50402edf3dfdc803bdf874c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live.s390x.iso.sig",
+                                "sha256": "b06bc7dad908a971c295072687c89b0a909f1b649b2ef62d403fece3b08f49de"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-kernel-s390x.sig",
-                                "sha256": "3e6ea6448e01968e71b7604c81cb8fcd9eaa793ead0d7b41b1ee63a992ca7cb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-kernel-s390x.sig",
+                                "sha256": "5ef1cd96c43354f9e87874e24273149d1ee882a86157abf5e09c149e8b2bc60f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "f64f19c0af44e1f07c6168aabf95d59287889ecfd2219c08fa26c50635b04699"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8d8782e5fa7d4a3b60f3f93a5369b992d50df170fe5c9108bbe5decba3ac688e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "4491319525a632d0bc7c7e1c56216a81e0d43c354b3c9b8ab90a68ec6ba267b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6e4d29508d554996c5b81c8a1a9738a54f05c08af5fd42f1a088a6035d1d6d45"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "02e146cbec6eeb4cbfb457f0f0f1ba063cd71b3f4e3871e8adce0a52792c723c",
-                                "uncompressed-sha256": "b616f65917fdd79e069adfc50db551bbe35f084c9459b744876e616b55bf9579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "ad9574c2b532723599f2c14782fbd1af1e5fec495b36d482863df461a206dbe2",
+                                "uncompressed-sha256": "1e8519a0feb72b4099a5dfe735b649acd0ed25cd0e94ffbc2af16d53939345e7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2dea2affc4aab4ae9f64fd36d6b0a7766756e5d89f28e9a17116e576fc2282a9",
-                                "uncompressed-sha256": "2fdb352f54bf4233b0861ec8c7552861d8a7634ed89e5448bd7811930faa058c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a0b79d2c01fe68825fcdcad420f818f236d6fff71559b1c1010f2ab7ae98f8b4",
+                                "uncompressed-sha256": "9b0037ad9b9125e5b742b86a55369d7716d40a4d133fab79770694631627aaac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/s390x/fedora-coreos-38.20230709.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "875bb9c945a7d062cbde2943c744d561682bc9e1554720708fe015ed5a2f2a09",
-                                "uncompressed-sha256": "93b9fb7a3db365b5e95f00dcd3e549156f76fd6ea6b3e2c7484e0c3e731ca1ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "94d9f0942c1eb93f79d8e5d1afbddda83031212f7ab9ddf174b4c5419bf78c7c",
+                                "uncompressed-sha256": "63afa360f3e287ecee00fe6e3ddf31b19b642cf57c4bf4020a875334b4844880"
                             }
                         }
                     }
@@ -416,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1a442f393d3415e2deaf3d423c9ae6428cdf059cfc705a0ebe57486043d5e6c9",
-                                "uncompressed-sha256": "546a12526b6a03786f87dc0d649556ef94347e060bb6a558a7585416214c2005"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f2b74cc359ab19b52fa81e546619259fa1ea388df53eabf108242b09aab53930",
+                                "uncompressed-sha256": "3abe4eeec572ed9a293674bce46cc773a228d3229a328dabca48fbe6dced37e8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e6e9f3693c773ce1311bf33c6998205ff3c7536df3e2186edfa69ad20a31224a",
-                                "uncompressed-sha256": "d66ac6c0336b42574ac19df521cc05358f1213a1e9df799d6fdf505c18b6541e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "831ae888ab839f552d8e98877ad12ddbac084f535b100f387c52ed04168981bb",
+                                "uncompressed-sha256": "2f4bf160ee387dc56505391531c071f13be9fe73fd7099d076776a66f2969f2e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1c3de2970a332333e3aa9aaaad05352e76fae0241a2d9962c3e8da5f7cd8f89a",
-                                "uncompressed-sha256": "7a298a6c2d0321a257b8b6367b657694dd82d3cc8db838765f87a459af5d8e1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8217c1dd2b7cba55288fdf4ee1af465efc551af20e2305742972acc03b1a4474",
+                                "uncompressed-sha256": "be46f36e17ec7f39aad6c1bb4d134c7d62e69c06c0b65310ba0eff564baaa686"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7bba7bbc05627176c31dba1e38495d5fadadd814e2cddec321ad4db139e5f2a3",
-                                "uncompressed-sha256": "2caddaa45da19b5e864d9d1b4eb2be299db081ef482c868f4f6e3a32baeb063d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f2cf6fe6d3ba447a0056f51269908eeea1bcd132973a33d059764469ab4def45",
+                                "uncompressed-sha256": "631c2822bc594cafda35eef086924c1cf8c2304456efcf9c6d9cefd698288f8a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "52aaf30edb3282d96519108473b7485eff90e97aed812bddd1ec76bce9242f60",
-                                "uncompressed-sha256": "54bf27fb8e481dfc46aa189824270daee03a048071702602d530810849743f89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2b8afe722b60dc28cb5bb6ed01d13a3578e97c93db3d0debe2b207c2c968aff7",
+                                "uncompressed-sha256": "2e54d8ce101394f0fe7a886802f44f151cb48732d8a2a9f0b320d58577601cdc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0e1530651c68a930a5c5488e5aa2b44f1bc59140093d3becf8efaa301763d84d",
-                                "uncompressed-sha256": "5e5d5a80862af9c22aabbdbce41af70f4fcd6d60d9c9b82526cf25b55a1bdf04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a093a6a3550b5375a75d204a74f1edb312bf3caf78eefee00f1ef445ec82d650",
+                                "uncompressed-sha256": "629a9304cb887c8da1fb70eeafe3e44823fc143d63e5fb58b6d41ac71722144a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7275882373f85fbfcb6c65b665a00637e1fcec8e8147ee7b1a414125b17a9ef1",
-                                "uncompressed-sha256": "77ab3ccb3541a666dd49167186f0225a875f6896d33fd162fffd3ae125947f18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "53a976deb2851759a99b8ffb2c672ecc347ab9033f1340b225c00840aaf90397",
+                                "uncompressed-sha256": "cc692447fa571122b4af435ba7c498591b790bbead6ccb1c9b3c9c6864bf57b2"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e3623258d5832e1c74329d39925b77c825a6c9eb6ea5214237d204c51e60f63b",
-                                "uncompressed-sha256": "58331000ff44fe923c88e40707cfaebd45f9638952993db2ae54558ad9a0cb9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4390c67d013e8f33b20b22b4f547b426afe161a5f0123ae2dd2cd7c46f3e651d",
+                                "uncompressed-sha256": "f08103b7c4c7f6315609d40ecdf0d01bb4878b1047d68b1a4ae2c265fa45f29b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "9bd52021fd8b53642e25964688f54db7c9c8da82201861a55cda7ddd0f7b1482"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a5405941dd2541fa4bc29df0c2d3647cc80c8c24344194b9e7c1c496f95977fb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ea42367c788cde2e2e9bf2d8467c817e45a34baf9ea145f2416cf1a2321daa76",
-                                "uncompressed-sha256": "dafeab33970ba5b6e5927e3683ba737a9114cf7905a7eeb2ed2a8bb3ba1008b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4c0ebb82671b8c58c3b496381a005a1cab868d98da987e7f0a884c4d23444c12",
+                                "uncompressed-sha256": "6cee5e584a5ae0c3354844816c68cebe331d89c8f4a7806df7f567b8af9c76de"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live.x86_64.iso.sig",
-                                "sha256": "79368e1609c6393b26ceb3722274b00583519a682f63590d65627b884d98a932"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live.x86_64.iso.sig",
+                                "sha256": "2681c314541adc6e0f65a7276b8a77e0021ba0004cb260fef315d926c70e9c3f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-kernel-x86_64.sig",
-                                "sha256": "47f50ceeb55185dfc29728d34fa939be712599bfa222e033e976ded9cb2fa938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-kernel-x86_64.sig",
+                                "sha256": "88465710467ae0d8e2b6f4c81fbac5d00f7afb2398c130dbd483431e7b6998ce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "2110a86a5b2cfdba9c3399ca6ab090bb6593c6ce48e332ee886d3022aae9b83f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e65e938077110b5d54eab570158df1c2df9096344d3a0d843ebc5f58f45f70a2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "0b4348c4184f4778c319a4c557aea950866881ea482c4ed43ca18554fc434ab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e24f96878cd7d4784bc09111a47935f1e0c622988bb17873025aa0b3b7f7b276"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "cf41d7e61af494b8515791075a0bf572022a893d86e610d3ca3772f5cc9022b6",
-                                "uncompressed-sha256": "ab57449744dbbdf841a4295cb2ec78aa0aea7a78c0e65fe5ca1e57d94c3d97eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "daf97f5bf56eb54c4accc89e02c424e331e18321cb2e559fd85316445421de0b",
+                                "uncompressed-sha256": "c73a51bff994afe75dd25505627b211c0e52ba1778fbbf1a65c42bd84d5ddc73"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "477d30be10cd360f3a0f56604fb650b3285cd0a88887eb54f94fa8d3672e8dc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "61144f6746bb5f483502bfa8d355730e2db237086bde0d93cce6e68a9517e4b2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8419e227b8c12a1278a04f65ad5b41ddb60abb4dcc61f139048da31213f13cd8",
-                                "uncompressed-sha256": "17d2c7880ebd61b6a88642fc6def1d2f41b0c2627c245c9f2d9ff03550788bcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5b29ba694c577b7e804a60eb2f5fe41ecdcbb5442f879311b7c58ce5899a93ea",
+                                "uncompressed-sha256": "82fec04ee8d67d5712ee6c8be1e4691ca57cbb76c9e4e5c53ead632c49eefc39"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8aefa313ba2df4f84d1667a64d643b703dbf10d00e1bba2ea37692eabb3c0563",
-                                "uncompressed-sha256": "6666801c9a234f650605a84502c3bbaff8cdb2a414d48aed7415f56fb77bbb37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "61b0ddeeae75a329021a3169cf1f9048b43bb953e2696b266840453d39bb36a9",
+                                "uncompressed-sha256": "5a9634f02addfec848e77d7a03d6b8f27f1e6bd7ad3011e39171ed0a8f974c82"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "857779221b381a0d7ac310e09260bc866436af2f6448a822732e39250bcd1205"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7bd43e575bec40c696e1c6210b814d15760347be59b2b41c116e05f728208f65"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "80d21b9ec6154255fd906b9b55a04efc3f7e2e3f600d753125ecdfa03f413250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "24556a87e5ffe9057c55a26631d81bc4d16068651484d8419f0dc85b4d60ea48"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230709.1.1/x86_64/fedora-coreos-38.20230709.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "688bc3b8253d1780af3d3946eeee600efa5e4388a0d79b36af11009958db1a2f",
-                                "uncompressed-sha256": "91d936ab0e25ddc0439b81ee7862b7cf7f4eb33ca66bb9c6b492132b062c2bb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a959966af59692ab4467d52f05d1870506a2dbcaa643958653e4d04d358c2903",
+                                "uncompressed-sha256": "1397f4007c9742389ffa998698e1a8e7d7d12f1db1bc9f10149410eb1660dbad"
                             }
                         }
                     }
@@ -656,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0c6681dce77df2647"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-001631704d495c2a2"
                         },
                         "ap-east-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-06a775ca016fa90cd"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-070389b892588b306"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0bccda3c60763e73c"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0d685ae09f35c2b05"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0be2fa72b366f06c2"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-000e8b6ade2d03e62"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0d3ef7ee60ba06c3c"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0e1210fbea6ba6234"
                         },
                         "ap-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-073c2d785211b7274"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0bcb27e3121780eb7"
                         },
                         "ap-south-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0e377813e2380f29a"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-068d077dec36fd62c"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-04dbb20278cbc48b2"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0071cc9113c5c1006"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-089c678754f27cb8a"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-043339c098310d0f4"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-04f80e92d2be37dcd"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0fcfb10bc39392428"
                         },
                         "ca-central-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0a1dad4ee3c88e470"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0748eb7c9658e87ad"
                         },
                         "eu-central-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0270a2fd7d9f4fa0d"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0778cb452fe740e2f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-02bacca15606d2fbb"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0e0629a7bf7b767f3"
                         },
                         "eu-north-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-03ccdfe8b8ce7cb7e"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-040257491fad99acf"
                         },
                         "eu-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0ade1a3e128021a8e"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0785a2f691357eab8"
                         },
                         "eu-south-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-07f3fa6be6e42fa52"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0d325d8fb2ff99a6e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0b9c3488acf18f8cf"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0861e7f651e5c6fbc"
                         },
                         "eu-west-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0fb57de41b892c051"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0cc44997d12ffb6da"
                         },
                         "eu-west-3": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-00bf6895aa5cd2d99"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0b95983da4ed06934"
                         },
                         "me-central-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-0113799f03cd4f8f5"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-00a4d8b85668a3f8a"
                         },
                         "me-south-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-04c38ebda442c165d"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-0d85614da62de6ca3"
                         },
                         "sa-east-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-01d97659c4ce653b4"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-03f69237d1d26e1e9"
                         },
                         "us-east-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-08b6c3aa41b7f2170"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-03fb103854869e89d"
                         },
                         "us-east-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-04a11dc81038e0d19"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-06cda844fdfb24efb"
                         },
                         "us-west-1": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-08f5cb792efdac033"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-042f284716ed314e2"
                         },
                         "us-west-2": {
-                            "release": "38.20230709.1.1",
-                            "image": "ami-08253611dfdeeac13"
+                            "release": "38.20230722.1.0",
+                            "image": "ami-084aa2f120881f48d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230709-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230722-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230709.1.1",
+                    "release": "38.20230722.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:47e355fe49b0a54f3e1b466dd174215149834be90cca736cad78212c871cd749"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8d189c8f044ca0754d1a41f17c8cdcc0d30451cbbd6808bf1acb7a79d3c402a0"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-07-11T20:42:11Z",
+        "last-modified": "2023-07-25T18:00:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "51e7fd86d8f061e49378350e233bd7d2a465cd476acdd0f2ce408fac4112020d",
-                                "uncompressed-sha256": "0c5563b5e25015739d4d55be344adfd723deeb23e1735b5693ca57f772e44b1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f70a82e12944c0c34c763cf14d1a25384017944dc6b00559f816096e2678f01d",
+                                "uncompressed-sha256": "9c7b4f268ccb00e47f0066af4816a3f352311d80dbed4aa4fd0ca7806e0e6e40"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d636a08771d969b7d69baba7d781361cd36008aa6ab125c05a2e8c186cf9f5e9",
-                                "uncompressed-sha256": "66d333ee0cc8979c4e7836fc82ab0d448a10b698b93f87484321eaea7d548e48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a807d837aa03b1a2e1e3f54486d51510602b2e7278b631709f1a08d30ffff426",
+                                "uncompressed-sha256": "a5b6d25148a83d6e3ae15f161b29fe1756a6533b0d43bcd8688b2bac3c9d4be6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "148a086715e18c446f2deaa305e65026130a4892a89756d4c84428cbedb55d81",
-                                "uncompressed-sha256": "15c13e80a713efb4765bc1650fcc6d89de7ff604ae7384175c4f37066b9867f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "524a1d8720933c00f935584925b373f1d4f4866e6cf19099a205f7595b0f9d37",
+                                "uncompressed-sha256": "16c133b6aadec5625f3691afdb9859bd07bbcc1744310190a1d31815e7e8d319"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ee03100f04254aa309f3d1ab06c33f74af033d3ec5efd08ed5bb1377d080bf30",
-                                "uncompressed-sha256": "87a4da8ab87055f0f834eb35fabad15ed7de5ae8ef10dcb0221c808061d6cfe9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0bd733d57afd3daa86efd31e40f3bd2a8f6a5ee198f2dc1f8a0a8d8db6d05cd2",
+                                "uncompressed-sha256": "172690d1ca095b5d981b5e85b41fe863dda11a2896c7f4873e82168a471db38a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live.aarch64.iso.sig",
-                                "sha256": "6985c8b34cd359c60070caf6d73a6088a3e1f5b9c51dac71cc8da6e9a6d913e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live.aarch64.iso.sig",
+                                "sha256": "aa94db36cb90219fbbb87e499bc000f7659a4d7f5b4842dcf7d2e050a0a15a34"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-kernel-aarch64.sig",
-                                "sha256": "76761feda014f26804e68539d69f3906a3572539369f646f4497456af9ede553"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-kernel-aarch64.sig",
+                                "sha256": "c7fbb56fc10168a448f0ee5eb04cab81a23d31957ce9eed9bd4a1c987c61106a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ed55c85c068a2cb4114f47dbcd47167cfbc62f4914d6d08b01a376d21d4d3c80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "f79268706a09d3a1ed619058a8164e9d45a55f31bca31b5bcabc5b701bd51222"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0081fc1d6c2db04bec96cb3711ce7735e3a4955acc61a92bc8566189d0a51811"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "63ee824e02a07e59ad9d251674ef44d6bd74fbd720045f2cb71f0fa678388195"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0493d47a4f1e98120cbfb7507ed1dd6137ea1d07305eb9225b4804044c06c79b",
-                                "uncompressed-sha256": "d0a4dda1cff18ad5204152dc578e76719078822b5e693d417603b16a31a7b597"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "b8562adf601e36130653e7c5d05665c1c30863fdf85bad7de8aed896e5288f4d",
+                                "uncompressed-sha256": "ac64a9ee85ffbb2d983bd38b311382b9cd9e662a1cac4c29f9405748f858bb60"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "029fb8f53d9bbfb58f58c89afa1ae4e72967738908d298804b43778dc9ac168e",
-                                "uncompressed-sha256": "c2b1880e255e5411505ff8b113935405b23330a05d259f5025e5fef7ebcf7c4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e43846760718e0c896f552c841be4d64c0b2935a365a5b9621ab22eb1b6f31b8",
+                                "uncompressed-sha256": "530378be3c5f65ffeb4709a8e490e537fe38bb131c80d4e7b2d7c8eeef8aef41"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/aarch64/fedora-coreos-38.20230625.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f40ace486d2f75b686c879ef09a0842223222062640e84492b20d38da4eec5a3",
-                                "uncompressed-sha256": "79242ddd409488dc4a4a30434ed8dc49f44f0c8b466a07cb689e2beaf2e0c285"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "68e365668deea18084b3e20f626bd02bd39e43a0cd8d4413c8efbccfb1dcbcce",
+                                "uncompressed-sha256": "1c51a09de01449be24d9e2f9b1273637a3869d72170896ac8cd25b1c43562ac7"
                             }
                         }
                     }
@@ -122,201 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-01f7c00e5795f1813"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-08de74558d402bde3"
                         },
                         "ap-east-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0f4e4852bc092754a"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-076b79620ef0701e7"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0fc515b952c5f53f0"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-06b2609277299e74c"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0d4a5c2ae8b33d81c"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-099b3c9933a4c7d33"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-09e3031f33b5f76a2"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-07e6d934f35a78d13"
                         },
                         "ap-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-05a75e773fc4f43de"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-08cd04015c18ef02e"
                         },
                         "ap-south-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0b29f5818f615ef6d"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0f06fb5b32eacffc3"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-09a544a1bdd906f71"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0731f849be7c62373"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0258425926248f642"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-086b387aba4aefb9d"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-02082360a089d9112"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0e94d2ee5c8988eda"
                         },
                         "ca-central-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0122b01e6164270d8"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-03491d8ce6e007bda"
                         },
                         "eu-central-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0e4c1216385f64182"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-05f130201d8d1ee64"
                         },
                         "eu-central-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0d859e8901b4d59c1"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-073d4e22d8bfc8293"
                         },
                         "eu-north-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-01ef2b44d89267219"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0148e0c7f0f4ad71e"
                         },
                         "eu-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0ae8b86410081f5d0"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-042a1cdd99768e890"
                         },
                         "eu-south-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0662ec28fbd54e465"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-052bc71cf7c2cf1ec"
                         },
                         "eu-west-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-02794e669ea2e2c3d"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-02618c8348d0ba274"
                         },
                         "eu-west-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0f3b1ac63f7736519"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0c7c7c0f4a5b09dee"
                         },
                         "eu-west-3": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0d97a4167f65abbcf"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0a13e74703563d2a3"
                         },
                         "me-central-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0a924a6ce80af08d4"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-009979a94dc1b3e95"
                         },
                         "me-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-099100e99f02b72c4"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0b25a899f8d19690d"
                         },
                         "sa-east-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-08a16ec7e0e606f63"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0aefc6ea94210a2d6"
                         },
                         "us-east-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-03777816913e8e8a6"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-06f19c97b37fa0edc"
                         },
                         "us-east-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-082637480ae288e56"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0dc1fbdbc3cf897f4"
                         },
                         "us-west-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0b619c21b51650a8f"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-08bea38c73809ca16"
                         },
                         "us-west-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0c4e16efb57452a60"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0b757b986982648f6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230625-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230709-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ed967f68a75618712b8f93b0cfa9595797c4421ddac3470a9ab52c80db656bdf",
-                                "uncompressed-sha256": "15187188965c5f947e4ad47bfee4d94a45dba0cc6bfa812d20edf59b72968975"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "39d1fa1af11a0b2a08cafd7c6b08cdfe96151f4d85910cb7e95514fc3234902a",
+                                "uncompressed-sha256": "f477de16c5db1de17d5fa1478d663487550712d8193134d7f4e0abdc77313b73"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live.ppc64le.iso.sig",
-                                "sha256": "3c82e4273feb0314ba4e0c7e326a3ca4ce0cb193ad077337b9e778349a097e19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live.ppc64le.iso.sig",
+                                "sha256": "2111e499518f539620c11a238c766d95b19ef08bdb83d2e06a89b7bbbda3239a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "f0e3495fdc3d80eda9e8642a248686ad5d1a15d841a99252c11f7043f2323a37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "fe2b37977e0d98b4742d7fabf60d53cc8ad5c32e6d8f5351c067294c47c08aaa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b7a459d0f05501794a911622c404bdff1b1ad21ce18a4385260d99c4b1063bbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7fe6d0bb6f0b8af4ba0a705a9f86ce683ca0c8ea7dfe10d0e67d837ab5ed0f52"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "530e448edc81bb465a9e9621432b33efea0e1f12b58a54c550581ba96678b083"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a57726efa9d3aaad5eb2fac469e1349f706ba968806140fd9e325b63740af93b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6a2b10a5ce74fabd5acb37c49f5fac76ce8c586ebe38b29274803a32aac3b482",
-                                "uncompressed-sha256": "9211490f16bd7d983e23c138ab5362da315f783c7b45e7c372e1084b18178873"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "7c7ef208bf6c2a42331dcdc7d939f79ab401323c58b9d1a7491d64dcbda1919b",
+                                "uncompressed-sha256": "aec1c3323459e092d502bcd9b3946ce8ae7bf0b592fab215fe4864fc789f242f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "382a69fd8fe8749a53f8349c66bf4d9dfefe03ce885005bb3adfa66dedffea0c",
-                                "uncompressed-sha256": "51b65ed8398c042f40aaaed1528ceee98ee347780c87f81b684883cdb7ddd54d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a520e4792ba728a9924e9c8bdec52989d1f677943186c047e0319d6aded64e22",
+                                "uncompressed-sha256": "19432e0d26ca635318c4be1c99bf3d7bfcbb77aa1b40100461643736a73aa8f0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "9d9a7de3d2648bd2e5633983139eb05e29b93fc67dec2b9671f39205d58e5a30",
-                                "uncompressed-sha256": "1d30c0925c1364b9eff56f54d738c8aa371a6754e7afafc336e13d8515575425"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "95b28e5012991684f932bcb0a980d079cccfce8a87d945e0e3a33f164e599599",
+                                "uncompressed-sha256": "18e630931d38db7268c570e38873ea2f926b05733ba9db2858e17a5ab1355adf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/ppc64le/fedora-coreos-38.20230625.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7fe5c6a29af7ba7471371154450fe4ac797ab42d90302a91d5daa30f7719dd34",
-                                "uncompressed-sha256": "6d29a4e3bb967fa3eb2cd1696f3ed2ede83ef8926f0700eea93a9544fd85146b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9244e411ef0dddc0e23d2decdef010178280a9835be48d7d678906911baa8a79",
+                                "uncompressed-sha256": "9ac13429517ec5880ce94a5788fa91e8d0c60371dd16b74acc2ac912d0cf1cbe"
                             }
                         }
                     }
@@ -327,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "5aac3b3ed85e3ac53af130c6750cc4848e0682d201651347439dfc95ef559763",
-                                "uncompressed-sha256": "b25df86719abadcb5445b126727378e26e3612bb6a8a5a930a1bf840f7db542d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d4d73e1b031f79000f5f00ba073614797d81e63f4b236fed357fb97f44846811",
+                                "uncompressed-sha256": "5e3d72be30f9828f5137134a07223f675a6c328f2cbf8a2f6ca1799c5853f8c0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "613e4aa86c64e29fec75dafd42081e4b7338e38e7e1d065b9744eef1cba7acc9",
-                                "uncompressed-sha256": "fa425c6735d6aabc4b2411289241370fdb77525745e8c0b09be6ec9996f564ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3e8f09c858285806c9915d1e3b233c26d2e582b25b01d57bc3960534c4d6e782",
+                                "uncompressed-sha256": "29d104c299243b35d3ef5963491afd65c88f3514590695b2b0f8dee53c2eabe6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live.s390x.iso.sig",
-                                "sha256": "8827df17434f63bf65e636e5ec4b90df5796a9bf854db2694cfa407d300cb3ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live.s390x.iso.sig",
+                                "sha256": "7d09090d2c4ce2a59470024c3fc10c37e8894617e51ceccd9d7276efc99769ee"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-kernel-s390x.sig",
-                                "sha256": "975e859bd56ef68e78e05af715c5ff167edff175f7987f67ee513ff8c3fdd68f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-kernel-s390x.sig",
+                                "sha256": "3e6ea6448e01968e71b7604c81cb8fcd9eaa793ead0d7b41b1ee63a992ca7cb2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "6882683dc9dc4118ab8a10bebb38a25a05e93c9d1d9847b6a6eae31c7b2773ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "2e33da5caaea041a0a71c13c64ce056f8d44f05572a838fa1a422cb0a64ea0d2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "8319b5fe4523b0e0d4c64c2fc1630b09c773874133aedcb2e4814f563eca4da4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "febd8ce841ab9ca169cbcc75a85df2daceadefb67fcc948c93ce40ea331a5db1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "50098c68166f8908ebd1844721ae68623f62f63883afafa22fb58cdecc509f51",
-                                "uncompressed-sha256": "3d104dbd620a389b0af668285ee013fcaa8210cc2bcc0169bc31923312cacbeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "9867bf6358181ac33cb1e511c8b38491013534cf5cd8d1ec1095e97c4f7eccff",
+                                "uncompressed-sha256": "204c8afbb008235205d9b88ae5dd68540e6c88f7aded3df543ee4c226841c4a3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "796745d4f85f61ad1b2c027b6ebf10d57aab370a54de604ff4fd509bdbcc037f",
-                                "uncompressed-sha256": "c5738e0d17b17209edb5ecd4b474b7c205d51c9e642c0c9caf8d1456f49892bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ad383f54ce61908faf152938a511356b9018e36bd842c4870b7ebe725a6028f5",
+                                "uncompressed-sha256": "fb66eca1d9bf37412c7d80648b884bb361373a4e73995e4a975b300fae297d02"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/s390x/fedora-coreos-38.20230625.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3e533bd24b72845e23846ede4b43c1619b457ca49260b4ad4af026eb9d238758",
-                                "uncompressed-sha256": "2db3a36a67c142d11606b1c98ec4f9d1e27c31e2c80d277392b00423cf6a2371"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "dc16d79ca571efc45b1bc521308c20fd5575251fbe44915d2401a2dc76cdb00c",
+                                "uncompressed-sha256": "13dd10277cb284e3671ce987346804bea4339e7f1f3a204c847c0a3476c420f5"
                             }
                         }
                     }
@@ -416,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "878a3313e1c18270ecde111802b1d85b822ed678c62297a1097b2003a91261b2",
-                                "uncompressed-sha256": "de589de41479541eb3084a086db2a1e17aa060bcdccab1b820a89ebdb0b08064"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1400f62b101f3b72cd4a4687937fcb62b58831fa2688c711f52bf3557324efc0",
+                                "uncompressed-sha256": "ed8023fc1757a88f3e931c84e58b97958807fa3b00ec0bb44cf87c2059579de3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9ec2904940f1502131f93bf62d331339040bb3a840cb2744940e1f931c9289d4",
-                                "uncompressed-sha256": "a90fac165be7e9fa32e7c9572e63e46e0d20eb0deacfbb286f5aab737cba1ba0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ffcf6b2049b2f1add14802ae600be3e4505f7b7d3588e89215612f334192d547",
+                                "uncompressed-sha256": "4b79c0597d0e6887693c387e26d6aee2921212ef05b6907159559a485c32bc14"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4c2cea7301093bde854a9331df54f2767f369c70d1c325ced2d5579b1551a0a2",
-                                "uncompressed-sha256": "f0e85cdebb1e8ad65bc5f0c124d8653de64fcd89e7f18f4ecf85a7676c207b5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7268049da8681e77b18b44720a12b01c7cef45114ed9ff2169f4bdb0dcbddf68",
+                                "uncompressed-sha256": "4d071b75148f95825c53ab7890968ca3aa9bff6ea1a599da66a87ea6903f48f1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a6efcdd15b3604d127e152f5c418fe86627b379243cb3195680abc8017c2aaa9",
-                                "uncompressed-sha256": "57e2a4a42c889e5304c91307fab02d461ae9647cb59a701647220d544f16c261"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cffe59b6f6ea0c391e28345bb689693fb606e9d23ab50bde13fa70df9915c145",
+                                "uncompressed-sha256": "849486a9efe0f43e9107d8bbb248978599544955d1129a7ae91b43d0bf5e8059"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0c60f29aee6fd3994cfd8aec1398f2450419157c095516f3a2eefa944730addd",
-                                "uncompressed-sha256": "505508dcb9bc61dd8099b69bf17978f2f5e456788944bf03ceb55459a2653dbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "192b26d636c30c3edac71c768c2541689d83160c2ed40526a4fd6b47e0c648ed",
+                                "uncompressed-sha256": "453468e5681404e745ab693c7bed63dfed4d74d38490cc382eb31a70d0dfb672"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "147516d337cf5cfec062bdf4440565170d6c3fb40e1a9152665627ac76c1f3f8",
-                                "uncompressed-sha256": "47c4dd32c4ab600b261c5e60bff222574cf18f9aae1cc608de430839511a8977"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "73c08af002a247bba3a1ec40e784db2bd520cc3fbc00182c394736658bc183a5",
+                                "uncompressed-sha256": "4df84186f9800f5865c9800c49968cf6e6a58a5a9fdb8d3f2ea399e56278a5a7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a95553657d65e074a82a579b3572480ae7d6c9b0f7e33ac5ca2cb6ef6cf2e771",
-                                "uncompressed-sha256": "e81529a15241ab69c167230063158fd1ede782955c3c85500a50c54c51880ef8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4207877a03cf1af8a2c0170a84cb15fa924b936be07648b6b91e286225af6d15",
+                                "uncompressed-sha256": "78dd4194e10243377209948b29136402a33d8a7ae0fe006c72255df1de8f58cc"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7e003646479d5b43f6ef0851f420ae4715954a9d0773bf6feea38a1e5d972e1e",
-                                "uncompressed-sha256": "0f31b2611b87427b73c207c9a2a9c8d53abfef528cc4b614e5f4826d21abc9f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "66917b94da4d542fa9fdf7b0671c22a090ce9dcff091860253a03da3118bc66a",
+                                "uncompressed-sha256": "e48381dffce50e5b1fd020a7c841d43ef6d8ccf02d15baa9b22b3edce26e3613"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "40861d453771e094748a41d52c86f55f637383b9b4ecb9783efb11c59b375393"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c5ea436da7bccf74025694660fd4488da30c31cb6c12296340a15fd2271a444e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "43e33d6125136be7d430770d6ad35d5aa3e0fc45ba458887bb32835a279e68fa",
-                                "uncompressed-sha256": "6be2328c2345615c1ca136b83e37581964d1a4612045ee63f2c5c3a9b09a746b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "44b00329cb619c9b3c864c84120fe7b5d31354d4006a7009fe58359d522d85c0",
+                                "uncompressed-sha256": "fb229232e439ea5acda7e5f15d2b7cdc43354c961a070a698a810942895e5d74"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live.x86_64.iso.sig",
-                                "sha256": "9ba1f05947a34bee54b08cf3411f41964ae98b1f5f5a4c01e4ce6539089b4d3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live.x86_64.iso.sig",
+                                "sha256": "89faf8eccad95f3b15dfad591389d474940883997e2741a4e755e8f0a132685b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-kernel-x86_64.sig",
-                                "sha256": "6da41b956f8aaa6e456e6eae6be356f0c8c5000de6f25c60316ec863e1823bf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-kernel-x86_64.sig",
+                                "sha256": "47f50ceeb55185dfc29728d34fa939be712599bfa222e033e976ded9cb2fa938"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e5cefadb005956e1675c547e926f68527000c18c8b8c4310217d7e3c9b76dbac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e9b56e7d98fa5fcc04b39b17f03d62a5b890d77c7336666780c1b6d383037573"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ced45e534009c1675130914243abd7603b352f59deb61af1877bf189347e8073"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "dc54cce3c5e4003932f7174b1a2cf8484ac9c4fd00f7d67908caf3de1348ccbd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ecdb57caf5a32326e62dc576d75cce31e5b3ae201e4022dd6300cb21daae6474",
-                                "uncompressed-sha256": "c93026b3b9faca045037ff72d3c550f1d5986f6e0b032eec09c1e8e0f40cf36c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "24c79a1e6e51020847d3352cb61b644167657165fa8472c12f79a1d7d84e80b2",
+                                "uncompressed-sha256": "7bca5662878546cdb44cbc067806776dfa352bd1a6abe4b2b4a7bebcecd27e79"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c7aa1e213bae2975e65db718e190e4c88b4a9416c221f2396513c16b04ac0535"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "228430f07cf57a35eef6147ccac6daf1d730f9119d6562211a3bba8725e13b78"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "85788f8a7ee75904b01b3f61cfe69c6a9bcdd3bbb4e1e35a397783542c306744",
-                                "uncompressed-sha256": "b07b84fbe8ebf98079b725a3ef98c464bd89fbdbcd6b5df8d095a5002b5ecfea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b2460c4ff2a47f5a86f36d633aa3655a4e7a379538b92964c58d1579e6ab1fb2",
+                                "uncompressed-sha256": "e6e239e8710a8dd2e4f541aa12ae1149afccc5cbba5a38c7d2a9000a031bba67"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "96b587d1c6cb71306f275395988ec4a5feac7f1a5bd6b74c1f50fb25e5c6aac8",
-                                "uncompressed-sha256": "86af114d870a7bd15dcb5a44c1e8758d0ff32418cab4b92312e9882d5d938ccf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "89cd1b9b236d6b6e1a4b8886810323f6c376f29923fbfb99ec31024919dd3d69",
+                                "uncompressed-sha256": "9df3559c8cebab59ccbccea14cd605850f57c6cc5963a51c61d0ad377e2a53ea"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "2ad09f2412840d368f49e35fe419247fd561d47209ab0380cb42672bb8d6d878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "637f5d39ae4af68f3904a6694e51487fad5d8a5f40d44b49bd2c93c646c842ea"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "a62fc2a50973b08721982a0240192b71256aed8c2906aa399a45f081fbef2ad2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "c6096ff0a77523abc4cda5234f45428ee6fe017f209cd93e667d2b1cef362359"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230625.3.0/x86_64/fedora-coreos-38.20230625.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "78889c3f4cb792a02629b61c6e2afbaf07ab7d962e583b5f3f57bac894d381c2",
-                                "uncompressed-sha256": "97d43e4b35b9e799e58e725fafc25436d834c3547588bf87dbefae58de4db1a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b002c9ac9243437885d6f315357ceed045eaf97e9f391474988d80298c206519",
+                                "uncompressed-sha256": "ca6b9b2e768d111c3c0fdbf3c7296258639314620164c4cdce74b89c1a2b1316"
                             }
                         }
                     }
@@ -656,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0ced9fd4cc692736a"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0fb4cd2dc30a6851e"
                         },
                         "ap-east-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-07e2a9712557e2e65"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-01bf37102b420b701"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-048b7bc42ed92417b"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-04a1cea9fd139756f"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0bb5b8b4f22d417c2"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-014784200c5a4686d"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-027c437721bbf807b"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0ebbce40fc5ec2ddf"
                         },
                         "ap-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-02edabd4aacf124cc"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0b671c13f0b14a4de"
                         },
                         "ap-south-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0ddc19a3b5a95db5c"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-05171d0b71c275eb0"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-04ce6814f20131aa2"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0cb7255b419ab1443"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0c72fb95d1b40f98b"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-078e50c397d493c1f"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0cbe0d2501a313147"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0373826c5aba47d32"
                         },
                         "ca-central-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0c03791278c6a078c"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-011b5c781bd9c55aa"
                         },
                         "eu-central-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-059bb9e317761101a"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-01616b3a6ec881521"
                         },
                         "eu-central-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-01c12597c2b42f9f0"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-02b89e6a364fadf20"
                         },
                         "eu-north-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-09aafd4f74eb15648"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0420cea6c41f92ceb"
                         },
                         "eu-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-018ad7bd7045e63d2"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0c8e151041536e55f"
                         },
                         "eu-south-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-05833185c4cfb6b3d"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-04d63736c5983a8ce"
                         },
                         "eu-west-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0f047c181a4fa1f86"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0ea3c2efdcead938c"
                         },
                         "eu-west-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-0a526d65b798bb9dc"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0eab44b42ccc71871"
                         },
                         "eu-west-3": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-08225414d335978a9"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0b1954fbde2d0caa2"
                         },
                         "me-central-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-05223533929966193"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0dc9992e1352809d5"
                         },
                         "me-south-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-089125938ff3bff82"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-02fa6fe98757840e9"
                         },
                         "sa-east-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-07b01ae7ad6a2ebbf"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-014f012e6fb255e53"
                         },
                         "us-east-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-04bf330fc88571ad6"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-095af7370092f3991"
                         },
                         "us-east-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-07358bdd48a3cb72f"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0112b354811216a88"
                         },
                         "us-west-1": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-05d0a47fc2de0a4af"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-0edb112f562b6e80b"
                         },
                         "us-west-2": {
-                            "release": "38.20230625.3.0",
-                            "image": "ami-09e00edcd5c39ad7f"
+                            "release": "38.20230709.3.0",
+                            "image": "ami-01b32c5ae2e279b6c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230625-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230709-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230625.3.0",
+                    "release": "38.20230709.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ce6a92a122f5f5107da2fcb596098cdd7309d9f20cc4dd6cdc07e5a27c60eb18"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:39a770b2b06e48c3ce4b63d2f399ed282899e5c9dc0e00c4a6ea9e11e260fa49"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-07-11T20:42:13Z",
+        "last-modified": "2023-07-25T18:00:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2fb2d843438aa0254c01bfd9213df225532b88b5449af6ef05d5eb06c5902a56",
-                                "uncompressed-sha256": "11b5bbf15528fc9fc646680e296d825b51c509ae20be86e65eab4992344b7228"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b3894ea19a778240f624610dd706071df451fc27bd50b04332015e962c00172c",
+                                "uncompressed-sha256": "c66e2b31cc846a1125769ebf694870aedecbae4ab8181c129f242d24f7c044ea"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ba24e29c7d5e742f6d3ac3e0177fede3cf4ff89e661a8c8f9f1aaca95c9b0af4",
-                                "uncompressed-sha256": "ef70800223c62fad9e90428deaac3acc5f9d0557191bd7e5814befc0fb46378d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "26ac78792ce896a165519b24bb9675c37ed77323b3d0a0cadf9e266edcc4d7b4",
+                                "uncompressed-sha256": "a77b5e7a2fae2194c7b12c360e288efd4bcbc1cd4443437ff3be09e82f3f9f67"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1088a36fd906751e9b8ce899fbee9c42d1b33465545517b4c104ea734b44c0b6",
-                                "uncompressed-sha256": "570e250334c8a63f5a286e5d2763c84eefe52723cda40df7fe1829314ddceb62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "8294db513d7fdb357b05baa2d228636eeb35a8ae815e765b2ed5ca5c86af3f81",
+                                "uncompressed-sha256": "ca8cf6c54771cd9d39f51417a6ffc3a63d3559fa342ed0375e7f0edb4225a0fe"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "9a3e0355cf6e360ff729f5c8f37f78ef7d061b2914e805ab8d4b86f33aa0acbe",
-                                "uncompressed-sha256": "c5a8576990391a6c9c4bd67c5905ff0ec7084b285deedbe2c10e62124eb5f714"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "033ffcb74d5873815e1a1acfeee3df5f7123e59788eb8cbd107081ffb28ba76f",
+                                "uncompressed-sha256": "d961278c2658818345b7633868ee0ff718d85c9628656aeabd77b66a574dd71f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live.aarch64.iso.sig",
-                                "sha256": "d0e1a026e747d489dad8e60b06b124b7f91f00f003e0a5e2eda89648cc776505"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live.aarch64.iso.sig",
+                                "sha256": "c07b77f09384cc4f16d06dfe0e10243d0b6b93c2423b8baf072df5c290dd21fe"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-kernel-aarch64.sig",
-                                "sha256": "c7fbb56fc10168a448f0ee5eb04cab81a23d31957ce9eed9bd4a1c987c61106a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-kernel-aarch64.sig",
+                                "sha256": "94784d5835a4cd49de420d4a04368cfe9433eec5a2da488481261457a1dce000"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ff8cfb9e44568298d243f40a98427faf30078896780210aa99e242fd182c9d8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "6fea0908a803c831f411708614effdd913550a06095109e9307c06820a9b5724"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "40766fdab99f41597c0d614b9cc6489c3412b452b19f980a0e468ce3d3521656"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "383b43a72e49989614d5cab88b3bfdb547d27f24add7b5d64b8f3fa3285df307"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7cb6aa0957df32ca49c524f9a156314db3a4d7b233a94e718c620bca19136ab8",
-                                "uncompressed-sha256": "f5da78927082ec7eb897b735c9a7fc6be9b53094e712fd0e75b00f8dd8cc1061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "45d0a12070736afb286e111abe89d9986ac52935d1bb83e4d77f132824b381b4",
+                                "uncompressed-sha256": "6e5806bda723beb443b396b277aa819058324b243b5427d6b59271beea92b88b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c03a48f2090739486e42673378e6c935dc9b03fc143ea71745391a11ee155426",
-                                "uncompressed-sha256": "751324bceb878e2b98bf04cdae7fcab4d16f18b3c312dfd091e2cf8ece49c587"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7559cfe5dd22b65b75de606b4ea5347aa8a44953d630f4f0cfd9ae8cc0bad44b",
+                                "uncompressed-sha256": "4a989bfa544d543078ad96c9a26f8d6bb0501f339c3627ca807cb522b06ddadd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/aarch64/fedora-coreos-38.20230709.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e54f863b1532c65873a8e332689939edbc5b324bd6c4eaa63d2e9f1fb2de9bd2",
-                                "uncompressed-sha256": "90511cece6795cc6596117e3512370288f09f7edb5a13bc2e2324d068e72df3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8c101e3e3adb81fac89e643496b81f4dd80f522930baf78569f7e519f74e24c4",
+                                "uncompressed-sha256": "49009973553a91f9a488f4303653128b8a1fb79a46df5e63d6378c931ba4e8dd"
                             }
                         }
                     }
@@ -122,201 +122,201 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-06af10f49c6835b29"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-024ba231a5e3628a8"
                         },
                         "ap-east-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0bcf486b9602e2e14"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0c1084cabc649212a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0892a65944c26936f"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0c18190f7953cf5be"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0e9e1f66cdc176940"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0023f3d450a35f455"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-01de684000c808371"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0badf382250e2000b"
                         },
                         "ap-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-07081840bd56b5bf6"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-069dbd086cf507092"
                         },
                         "ap-south-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0e785d41df6e0edee"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0569a3d6b18d8def7"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-052e3c0da354ca3ab"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-05354b4f089831ee4"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0cc1cd71cd89ace12"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-079de026c1e7189bc"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-06b11d1f3525820e2"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0b21f23d8eb778ecb"
                         },
                         "ca-central-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-09deb4c3d35303401"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0639e40daf284b987"
                         },
                         "eu-central-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0a1b4fc6b0bb1816c"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-098bfcfb9973fce5b"
                         },
                         "eu-central-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0ae9ec6dcef0c5087"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-054f1328cdb7139f4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0da773f666e105a62"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0f0553b95d16d7998"
                         },
                         "eu-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0d4f8024abde08a58"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-05bcff9602029e69d"
                         },
                         "eu-south-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-09866fcc54aac97ed"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0ff4d81b1e626543c"
                         },
                         "eu-west-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0372e5a78ecc389b2"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0dedd858c9c72620b"
                         },
                         "eu-west-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-08e0e457c4208ceb5"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-01cc7e5434020febc"
                         },
                         "eu-west-3": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-06eba7efc5f763640"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-04a8b44f99baa0542"
                         },
                         "me-central-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0166267d9094eb32d"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-072bfce357533d641"
                         },
                         "me-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0d10490cf11360602"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0cc70cdd08312fa64"
                         },
                         "sa-east-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0ea6cbd199d9bdf97"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0380e33009f5cf2c1"
                         },
                         "us-east-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0394c0b298094dbe4"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-034131bfd8580d801"
                         },
                         "us-east-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0ff3a427c553c471e"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0869a4125109d69fe"
                         },
                         "us-west-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-04a26ba53d31cb253"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0d0c3274dfdb515d2"
                         },
                         "us-west-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0db6b075ac341fbea"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-05fb28996c2c60cba"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20230709-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230722-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3697a238981c7e011a8b13f367a52fa3771378859ce2ef8a021ff516aa99c864",
-                                "uncompressed-sha256": "0cad77f4a4719e1d4eb2e8aafad1cc628c07e26b003c2b4cb96f0dcd098bd9c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f1cc837acc9c4a5a75e26a1c1735948a6f8e6938435173a141760bf6a9696dd3",
+                                "uncompressed-sha256": "9d8897cd58f12f5cc5c8dd17e7c55cb4ccd88e046441955d950d3dfcdfe259d0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live.ppc64le.iso.sig",
-                                "sha256": "2a8d80d1665f5e69e77d9bbfb70c6295b0eb37846701db415e373b2a9bb8034c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live.ppc64le.iso.sig",
+                                "sha256": "525f42d28105532559dde32d0fd7b77d2b6ee71cb2f825863316d867eb5982c5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "fe2b37977e0d98b4742d7fabf60d53cc8ad5c32e6d8f5351c067294c47c08aaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-kernel-ppc64le.sig",
+                                "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "4350e5e626eb7e0d19a78019070d6e140c02b1654dc9481ba5f07b033a08bb42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0ea439ccbfb41695456fce6bf701d489ef58516c1ea51a144e2de032387ac23a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "6b5cc34ae8d25622c855c69728d8c8e5a2ddee822c404cba68c055fa4fc25d92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b2dd99ebaf9f78a953c8dbc60b9750ca0a5181282afac77128f80a6726ee3ea8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3ae1c1d4df31bce88e0f7b518f826efac41f0b681efa0226a25cc672325b3610",
-                                "uncompressed-sha256": "b0bf5a5b15c8ab6457781ab952ea760fbf53ea121638b8060487d9836d7960bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6c163c48687908cf0d4775435d3f2d3961dacd5917f4e4e620ac52c64f968df0",
+                                "uncompressed-sha256": "c5e2c00be621699073fc8b7ae22de97380a2a3a1967e16cdf5537fb385ba8602"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e09f34e907146f29d32b9b9d29ad12ff53c1da61cc654f965041a90f8fa27dc3",
-                                "uncompressed-sha256": "d3d03df828a9b673574785c72c61b088965c532243bc95d5a56e9e76a4f9dcf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "553baf172d5b852847c1c227793ee24347632c411089495e234e0b115f43e94a",
+                                "uncompressed-sha256": "bc4a4a4c0146bc1739cf02a299149a8f616a75fb3a9fd9e53097c0f51ee91d38"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "034068c3bb871ba963b517b5819d86ea4dce57348c7cba180fdeb5741cb982e3",
-                                "uncompressed-sha256": "163ee797fcc71d0e824cb72e30960d9e1228d74698568192896e123cf8a090a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "39a08909d4d372faf4812a3438cab4882780c6159a10a599a22e732bf1107e75",
+                                "uncompressed-sha256": "84e674146022e993e9bc1e33d7b08c8c11af546433102156d6dc1ad4397629ff"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/ppc64le/fedora-coreos-38.20230709.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4031fb45227a663cf607583a9cc12561d425573ae27593f06376dd7676976106",
-                                "uncompressed-sha256": "cc7e5465947d12c0bbe36498371986fe82d97d9cc3e0d9c4b95fc667acbf3b28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "3088c765b8dc5761595ed8f6a006f77c8031b10a2092e8c63f8ba75ac3d41ab5",
+                                "uncompressed-sha256": "16ccfc35e060b3bc6fdff6bfa2934363e26bb9bffdf3f3d9ea3a5692c745f58b"
                             }
                         }
                     }
@@ -327,85 +327,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7e9d1abaaa2e2aa364c67ba8dd270c4ce23de1c5da599a6584a76926577cd8cb",
-                                "uncompressed-sha256": "da9245c73e4a4a6d4d334eb6b0e6918eb27e38c08f28ad068bf6256edc57d30f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3203b427f9a442b68d9ade9438f4ad6c76efc291a3cadb7bd4038479ddbfba61",
+                                "uncompressed-sha256": "c78c82c51efdfe84be2e6aea938d416de75627edc7a1c2b448f81c239d1b7fec"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "bc3d4e16185f902ec66a38a94f521a97d3edc71d91eddc4285f19f473fe7f7a3",
-                                "uncompressed-sha256": "33c82ecb2de4562e10c71da40873da7ef8000d4091f25c8b3678297d577a9f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "48505ce18160070c181f1acc00f8fbcf917abae5ed24c8ca9b9c17477fb26d22",
+                                "uncompressed-sha256": "602e8c31729ffdea2612563ed92cdf6cf5fe6203a6e80f07100443bcfec3f6e1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live.s390x.iso.sig",
-                                "sha256": "4e430936dccb185b3ed9abf2902616676fddfde84b6dd973c805eb2e376de4c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live.s390x.iso.sig",
+                                "sha256": "aa3493efca234db497fb336114b38e85fe52ff07dd5fda985b6ded1862d2af19"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-kernel-s390x.sig",
-                                "sha256": "3e6ea6448e01968e71b7604c81cb8fcd9eaa793ead0d7b41b1ee63a992ca7cb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-kernel-s390x.sig",
+                                "sha256": "5ef1cd96c43354f9e87874e24273149d1ee882a86157abf5e09c149e8b2bc60f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "d6627a80a7857e93db0b28571e0baeebf9ac22db1446f9219b0b6918b7749116"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "8468ec5e48bd9974cb8378cf20fb74bee307f42987d10756749e4b56dda68179"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "37b88c91ac1b851418c3ef4b55e4a1065bb78c97a6c4947a734326f04cc0bd18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "ce62603d2fc286fd45253697cf5a08456940f5d096949b51f9a3740c7c5a65ea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "18e73c3f3dae222a3b7a14fee53c92e59d6a2d21b41c1697fb04e8830bf541e0",
-                                "uncompressed-sha256": "ddb084e3ce558b3c7f25712c4f46b5011c6f8d4d51d4d1cdfbdbb7e4d754f62e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "8d51caac46ed885e30b123162a0f2c99fcef160ade46e202e19ea2b327bed7cd",
+                                "uncompressed-sha256": "d748f21c9d73e223a807efb23c9e553bebdd0ea5eca8d0f42d7fcf888d818d31"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "47df1455ba89f27e010a8f82a0c4db52a19c6cf7d06394b3f4e1556c65b7e130",
-                                "uncompressed-sha256": "736ad0911be39de6653a2812e2599cd26cc3e8b7e42a7a72876cdb18180055f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f5e70e2abb534789c93f521079029ffde8007bd3b2fc448ef89bcb5c4a0e210d",
+                                "uncompressed-sha256": "ee82a3f2e9ac8736eefd532d22c24099d57940a113a5549a253e5263ceecd474"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/s390x/fedora-coreos-38.20230709.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9d314ad58c42f249513ebb3c194d875f8a278dc62463e9f77a3bc0c338373dda",
-                                "uncompressed-sha256": "f57ecf85c4f3a58b96072d1c383df2b353d4418e87d8503a469ad4b75f1f1bc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6cba97af36ed4fdf2ac742d8e177167faf8ae83cb2e57f4e052e26b9c89be151",
+                                "uncompressed-sha256": "f750f90eef5024673b63c874e40d8dc7266b8629eb957746c45053195aa2c525"
                             }
                         }
                     }
@@ -416,237 +416,237 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "bdb1507fcdd14eaf6840b4fbf9bb3ba1efadd0d7ffdf88cfde50e8c86493b335",
-                                "uncompressed-sha256": "175cbd22aacc7316b088be0822c2d44af9fbe5203d605e01988531f8ad4892af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4207bd524f728f90dd6269e8e679417090bf3d84d193eb72c0f83c322d3fac2e",
+                                "uncompressed-sha256": "aebd8dc45a3c44f4572712898d133b7df60fc3fb0e9a9e738bdecca0fe321bd4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d0e0ad15192524f6c9ffe02793c7a4e7f3b3894928e6520d2bf393fc4decaca7",
-                                "uncompressed-sha256": "c59dfd7280e65413b776cb98e7035c9f4c2d9bfeaf6d7ce3b4c97840b098e789"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2ccef2ae61312b9b91f35df1a43359a3000866259c44961000fac7c53fb9ac41",
+                                "uncompressed-sha256": "eef6af4cfae2c28477544360f3819334cee3ba82d2f49602ac37efc60d0aa53f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "03a392f987a91c3a7fe85296b0989b807f89d02e96e79f5b6990bbbdb19d769a",
-                                "uncompressed-sha256": "732db2b7e506f6a8edc42313ad84289c3c8aa7bf82d407b80753fa0f9131adc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f4fa72e367e6bbe1080b56ffa7649e421ea87cd4298fb58f89bf2bf2488c5979",
+                                "uncompressed-sha256": "7d22bdab4d0729e41aae28787ee31beffa2457b4781f1a9db91359b5044cc53b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7347728735d256c398560d6b7068239578931db26d0c735cf9f2f5a5dd6c3725",
-                                "uncompressed-sha256": "2d112df55ba5ca6e50f7239f9cefcaf5e454e1cf8488013513fcdc63d7e40365"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "15c5b55c95613bdd89d506a8cc5069788e14722d5dc2e578274b7da969f92618",
+                                "uncompressed-sha256": "b926825de35cdf1aaa79c50bcc8ee901f2a4a2408f11b294817a6ad88633354d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "780bea2a0a935956cb4bb22f2080779434ce79919a91e7bf27fb0f6fecc314e2",
-                                "uncompressed-sha256": "74b2ee58a2d74824d27007368d3aea7870a448a0367bf4d78d413d06099dff26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "615ab7d66a72ab21389ce7690b294a2da96c7986e54e56785b980088befe4e8c",
+                                "uncompressed-sha256": "4959f7af798af69d3f63d0f20fc43fad6bece0e3a20f6d8faa6bdd9d4eb553d3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a68272a03c0bf581e36a64825bcfdf4959a82a6bd06c73bfd56c211e06953760",
-                                "uncompressed-sha256": "994189d3d3fbff1f9793a6243e9b014f3dd493fc840c5c4802d3c7c51fb24b93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "54a1dbae95a0e39eabd89f1577df32a054e538afde97300608c45f5102f4eef6",
+                                "uncompressed-sha256": "6d767c4a56508cf714775dc43af952d09d9ddf61a19a1f7ef691c4d81aa11a26"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2004425fb8a328d79b9e1a4a1be5ad123dc42daa04505b419245d0f6e6f25819",
-                                "uncompressed-sha256": "58e0065c7051e1b9e88f4ace64913faf4d5400e3ab30d7ceb1e304cd46c5e158"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "21bf786423995ab162b50b00fb7852f39a36650fa3dedd786491f4ea8156d85d",
+                                "uncompressed-sha256": "87f1296fb3fb66926e5161ec3a44edeff4c3119002d1d026c4d230d0e133e842"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "afab407672e1d58b420d542941e4b2062f554b9c9b4ddc75c9a93c967f3fb22f",
-                                "uncompressed-sha256": "82ce4fafe2115e4f235116ed2c09fa239f62dfc98f2d636f973833c0c4e7fa0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f71dae4e0a4339845675a2367fc9475d55a61f666f79af555ed62d02f17caf03",
+                                "uncompressed-sha256": "94e32ef2fcaea6cb6f0f2d3dc39bd110751c4e99c200ad043798b6fac5d77454"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "73bf347532b3b2cfb18a7bcee77ec088911d22cb565d04f0a02849bf6b070348"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "06922ba6cf85ff0c5454a88e3d25464d225e9355cc1c200df5a4591ed15caf10"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "611109cdd1c26dbe34752d8f6d5b8b8536eec7ca0b5630c5356e4f0b7102a123",
-                                "uncompressed-sha256": "64cdc38cde4d37339824cbf5046e060f9717c108ddd5d7210133bd601674703c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "12d850de03212b224c5350237d09ea9bad2cca8751a85a78f5cb9c1b8406e5d5",
+                                "uncompressed-sha256": "d54e3514a2e721b81301ddf95f62b1f8616a0aa21c3eceed7c6f605c51efe04e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live.x86_64.iso.sig",
-                                "sha256": "898851c3119590925bdc6e9b41ed6b5a5878c9f78cf57846cb0f0dcebc9b384b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live.x86_64.iso.sig",
+                                "sha256": "913e5176117bcdd06deb5866cad22b469695e972767d28e0ace247dccac38062"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-kernel-x86_64.sig",
-                                "sha256": "47f50ceeb55185dfc29728d34fa939be712599bfa222e033e976ded9cb2fa938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-kernel-x86_64.sig",
+                                "sha256": "88465710467ae0d8e2b6f4c81fbac5d00f7afb2398c130dbd483431e7b6998ce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "2589fe21e29827593c223f6bb294e963ba253789431a6985e8c080bd9c74016e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "cec9a48d95c0c03e8b399f18cda4a9f9a2c795fa56a13a81e5fbfbecac27885b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6f931f22f169b07136cd9cd46aa7b753e478e2765f97ab837a0371f5b9052e65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "702e86c37c6ffae3b2a63cc7aca54edd40915a2c1ec1d66fbfbb92b979c8b979"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1c9e0a039d69130e98ba146f7ee2669b50319dffd50ea6130be685d4440651de",
-                                "uncompressed-sha256": "fbcdcbbdd785c94f69601b3d87d8e771f90c7c9c768fc48079ce57d33932c002"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "d2e1f34ad9b733c764c83f599e206981d297b0889a6a80e36e16b4690109746d",
+                                "uncompressed-sha256": "9b54e4c4e51753fd06c3b0052d843337ff81b9015f6a72add73cb4c27bb20487"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9c54aec6636ee690450ba38a7070c9eb7a0df9753c22f5d9caf5b46eebf69ef5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a64f5719f58805affbef1b4fbe2016a83403888fa79151341fb35a2ea755b2a7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9dabcd47b035201ef13ff79252f805598dad4f4c77ad0447aac60050deccf05e",
-                                "uncompressed-sha256": "4064e2b8e474847de3e18cfb460f2b6b9719c840993e9b27d7bed5ce2f4ffb17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "884124087b7cd1adaa2ac6b39893ae1ae20202076038fc4debcd45cbb0563ff7",
+                                "uncompressed-sha256": "ba44f0d873f72feb1031a106ddde54b5190d1f82f6c1423b6c2de7b13b249844"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e425e5b60c52415068797460f2ee456b1eb4cc209a1e0e0b3cda453667873a89",
-                                "uncompressed-sha256": "cac94a7cf00d903e060a3cb964cbf8eec06620a126f63f0017b26f35717179de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e64b55d5c98827d35f35b4fe0703bb6abcf8489afd1eaa811abf4c9c67adeba0",
+                                "uncompressed-sha256": "b5a13a281312c9cdb4339ffcb8bec1d32c0470031e7c46d55cc59052739c4ed4"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "6e4b36fa698d052e431fb0b412b7bd561569f9b95740d6dbf168bde6c68c6b68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "4d0a4a10b6d8aab854fea4f856e3958b3a5f2c68bf454d97d2dba018339acb4f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "8eefd3964b09c10fac883de7f8d3aefbe801be23c370f6a33432d4b4e4f2b223"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "4e6c24ed11dce5dea0d7fa94c07e88ff5725175b5b4494e4429bad098e99921d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230709.2.0/x86_64/fedora-coreos-38.20230709.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "78421b4b79d3a56b0aa2676790f78b55f5d46ae441bd0e3eee5b6869735cac97",
-                                "uncompressed-sha256": "3737e731ea8d447e98eb813576a0d224d72aafe1b724a5f232b9384e6550cdb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "11d66961b719d8b0e1327f69fc5d5b51e0e598576db45ed6c6c40fda4978618b",
+                                "uncompressed-sha256": "24178407cd96fe025c34276ba066de4021f3aea3ceca46d546d4335ebde8ab3a"
                             }
                         }
                     }
@@ -656,121 +656,121 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-08939c3c317159b24"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0f965a3d684a7ebbc"
                         },
                         "ap-east-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0b057a5366e602692"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-088e01d7db50eb053"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-00d681546a59ef4ef"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0306506645dfa5a9d"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-044040e3f17c21a2c"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-03c7aa1f8e1c6873a"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-05c2cd6c272a46882"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0b2ac8c4261ea5199"
                         },
                         "ap-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-027469d05af0f50f4"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-07bbe51e21b7cff62"
                         },
                         "ap-south-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-07254bea6448f68a6"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-017e684d7ad308e77"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-04b0c6c434915e2d2"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0d52c54539f710a0b"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0fed346a5de701eb2"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0980cc959f49748d2"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-07efc9b5c25768777"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0dafa98e2f3759623"
                         },
                         "ca-central-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0caa178cdecf3b52b"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0d776c68cfd38926d"
                         },
                         "eu-central-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0daea999aefd3c1c1"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-088b01eecfa333233"
                         },
                         "eu-central-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-045d92a7e7adabbb2"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0fbd95112ea742f17"
                         },
                         "eu-north-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0475597aec418cc84"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-00529f32d3ef66482"
                         },
                         "eu-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0cc35cc5a5f360141"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0b7c36e1975fb426d"
                         },
                         "eu-south-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0d959ceb19fc13873"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0ffbd5117a687d311"
                         },
                         "eu-west-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-05a4cee94085be36e"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0db0bafcd86144436"
                         },
                         "eu-west-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-08eaf44470690aabd"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0d33839fb71d78552"
                         },
                         "eu-west-3": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-06b701fdd982cfba1"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0c651fa14ccfaa0d5"
                         },
                         "me-central-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-08aed2bcb9a38be43"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-05ba621cbbd279bd1"
                         },
                         "me-south-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0778ceb6d9df2d212"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-025609ab020b62382"
                         },
                         "sa-east-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-028491997a9826f2c"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-08b803f7984417fe8"
                         },
                         "us-east-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0ebd689498ee36f75"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0ef6322df39b7f11e"
                         },
                         "us-east-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-03b575b8501da47df"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0c3f71dedf3779651"
                         },
                         "us-west-1": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0c2e69c261af78ebd"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-0ea29c0f8085a0038"
                         },
                         "us-west-2": {
-                            "release": "38.20230709.2.0",
-                            "image": "ami-0f5ddb53b71a6039e"
+                            "release": "38.20230722.2.1",
+                            "image": "ami-000812e56ba909f6d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230709-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230722-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230709.2.0",
+                    "release": "38.20230722.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:91786b35b1c200123ce594c26572d5e90305b4166fbb43feb773586ae606aa8d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dcc5949e9dad309afe614cd7b015822fe055b8433e4b93e728a9c070f85d89bc"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-07-11T20:42:14Z"
+    "last-modified": "2023-07-25T18:00:05Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230625.1.0",
+      "version": "38.20230709.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230709.1.1",
+      "version": "38.20230722.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1689170400,
+          "start_epoch": 1690380000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-07-11T20:42:12Z"
+    "last-modified": "2023-07-25T18:00:03Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230609.3.0",
+      "version": "38.20230625.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230625.3.0",
+      "version": "38.20230709.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1689170400,
+          "start_epoch": 1690380000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-07-11T20:42:13Z"
+    "last-modified": "2023-07-25T18:00:04Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230625.2.0",
+      "version": "38.20230709.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230709.2.0",
+      "version": "38.20230722.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1689170400,
+          "start_epoch": 1690380000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).