### PR TITLE
Roll out stable 38.20230722.3.0, testing 38.20230806.2.0, next 38.20230806.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-07-25T18:00:05Z",
+        "last-modified": "2023-08-08T18:34:24Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ab7e267998451213b01da83143bc43dcf348041c75dea7157a1054134788bec3",
-                                "uncompressed-sha256": "86e5b587eb45340c3caf80e64125fdaa00163af8a0a1b9b40372e67d80261dce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "670771af2cd1110726321299d753c9a1f6fa70f4e141da96c5a874c4d9c919ed",
+                                "uncompressed-sha256": "73855ddf7f806df1035386c3605162eae9326d949817584731545582a74e889c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "6c639358942f26e9faab13ecb8f5567a5c0748996bbe0397e8104cc94383cd34",
-                                "uncompressed-sha256": "fda82601ac1df6f07876aab3c909de3dbf470bd530e64c1af74bde957c80d3e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "87fb63e120cf10e9e3cea240a2ab44abeab997025d12a8d86ef7a3c03a958628",
+                                "uncompressed-sha256": "5e8adef5e5222b04409f7cd1010b906aec9c44d78b8c72c8a5dfde951751ea40"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "c2a9aef77b88de4dfb65b5b413fc7017a641e476e4785fd179c4e827520b7a2f",
-                                "uncompressed-sha256": "fb24ae1ae1d17e99352f550c62b6d3ba098e49aa1ddca6c9ea1f5c15dee902e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "7e1db99e642c0172c0b48b1a2e6d9dce878542cc6d1d8a8c70e76f4761e6ebe9",
+                                "uncompressed-sha256": "44db1de66c6915408caeb6c4075adacd4a9292d46bd350d9ebd1f2a2a24a186f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f0af2c7a3f4ca7359368f09e17c014614144e88c526835643951df7d7c4c95cb",
-                                "uncompressed-sha256": "fb3d6c1abf271f94defa0e8a4e9f641cca805f98dd06dc82305e2f7a18857317"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f5c0b281cfce92b1ceeaf3bbda66f2897d5d860a4feef4ff429d7f13b62ecfda",
+                                "uncompressed-sha256": "94e52f59a46da8fb279e62641aa685919b974c3d275325374faacb6bcd6d0993"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live.aarch64.iso.sig",
-                                "sha256": "f4d96bb01f7ea00e97f964877fabc0d82905b34c09731c36514292ce1234b808"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live.aarch64.iso.sig",
+                                "sha256": "955e0ae030de782c09be2654bddb4fd6764cd3ef9488362c4e82f93445628e00"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-kernel-aarch64.sig",
-                                "sha256": "94784d5835a4cd49de420d4a04368cfe9433eec5a2da488481261457a1dce000"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-kernel-aarch64.sig",
+                                "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "90d074f10ca2c1417041895ceb745b9614beafb9ac9626bf68113a2a02a174ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e9b3d9c8fb6c31a7611b71c107de7a2e74ac8806b516cdab28077fd8854d2b6c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f1689028b4acc28cb93eb502b437da66c4553b4449377c58e10ea940e666f967"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "fa5fb5f8b6db2edafa95507e50c5192f16477b39bf4187971d3377e9407b499d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2fa2547ce00ab8f455dbd1c1ea6f4926dab5fa4268b3711e844ac94f5a332a56",
-                                "uncompressed-sha256": "81a4e8fecc84fb5576afbc6b8a67dadcc4e0240a9436619eca599c92969e78eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "23b4a94bf16db0420e551eb4ef616fefcba1a0014d4ab8e8ada3c42b4f25f72e",
+                                "uncompressed-sha256": "e743cba0049a08c1b8e14d5b1418eea29e12da1c03676e33ac2ec2d3128218de"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c7625d73266b00ca2fa0c2e1db2ea464f0a68a77372d10b53d938a282d137262",
-                                "uncompressed-sha256": "5ea4d8d70e2522dbf16579d742e590537c9a5f47f99d805292d4cbb9a025a822"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8c21867deea404ce95978144ec1082252c2f4cf19484d8884da6cbdcbf173e1e",
+                                "uncompressed-sha256": "420ec470e851bb5fff1e81bfc0b74cc6ba914f7e543d9751d352554ee13852c4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/aarch64/fedora-coreos-38.20230722.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f365bb9f25972ae65d05e5e8de73e4abb5f972161c9aaf570bf83e48de2c25ec",
-                                "uncompressed-sha256": "eb085ce1b1278474ff2f3ebbd8b5ded9ddd5c68b42d8e2b002808eea4e25325e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "091aac855e55f61a65582cff9b3b131f98a0ecc030b4cbe26712299eba32dc5e",
+                                "uncompressed-sha256": "c0efa7cdc17e42c67e84e560d81909079bf3dd71916b87a1940029d008dffab1"
                             }
                         }
                     }
@@ -122,201 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0a80ce8c8190c47f6"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0bc9b74193ebf3d14"
                         },
                         "ap-east-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0adbd833bbea29ad5"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-015142c2f5e9b4438"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0404c1e86f5ce44fe"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-028ef8ebcefd82373"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-05ec727e85165a833"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0fb9d6aa6860d83b7"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0ed025f291e9ef0a9"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0dab6c32621294fa6"
                         },
                         "ap-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-007204aad18a7d1ff"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0971c98bbf714a935"
                         },
                         "ap-south-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-02c2c451572d3ab4e"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-084d66c2490bc49b0"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0035785afedb3f4c5"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-029011e3267ce4327"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-06b1e2e726175ce24"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0837c3cbab9b4a568"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0259c9220fe727fc4"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0b2c8245df48d678a"
+                        },
+                        "ap-southeast-4": {
+                            "release": "38.20230806.1.0",
+                            "image": "ami-09e6059c11396e76a"
                         },
                         "ca-central-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-08af8b9c13e7a4b16"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0ed915a79b79566e8"
                         },
                         "eu-central-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-02d293f43b3c57bed"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0810b9ca59a250a1f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-076e7254c98b356e4"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0dd644a9525342185"
                         },
                         "eu-north-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0c425e599dac35cf7"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-047fad2cfc50492f8"
                         },
                         "eu-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-007ddf0a17cf28866"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-057e138a752b4a30d"
                         },
                         "eu-south-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-00dafc336b3ab76c5"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0dbe24f3201b0d646"
                         },
                         "eu-west-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-013dc23bc5189a98e"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0b8bc978368f1cc54"
                         },
                         "eu-west-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0cba69f4a20c295a0"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-03ea2041cdbaafa23"
                         },
                         "eu-west-3": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0690a3b3e0b196864"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0f03af4e993ec519e"
+                        },
+                        "il-central-1": {
+                            "release": "38.20230806.1.0",
+                            "image": "ami-057f6ba162325efba"
                         },
                         "me-central-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0ce1b1e6aabff6a91"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0b69e9acf6f8ffd14"
                         },
                         "me-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-06cef37bd29441f5c"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0291a3d0672ab33e4"
                         },
                         "sa-east-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-055b6d91f10e46210"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0f1702a4392837a4c"
                         },
                         "us-east-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0dbdc5b0825543a72"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0b7db3d4785394a85"
                         },
                         "us-east-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0c98d7e14ab768ad6"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-02a36010819ce7f6d"
                         },
                         "us-west-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0b4577fc26dfa0a41"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-08f1830b4ad0d01a7"
                         },
                         "us-west-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0b7a4b195d6170318"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0b98ee819a3ec7662"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-38-20230722-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230806-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f53b29a4a6386187e2945e40a326894c2949f1d7cfe1c9393ab910ff6eef319a",
-                                "uncompressed-sha256": "6efc18fc3f813b811093fa105384f7f2621f8b0d23446047303443aaaf8594d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3ef39ffedb6dd9afe06e326cba861384762c8696ec09b6a55a6e8f25477db8c3",
+                                "uncompressed-sha256": "d3778daf654612a00bcab478935f81034759eca1104e0f7db7ddbc1be7f65044"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live.ppc64le.iso.sig",
-                                "sha256": "1a9bc89c6af8ac39c4e7aa503c69f78108ccc5bc09e063efbfa58c8c30ab414d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live.ppc64le.iso.sig",
+                                "sha256": "20fd0c555e3888c465cfa1e6c8789021bdc9139c3762f5b8dc59f6f1b812c77a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-kernel-ppc64le.sig",
                                 "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f6c216fafa87db76197ee5ed42c2d28198bb0c1d8e0a02f281df4e11d5902122"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9b995298aab00fdf9d5389747bd9ec7821b3ae6850aeda7e46dab506437bc1b6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "6ba6e6118c47526fdf4a80b9177480947ad1b988f54eeb29eb6007edcf8abcb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "071a899a73f18ddd8abc3957429ad10ff10eb3a50a0be1f5bb0586b4dd6d8e78"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f4475e8a6a394c2b8b1711f2350b065c26fb1e0df65b9c304926bb60777ca1d8",
-                                "uncompressed-sha256": "06088ff50ed6ddb05a5b88a6ed9f79287a1eeea1efccfb384aed96f4d3814b28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "34f3ea225756342a49006462121c6503218fe9f0157660f10c3093c056a4c8cc",
+                                "uncompressed-sha256": "22d542c79aa5d80d5f686cac9c1071d18ba863e35e61bf2c394796854865dae4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "bccf5533bae5c2ec94b42bf995a772add3edf20a3450d76fb9d8fe8a18bf2536",
-                                "uncompressed-sha256": "f7ed190daca7976a19022d07da49afca2637aca21f83bc1f77d8ebd310c7f968"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "fbb6dff64fde317e8672482109d5b364ca098f6401a770a0cba9fb04dc27bb0d",
+                                "uncompressed-sha256": "fa85b62d3931658acfa32e91d3c9b3a18cfb605bcebb6cd1106402431161e7b5"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f06092e03bd2ba2ee10a21935bdbbfc67715b46415a1aab07cbb2acb317e6789",
-                                "uncompressed-sha256": "8f594f5a065c70c523f01cd7e89e12f6d6151a71eab4efb82b29ba5813736f1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ae0c69e25dd31c90ab786901ecc3c46cd3fc9140192183c5e69c72db3bc90913",
+                                "uncompressed-sha256": "6984d7c1146e225fb17672c07dd972d297440852fef02b675c23a01c0c7c5714"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/ppc64le/fedora-coreos-38.20230722.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "72ec0805d019e8654c32cfa2c69fc98ab1192c85e274d37414d725d3ba59ad7f",
-                                "uncompressed-sha256": "5fb45550dfb7e5b4fc4dd96ae18d62818e82801a215ece7333bd4416c7a4197a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bd116516619f011589cb4fe130a39a7dd53b6cedbc9f5ff0a97f05d0a27ae9ca",
+                                "uncompressed-sha256": "3359d92468f670576c68460ea8ade34d7a1eb0b47776f86b65911152091652d9"
                             }
                         }
                     }
@@ -327,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7fd2fe4b2fe1bc2e4696c752bb9eb026dc044d046a880856a533748b7ace1907",
-                                "uncompressed-sha256": "8c5182a8da3179a4f108513cfcea7c46309e9b21dabab60230411bcf62fd7686"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "2191436160f0d42ad460790c8189d6ce77871f78611f61da45ab0bc29e2c5ced",
+                                "uncompressed-sha256": "9af2816e24ca047fc972f5b80c3e765d231eb90421d143a158ffbdf9e45d11b4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "376d62826fdc885ce32e719f3da2b91514273021b649611a2886b87b00e7cbb7",
-                                "uncompressed-sha256": "121991221828c43e294d22434ba5f2c002e5591dd4b3ea7736ffac34665b7aa4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "30705ad4a55d15e44a1922edd85bef53acbd149439b785f29bd5886011244bfd",
+                                "uncompressed-sha256": "b54837c58294d681d902bf0907d7590232f491cb9ebe5a2e6f14493f7c51629f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live.s390x.iso.sig",
-                                "sha256": "b06bc7dad908a971c295072687c89b0a909f1b649b2ef62d403fece3b08f49de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live.s390x.iso.sig",
+                                "sha256": "c61b14a5aea3c71037dfb755a8aa09240307804d5eae9bc8c13093921fe8343a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-kernel-s390x.sig",
-                                "sha256": "5ef1cd96c43354f9e87874e24273149d1ee882a86157abf5e09c149e8b2bc60f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-kernel-s390x.sig",
+                                "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "8d8782e5fa7d4a3b60f3f93a5369b992d50df170fe5c9108bbe5decba3ac688e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c1f1c4c8b03898529ab1f182ebc8acaa41ac19ce57684de35ea6c7ad0825cd9d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6e4d29508d554996c5b81c8a1a9738a54f05c08af5fd42f1a088a6035d1d6d45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "1a7541b90d0b30a190cc37f5a39f1dbacf666c8502c844e46dd8a09bf0a3baeb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "ad9574c2b532723599f2c14782fbd1af1e5fec495b36d482863df461a206dbe2",
-                                "uncompressed-sha256": "1e8519a0feb72b4099a5dfe735b649acd0ed25cd0e94ffbc2af16d53939345e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "330c305d9b6c2e985bb53b20a435fcae2b06eb73bd9635b946039abe805aa98e",
+                                "uncompressed-sha256": "d05e96ead8b24cab64e9d519696740323739e8e92d1b1e280c65097f1ab65c17"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a0b79d2c01fe68825fcdcad420f818f236d6fff71559b1c1010f2ab7ae98f8b4",
-                                "uncompressed-sha256": "9b0037ad9b9125e5b742b86a55369d7716d40a4d133fab79770694631627aaac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "754cea8801ae3bb91290036f0f39f5d88bf94619de39e56ea89a7ec4e2bb772a",
+                                "uncompressed-sha256": "9e4d07a60a0e979375c9de068dbe71e8cf05e405c692a21300c0c259a35ec009"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/s390x/fedora-coreos-38.20230722.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "94d9f0942c1eb93f79d8e5d1afbddda83031212f7ab9ddf174b4c5419bf78c7c",
-                                "uncompressed-sha256": "63afa360f3e287ecee00fe6e3ddf31b19b642cf57c4bf4020a875334b4844880"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d90859aad0107c06626da5b6a7cab83f3fbcfc2e49b3126589620efecc9ab9a0",
+                                "uncompressed-sha256": "28422723a4b14cb4d74dc52a7fd6bef91f29a981ce228fdb0d98c6a07e41167a"
                             }
                         }
                     }
@@ -416,237 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f2b74cc359ab19b52fa81e546619259fa1ea388df53eabf108242b09aab53930",
-                                "uncompressed-sha256": "3abe4eeec572ed9a293674bce46cc773a228d3229a328dabca48fbe6dced37e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1f229785ca17b2e613c5532fb83ec795f049edc743b6771434b7b0df020bf4ff",
+                                "uncompressed-sha256": "ef3e419788254127e02887227235f4289888447c99993f20a4598b4bc25bd13a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "831ae888ab839f552d8e98877ad12ddbac084f535b100f387c52ed04168981bb",
-                                "uncompressed-sha256": "2f4bf160ee387dc56505391531c071f13be9fe73fd7099d076776a66f2969f2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cf50a05735e3fc59284483e88ef65ea879bfaa7405d29446810b1b2373a1e338",
+                                "uncompressed-sha256": "e1efa34d84f4dd0bc16e87aaef0645cd0bc04c50d35202cacb1344ff99162a9b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8217c1dd2b7cba55288fdf4ee1af465efc551af20e2305742972acc03b1a4474",
-                                "uncompressed-sha256": "be46f36e17ec7f39aad6c1bb4d134c7d62e69c06c0b65310ba0eff564baaa686"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b4b74867c7470125919ae20af5042ce38fa250c198f2b0d4ad4eeeb40df9d52b",
+                                "uncompressed-sha256": "f7ee2a6a1379c2abb9aa82d976cecf4458bb7a0ffd661b83cab68f6e3580eaea"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f2cf6fe6d3ba447a0056f51269908eeea1bcd132973a33d059764469ab4def45",
-                                "uncompressed-sha256": "631c2822bc594cafda35eef086924c1cf8c2304456efcf9c6d9cefd698288f8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c1769776d7fe6247a2d54749acddd31c4f5f08a7e49a3ad2b9d71ede142ee1cf",
+                                "uncompressed-sha256": "55df55b2147b48fdd34b27f5a486ffe454475c8eafc00f564d2ba55929d5d1f3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2b8afe722b60dc28cb5bb6ed01d13a3578e97c93db3d0debe2b207c2c968aff7",
-                                "uncompressed-sha256": "2e54d8ce101394f0fe7a886802f44f151cb48732d8a2a9f0b320d58577601cdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3e59c88b2d98fc862921135f21e50698574a4d1b130bbf264fbc804102e52d36",
+                                "uncompressed-sha256": "ba18ea8ab7f31e4de316d6dee2f2365c2c946e4b5095250ede9012d195584e5a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a093a6a3550b5375a75d204a74f1edb312bf3caf78eefee00f1ef445ec82d650",
-                                "uncompressed-sha256": "629a9304cb887c8da1fb70eeafe3e44823fc143d63e5fb58b6d41ac71722144a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2c86a643fe635ea9253cddb4b2bae7b101b634c8e2d274fb4a056a2a4d446040",
+                                "uncompressed-sha256": "a2f830eb2ea13a82b0d4f70bd8ed600d8cabc037c48fe4c81e48e643351d62ff"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "53a976deb2851759a99b8ffb2c672ecc347ab9033f1340b225c00840aaf90397",
-                                "uncompressed-sha256": "cc692447fa571122b4af435ba7c498591b790bbead6ccb1c9b3c9c6864bf57b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8d13a3c776235b4d21c953196fd5c10f9e61bfe36f5f85b3c598e2b30f6807c6",
+                                "uncompressed-sha256": "934536027b0fbae077157cce1a4d54e31d61c2212ad14e55e5f68fbb24fea853"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "38.20230806.1.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "639e6b96b8d458cc6fc9bbb705db125a2c32d0cacde82db30955901750c52dd9",
+                                "uncompressed-sha256": "d62e62abefc331c622ff8a4c6419877671577505de0adfbf8ab9516bf0da2eca"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4390c67d013e8f33b20b22b4f547b426afe161a5f0123ae2dd2cd7c46f3e651d",
-                                "uncompressed-sha256": "f08103b7c4c7f6315609d40ecdf0d01bb4878b1047d68b1a4ae2c265fa45f29b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9267bcb2d3f1b56316d5b2ad85a3f6dc7cdf2749dfa26f9832466e084d036512",
+                                "uncompressed-sha256": "0b4c38186db4a6db681377eeef6065b83b66c31ff9949a1c9afefa706549c4c5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a5405941dd2541fa4bc29df0c2d3647cc80c8c24344194b9e7c1c496f95977fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5f55ec20058a75ba2b2e6d928f256cdf24fb8a0ebd3790100bbb7aa07e80d305"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4c0ebb82671b8c58c3b496381a005a1cab868d98da987e7f0a884c4d23444c12",
-                                "uncompressed-sha256": "6cee5e584a5ae0c3354844816c68cebe331d89c8f4a7806df7f567b8af9c76de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4d175aa88208a738903ec92accf036a21c166ac680d880727ff111cc493d0737",
+                                "uncompressed-sha256": "321329ae44d94c414a1b5a3b53ed29fd20eb81c8bb541afd7dd833f80cd2ed05"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live.x86_64.iso.sig",
-                                "sha256": "2681c314541adc6e0f65a7276b8a77e0021ba0004cb260fef315d926c70e9c3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live.x86_64.iso.sig",
+                                "sha256": "bc25b9aac6ce1af7828fe1e7d51430d76c43060838ab1edd9b8bad770d55c9ea"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-kernel-x86_64.sig",
-                                "sha256": "88465710467ae0d8e2b6f4c81fbac5d00f7afb2398c130dbd483431e7b6998ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-kernel-x86_64.sig",
+                                "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e65e938077110b5d54eab570158df1c2df9096344d3a0d843ebc5f58f45f70a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3cbf19abd54723c4c50c589303eb290b3a98ff46c5b68331f3113c1729a90319"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e24f96878cd7d4784bc09111a47935f1e0c622988bb17873025aa0b3b7f7b276"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "92f35fe8065164ffbedd82b35667147c7ea6464a7645a85e4a83fa8e39c802e5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "daf97f5bf56eb54c4accc89e02c424e331e18321cb2e559fd85316445421de0b",
-                                "uncompressed-sha256": "c73a51bff994afe75dd25505627b211c0e52ba1778fbbf1a65c42bd84d5ddc73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "023dea0b6582b5f5cb1217a7903af43a2c425930490fbab050ff05983b2c378a",
+                                "uncompressed-sha256": "a4cc0c217c81353a7a88ae4768315766ce7e5c754df4faea70332b75605a869c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "61144f6746bb5f483502bfa8d355730e2db237086bde0d93cce6e68a9517e4b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3fe1b7ef1a7177b8b45bbf7a4eae7c6515d7d907792a807d2e56d23128a8b693"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5b29ba694c577b7e804a60eb2f5fe41ecdcbb5442f879311b7c58ce5899a93ea",
-                                "uncompressed-sha256": "82fec04ee8d67d5712ee6c8be1e4691ca57cbb76c9e4e5c53ead632c49eefc39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f4a286517985c1565921b25b61319c356b6110e15242eaff2bbe4322c426e553",
+                                "uncompressed-sha256": "0fcbe77d88555e4fb62972326dfec97e0c419f7c44dbf4f32c22d10d143a8d56"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "61b0ddeeae75a329021a3169cf1f9048b43bb953e2696b266840453d39bb36a9",
-                                "uncompressed-sha256": "5a9634f02addfec848e77d7a03d6b8f27f1e6bd7ad3011e39171ed0a8f974c82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "26517edd4bfc3a48a8fb6e09c63eda47c28880729fa968f56d50441ab959cfa1",
+                                "uncompressed-sha256": "8a5e9f03158ca11fd867d4100058e6299be2d66bcb4ba500e729b8d6a2ee4f77"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7bd43e575bec40c696e1c6210b814d15760347be59b2b41c116e05f728208f65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "21eb57f0ae9535d2ed5b28e6e8955886d4a1e5209f118c6142f3807025d971c4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "24556a87e5ffe9057c55a26631d81bc4d16068651484d8419f0dc85b4d60ea48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "c4808f2c08c0fb3dc5c72801e8927f2e01fa0ea224f3ddddb4240c741fc63944"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230722.1.0/x86_64/fedora-coreos-38.20230722.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a959966af59692ab4467d52f05d1870506a2dbcaa643958653e4d04d358c2903",
-                                "uncompressed-sha256": "1397f4007c9742389ffa998698e1a8e7d7d12f1db1bc9f10149410eb1660dbad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0ae015a5ae6b6a5af81c38e85e41827f55f66d76a2b7c2350701e3a4fefdb692",
+                                "uncompressed-sha256": "7c3a12474182ad30702143b8aa785241b044e87de3c5143da9799bf5b20d6a10"
                             }
                         }
                     }
@@ -656,121 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-001631704d495c2a2"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-05db313f68ef1f082"
                         },
                         "ap-east-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-070389b892588b306"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-09584f35920ef0e8c"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0d685ae09f35c2b05"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-08b8a2678ed92a213"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-000e8b6ade2d03e62"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-00f8a282fd453ba3f"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0e1210fbea6ba6234"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-018a80b580d9d325a"
                         },
                         "ap-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0bcb27e3121780eb7"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0cde35417dde5e35e"
                         },
                         "ap-south-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-068d077dec36fd62c"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-076b47a829c84039c"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0071cc9113c5c1006"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-00e39c15baaea64f2"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-043339c098310d0f4"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-043bfaf90fd8b8922"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0fcfb10bc39392428"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-05744d591a62bad91"
+                        },
+                        "ap-southeast-4": {
+                            "release": "38.20230806.1.0",
+                            "image": "ami-062bd18e069f58afa"
                         },
                         "ca-central-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0748eb7c9658e87ad"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-077809e59268024bc"
                         },
                         "eu-central-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0778cb452fe740e2f"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0ae5ce89fe3612a96"
                         },
                         "eu-central-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0e0629a7bf7b767f3"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-02692fe8efb1e543f"
                         },
                         "eu-north-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-040257491fad99acf"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0579d6b858f22be0e"
                         },
                         "eu-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0785a2f691357eab8"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-05ba97dcb8bc7e6c8"
                         },
                         "eu-south-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0d325d8fb2ff99a6e"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0746cb4357fb58303"
                         },
                         "eu-west-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0861e7f651e5c6fbc"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-03469d7b35a350d89"
                         },
                         "eu-west-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0cc44997d12ffb6da"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0e51fdbe212fdaa60"
                         },
                         "eu-west-3": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0b95983da4ed06934"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-034358f860e07dcbe"
+                        },
+                        "il-central-1": {
+                            "release": "38.20230806.1.0",
+                            "image": "ami-08b1f2c83bb74b2fa"
                         },
                         "me-central-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-00a4d8b85668a3f8a"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-09592d3da79570835"
                         },
                         "me-south-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-0d85614da62de6ca3"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-051f9040f4c9cb72e"
                         },
                         "sa-east-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-03f69237d1d26e1e9"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-00a5eea4f1a1237df"
                         },
                         "us-east-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-03fb103854869e89d"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0b98edc76d3f2e764"
                         },
                         "us-east-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-06cda844fdfb24efb"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-04244dc7fa291d02f"
                         },
                         "us-west-1": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-042f284716ed314e2"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0c6e3316ac7e21fe8"
                         },
                         "us-west-2": {
-                            "release": "38.20230722.1.0",
-                            "image": "ami-084aa2f120881f48d"
+                            "release": "38.20230806.1.0",
+                            "image": "ami-0ab39263c700fb3a9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230722-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230806-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230722.1.0",
+                    "release": "38.20230806.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8d189c8f044ca0754d1a41f17c8cdcc0d30451cbbd6808bf1acb7a79d3c402a0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3b94f744a4040762ea95bd929951041d6bf96fa41c83632500ef6dbd3967a6e8"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-07-25T18:00:01Z",
+        "last-modified": "2023-08-08T18:34:22Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f70a82e12944c0c34c763cf14d1a25384017944dc6b00559f816096e2678f01d",
-                                "uncompressed-sha256": "9c7b4f268ccb00e47f0066af4816a3f352311d80dbed4aa4fd0ca7806e0e6e40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "7bd30b0ef43c4e2989d1308ee84f13631b278eb08348d095711fb5ba7b902dff",
+                                "uncompressed-sha256": "f91de678f1001ea47edebd3c941af895b4d0815412890ba758847fcded3ab1b1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a807d837aa03b1a2e1e3f54486d51510602b2e7278b631709f1a08d30ffff426",
-                                "uncompressed-sha256": "a5b6d25148a83d6e3ae15f161b29fe1756a6533b0d43bcd8688b2bac3c9d4be6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "971d07ceef071321b8525a7ca10d9b46a49858236c31e230f641b6d5315e4001",
+                                "uncompressed-sha256": "b4eb87016efe4058b4433c69cf7979e9072416497f9081fec373cc1a19ee8dae"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "524a1d8720933c00f935584925b373f1d4f4866e6cf19099a205f7595b0f9d37",
-                                "uncompressed-sha256": "16c133b6aadec5625f3691afdb9859bd07bbcc1744310190a1d31815e7e8d319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "7665aa78cb3218d8029b6eb3681f148b6605e2b6c6f46e26267c9b782187abc4",
+                                "uncompressed-sha256": "414e8bed4a8b67db9428652dce94feea0474dfa17decb2550ea51c096f06f5b9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0bd733d57afd3daa86efd31e40f3bd2a8f6a5ee198f2dc1f8a0a8d8db6d05cd2",
-                                "uncompressed-sha256": "172690d1ca095b5d981b5e85b41fe863dda11a2896c7f4873e82168a471db38a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "90e8a51f3ebc9d20e5751a639ea58f33746fbfe4de77bd490c08e9d81bad5c61",
+                                "uncompressed-sha256": "32ea5f1f54647f906e8837211d5ab5fc69c1ec29dc1c478c9163feedd2159817"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live.aarch64.iso.sig",
-                                "sha256": "aa94db36cb90219fbbb87e499bc000f7659a4d7f5b4842dcf7d2e050a0a15a34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live.aarch64.iso.sig",
+                                "sha256": "4c22126a71eb29d5b182525e7d755891fd0b1890fcec9fff3226526a28c89936"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-kernel-aarch64.sig",
-                                "sha256": "c7fbb56fc10168a448f0ee5eb04cab81a23d31957ce9eed9bd4a1c987c61106a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-kernel-aarch64.sig",
+                                "sha256": "94784d5835a4cd49de420d4a04368cfe9433eec5a2da488481261457a1dce000"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "f79268706a09d3a1ed619058a8164e9d45a55f31bca31b5bcabc5b701bd51222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "b17207c691f17a140614b8dc656a94c9c4f9a631b2e5685ce8ed2d6162ff9407"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "63ee824e02a07e59ad9d251674ef44d6bd74fbd720045f2cb71f0fa678388195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1d63e00a62463345791722ce53b269bc6376a8623acbae1a7af285787ed55f1a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "b8562adf601e36130653e7c5d05665c1c30863fdf85bad7de8aed896e5288f4d",
-                                "uncompressed-sha256": "ac64a9ee85ffbb2d983bd38b311382b9cd9e662a1cac4c29f9405748f858bb60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9c335b0dfa8e5334b0c7bef1c6623d91316fd5d8cae86bf0d1ce97ee27bb36d3",
+                                "uncompressed-sha256": "878e9e8e9c6cefcdfcc312c0e9dbff399912c25873fe482e1c1accd1e44eb419"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e43846760718e0c896f552c841be4d64c0b2935a365a5b9621ab22eb1b6f31b8",
-                                "uncompressed-sha256": "530378be3c5f65ffeb4709a8e490e537fe38bb131c80d4e7b2d7c8eeef8aef41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9e02954496965266e028d6e46ca21c52cd9092ec63998c7a744e25772937cf7a",
+                                "uncompressed-sha256": "1443db95193ccb06b7b5b82d3a972680550745c981d5acbc9ea0747f2bb2a715"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/aarch64/fedora-coreos-38.20230709.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "68e365668deea18084b3e20f626bd02bd39e43a0cd8d4413c8efbccfb1dcbcce",
-                                "uncompressed-sha256": "1c51a09de01449be24d9e2f9b1273637a3869d72170896ac8cd25b1c43562ac7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "dfde13319519c398214200a32c93104c7cd0c7905e4587a3fcf9f5b781efc178",
+                                "uncompressed-sha256": "d4487cece3565ed72fefc7645f07ee811d45a7cbf55665882c264088e84ea319"
                             }
                         }
                     }
@@ -122,201 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-08de74558d402bde3"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0aacf5cf66314afc7"
                         },
                         "ap-east-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-076b79620ef0701e7"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0348a3cf2b44bc865"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-06b2609277299e74c"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0fe607dbe1e2116c1"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-099b3c9933a4c7d33"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-06eb55c782f3fc2d9"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-07e6d934f35a78d13"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0d629a1dde030ad55"
                         },
                         "ap-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-08cd04015c18ef02e"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0fc480dd2ed8753ac"
                         },
                         "ap-south-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0f06fb5b32eacffc3"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0df322a749f79f1e2"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0731f849be7c62373"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0354b141dc2d47891"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-086b387aba4aefb9d"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0d361b99e54c041d0"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0e94d2ee5c8988eda"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-09b54918100676377"
+                        },
+                        "ap-southeast-4": {
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0f364fecb5f8147d7"
                         },
                         "ca-central-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-03491d8ce6e007bda"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0e145edf837fd72ee"
                         },
                         "eu-central-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-05f130201d8d1ee64"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-00b24ca76ff22efad"
                         },
                         "eu-central-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-073d4e22d8bfc8293"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-04312267c0459d729"
                         },
                         "eu-north-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0148e0c7f0f4ad71e"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-05012a37b76186011"
                         },
                         "eu-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-042a1cdd99768e890"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0e1abdcffff34dcd7"
                         },
                         "eu-south-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-052bc71cf7c2cf1ec"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0fc465034e590a865"
                         },
                         "eu-west-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-02618c8348d0ba274"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-04b4db2e4005d8bfb"
                         },
                         "eu-west-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0c7c7c0f4a5b09dee"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-03830281286810662"
                         },
                         "eu-west-3": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0a13e74703563d2a3"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-055427b16a907c659"
+                        },
+                        "il-central-1": {
+                            "release": "38.20230722.3.0",
+                            "image": "ami-01bf2b49ca8491955"
                         },
                         "me-central-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-009979a94dc1b3e95"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0236b8f26975e5755"
                         },
                         "me-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0b25a899f8d19690d"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0f7befdd31aa63988"
                         },
                         "sa-east-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0aefc6ea94210a2d6"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0092a2b172e425168"
                         },
                         "us-east-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-06f19c97b37fa0edc"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0f27f23abc5e0e595"
                         },
                         "us-east-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0dc1fbdbc3cf897f4"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0d6471d1ada213433"
                         },
                         "us-west-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-08bea38c73809ca16"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-043694869ae789a7a"
                         },
                         "us-west-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0b757b986982648f6"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-063119d4cd8da7a9f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230709-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230722-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "39d1fa1af11a0b2a08cafd7c6b08cdfe96151f4d85910cb7e95514fc3234902a",
-                                "uncompressed-sha256": "f477de16c5db1de17d5fa1478d663487550712d8193134d7f4e0abdc77313b73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8a4e02e3cd1cd3b6a2c2e37b4a3ebdfbdf8c2ae2c93b86dde9b72d65a2be5070",
+                                "uncompressed-sha256": "95501c5c42dc2e0bb779c859dd0daa181cafefe89b1bc4d679df5bbc162c7d97"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live.ppc64le.iso.sig",
-                                "sha256": "2111e499518f539620c11a238c766d95b19ef08bdb83d2e06a89b7bbbda3239a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live.ppc64le.iso.sig",
+                                "sha256": "5bc874479d91520bfb3489cec3113f3c1bcf7bac0070fbd294d6cf3e304c8359"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "fe2b37977e0d98b4742d7fabf60d53cc8ad5c32e6d8f5351c067294c47c08aaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "7fe6d0bb6f0b8af4ba0a705a9f86ce683ca0c8ea7dfe10d0e67d837ab5ed0f52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "4cfaf35f83a8eb4c05dff11bf8eefb9b967a7d532063a3355ba9621f5b1ef06f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a57726efa9d3aaad5eb2fac469e1349f706ba968806140fd9e325b63740af93b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d624c1827708d4a7c8670eafdae9697f54142c77c9c8171cdaf0f317e8824107"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "7c7ef208bf6c2a42331dcdc7d939f79ab401323c58b9d1a7491d64dcbda1919b",
-                                "uncompressed-sha256": "aec1c3323459e092d502bcd9b3946ce8ae7bf0b592fab215fe4864fc789f242f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "81a9ca0b26ef2e07699e4b309773be0bfe4a92404d581695e507ba5157e75e46",
+                                "uncompressed-sha256": "576139b66ebc7b7f6bc8a00ae9b3ce40830f5a5fe1ce6855e1834610ce0937cb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a520e4792ba728a9924e9c8bdec52989d1f677943186c047e0319d6aded64e22",
-                                "uncompressed-sha256": "19432e0d26ca635318c4be1c99bf3d7bfcbb77aa1b40100461643736a73aa8f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "5ca70ea7935e2434f29abec65977ad067486793aac8c8c4b7b0c1339bfa95ead",
+                                "uncompressed-sha256": "51875a7c37974f626423a5ceb7d2b34f565e115b988ee748bba920b5b0159272"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "95b28e5012991684f932bcb0a980d079cccfce8a87d945e0e3a33f164e599599",
-                                "uncompressed-sha256": "18e630931d38db7268c570e38873ea2f926b05733ba9db2858e17a5ab1355adf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5c20fc73aa15b09d0c8e784e2a26854f956f6c824e8b1e63c4bdeeff4d15dcf4",
+                                "uncompressed-sha256": "eabc738551c6ad8b7a9e8cf822e56b3a02924416246ddee71868d9ee2591cb7c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/ppc64le/fedora-coreos-38.20230709.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9244e411ef0dddc0e23d2decdef010178280a9835be48d7d678906911baa8a79",
-                                "uncompressed-sha256": "9ac13429517ec5880ce94a5788fa91e8d0c60371dd16b74acc2ac912d0cf1cbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "81fe8b3ddcc2198721e21fa5b1ec2c4cfdd58287aea379a93559e5551d6896d0",
+                                "uncompressed-sha256": "09f249c1e63bc614cd43a57bff16f68a59f921496be39db52a25b9ce48176ab5"
                             }
                         }
                     }
@@ -327,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d4d73e1b031f79000f5f00ba073614797d81e63f4b236fed357fb97f44846811",
-                                "uncompressed-sha256": "5e3d72be30f9828f5137134a07223f675a6c328f2cbf8a2f6ca1799c5853f8c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "feddc60844b11f3bf1a5d42ec7e598116a5dffd1a248f9d5b350a1584d282b7d",
+                                "uncompressed-sha256": "7b1402b5d9c7c2e52e39132523e952444ce26533e0552ed13168c4b169af50e8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3e8f09c858285806c9915d1e3b233c26d2e582b25b01d57bc3960534c4d6e782",
-                                "uncompressed-sha256": "29d104c299243b35d3ef5963491afd65c88f3514590695b2b0f8dee53c2eabe6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "35901ab557861eb9dd6f664fff393e6cdd9e4ff3e0e51cafb305a0e50d057646",
+                                "uncompressed-sha256": "02d68f449f447ae973b7bba8ac7152c4b311cf1c41ea17a46d74a1961fefe2ee"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live.s390x.iso.sig",
-                                "sha256": "7d09090d2c4ce2a59470024c3fc10c37e8894617e51ceccd9d7276efc99769ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live.s390x.iso.sig",
+                                "sha256": "9bd9cde6f96a9214af4b151afeb546d9099e7f423ab6a3430a2fb6683d42df1f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-kernel-s390x.sig",
-                                "sha256": "3e6ea6448e01968e71b7604c81cb8fcd9eaa793ead0d7b41b1ee63a992ca7cb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-kernel-s390x.sig",
+                                "sha256": "5ef1cd96c43354f9e87874e24273149d1ee882a86157abf5e09c149e8b2bc60f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "2e33da5caaea041a0a71c13c64ce056f8d44f05572a838fa1a422cb0a64ea0d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b3aeb06692140947e02ba87d938c9b398e1598ec43e8b9ddabc230cbc7fbaa01"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "febd8ce841ab9ca169cbcc75a85df2daceadefb67fcc948c93ce40ea331a5db1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b747fe28d5957b2c38e9387b51aaf08fe49b4ca66d06131ded4e13980cdebca8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "9867bf6358181ac33cb1e511c8b38491013534cf5cd8d1ec1095e97c4f7eccff",
-                                "uncompressed-sha256": "204c8afbb008235205d9b88ae5dd68540e6c88f7aded3df543ee4c226841c4a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "037145dd9fad737655dbfdfcd62ce5f290636e37dd4169c10952c3ac2f806f4c",
+                                "uncompressed-sha256": "58406856871becf78609e1e5706a8749749e0bdba8d3545ba8c7fecf5fef3bb0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ad383f54ce61908faf152938a511356b9018e36bd842c4870b7ebe725a6028f5",
-                                "uncompressed-sha256": "fb66eca1d9bf37412c7d80648b884bb361373a4e73995e4a975b300fae297d02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7ae787c0e6f8ec9b20085df318ca16b578b8dae50d883a6a76c541c02502c39d",
+                                "uncompressed-sha256": "d56ad52d603cd09f891c9af75ac6c0e0851d3a21833d4007a29c706ac914a93f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/s390x/fedora-coreos-38.20230709.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "dc16d79ca571efc45b1bc521308c20fd5575251fbe44915d2401a2dc76cdb00c",
-                                "uncompressed-sha256": "13dd10277cb284e3671ce987346804bea4339e7f1f3a204c847c0a3476c420f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e911ee9da53081f25d311f7b20129cb496cf3800fe6ee4fd6832474bd238e3cf",
+                                "uncompressed-sha256": "7fe9ca3a1fb9171e26737595e39ca869ee37f59b3a3cb688986f9f543581bc15"
                             }
                         }
                     }
@@ -416,237 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1400f62b101f3b72cd4a4687937fcb62b58831fa2688c711f52bf3557324efc0",
-                                "uncompressed-sha256": "ed8023fc1757a88f3e931c84e58b97958807fa3b00ec0bb44cf87c2059579de3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f48fa6c8d5c8dd735b90b578ccde7001bab35fe5045ceab0241da53bee0225d2",
+                                "uncompressed-sha256": "edc06486e6e1a2981f53aeab5fc3c9ac31fce8d7bbf3e88b59f7204fb809e0d6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ffcf6b2049b2f1add14802ae600be3e4505f7b7d3588e89215612f334192d547",
-                                "uncompressed-sha256": "4b79c0597d0e6887693c387e26d6aee2921212ef05b6907159559a485c32bc14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0c36bc240a1bdea978e4950866462e454332fba4dc67232fc6b872aee5d96e22",
+                                "uncompressed-sha256": "fe5716c94449d9b85179fec3e201a90e54d517c411333fc7206e4e050946e579"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7268049da8681e77b18b44720a12b01c7cef45114ed9ff2169f4bdb0dcbddf68",
-                                "uncompressed-sha256": "4d071b75148f95825c53ab7890968ca3aa9bff6ea1a599da66a87ea6903f48f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e7caad3b0f7883e1da0acbccdf7f3db419deabc82d4119b636485a69de8d0a92",
+                                "uncompressed-sha256": "ac4b0ddc37a915372ca0a139f98dc52cc183c14ef5a9dae4216eff8818b72b47"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cffe59b6f6ea0c391e28345bb689693fb606e9d23ab50bde13fa70df9915c145",
-                                "uncompressed-sha256": "849486a9efe0f43e9107d8bbb248978599544955d1129a7ae91b43d0bf5e8059"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "221a684bfcc27a41bc592d0160d2abc4b3794715ceb9f12bd9f13e05385af087",
+                                "uncompressed-sha256": "1fcf61bfbbb18695450ef949c1da0d65b5c1a278e86d58059a2e78ec36c91cdb"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "192b26d636c30c3edac71c768c2541689d83160c2ed40526a4fd6b47e0c648ed",
-                                "uncompressed-sha256": "453468e5681404e745ab693c7bed63dfed4d74d38490cc382eb31a70d0dfb672"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cd0d891c998a51261d62d6673303f5993423003b0400124745607b7caa2ca1c0",
+                                "uncompressed-sha256": "41ceab7342f43d4a1acf0e9fe5b666eda3c619bf5bbc32fffdf7cec0a038edab"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "73c08af002a247bba3a1ec40e784db2bd520cc3fbc00182c394736658bc183a5",
-                                "uncompressed-sha256": "4df84186f9800f5865c9800c49968cf6e6a58a5a9fdb8d3f2ea399e56278a5a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ca1a08650b6e26c08f1331e858138fb02697652906cdff113b917277c4643a65",
+                                "uncompressed-sha256": "8590ac9d4187432230c9bb06a821f1c6b6f18da3b4ec9354cc486d758494315b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4207877a03cf1af8a2c0170a84cb15fa924b936be07648b6b91e286225af6d15",
-                                "uncompressed-sha256": "78dd4194e10243377209948b29136402a33d8a7ae0fe006c72255df1de8f58cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f05fd5fa6217d87c6c3c8df191cb31dad103df0a9470555182c6dece1ec09248",
+                                "uncompressed-sha256": "2c2cb8573e39e9659c0133c6da764b94721268bfdd99e9b4910de1d5f00a969e"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "38.20230722.3.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "f62e3a65375cdb3b3d1e309dded740a8cad8c05237d87669446e5815cd232f02",
+                                "uncompressed-sha256": "e812e4c45e10ae1b687fef345718e1ff5890594e841cb299a64a317fd256310f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "66917b94da4d542fa9fdf7b0671c22a090ce9dcff091860253a03da3118bc66a",
-                                "uncompressed-sha256": "e48381dffce50e5b1fd020a7c841d43ef6d8ccf02d15baa9b22b3edce26e3613"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4dced55e5ea37175db31e69c93c10fd32f8de70d4340010c8940c0cb5cdd0fac",
+                                "uncompressed-sha256": "f48ffd78e64e099e9319972383470a731553b9a95d869aa9702587da40b8f2e4"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c5ea436da7bccf74025694660fd4488da30c31cb6c12296340a15fd2271a444e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6ebfcff8249c0653b91c140289bfe5031c1cce9c72c01c2e66037723dc77c51d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "44b00329cb619c9b3c864c84120fe7b5d31354d4006a7009fe58359d522d85c0",
-                                "uncompressed-sha256": "fb229232e439ea5acda7e5f15d2b7cdc43354c961a070a698a810942895e5d74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f9e8c1690143fb23c58add24d680f4effb7d711ca5c5b58ffdd86209f9365e1a",
+                                "uncompressed-sha256": "d487982039e8eb0ac96275428c6435206d3a229125840872348eea6a4c47d6e5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live.x86_64.iso.sig",
-                                "sha256": "89faf8eccad95f3b15dfad591389d474940883997e2741a4e755e8f0a132685b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live.x86_64.iso.sig",
+                                "sha256": "2b786dec1a1c409e7f0045cbedd7fc54fb74c01063924d6111c3cc295e01822a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-kernel-x86_64.sig",
-                                "sha256": "47f50ceeb55185dfc29728d34fa939be712599bfa222e033e976ded9cb2fa938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-kernel-x86_64.sig",
+                                "sha256": "88465710467ae0d8e2b6f4c81fbac5d00f7afb2398c130dbd483431e7b6998ce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e9b56e7d98fa5fcc04b39b17f03d62a5b890d77c7336666780c1b6d383037573"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "39a59c892e109e13dee660e55cbe9ef82f0ec10f1c4e8e97798d0d2b43f8d867"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "dc54cce3c5e4003932f7174b1a2cf8484ac9c4fd00f7d67908caf3de1348ccbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "31ad0f9f7d248415aaeb8e2ff0c5ba0e94c44922d9f441fed1c79b7e9972b030"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "24c79a1e6e51020847d3352cb61b644167657165fa8472c12f79a1d7d84e80b2",
-                                "uncompressed-sha256": "7bca5662878546cdb44cbc067806776dfa352bd1a6abe4b2b4a7bebcecd27e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "73ac480d0878fe04e520362e1b331d6698d2011b07c2e598503abcf6e6a870e1",
+                                "uncompressed-sha256": "d328e77bfc18e25c634307223d3fe17518ea40f71341ec94113ef3f852acbf0a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "228430f07cf57a35eef6147ccac6daf1d730f9119d6562211a3bba8725e13b78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a880dd2b1cac76ea20c84ffd0c5cd6aac5ae4be4e5cbd7a80db35386ae73eb8b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b2460c4ff2a47f5a86f36d633aa3655a4e7a379538b92964c58d1579e6ab1fb2",
-                                "uncompressed-sha256": "e6e239e8710a8dd2e4f541aa12ae1149afccc5cbba5a38c7d2a9000a031bba67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "815763b89a8b343f866a1850d3345461d198d069898a8ef68a451e4c31306fa1",
+                                "uncompressed-sha256": "bf6a5d4e657ccaf0c8bd2263b94a2a39d8c2d0988e2a9a2211b9e61ed69333b4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "89cd1b9b236d6b6e1a4b8886810323f6c376f29923fbfb99ec31024919dd3d69",
-                                "uncompressed-sha256": "9df3559c8cebab59ccbccea14cd605850f57c6cc5963a51c61d0ad377e2a53ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ecb3bf1fc4da70fc99fb25706820aed9d3f46259ecee65ffd7e805569729e2b3",
+                                "uncompressed-sha256": "8a213ccac794df418139780cae2eab2222fbfcc4c85b59a1d6006fd0622f2205"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "637f5d39ae4af68f3904a6694e51487fad5d8a5f40d44b49bd2c93c646c842ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "fcbb4012a254cfc4b63556deeac6587709ef7d49df5ef96a73137252de072965"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "c6096ff0a77523abc4cda5234f45428ee6fe017f209cd93e667d2b1cef362359"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "4ca869c1a9ac76cc5c0dc74aac2f5189d1907abbfcf80c0a5b8b96a290afb6ef"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230709.3.0/x86_64/fedora-coreos-38.20230709.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b002c9ac9243437885d6f315357ceed045eaf97e9f391474988d80298c206519",
-                                "uncompressed-sha256": "ca6b9b2e768d111c3c0fdbf3c7296258639314620164c4cdce74b89c1a2b1316"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "626589c42b38afa46c6c87bb19972fe3f1a85066d5be9fd7b0c15db702f43b97",
+                                "uncompressed-sha256": "67fcd0cfb38dc5744a76293fc00d8b9a6e3ed4a22c5b9142f377aea60f4863ab"
                             }
                         }
                     }
@@ -656,121 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0fb4cd2dc30a6851e"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-03f51c0d93e769ece"
                         },
                         "ap-east-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-01bf37102b420b701"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-08d0a034848f6099b"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-04a1cea9fd139756f"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0f4fd94e8727d11d2"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-014784200c5a4686d"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0544680844cb72d12"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0ebbce40fc5ec2ddf"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0253c5827de3ca585"
                         },
                         "ap-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0b671c13f0b14a4de"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-05c75b7b3580d128a"
                         },
                         "ap-south-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-05171d0b71c275eb0"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0177601a7e4e0f237"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0cb7255b419ab1443"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-02acaf802ebcfdfde"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-078e50c397d493c1f"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0e6468aaaa04de1cd"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0373826c5aba47d32"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0c2a8976c6ca9b33e"
+                        },
+                        "ap-southeast-4": {
+                            "release": "38.20230722.3.0",
+                            "image": "ami-01f4f4b5745312ce6"
                         },
                         "ca-central-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-011b5c781bd9c55aa"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-02d68b74489172ac6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-01616b3a6ec881521"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-04d3750b706767b83"
                         },
                         "eu-central-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-02b89e6a364fadf20"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0ae263e89f90f2b46"
                         },
                         "eu-north-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0420cea6c41f92ceb"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-075649311ad04e4e3"
                         },
                         "eu-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0c8e151041536e55f"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0995d70238507ce18"
                         },
                         "eu-south-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-04d63736c5983a8ce"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-04cf181f9f6eca624"
                         },
                         "eu-west-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0ea3c2efdcead938c"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0688e6123cff4199c"
                         },
                         "eu-west-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0eab44b42ccc71871"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0a4dd3e46ac011ec4"
                         },
                         "eu-west-3": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0b1954fbde2d0caa2"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-03d10fa543d50bcf3"
+                        },
+                        "il-central-1": {
+                            "release": "38.20230722.3.0",
+                            "image": "ami-08cf65ee282088362"
                         },
                         "me-central-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0dc9992e1352809d5"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0aa447a43d4babf6f"
                         },
                         "me-south-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-02fa6fe98757840e9"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-03ceb3dfffd8ee064"
                         },
                         "sa-east-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-014f012e6fb255e53"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0171764c02dc6c76b"
                         },
                         "us-east-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-095af7370092f3991"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-083a735d0245929cd"
                         },
                         "us-east-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0112b354811216a88"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-015cdcda72748d3b2"
                         },
                         "us-west-1": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-0edb112f562b6e80b"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-00e1b69d489feea68"
                         },
                         "us-west-2": {
-                            "release": "38.20230709.3.0",
-                            "image": "ami-01b32c5ae2e279b6c"
+                            "release": "38.20230722.3.0",
+                            "image": "ami-0170f39c0014e6a54"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230709-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230722-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230709.3.0",
+                    "release": "38.20230722.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:39a770b2b06e48c3ce4b63d2f399ed282899e5c9dc0e00c4a6ea9e11e260fa49"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9f96cb3b94d71c03e44549b547054da630bbaa032fe96bbed16fb654c2d5ae19"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-07-25T18:00:03Z",
+        "last-modified": "2023-08-08T18:34:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b3894ea19a778240f624610dd706071df451fc27bd50b04332015e962c00172c",
-                                "uncompressed-sha256": "c66e2b31cc846a1125769ebf694870aedecbae4ab8181c129f242d24f7c044ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c4330232a46383d1e0320e22d014dc7aab5889e19f71053ddcada571edfb320b",
+                                "uncompressed-sha256": "fa56f88e652e7e981f6deb3ebcd0bbafcddf8f6b6bb078c36f0a0b168b49da5d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "26ac78792ce896a165519b24bb9675c37ed77323b3d0a0cadf9e266edcc4d7b4",
-                                "uncompressed-sha256": "a77b5e7a2fae2194c7b12c360e288efd4bcbc1cd4443437ff3be09e82f3f9f67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "10d4775792b1f220193c0770cf3f615895a6bf0807004097e45c61aa2526effe",
+                                "uncompressed-sha256": "b2b4a32c64fb05cc08b5f66a4f4410612efdfef3bdc0415223f5e92d68f4fa04"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "8294db513d7fdb357b05baa2d228636eeb35a8ae815e765b2ed5ca5c86af3f81",
-                                "uncompressed-sha256": "ca8cf6c54771cd9d39f51417a6ffc3a63d3559fa342ed0375e7f0edb4225a0fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "fdd41ead5f3dc0579a1281bb372f71bedc91f837b668211ed4f203d434a3e0e4",
+                                "uncompressed-sha256": "9fada854eeefa11405c7c97aa0b0036b62b3026dca85ee752f8a5bd85dfab8b4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "033ffcb74d5873815e1a1acfeee3df5f7123e59788eb8cbd107081ffb28ba76f",
-                                "uncompressed-sha256": "d961278c2658818345b7633868ee0ff718d85c9628656aeabd77b66a574dd71f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3c98718c8681154229f34fe3d965a6e613f0b1c4303fe48d90f21be41c2a30ae",
+                                "uncompressed-sha256": "d38163c4b99bbd504d827054346bc3759ee4d1be918cf9c7d1a370dd436c5a6f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live.aarch64.iso.sig",
-                                "sha256": "c07b77f09384cc4f16d06dfe0e10243d0b6b93c2423b8baf072df5c290dd21fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live.aarch64.iso.sig",
+                                "sha256": "8f80062dbc029d42b54b46bd9d4de52b16c27142764c33cd0a77729947ec9238"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-kernel-aarch64.sig",
-                                "sha256": "94784d5835a4cd49de420d4a04368cfe9433eec5a2da488481261457a1dce000"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-kernel-aarch64.sig",
+                                "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "6fea0908a803c831f411708614effdd913550a06095109e9307c06820a9b5724"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1e6923cf515cdeba5346d4a0a4f2b3f1eaa473d9b50b9a170ef0c682284312d0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "383b43a72e49989614d5cab88b3bfdb547d27f24add7b5d64b8f3fa3285df307"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4c87c163a22a6b333d9f94e4009f2725390cb25c8d4cccde668af0d8db79bfa9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "45d0a12070736afb286e111abe89d9986ac52935d1bb83e4d77f132824b381b4",
-                                "uncompressed-sha256": "6e5806bda723beb443b396b277aa819058324b243b5427d6b59271beea92b88b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "4f129091ba027742dd57b8c87dde92b7b27e6a01188e848ca9639f190b09aa6e",
+                                "uncompressed-sha256": "f3869f3568a7f8d7ac910f7f6b95f0fde460e5c6d4ac01aaa5660f5b4dcb09d2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7559cfe5dd22b65b75de606b4ea5347aa8a44953d630f4f0cfd9ae8cc0bad44b",
-                                "uncompressed-sha256": "4a989bfa544d543078ad96c9a26f8d6bb0501f339c3627ca807cb522b06ddadd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "cf7a44850c267a368dfec89e9c6222ba75ce4ec279f11eb62f09ecbe0adeb9fe",
+                                "uncompressed-sha256": "dfeb44ee1384476ef61f4c3cec18b4a0b7b57168a80207dfea3e7d689c9a4605"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/aarch64/fedora-coreos-38.20230722.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8c101e3e3adb81fac89e643496b81f4dd80f522930baf78569f7e519f74e24c4",
-                                "uncompressed-sha256": "49009973553a91f9a488f4303653128b8a1fb79a46df5e63d6378c931ba4e8dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6d88d88f28ea10409c280358fd220672a9042419e2176102a379e49133bb8e88",
+                                "uncompressed-sha256": "5c04a042a23c17059a115852d787c6a68026a6d07c8bd5db71fa134aaf72d6d2"
                             }
                         }
                     }
@@ -122,201 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-024ba231a5e3628a8"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0e3755ec7f7cb1d40"
                         },
                         "ap-east-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0c1084cabc649212a"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-08cbdb9ff38195cc3"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0c18190f7953cf5be"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0a65731524b9eeea3"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0023f3d450a35f455"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0153c74e61edcac0e"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0badf382250e2000b"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0b1b4ba1c3cf480e5"
                         },
                         "ap-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-069dbd086cf507092"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-09e0637664318612c"
                         },
                         "ap-south-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0569a3d6b18d8def7"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0ab28e6d3e132cc48"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-05354b4f089831ee4"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-054c2b6337db0e9ec"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-079de026c1e7189bc"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-03b9e9315499414b2"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0b21f23d8eb778ecb"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-09fcc10dfe676fd3f"
+                        },
+                        "ap-southeast-4": {
+                            "release": "38.20230806.2.0",
+                            "image": "ami-07f992189b88224af"
                         },
                         "ca-central-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0639e40daf284b987"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0433b795091aaf4b8"
                         },
                         "eu-central-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-098bfcfb9973fce5b"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0724654014d5fddb0"
                         },
                         "eu-central-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-054f1328cdb7139f4"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-03918beedae34eda4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0f0553b95d16d7998"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-09e35885f0590c6bf"
                         },
                         "eu-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-05bcff9602029e69d"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-00872514a535cfca3"
                         },
                         "eu-south-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0ff4d81b1e626543c"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0171902c81b1df9d4"
                         },
                         "eu-west-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0dedd858c9c72620b"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0e399874831164df6"
                         },
                         "eu-west-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-01cc7e5434020febc"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0cb5ffd3b14fe9b93"
                         },
                         "eu-west-3": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-04a8b44f99baa0542"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0e9223ef3e37824b2"
+                        },
+                        "il-central-1": {
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0d7adf078977b7ed6"
                         },
                         "me-central-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-072bfce357533d641"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-057227aa8edb88e8a"
                         },
                         "me-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0cc70cdd08312fa64"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-046fc2003a3ea6505"
                         },
                         "sa-east-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0380e33009f5cf2c1"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0fa79514cdebc17a6"
                         },
                         "us-east-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-034131bfd8580d801"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-04e5a9107c59e9700"
                         },
                         "us-east-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0869a4125109d69fe"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-08de29d214495f76e"
                         },
                         "us-west-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0d0c3274dfdb515d2"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-06f24be6aeb0f47e6"
                         },
                         "us-west-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-05fb28996c2c60cba"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0fb7bd219fc782fdd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20230722-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230806-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f1cc837acc9c4a5a75e26a1c1735948a6f8e6938435173a141760bf6a9696dd3",
-                                "uncompressed-sha256": "9d8897cd58f12f5cc5c8dd17e7c55cb4ccd88e046441955d950d3dfcdfe259d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c1cf357cd60a6805b4326e834b8f6ef0c41ea4cc90b208866e8f2bcbd94f8b9e",
+                                "uncompressed-sha256": "56f55c4e805075728247a7edb8fadfde78afc18feb065eae139a633cc5154c6c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live.ppc64le.iso.sig",
-                                "sha256": "525f42d28105532559dde32d0fd7b77d2b6ee71cb2f825863316d867eb5982c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live.ppc64le.iso.sig",
+                                "sha256": "2be9fac4e7c057b062aa1863f79a2210eae2a46393b7b6e7a9e6bf0986b9ce5b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-kernel-ppc64le.sig",
                                 "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "0ea439ccbfb41695456fce6bf701d489ef58516c1ea51a144e2de032387ac23a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "179eaa65e88b65f2e534e06831ff55d898f571cfce4b81ecdb487abd7b58d590"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b2dd99ebaf9f78a953c8dbc60b9750ca0a5181282afac77128f80a6726ee3ea8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f89f80519841731f277b559dc8364637135836ec0965f1350009ad7f5b3bd70d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6c163c48687908cf0d4775435d3f2d3961dacd5917f4e4e620ac52c64f968df0",
-                                "uncompressed-sha256": "c5e2c00be621699073fc8b7ae22de97380a2a3a1967e16cdf5537fb385ba8602"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "06e9784de945af6999c68b8751b8cc98c06c14d728c54721b3a2aeef04ccd686",
+                                "uncompressed-sha256": "a417fb0ace4d9eb7e0c3193c5404b94bc62ec34d36b6de2ef70dbc90c0b30d58"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "553baf172d5b852847c1c227793ee24347632c411089495e234e0b115f43e94a",
-                                "uncompressed-sha256": "bc4a4a4c0146bc1739cf02a299149a8f616a75fb3a9fd9e53097c0f51ee91d38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "c14e1fcae48eeb777b392cf3b563c9888f71bc00b8dc2c35b6787e102a4651d2",
+                                "uncompressed-sha256": "08d1478a0cb28fc69d420e1e478e7f9f6ade84d0566fc45ffb4a4eb2f6eac78e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "39a08909d4d372faf4812a3438cab4882780c6159a10a599a22e732bf1107e75",
-                                "uncompressed-sha256": "84e674146022e993e9bc1e33d7b08c8c11af546433102156d6dc1ad4397629ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "87d1a55a1c04a6ec8b14a2cfaf5889b31da83d9d29cd572d425d45e2e1931c3d",
+                                "uncompressed-sha256": "620405f6ba178a0c2d68a1e9f7f1efef390e34692e37f3bd94b8aad147edc14d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/ppc64le/fedora-coreos-38.20230722.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "3088c765b8dc5761595ed8f6a006f77c8031b10a2092e8c63f8ba75ac3d41ab5",
-                                "uncompressed-sha256": "16ccfc35e060b3bc6fdff6bfa2934363e26bb9bffdf3f3d9ea3a5692c745f58b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c588100d95996fc63d8564db3a854772a81bb901deffa04e19b352475b70d3cf",
+                                "uncompressed-sha256": "27c51ee347893bad8065c633a42bdad375c2b71c484fc1c10ef734f34fed7525"
                             }
                         }
                     }
@@ -327,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3203b427f9a442b68d9ade9438f4ad6c76efc291a3cadb7bd4038479ddbfba61",
-                                "uncompressed-sha256": "c78c82c51efdfe84be2e6aea938d416de75627edc7a1c2b448f81c239d1b7fec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6723e067050f3d8b4b5547eb2a4a6bbb13137f430e67e54e0d5e9d166ec38e25",
+                                "uncompressed-sha256": "12d43bb561410f42e9a42e98ea767ccb64049b567ed661280098f887a8375a1d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "48505ce18160070c181f1acc00f8fbcf917abae5ed24c8ca9b9c17477fb26d22",
-                                "uncompressed-sha256": "602e8c31729ffdea2612563ed92cdf6cf5fe6203a6e80f07100443bcfec3f6e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "29db939859c026725717f5104f001193b140e84f57be19bfc9d1b389f037c686",
+                                "uncompressed-sha256": "1ae5b9abe3cd4b5e143e52198dfbde9ec40a5cf25a100f84528fa77d03951c30"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live.s390x.iso.sig",
-                                "sha256": "aa3493efca234db497fb336114b38e85fe52ff07dd5fda985b6ded1862d2af19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live.s390x.iso.sig",
+                                "sha256": "13d23f181817da0fefcf091530282e5d006f5588db1deb01881d33793666e871"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-kernel-s390x.sig",
-                                "sha256": "5ef1cd96c43354f9e87874e24273149d1ee882a86157abf5e09c149e8b2bc60f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-kernel-s390x.sig",
+                                "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "8468ec5e48bd9974cb8378cf20fb74bee307f42987d10756749e4b56dda68179"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c21e74ffb880b7f2728f7dd54f7db103f7f653bf4cfc160024114ff22e1fd7fe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "ce62603d2fc286fd45253697cf5a08456940f5d096949b51f9a3740c7c5a65ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "eb403279b19889e31d5d226b1f8e0137a205a5d8ccb053536a730d801ff43c4f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "8d51caac46ed885e30b123162a0f2c99fcef160ade46e202e19ea2b327bed7cd",
-                                "uncompressed-sha256": "d748f21c9d73e223a807efb23c9e553bebdd0ea5eca8d0f42d7fcf888d818d31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c6d4a5c12e36ee9d61ea72ee75bd846e8b474cffa84fd1d6a8e29b8af3bc3fc4",
+                                "uncompressed-sha256": "7b35a8ba906f1f9fc1754a4740b3ca8cdab064a2ba5a4aff1e9fdbb3defedbcb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f5e70e2abb534789c93f521079029ffde8007bd3b2fc448ef89bcb5c4a0e210d",
-                                "uncompressed-sha256": "ee82a3f2e9ac8736eefd532d22c24099d57940a113a5549a253e5263ceecd474"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2a3a2ab95bd4b9b046ecf78bb5b7f68d3b0ab0e05f7499cece05c55a0b27e297",
+                                "uncompressed-sha256": "f77dba9da2b83b06cb6e2a83fee8305ed1407e3c2fc99085300b401f9a0006a7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/s390x/fedora-coreos-38.20230722.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6cba97af36ed4fdf2ac742d8e177167faf8ae83cb2e57f4e052e26b9c89be151",
-                                "uncompressed-sha256": "f750f90eef5024673b63c874e40d8dc7266b8629eb957746c45053195aa2c525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "52b3c1508082aad82d98f213098758992fc391544106a0e641f43729dad65be5",
+                                "uncompressed-sha256": "0c31ced9a0a8cf065dfcc427e58f54f24ad059568b6377f9888a4386f1120e91"
                             }
                         }
                     }
@@ -416,237 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4207bd524f728f90dd6269e8e679417090bf3d84d193eb72c0f83c322d3fac2e",
-                                "uncompressed-sha256": "aebd8dc45a3c44f4572712898d133b7df60fc3fb0e9a9e738bdecca0fe321bd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6b2342b38ccbea608ad1e7b1841a666de095627356773bd5a9e985993a984ee6",
+                                "uncompressed-sha256": "767c3ca0a3e090d5da574a1f2e56b37adab361285643b4666f35a563ea19e3ec"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2ccef2ae61312b9b91f35df1a43359a3000866259c44961000fac7c53fb9ac41",
-                                "uncompressed-sha256": "eef6af4cfae2c28477544360f3819334cee3ba82d2f49602ac37efc60d0aa53f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8ab52a527558fb8a47d87e71f909ef453a15c8b2605019cc6bd990d48d01bf5a",
+                                "uncompressed-sha256": "7558a035837eda6e5e7e4a7dcf8be87565918aa5fea43fcde7a8556e220d4927"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f4fa72e367e6bbe1080b56ffa7649e421ea87cd4298fb58f89bf2bf2488c5979",
-                                "uncompressed-sha256": "7d22bdab4d0729e41aae28787ee31beffa2457b4781f1a9db91359b5044cc53b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a15faf9848a82be6fb99b8b25e98b2425f548462eb197955cdc79d94c30f598e",
+                                "uncompressed-sha256": "f338a95aefc88be9d3f71589ac0e31336f67ec0f2d97eafa17ca0ace9095c80f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "15c5b55c95613bdd89d506a8cc5069788e14722d5dc2e578274b7da969f92618",
-                                "uncompressed-sha256": "b926825de35cdf1aaa79c50bcc8ee901f2a4a2408f11b294817a6ad88633354d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "deb0b51bf5ca373adaa6e1f8e7887a4079d48d19bbd18f097cf347123b51b244",
+                                "uncompressed-sha256": "0f05b690c1ae13383cc2004a17cff378f3c03598a4d3d58270c181c19004f5b7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "615ab7d66a72ab21389ce7690b294a2da96c7986e54e56785b980088befe4e8c",
-                                "uncompressed-sha256": "4959f7af798af69d3f63d0f20fc43fad6bece0e3a20f6d8faa6bdd9d4eb553d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "26457349f09bab56a321137cb5d3c9d72a984074b3d36e74107e874773f712ab",
+                                "uncompressed-sha256": "0cdd4f16103345e3c7f1ec940978df62be50a0f8310b962138992c5b3937b4cc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "54a1dbae95a0e39eabd89f1577df32a054e538afde97300608c45f5102f4eef6",
-                                "uncompressed-sha256": "6d767c4a56508cf714775dc43af952d09d9ddf61a19a1f7ef691c4d81aa11a26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a3d4ec8fabbea40c3425bdda71c57da8b739f933383f39cf4877d01ae8e207ee",
+                                "uncompressed-sha256": "14e1264860d726ec40f11788a3e385f5be3b343c499f2a82676d7932b42f89c8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "21bf786423995ab162b50b00fb7852f39a36650fa3dedd786491f4ea8156d85d",
-                                "uncompressed-sha256": "87f1296fb3fb66926e5161ec3a44edeff4c3119002d1d026c4d230d0e133e842"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f79141c404262356e813b86d6fd96ea0c88000c3778dae62e0a4dfd3ab8a186f",
+                                "uncompressed-sha256": "2161e170ec958bf9f52c1dec36f079cadc69f5a404e426032e16c8b66d51f078"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "38.20230806.2.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "023f98804f71a1d0781df4a6e31a86d57da6e09ed7f6904466234e9bda871bbd",
+                                "uncompressed-sha256": "33946097cfdcfed320f078e4f9d557c0b9f1af5c12c4373a26e9b02ecf13ed67"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f71dae4e0a4339845675a2367fc9475d55a61f666f79af555ed62d02f17caf03",
-                                "uncompressed-sha256": "94e32ef2fcaea6cb6f0f2d3dc39bd110751c4e99c200ad043798b6fac5d77454"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f487b9b2b7120c3ec2ba6e2ee3652fd5fd6fb38775729d6b051fc6649c605165",
+                                "uncompressed-sha256": "cac2e5360a0a437b7b3c7eb18270ae4848a25041f15daca14e898a8bdcef278f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "06922ba6cf85ff0c5454a88e3d25464d225e9355cc1c200df5a4591ed15caf10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "fc9823fabfcc901cecb8950ecccadef3dd922710bf4068585832b3c82cfb486a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "12d850de03212b224c5350237d09ea9bad2cca8751a85a78f5cb9c1b8406e5d5",
-                                "uncompressed-sha256": "d54e3514a2e721b81301ddf95f62b1f8616a0aa21c3eceed7c6f605c51efe04e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8073f774d19361ec7b15ab957e09c2c3fabe2235362ed43e15aaf144e975a636",
+                                "uncompressed-sha256": "56a0c5be6a3f1f72b7ebe684c92e33616d4d3425e726bc257cdd1f18364f275a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live.x86_64.iso.sig",
-                                "sha256": "913e5176117bcdd06deb5866cad22b469695e972767d28e0ace247dccac38062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live.x86_64.iso.sig",
+                                "sha256": "c27e7aac3db4fef9207220bc92eefe3707debabe6d77abcbb3cdecd1503c246d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-kernel-x86_64.sig",
-                                "sha256": "88465710467ae0d8e2b6f4c81fbac5d00f7afb2398c130dbd483431e7b6998ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-kernel-x86_64.sig",
+                                "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "cec9a48d95c0c03e8b399f18cda4a9f9a2c795fa56a13a81e5fbfbecac27885b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7b48c435a4ffd7f6603be0279823f6e98ab6e035d00692adad1613b430c145c7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "702e86c37c6ffae3b2a63cc7aca54edd40915a2c1ec1d66fbfbb92b979c8b979"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8479f544d19e6860db2c0c7d12b6d717079198bd86950c88c3c5e07e227ac88c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d2e1f34ad9b733c764c83f599e206981d297b0889a6a80e36e16b4690109746d",
-                                "uncompressed-sha256": "9b54e4c4e51753fd06c3b0052d843337ff81b9015f6a72add73cb4c27bb20487"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1240985b4a7b2ccf1587aecf855c0befd3ac95e92b363356893c6b821fc3091a",
+                                "uncompressed-sha256": "96214cc94c79f6d185d12fcc968e61c8ddf9576538160c6123efd687c837fa4e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a64f5719f58805affbef1b4fbe2016a83403888fa79151341fb35a2ea755b2a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "055fc0045ee39aca5336667e26f9dc39fe1add5d1026bda16d95b45d69a22f2a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "884124087b7cd1adaa2ac6b39893ae1ae20202076038fc4debcd45cbb0563ff7",
-                                "uncompressed-sha256": "ba44f0d873f72feb1031a106ddde54b5190d1f82f6c1423b6c2de7b13b249844"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "824d0c355463eff7e8f1a4607949f88c398886c5041b84ee224905ec7ce7e216",
+                                "uncompressed-sha256": "51da48aca8940f07a6689a869327999e045b8ac719b959067212ed236bd1154a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e64b55d5c98827d35f35b4fe0703bb6abcf8489afd1eaa811abf4c9c67adeba0",
-                                "uncompressed-sha256": "b5a13a281312c9cdb4339ffcb8bec1d32c0470031e7c46d55cc59052739c4ed4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6acc38edcf7ba035fab3ae05303743b36fe1003b628658c6d9a0df690ab29f28",
+                                "uncompressed-sha256": "24c6ceabe854f328a6d9bbcc27833e79de403e23f2eb09840ecc3fcb2a807c40"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "4d0a4a10b6d8aab854fea4f856e3958b3a5f2c68bf454d97d2dba018339acb4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a80636eb853eb57d038040589670a46bc0b4826232a5fb5959523e5e0fd9f965"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "4e6c24ed11dce5dea0d7fa94c07e88ff5725175b5b4494e4429bad098e99921d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "fdd8daa65a01d211cbe9f95cc8d8807e81bb56401b4068b1bab97edaae618f1c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230722.2.1/x86_64/fedora-coreos-38.20230722.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "11d66961b719d8b0e1327f69fc5d5b51e0e598576db45ed6c6c40fda4978618b",
-                                "uncompressed-sha256": "24178407cd96fe025c34276ba066de4021f3aea3ceca46d546d4335ebde8ab3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5de5380a73e2ba3dd211a069820e5b0aa6344b6ddb82e9ecf585b9ce3f01843e",
+                                "uncompressed-sha256": "41a766f1105f7ff6bcb025151d29bfdc61670547dcde49529e9b61342070400f"
                             }
                         }
                     }
@@ -656,121 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0f965a3d684a7ebbc"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0f72aac5bffd65e84"
                         },
                         "ap-east-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-088e01d7db50eb053"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-02dbe69dc2ecb8106"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0306506645dfa5a9d"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-07b27fe3a69091249"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-03c7aa1f8e1c6873a"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-017c5afd5aaf5253e"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0b2ac8c4261ea5199"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-089b044c231e647b9"
                         },
                         "ap-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-07bbe51e21b7cff62"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0fcfb06d20554e171"
                         },
                         "ap-south-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-017e684d7ad308e77"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0ee6aaee921b50a97"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0d52c54539f710a0b"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0ca9f81a41a6ed86f"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0980cc959f49748d2"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-011793208ade39903"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0dafa98e2f3759623"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0c22f181a7a1864b5"
+                        },
+                        "ap-southeast-4": {
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0ab9bfb9a8fe77a16"
                         },
                         "ca-central-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0d776c68cfd38926d"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0127a215c083dc891"
                         },
                         "eu-central-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-088b01eecfa333233"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-075699d73ba0c3afa"
                         },
                         "eu-central-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0fbd95112ea742f17"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-001fa0f517b1342e9"
                         },
                         "eu-north-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-00529f32d3ef66482"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0f1ae7d4d969678f8"
                         },
                         "eu-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0b7c36e1975fb426d"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-03f9fa58cbbf6ea9d"
                         },
                         "eu-south-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0ffbd5117a687d311"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0b59f0b8eb39f66f9"
                         },
                         "eu-west-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0db0bafcd86144436"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0469c71b89f8b5889"
                         },
                         "eu-west-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0d33839fb71d78552"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-034d4a970e7d0970c"
                         },
                         "eu-west-3": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0c651fa14ccfaa0d5"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-053937becbcf85b23"
+                        },
+                        "il-central-1": {
+                            "release": "38.20230806.2.0",
+                            "image": "ami-03f813965b9a9a2e1"
                         },
                         "me-central-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-05ba621cbbd279bd1"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-07f072b83cd15d0e8"
                         },
                         "me-south-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-025609ab020b62382"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0a4d6e95c24a5c1d4"
                         },
                         "sa-east-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-08b803f7984417fe8"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0197e1128db318c69"
                         },
                         "us-east-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0ef6322df39b7f11e"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0952a723fe06cb5ea"
                         },
                         "us-east-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0c3f71dedf3779651"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-0826d37aa70bd75b8"
                         },
                         "us-west-1": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-0ea29c0f8085a0038"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-05fbad89d9fb83f05"
                         },
                         "us-west-2": {
-                            "release": "38.20230722.2.1",
-                            "image": "ami-000812e56ba909f6d"
+                            "release": "38.20230806.2.0",
+                            "image": "ami-03c2fd02a9b71de34"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230722-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230806-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230722.2.1",
+                    "release": "38.20230806.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dcc5949e9dad309afe614cd7b015822fe055b8433e4b93e728a9c070f85d89bc"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:68cde352544cecb9f2772a10229344b3b86da13f4a30e065e42eee93551ec410"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-07-25T18:00:05Z"
+    "last-modified": "2023-08-08T18:34:24Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230709.1.1",
+      "version": "38.20230722.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230722.1.0",
+      "version": "38.20230806.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1690380000,
+          "start_epoch": 1691589600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-07-25T18:00:03Z"
+    "last-modified": "2023-08-08T18:34:23Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230625.3.0",
+      "version": "38.20230709.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230709.3.0",
+      "version": "38.20230722.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1690380000,
+          "start_epoch": 1691589600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-07-25T18:00:04Z"
+    "last-modified": "2023-08-08T18:34:23Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230709.2.0",
+      "version": "38.20230722.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230722.2.1",
+      "version": "38.20230806.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1690380000,
+          "start_epoch": 1691589600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).