### PR TITLE
Roll out stable 38.20230806.3.0, testing 38.20230819.2.0, next 38.20230819.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-08-08T18:34:24Z",
+        "last-modified": "2023-08-22T18:29:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "670771af2cd1110726321299d753c9a1f6fa70f4e141da96c5a874c4d9c919ed",
-                                "uncompressed-sha256": "73855ddf7f806df1035386c3605162eae9326d949817584731545582a74e889c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8a683863a50f9dde645229b19d77a224d176066661094ae5d696401e220805f8",
+                                "uncompressed-sha256": "f7383956b0cf4b4ebdf729755a0efb9ec38b31e9eb2fa6feb52940e1116235c9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "87fb63e120cf10e9e3cea240a2ab44abeab997025d12a8d86ef7a3c03a958628",
-                                "uncompressed-sha256": "5e8adef5e5222b04409f7cd1010b906aec9c44d78b8c72c8a5dfde951751ea40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "344c69207430baa7d641d027a5014b16520d9b795519d598e7e1cf49ac7b9288",
+                                "uncompressed-sha256": "457d4bcd3e71d604f75914e0b10844cd06370b8ba5adade3f062ace0c833a8d9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "7e1db99e642c0172c0b48b1a2e6d9dce878542cc6d1d8a8c70e76f4761e6ebe9",
-                                "uncompressed-sha256": "44db1de66c6915408caeb6c4075adacd4a9292d46bd350d9ebd1f2a2a24a186f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c1d0690e8a1df0e703d96468e5ff2b34f58dafe96520a01bd784dd2af5b5a6dc",
+                                "uncompressed-sha256": "115169b4b131d4751a89f43f1ae658d57cb11322793f607b4291138bcebcae6b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f5c0b281cfce92b1ceeaf3bbda66f2897d5d860a4feef4ff429d7f13b62ecfda",
-                                "uncompressed-sha256": "94e52f59a46da8fb279e62641aa685919b974c3d275325374faacb6bcd6d0993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7c727805dc34d64ba2f8e0d32d67144e0ecaa4af99e77274225767886686a412",
+                                "uncompressed-sha256": "78de802d88e814218daae156b291d7d5753016990728405994973ca1b525d7a3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live.aarch64.iso.sig",
-                                "sha256": "955e0ae030de782c09be2654bddb4fd6764cd3ef9488362c4e82f93445628e00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live.aarch64.iso.sig",
+                                "sha256": "0a8a8fb5f9210ddbe1194ca1f77f930f4a79250fc03f79613c6efa3b11cf5ba3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-kernel-aarch64.sig",
-                                "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-kernel-aarch64.sig",
+                                "sha256": "ba9026ee27f6a3d4f37d34f493ac488895926358d5ca2c7e03119381b4cacd66"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e9b3d9c8fb6c31a7611b71c107de7a2e74ac8806b516cdab28077fd8854d2b6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "91af528d7c4e97f2fa5842b4b06290ad155df370e74efe5da6c7540111259312"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "fa5fb5f8b6db2edafa95507e50c5192f16477b39bf4187971d3377e9407b499d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a74a2eb005af7bd7ff5c1d615f1abb56adb1dfd7c0020dd4be022045a46b0c51"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "23b4a94bf16db0420e551eb4ef616fefcba1a0014d4ab8e8ada3c42b4f25f72e",
-                                "uncompressed-sha256": "e743cba0049a08c1b8e14d5b1418eea29e12da1c03676e33ac2ec2d3128218de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "bae6563b26d4ff38ebb2833841da917a78ad8b87e46e171a152c024ac1774b19",
+                                "uncompressed-sha256": "fd4d0d5da4c672b73fb92927db113bf3fc44522a5f8542be399d72f2bbf71a70"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8c21867deea404ce95978144ec1082252c2f4cf19484d8884da6cbdcbf173e1e",
-                                "uncompressed-sha256": "420ec470e851bb5fff1e81bfc0b74cc6ba914f7e543d9751d352554ee13852c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8c479240c134b11f7f5b1686dd615e57650c18fb32b8aa15e0b0e4891f3bd70e",
+                                "uncompressed-sha256": "0abc0a9c098bafa9da341c86fe93c75daa248f52c4983a3fabb26fcae276cb75"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/aarch64/fedora-coreos-38.20230806.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "091aac855e55f61a65582cff9b3b131f98a0ecc030b4cbe26712299eba32dc5e",
-                                "uncompressed-sha256": "c0efa7cdc17e42c67e84e560d81909079bf3dd71916b87a1940029d008dffab1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e96a4252122110cb2d464ec67a083b0d3d846003cfd3663f91b0c79585efe5b2",
+                                "uncompressed-sha256": "4d5900a756e5411d0364dc305dfd720dad590501e1937ef2685162c53d2111f3"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0bc9b74193ebf3d14"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-06d96004cb3ee4ab1"
                         },
                         "ap-east-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-015142c2f5e9b4438"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0021fa5ab71114ba7"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-028ef8ebcefd82373"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-039ddbacdac7472f7"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0fb9d6aa6860d83b7"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0fe46185a97248d2f"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0dab6c32621294fa6"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-06bc8450a0eb56dcd"
                         },
                         "ap-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0971c98bbf714a935"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-06921407cae78b349"
                         },
                         "ap-south-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-084d66c2490bc49b0"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-09db90b555cb2bd6d"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-029011e3267ce4327"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0437be10dea621544"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0837c3cbab9b4a568"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-02646e705766e7af5"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0b2c8245df48d678a"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0bd3121acce29df92"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-09e6059c11396e76a"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0d6655ed6f8e72ef2"
                         },
                         "ca-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0ed915a79b79566e8"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-01b61ac984e783c5c"
                         },
                         "eu-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0810b9ca59a250a1f"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0875babf890b51d5f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0dd644a9525342185"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-02d2b93d77193d147"
                         },
                         "eu-north-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-047fad2cfc50492f8"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-00df78804b8a3a1c1"
                         },
                         "eu-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-057e138a752b4a30d"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0ebcad96155c99c09"
                         },
                         "eu-south-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0dbe24f3201b0d646"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-02bfbbfb1862638ab"
                         },
                         "eu-west-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0b8bc978368f1cc54"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-07640761212ecac13"
                         },
                         "eu-west-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-03ea2041cdbaafa23"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-01ba12d6aceddd4dd"
                         },
                         "eu-west-3": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0f03af4e993ec519e"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-03dd6bba5232469eb"
                         },
                         "il-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-057f6ba162325efba"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0e94a510e6ef075c7"
                         },
                         "me-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0b69e9acf6f8ffd14"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0d86aca7073847db9"
                         },
                         "me-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0291a3d0672ab33e4"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0c1ae3a26660b1cf1"
                         },
                         "sa-east-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0f1702a4392837a4c"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-084776463ed8de082"
                         },
                         "us-east-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0b7db3d4785394a85"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0fdf8488e66560943"
                         },
                         "us-east-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-02a36010819ce7f6d"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-04e09c7f6ce699c70"
                         },
                         "us-west-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-08f1830b4ad0d01a7"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-02537e927b57f30be"
                         },
                         "us-west-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0b98ee819a3ec7662"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0dfe7b935beb342fd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-38-20230806-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230819-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3ef39ffedb6dd9afe06e326cba861384762c8696ec09b6a55a6e8f25477db8c3",
-                                "uncompressed-sha256": "d3778daf654612a00bcab478935f81034759eca1104e0f7db7ddbc1be7f65044"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "40aafda1aafe1a4e6c5cc55cbc7ba7056ba39f9a574368a8edf6c815a4671193",
+                                "uncompressed-sha256": "205e42e84b399e92d680f1a1c0ce3de9608d4e30d90e428347723fba2337309d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live.ppc64le.iso.sig",
-                                "sha256": "20fd0c555e3888c465cfa1e6c8789021bdc9139c3762f5b8dc59f6f1b812c77a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live.ppc64le.iso.sig",
+                                "sha256": "0dc791e25e0ae75dd0669590462c68c67bb6a037e7a266a9c61398a8fad50260"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "0b427366e3121d50864102fbab7ed00654da6f0b8c12974ad5d75602685e91cf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "9b995298aab00fdf9d5389747bd9ec7821b3ae6850aeda7e46dab506437bc1b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "bb672a270c1b8a77703ce71a7918014428abd6c0cecd78b7bf1ba297f6a3a4af"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "071a899a73f18ddd8abc3957429ad10ff10eb3a50a0be1f5bb0586b4dd6d8e78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c7440b4697062c4009794d9ce04bf19b465274e55c89bcbe628f18cfbe1bd5f8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "34f3ea225756342a49006462121c6503218fe9f0157660f10c3093c056a4c8cc",
-                                "uncompressed-sha256": "22d542c79aa5d80d5f686cac9c1071d18ba863e35e61bf2c394796854865dae4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "fd1f5f79592d97ea746a78c4e858fce38e14a6e7dfd0e0895063bcf68cfc0dcb",
+                                "uncompressed-sha256": "38cf67ef2f64165680d9f6cedc793357778cc51f75c7d95d2ea0907705794793"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "fbb6dff64fde317e8672482109d5b364ca098f6401a770a0cba9fb04dc27bb0d",
-                                "uncompressed-sha256": "fa85b62d3931658acfa32e91d3c9b3a18cfb605bcebb6cd1106402431161e7b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e110c4edf4033459a7fadee9998950568f1f1512a8a4085f9cf4a99742d1b66e",
+                                "uncompressed-sha256": "1ec9dafcff18717deeac057b69c9581f2d568666f21888b96dc688ec3b022cfc"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ae0c69e25dd31c90ab786901ecc3c46cd3fc9140192183c5e69c72db3bc90913",
-                                "uncompressed-sha256": "6984d7c1146e225fb17672c07dd972d297440852fef02b675c23a01c0c7c5714"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "d15a84aa5a6bcd30f9e3b2c86b5221842f965baf60dc8c53360667f3774b1b62",
+                                "uncompressed-sha256": "ea5512d351327ebd710a607172e8031caf111a03dd63f6f3c59e6e01a4d1d801"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/ppc64le/fedora-coreos-38.20230806.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bd116516619f011589cb4fe130a39a7dd53b6cedbc9f5ff0a97f05d0a27ae9ca",
-                                "uncompressed-sha256": "3359d92468f670576c68460ea8ade34d7a1eb0b47776f86b65911152091652d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "10b57150bc0572644be705fe1f783679a760582b381248709a752726fffaf42c",
+                                "uncompressed-sha256": "c790527bb371d77ff7cf02888191d3d20c6f5d28c3734fb1d352c621064d0437"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2191436160f0d42ad460790c8189d6ce77871f78611f61da45ab0bc29e2c5ced",
-                                "uncompressed-sha256": "9af2816e24ca047fc972f5b80c3e765d231eb90421d143a158ffbdf9e45d11b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7860b61a940bcb5ec7214fa32a65ce76a47a969ac0c54008d126cccfc9c9ddba",
+                                "uncompressed-sha256": "956a655a3df288d2762e32ce1e9dfc037b747a8c21f807b3fbe766ed9fb00c1a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "30705ad4a55d15e44a1922edd85bef53acbd149439b785f29bd5886011244bfd",
-                                "uncompressed-sha256": "b54837c58294d681d902bf0907d7590232f491cb9ebe5a2e6f14493f7c51629f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "08abe6c4764a266e715a58de961b9cc452d50dab0b31231c87d750a2a641d3c2",
+                                "uncompressed-sha256": "82e5adb2eab5a114b88a27ebe8f784de4bed8992efa2b5e1e09119f284ad8d1b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live.s390x.iso.sig",
-                                "sha256": "c61b14a5aea3c71037dfb755a8aa09240307804d5eae9bc8c13093921fe8343a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live.s390x.iso.sig",
+                                "sha256": "b9b31bacb9241e0b87260cf9880e7e241c14396434a7b1e84f1756f3f31a9ade"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-kernel-s390x.sig",
-                                "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-kernel-s390x.sig",
+                                "sha256": "d73c2dd854f81ac24587d8e7752395fbe51d8cddf775a70208e0d5161956da19"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c1f1c4c8b03898529ab1f182ebc8acaa41ac19ce57684de35ea6c7ad0825cd9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ae0ae8526395cf076846ee4681ec018cc1d4ab1cc0d9c91b485d29db49d082a0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "1a7541b90d0b30a190cc37f5a39f1dbacf666c8502c844e46dd8a09bf0a3baeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6708c14471bfb9e4eeb78fdbcc2ed70ac0858e512754bf3a67fc9c3ab60767e8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "330c305d9b6c2e985bb53b20a435fcae2b06eb73bd9635b946039abe805aa98e",
-                                "uncompressed-sha256": "d05e96ead8b24cab64e9d519696740323739e8e92d1b1e280c65097f1ab65c17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a0451e32ba9da45c3cb4a029fb956ba6460f075ddee532005df90c8276405259",
+                                "uncompressed-sha256": "d718333962d1a121c0575b1d48a0816dc028da500681f02700cb476bbebbc9b7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "754cea8801ae3bb91290036f0f39f5d88bf94619de39e56ea89a7ec4e2bb772a",
-                                "uncompressed-sha256": "9e4d07a60a0e979375c9de068dbe71e8cf05e405c692a21300c0c259a35ec009"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b96f3bc8234c8343f87bb2f842377b66b189ddeb6df6efc2f6ba9cbad8ce64e5",
+                                "uncompressed-sha256": "f991f25119c8a123ef1c2babb268d7fcf1026b9826af5180362b49445f990a3a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/s390x/fedora-coreos-38.20230806.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d90859aad0107c06626da5b6a7cab83f3fbcfc2e49b3126589620efecc9ab9a0",
-                                "uncompressed-sha256": "28422723a4b14cb4d74dc52a7fd6bef91f29a981ce228fdb0d98c6a07e41167a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6a8e10d9e3a4dd79fe2720d3a631c78df32ac381cc41fdb05e6a6d3d98a30f3f",
+                                "uncompressed-sha256": "b009f630463642aebdca49b14c40ff4c9c04c33d4ab5e8c109f4a047b9d24ba9"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1f229785ca17b2e613c5532fb83ec795f049edc743b6771434b7b0df020bf4ff",
-                                "uncompressed-sha256": "ef3e419788254127e02887227235f4289888447c99993f20a4598b4bc25bd13a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ba9d9e2b76dd4c06accd9e8cbc80bed65620d5a8967a36a74bfbeeefd46fb581",
+                                "uncompressed-sha256": "6126c55a319613ca571858676e30b7d3824554fe6bbc1cfda78d2206be7bff80"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cf50a05735e3fc59284483e88ef65ea879bfaa7405d29446810b1b2373a1e338",
-                                "uncompressed-sha256": "e1efa34d84f4dd0bc16e87aaef0645cd0bc04c50d35202cacb1344ff99162a9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "02731a0db625cb32f1f5b872cc146d8af74adec8055213493a2f83ac27b42bc5",
+                                "uncompressed-sha256": "9fbe96fb2cdbe11a317daca697f0c436da2976e06f704406ef44ce6304eefeed"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b4b74867c7470125919ae20af5042ce38fa250c198f2b0d4ad4eeeb40df9d52b",
-                                "uncompressed-sha256": "f7ee2a6a1379c2abb9aa82d976cecf4458bb7a0ffd661b83cab68f6e3580eaea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "66852437f6832b8a99bce3297535e505a564ac18b87bfca1a6ac8fd8027cfad9",
+                                "uncompressed-sha256": "d4a592ab5e3cd57833571900266a3c79e98c21d87a404904627220a40ce69ca7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c1769776d7fe6247a2d54749acddd31c4f5f08a7e49a3ad2b9d71ede142ee1cf",
-                                "uncompressed-sha256": "55df55b2147b48fdd34b27f5a486ffe454475c8eafc00f564d2ba55929d5d1f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "746817517e02a30f3e1c3d1653fbecb630c385b41b271cc5d6fc85453eb42a90",
+                                "uncompressed-sha256": "1fa07d6d901be44919e5d7d720f053427b9add0eede2a1ac3467afe1ab70ee8c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3e59c88b2d98fc862921135f21e50698574a4d1b130bbf264fbc804102e52d36",
-                                "uncompressed-sha256": "ba18ea8ab7f31e4de316d6dee2f2365c2c946e4b5095250ede9012d195584e5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1601e55c4d25797527db83025ff358956dfcba34214552ff5aeb729dfbc14d1a",
+                                "uncompressed-sha256": "6352032fb779ade48f93675e4e32aaf84457977d50cbf95cde83dd2be0415cfa"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2c86a643fe635ea9253cddb4b2bae7b101b634c8e2d274fb4a056a2a4d446040",
-                                "uncompressed-sha256": "a2f830eb2ea13a82b0d4f70bd8ed600d8cabc037c48fe4c81e48e643351d62ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "89801d4a3902e78cf495d4843c8b21fbb39be20ab69559c03a59269944508d1e",
+                                "uncompressed-sha256": "0cec7d0768d1e6b6b97ceadc559a26a7ca960ea06d3b24d8813c6c2fd96bf486"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "8d13a3c776235b4d21c953196fd5c10f9e61bfe36f5f85b3c598e2b30f6807c6",
-                                "uncompressed-sha256": "934536027b0fbae077157cce1a4d54e31d61c2212ad14e55e5f68fbb24fea853"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "aeadb0262f8b3d144fe9e1938e3ed1631b80298f295f644cab8218a0726c2aee",
+                                "uncompressed-sha256": "041e1756ff89b669e2920849308a8d69af25ae6fb69452f93a7fa93cc5aca061"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "639e6b96b8d458cc6fc9bbb705db125a2c32d0cacde82db30955901750c52dd9",
-                                "uncompressed-sha256": "d62e62abefc331c622ff8a4c6419877671577505de0adfbf8ab9516bf0da2eca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "459b29cc81055424b0dc54202fdae88831951f619f4f7472e977d5d640281b43",
+                                "uncompressed-sha256": "defa2e45975d1025ced7cca6d6ae8d5e3a7aed577016781813a2ad0b6d04b0e1"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9267bcb2d3f1b56316d5b2ad85a3f6dc7cdf2749dfa26f9832466e084d036512",
-                                "uncompressed-sha256": "0b4c38186db4a6db681377eeef6065b83b66c31ff9949a1c9afefa706549c4c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "dd764eb470616b65d50675d619fea41007f67f3a4c16bfe242c5dc226c59aee7",
+                                "uncompressed-sha256": "18b3b432a5b31147bd49d45394c6c0775b5074ba95e6ac63139b40ddc3a031cd"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5f55ec20058a75ba2b2e6d928f256cdf24fb8a0ebd3790100bbb7aa07e80d305"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a3e34b6e676c080071db608790de59724c25678bb4aa887101bdea856eb7d96a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4d175aa88208a738903ec92accf036a21c166ac680d880727ff111cc493d0737",
-                                "uncompressed-sha256": "321329ae44d94c414a1b5a3b53ed29fd20eb81c8bb541afd7dd833f80cd2ed05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "326aae3a93676191ac9d263e39d2348499453b5825ee0a55b9b4bafc2a3ee5f1",
+                                "uncompressed-sha256": "1dcc2351641cce0b9242970d290d0ad31360b523b76cebfee518c4a32f0e9938"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live.x86_64.iso.sig",
-                                "sha256": "bc25b9aac6ce1af7828fe1e7d51430d76c43060838ab1edd9b8bad770d55c9ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live.x86_64.iso.sig",
+                                "sha256": "eab6d063c9123aa83fa8c87a47335c0eaba05733979b5d22904597c7815b8f65"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-kernel-x86_64.sig",
-                                "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-kernel-x86_64.sig",
+                                "sha256": "ecf92904e2df6ea872fef9cf07702eb876f5131fdc0d0e09ad54c6a8456618fa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3cbf19abd54723c4c50c589303eb290b3a98ff46c5b68331f3113c1729a90319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "83f9d25521bb255022fcb875e05779f40915b5a1c6b6bd4aa7c1043ebabe03f6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "92f35fe8065164ffbedd82b35667147c7ea6464a7645a85e4a83fa8e39c802e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "388aa8718c895e5425c664e28363517d5dc16f0f274c9738c7750c70639f36f1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "023dea0b6582b5f5cb1217a7903af43a2c425930490fbab050ff05983b2c378a",
-                                "uncompressed-sha256": "a4cc0c217c81353a7a88ae4768315766ce7e5c754df4faea70332b75605a869c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c088eac8747313a641622ddea77ef6f55aa38b3cc3671fc0ba2a7bc61ade4563",
+                                "uncompressed-sha256": "0a1e4fa815df5b5b85b3b9088abb5063c82165cd8b9818b759500b07e9d8f93b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3fe1b7ef1a7177b8b45bbf7a4eae7c6515d7d907792a807d2e56d23128a8b693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b916e857a8a14fa0927c3ce05c94def25ba11a6bec97f9e290299abff0eaf18a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f4a286517985c1565921b25b61319c356b6110e15242eaff2bbe4322c426e553",
-                                "uncompressed-sha256": "0fcbe77d88555e4fb62972326dfec97e0c419f7c44dbf4f32c22d10d143a8d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "102b84f0dccc5d2f1de8ae9a5ee79637f07f8aad7547fb3630bced541139d3b0",
+                                "uncompressed-sha256": "9aeb247d24d1a986aedfbee71be5d9bffc33e6b8beb2b90208ae4fef8f7d32a2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "26517edd4bfc3a48a8fb6e09c63eda47c28880729fa968f56d50441ab959cfa1",
-                                "uncompressed-sha256": "8a5e9f03158ca11fd867d4100058e6299be2d66bcb4ba500e729b8d6a2ee4f77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ea362f44eaa145c24cb5c37b5ad39631db2574b502145aabd4b889a9a065be21",
+                                "uncompressed-sha256": "0bd325ae4f2e41a5178dc2d99565d80b80ea40bb9067719055cb1189bad2b06e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "21eb57f0ae9535d2ed5b28e6e8955886d4a1e5209f118c6142f3807025d971c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "2a737b7c20f1ce7e7ba41177fa50444b436816ecdeea7434d13dfa5e5e55612c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "c4808f2c08c0fb3dc5c72801e8927f2e01fa0ea224f3ddddb4240c741fc63944"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "5aa6f73e5ecf99644a5601191c3a9cee681132f4f9589dc3b82a4ceb11b8c0da"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230806.1.0/x86_64/fedora-coreos-38.20230806.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0ae015a5ae6b6a5af81c38e85e41827f55f66d76a2b7c2350701e3a4fefdb692",
-                                "uncompressed-sha256": "7c3a12474182ad30702143b8aa785241b044e87de3c5143da9799bf5b20d6a10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "40b98d39b12c832c4d7ff0d6733f2814d73a8f2bce6db1b4d3b94747d4ebf6cc",
+                                "uncompressed-sha256": "e6760d5be3e7c17a3669c81d9744f22f3190a8f3d4fd4a070a12681695c6fca7"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-05db313f68ef1f082"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-004cd58047681a9b4"
                         },
                         "ap-east-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-09584f35920ef0e8c"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0e9a9a7f57ca750fc"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-08b8a2678ed92a213"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0343aa22179ac2767"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-00f8a282fd453ba3f"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0734cd31472bafb85"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-018a80b580d9d325a"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0b870b79f923fd3aa"
                         },
                         "ap-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0cde35417dde5e35e"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-00dbe525256cc9ab3"
                         },
                         "ap-south-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-076b47a829c84039c"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0a6ba615edcab0dcf"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-00e39c15baaea64f2"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0edd453598ee74ed4"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-043bfaf90fd8b8922"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0f1a11240dea9873a"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-05744d591a62bad91"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0a575141ba5ed63c3"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-062bd18e069f58afa"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-074ca2e691cb07193"
                         },
                         "ca-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-077809e59268024bc"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0b6a3b8ca21c9c144"
                         },
                         "eu-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0ae5ce89fe3612a96"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-01730e24981df715c"
                         },
                         "eu-central-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-02692fe8efb1e543f"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0259e7f89e1351116"
                         },
                         "eu-north-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0579d6b858f22be0e"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0acb7af6cb144a794"
                         },
                         "eu-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-05ba97dcb8bc7e6c8"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-05e9d3035762b909f"
                         },
                         "eu-south-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0746cb4357fb58303"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0e118f28721af9a31"
                         },
                         "eu-west-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-03469d7b35a350d89"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0b22f81b6aa0e061a"
                         },
                         "eu-west-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0e51fdbe212fdaa60"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0708c0fcd0ab987c5"
                         },
                         "eu-west-3": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-034358f860e07dcbe"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0a8feacde3c925480"
                         },
                         "il-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-08b1f2c83bb74b2fa"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-041a247b18d42e9d9"
                         },
                         "me-central-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-09592d3da79570835"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0f7721a05a691f774"
                         },
                         "me-south-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-051f9040f4c9cb72e"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-03fd226b840f76659"
                         },
                         "sa-east-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-00a5eea4f1a1237df"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0a49ea395d8ddcf03"
                         },
                         "us-east-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0b98edc76d3f2e764"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0d20ac32c2c7d4a28"
                         },
                         "us-east-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-04244dc7fa291d02f"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-0d9e553f1d87e4184"
                         },
                         "us-west-1": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0c6e3316ac7e21fe8"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-05fa1985806819560"
                         },
                         "us-west-2": {
-                            "release": "38.20230806.1.0",
-                            "image": "ami-0ab39263c700fb3a9"
+                            "release": "38.20230819.1.0",
+                            "image": "ami-056314a2a02067342"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230806-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230819-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230806.1.0",
+                    "release": "38.20230819.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3b94f744a4040762ea95bd929951041d6bf96fa41c83632500ef6dbd3967a6e8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6fef84324bc13415a89fc8e4d1366562b2412f086f86085a039593c8ee8f7ac4"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-08-08T18:34:22Z",
+        "last-modified": "2023-08-22T18:29:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7bd30b0ef43c4e2989d1308ee84f13631b278eb08348d095711fb5ba7b902dff",
-                                "uncompressed-sha256": "f91de678f1001ea47edebd3c941af895b4d0815412890ba758847fcded3ab1b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1714d8ef458ecb62149ea43ae882bb0932e9dd995564e62225bd6c1f40035f44",
+                                "uncompressed-sha256": "d64d7361c0f21af2aaec92d071824d62d194d9e5bd2e49e3dfc5ac8134819e8f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "971d07ceef071321b8525a7ca10d9b46a49858236c31e230f641b6d5315e4001",
-                                "uncompressed-sha256": "b4eb87016efe4058b4433c69cf7979e9072416497f9081fec373cc1a19ee8dae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "cb7890593ea9811fb746dda0325373547a1e5982ba442baff58b86228226eb76",
+                                "uncompressed-sha256": "84b5f64aaef175ceb404fbc069e23b7e68f0d2c2d02486649ea195da85efaaf6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "7665aa78cb3218d8029b6eb3681f148b6605e2b6c6f46e26267c9b782187abc4",
-                                "uncompressed-sha256": "414e8bed4a8b67db9428652dce94feea0474dfa17decb2550ea51c096f06f5b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2b5df874026e9b1d05e2beda20c565ebd926b059a0f17e3e0fc135df0b18980d",
+                                "uncompressed-sha256": "86da4f5a2264c2c4c941e583801d5f42e824241da904935764a8872c34a82d3a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "90e8a51f3ebc9d20e5751a639ea58f33746fbfe4de77bd490c08e9d81bad5c61",
-                                "uncompressed-sha256": "32ea5f1f54647f906e8837211d5ab5fc69c1ec29dc1c478c9163feedd2159817"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "dc6a7e759d096fe9fb57b63f51d4eae31239da3cc53b8b410fd8f55d9cbc9b0a",
+                                "uncompressed-sha256": "87c7c1629d2969fd7455aa36541f9afc15d947fd35a65c5bd574180cf111db10"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live.aarch64.iso.sig",
-                                "sha256": "4c22126a71eb29d5b182525e7d755891fd0b1890fcec9fff3226526a28c89936"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live.aarch64.iso.sig",
+                                "sha256": "57c18395b40796572eadda36eb8495bce4a120e15157c36a0a3f5ec0c48da6b8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-kernel-aarch64.sig",
-                                "sha256": "94784d5835a4cd49de420d4a04368cfe9433eec5a2da488481261457a1dce000"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-kernel-aarch64.sig",
+                                "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "b17207c691f17a140614b8dc656a94c9c4f9a631b2e5685ce8ed2d6162ff9407"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "86d78e3921b4b9793fac9108a5ce2f4e0b9d0a8406bdf1860c2cde49015552f4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1d63e00a62463345791722ce53b269bc6376a8623acbae1a7af285787ed55f1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c38f7f3378e6e21268066f61c34af1b03cd1d7b1ec7cf71d6a7fd5710fc9bf8b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9c335b0dfa8e5334b0c7bef1c6623d91316fd5d8cae86bf0d1ce97ee27bb36d3",
-                                "uncompressed-sha256": "878e9e8e9c6cefcdfcc312c0e9dbff399912c25873fe482e1c1accd1e44eb419"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e07df477c3c1909541acba4e8e8e3608ee1fa8b2f1e50c414dc3d87e341ffb7c",
+                                "uncompressed-sha256": "16abc9c2adf19ca2c72a912305e58fdd595cbe8dbba0f8e913a6846ed643fc88"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "9e02954496965266e028d6e46ca21c52cd9092ec63998c7a744e25772937cf7a",
-                                "uncompressed-sha256": "1443db95193ccb06b7b5b82d3a972680550745c981d5acbc9ea0747f2bb2a715"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "796e8cfa5165fdc020d858181dc3ae0aac8019e0829e1c0812b5153c17d983c8",
+                                "uncompressed-sha256": "2b8eef5eb294cad5b8653f2ad3533cf77ae37ac023b3c3f371362574a0dd048b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/aarch64/fedora-coreos-38.20230722.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "dfde13319519c398214200a32c93104c7cd0c7905e4587a3fcf9f5b781efc178",
-                                "uncompressed-sha256": "d4487cece3565ed72fefc7645f07ee811d45a7cbf55665882c264088e84ea319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "17adba525527f6235d2819488269adebb6594d0d22cfa3e8ba31795571f43863",
+                                "uncompressed-sha256": "8ca5eea802d653382a861189ff752d7afd3c5fb401d4a45164b37ee674535763"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0aacf5cf66314afc7"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0bb75d130b38ab37a"
                         },
                         "ap-east-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0348a3cf2b44bc865"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-069be3627758158bb"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0fe607dbe1e2116c1"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-04393e0a61c6eaa4a"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-06eb55c782f3fc2d9"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0d87b8f5c15303c4c"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0d629a1dde030ad55"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-082bb2197af25e50f"
                         },
                         "ap-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0fc480dd2ed8753ac"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0855ed6c20cc6ceb3"
                         },
                         "ap-south-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0df322a749f79f1e2"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-04644028ea4643a73"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0354b141dc2d47891"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-08b02bbacc7a72ad3"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0d361b99e54c041d0"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0f535956a46580fcc"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-09b54918100676377"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-01b0f55ddd61eeacb"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0f364fecb5f8147d7"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0a4220c9413e90a84"
                         },
                         "ca-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0e145edf837fd72ee"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-06afe0f5dad6e6570"
                         },
                         "eu-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-00b24ca76ff22efad"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-066fbfc14654cfcd5"
                         },
                         "eu-central-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-04312267c0459d729"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-05c89668815a2047f"
                         },
                         "eu-north-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-05012a37b76186011"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0a8234553a6e41323"
                         },
                         "eu-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0e1abdcffff34dcd7"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-01362b1118bc10ba0"
                         },
                         "eu-south-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0fc465034e590a865"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0e9840bcb36ec6cda"
                         },
                         "eu-west-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-04b4db2e4005d8bfb"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0d899494dcc619c6c"
                         },
                         "eu-west-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-03830281286810662"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-03d0f67ddbb49e547"
                         },
                         "eu-west-3": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-055427b16a907c659"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0980f8b43fec4950a"
                         },
                         "il-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-01bf2b49ca8491955"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0f2cfebeecd244e48"
                         },
                         "me-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0236b8f26975e5755"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0086d65b481ee78ce"
                         },
                         "me-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0f7befdd31aa63988"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-001e551c948f123cf"
                         },
                         "sa-east-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0092a2b172e425168"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0f298e70e0ae153c3"
                         },
                         "us-east-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0f27f23abc5e0e595"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0429e7b3ee561f625"
                         },
                         "us-east-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0d6471d1ada213433"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-068284c85603d7e8a"
                         },
                         "us-west-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-043694869ae789a7a"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0badd0e9b86e1c6ac"
                         },
                         "us-west-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-063119d4cd8da7a9f"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0a8ba63e7bef50c78"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230722-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230806-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "8a4e02e3cd1cd3b6a2c2e37b4a3ebdfbdf8c2ae2c93b86dde9b72d65a2be5070",
-                                "uncompressed-sha256": "95501c5c42dc2e0bb779c859dd0daa181cafefe89b1bc4d679df5bbc162c7d97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "64b0a13ccd6d41292cae3931069296e0906ac339dd3cb9aca7b50bc3bf817d62",
+                                "uncompressed-sha256": "82ed335fce1200c44114cc6d3b79a8e3f4406e85ac7b0871cbecb70305e3e99e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live.ppc64le.iso.sig",
-                                "sha256": "5bc874479d91520bfb3489cec3113f3c1bcf7bac0070fbd294d6cf3e304c8359"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live.ppc64le.iso.sig",
+                                "sha256": "f032eb4320453ea55c0e2dcdffa3e19c29c76512fa2c68e1208f88530fef8d51"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-kernel-ppc64le.sig",
                                 "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "4cfaf35f83a8eb4c05dff11bf8eefb9b967a7d532063a3355ba9621f5b1ef06f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c54d8afbd13e7f758e45e9f1e6349542abdf825d5a0a9dd7c37e5d3b003158b7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d624c1827708d4a7c8670eafdae9697f54142c77c9c8171cdaf0f317e8824107"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0982cc06f195f83550a8d0465177bd1dfd91c38b5488d147501f3bc667615877"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "81a9ca0b26ef2e07699e4b309773be0bfe4a92404d581695e507ba5157e75e46",
-                                "uncompressed-sha256": "576139b66ebc7b7f6bc8a00ae9b3ce40830f5a5fe1ce6855e1834610ce0937cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "8326d275bc3878121952ccfe89efa8f48bd8e80f2aaa6c2f56df1f356cbbe778",
+                                "uncompressed-sha256": "2043fbd10396f979f788b4e75ded99d13781d86a6b61537297754b92a0a3efd2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "5ca70ea7935e2434f29abec65977ad067486793aac8c8c4b7b0c1339bfa95ead",
-                                "uncompressed-sha256": "51875a7c37974f626423a5ceb7d2b34f565e115b988ee748bba920b5b0159272"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0a8d8da43a383cf8507d81ddb182cc3d39e9ccdca21a66539adbeeb6444864e2",
+                                "uncompressed-sha256": "cd8ae08d4b31c82644b87c3af978552489eadc00052cec451ed35302865c99d5"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5c20fc73aa15b09d0c8e784e2a26854f956f6c824e8b1e63c4bdeeff4d15dcf4",
-                                "uncompressed-sha256": "eabc738551c6ad8b7a9e8cf822e56b3a02924416246ddee71868d9ee2591cb7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "eec9140e0807288fea6ae43d76c4a384f76fc964fc1307ccd04cb494be694d6e",
+                                "uncompressed-sha256": "624c0a080a7d10d54a5c949e2789db928704ece7dbc39bc7c0967cce65f7fe26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/ppc64le/fedora-coreos-38.20230722.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "81fe8b3ddcc2198721e21fa5b1ec2c4cfdd58287aea379a93559e5551d6896d0",
-                                "uncompressed-sha256": "09f249c1e63bc614cd43a57bff16f68a59f921496be39db52a25b9ce48176ab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "77d13792051d2bed417828494e8388595e33cec1648cc76ee1de0b086fe471af",
+                                "uncompressed-sha256": "4692644a5a818303393e624d62b7e4b1774a499c7edf85dcedfc8177e8bdc641"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "feddc60844b11f3bf1a5d42ec7e598116a5dffd1a248f9d5b350a1584d282b7d",
-                                "uncompressed-sha256": "7b1402b5d9c7c2e52e39132523e952444ce26533e0552ed13168c4b169af50e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ba4bc19196f897c0df732dfe85c17a617b629da65b9bfd4859abd7273049e42f",
+                                "uncompressed-sha256": "2bb29f98f8ffe313db206632cc647cb9ed4836aa18bfb82d2809158135235bc0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "35901ab557861eb9dd6f664fff393e6cdd9e4ff3e0e51cafb305a0e50d057646",
-                                "uncompressed-sha256": "02d68f449f447ae973b7bba8ac7152c4b311cf1c41ea17a46d74a1961fefe2ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d106c8d912a6f4c1674faec324b0a256c3337ade1df716b22f1b80e4fad69079",
+                                "uncompressed-sha256": "f74c242dae885b28a2bee2541f71393ba9f072fc54de4c4d0fadd559545e9285"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live.s390x.iso.sig",
-                                "sha256": "9bd9cde6f96a9214af4b151afeb546d9099e7f423ab6a3430a2fb6683d42df1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live.s390x.iso.sig",
+                                "sha256": "e1c4acd88b23e548fc12d1ca2ec36b72e1446817c0bbfa833df9e8809c7e86cb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-kernel-s390x.sig",
-                                "sha256": "5ef1cd96c43354f9e87874e24273149d1ee882a86157abf5e09c149e8b2bc60f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-kernel-s390x.sig",
+                                "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b3aeb06692140947e02ba87d938c9b398e1598ec43e8b9ddabc230cbc7fbaa01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "42f394416efdda2e713f3fc29962cb9a6e3416e5ac251df271e67520a0e59308"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b747fe28d5957b2c38e9387b51aaf08fe49b4ca66d06131ded4e13980cdebca8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "112a4f48d356d4b420d8d024b77d011e240082a650b06eb2a558ace2833637b0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "037145dd9fad737655dbfdfcd62ce5f290636e37dd4169c10952c3ac2f806f4c",
-                                "uncompressed-sha256": "58406856871becf78609e1e5706a8749749e0bdba8d3545ba8c7fecf5fef3bb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a1c6b90ba9860e4f4e5ad5dcca480ce05e38953a2b50f94e8e47d777ab8c62b2",
+                                "uncompressed-sha256": "82dce0b27e5888d53f472e805e95e2ec4ad6093c04fd8c7591909e0417862314"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "7ae787c0e6f8ec9b20085df318ca16b578b8dae50d883a6a76c541c02502c39d",
-                                "uncompressed-sha256": "d56ad52d603cd09f891c9af75ac6c0e0851d3a21833d4007a29c706ac914a93f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8f24453646f2a9478782bcb5e4a6a4779282636d9046ee337c323546abdf11a3",
+                                "uncompressed-sha256": "e588d6954661d7eca67bf0d72bda9830b706fa23115c0238eb8bf9b1cfdbce5b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/s390x/fedora-coreos-38.20230722.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e911ee9da53081f25d311f7b20129cb496cf3800fe6ee4fd6832474bd238e3cf",
-                                "uncompressed-sha256": "7fe9ca3a1fb9171e26737595e39ca869ee37f59b3a3cb688986f9f543581bc15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "97ff6c751611b3ff88432535c82107cc766d92f02174013f2015dbdca152c559",
+                                "uncompressed-sha256": "6b2ece5417704b11d3b67da630ea2c3c5df9a23c327fb96a581b2d970a07287f"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f48fa6c8d5c8dd735b90b578ccde7001bab35fe5045ceab0241da53bee0225d2",
-                                "uncompressed-sha256": "edc06486e6e1a2981f53aeab5fc3c9ac31fce8d7bbf3e88b59f7204fb809e0d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5c876aa07dce24942fd9e051d9d536f6ecfbbc57e5d6c499c11756e93243039f",
+                                "uncompressed-sha256": "4da096e34864ad0b4530cc8616a07d9a16f01f7a13e09d367858500059dc3224"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0c36bc240a1bdea978e4950866462e454332fba4dc67232fc6b872aee5d96e22",
-                                "uncompressed-sha256": "fe5716c94449d9b85179fec3e201a90e54d517c411333fc7206e4e050946e579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9f7ba8ee2c9f398cce59fc20fce40fa18bba59d44215f9d29280c304596b9af3",
+                                "uncompressed-sha256": "33b57e4e8a583ddfe88f18d7c1c1ea7868583e302b34869cc24ee75b11ef484c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e7caad3b0f7883e1da0acbccdf7f3db419deabc82d4119b636485a69de8d0a92",
-                                "uncompressed-sha256": "ac4b0ddc37a915372ca0a139f98dc52cc183c14ef5a9dae4216eff8818b72b47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b070c059fb2f9dc6d38646a3320455d3d20ab2401b90df26cf621ffa79876457",
+                                "uncompressed-sha256": "fdac53eef74fc888fc1d5b12702f3711d1606b90581d33aff1013726505c767b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "221a684bfcc27a41bc592d0160d2abc4b3794715ceb9f12bd9f13e05385af087",
-                                "uncompressed-sha256": "1fcf61bfbbb18695450ef949c1da0d65b5c1a278e86d58059a2e78ec36c91cdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e70e27c34dd46146dc2b526b58819f9e3262488cbf7f4e2e58068418e33c0299",
+                                "uncompressed-sha256": "a0c3413cd7c2ddf322348041bf8813d30f1b7868905c2252f1e2f5f6ceec6cf3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "cd0d891c998a51261d62d6673303f5993423003b0400124745607b7caa2ca1c0",
-                                "uncompressed-sha256": "41ceab7342f43d4a1acf0e9fe5b666eda3c619bf5bbc32fffdf7cec0a038edab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f21cdfb85b3174c7647033ed42f42d31c52bc609f9a089569e510a35e206e951",
+                                "uncompressed-sha256": "f9b97f71752ab93a9468a08bad5b070a1feec908840a2f0764f7a2c3a53d302f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ca1a08650b6e26c08f1331e858138fb02697652906cdff113b917277c4643a65",
-                                "uncompressed-sha256": "8590ac9d4187432230c9bb06a821f1c6b6f18da3b4ec9354cc486d758494315b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a025669433cdb657fd68b42666488a242680b67b61c0f736011b1598c2668ccd",
+                                "uncompressed-sha256": "385c57a3f97d1d71740570a6de37188b1fee71dac545f5eaa53588f202244784"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f05fd5fa6217d87c6c3c8df191cb31dad103df0a9470555182c6dece1ec09248",
-                                "uncompressed-sha256": "2c2cb8573e39e9659c0133c6da764b94721268bfdd99e9b4910de1d5f00a969e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d022e2e6b127eed89f00f1afac5889ade714c5ff45152b6805d569bf6c98864d",
+                                "uncompressed-sha256": "152540eb6fbee931e21439cc2d80a6cc210f676e3e4db216484689a2a3546b45"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "f62e3a65375cdb3b3d1e309dded740a8cad8c05237d87669446e5815cd232f02",
-                                "uncompressed-sha256": "e812e4c45e10ae1b687fef345718e1ff5890594e841cb299a64a317fd256310f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "75c3f86838d0ad39caf01b6873c1bfb4a5591dc8304602a281fe8a4c6465e022",
+                                "uncompressed-sha256": "bbc6f59c05213d27528e4e04d6b295c87037dbf1e5f4294e8b951821678a6d59"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4dced55e5ea37175db31e69c93c10fd32f8de70d4340010c8940c0cb5cdd0fac",
-                                "uncompressed-sha256": "f48ffd78e64e099e9319972383470a731553b9a95d869aa9702587da40b8f2e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3e1df0b0d9554d812bbfe2326e9f5574b9bf0d626077947a5c47132df1621dc2",
+                                "uncompressed-sha256": "5de0c26ce6d196ef2f241e53ac2fa5736f96ac7ede4b2011a313fab3143cb3ce"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6ebfcff8249c0653b91c140289bfe5031c1cce9c72c01c2e66037723dc77c51d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "64da9fd61b5fe853851fb15956dab14390229fe9425cc969897505910c7f8531"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f9e8c1690143fb23c58add24d680f4effb7d711ca5c5b58ffdd86209f9365e1a",
-                                "uncompressed-sha256": "d487982039e8eb0ac96275428c6435206d3a229125840872348eea6a4c47d6e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5d97b8ecaa57d62bac3d8a538ada00c79afd48e205578b13f2cdf016feb773e2",
+                                "uncompressed-sha256": "aa55ff950724ed5feee6b66080453fbf8a757e72e505bd176f5986447795d9dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live.x86_64.iso.sig",
-                                "sha256": "2b786dec1a1c409e7f0045cbedd7fc54fb74c01063924d6111c3cc295e01822a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live.x86_64.iso.sig",
+                                "sha256": "4305aa0f7fb9f32a4c4b2559086311200db94e1ef0b5d4c7897424119074fdad"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-kernel-x86_64.sig",
-                                "sha256": "88465710467ae0d8e2b6f4c81fbac5d00f7afb2398c130dbd483431e7b6998ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-kernel-x86_64.sig",
+                                "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "39a59c892e109e13dee660e55cbe9ef82f0ec10f1c4e8e97798d0d2b43f8d867"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ce80e86da7cc1b51ce62dc87a6b152a9b2863b6289bafc07edbbda28d7b28d57"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "31ad0f9f7d248415aaeb8e2ff0c5ba0e94c44922d9f441fed1c79b7e9972b030"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d75315a83a7da1ab17a7f74aa06ddc23bcfa0adc13881890df052f4a7b098d27"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "73ac480d0878fe04e520362e1b331d6698d2011b07c2e598503abcf6e6a870e1",
-                                "uncompressed-sha256": "d328e77bfc18e25c634307223d3fe17518ea40f71341ec94113ef3f852acbf0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "442b02d43c42c79c73859ec6049415b22ca3e69af4edc23a35d4c3dd18bed953",
+                                "uncompressed-sha256": "a6711fd709712d63e4b24ed66bd9649ff5a3d32dac93d8575bbb46afcd88f4be"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a880dd2b1cac76ea20c84ffd0c5cd6aac5ae4be4e5cbd7a80db35386ae73eb8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "de2717d8099023c15d065a25f1d62bf1795b0f02289e82fbe2c4e9a14a93fb05"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "815763b89a8b343f866a1850d3345461d198d069898a8ef68a451e4c31306fa1",
-                                "uncompressed-sha256": "bf6a5d4e657ccaf0c8bd2263b94a2a39d8c2d0988e2a9a2211b9e61ed69333b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8f76f70ff645edc35fb29817cb20b9cf2e1ab46efc9d75a37257a6689f128cd9",
+                                "uncompressed-sha256": "1e7ca33cc0afda45b51587709575244daac050856d820e527e481f46689d5b5f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ecb3bf1fc4da70fc99fb25706820aed9d3f46259ecee65ffd7e805569729e2b3",
-                                "uncompressed-sha256": "8a213ccac794df418139780cae2eab2222fbfcc4c85b59a1d6006fd0622f2205"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "63e13b12fc147a38cfc7c40ecaaa373ba32134a9ea4fe74890a3b6f828554ca0",
+                                "uncompressed-sha256": "b1561741399a8f1354e207572efd403d5f7b1a409f7ca159c824e3b579ad33d5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "fcbb4012a254cfc4b63556deeac6587709ef7d49df5ef96a73137252de072965"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "eada8aa451ef363b6b16ae145f962586259ffa4c3179d20204483eaf6f841ecf"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "4ca869c1a9ac76cc5c0dc74aac2f5189d1907abbfcf80c0a5b8b96a290afb6ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "6d7d1ecf24ca451fb675d51e2abeaeae93d6220812c5f6f65f4a46b999eef35a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230722.3.0/x86_64/fedora-coreos-38.20230722.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "626589c42b38afa46c6c87bb19972fe3f1a85066d5be9fd7b0c15db702f43b97",
-                                "uncompressed-sha256": "67fcd0cfb38dc5744a76293fc00d8b9a6e3ed4a22c5b9142f377aea60f4863ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a078df213207a72c94a217a148fd84a8b82696543cfb98087d2f772cb74cc8ae",
+                                "uncompressed-sha256": "9ca1312f84e1438eed31a14b198f46688bc3070d2e29fb39fe1f7eb050177e27"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-03f51c0d93e769ece"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-08466b5c2a92f41ce"
                         },
                         "ap-east-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-08d0a034848f6099b"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0868c51a597245ba5"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0f4fd94e8727d11d2"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0a835dbeaed3f9f5c"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0544680844cb72d12"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0d9218df8d07f76ed"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0253c5827de3ca585"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-092234a0ed3b0faca"
                         },
                         "ap-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-05c75b7b3580d128a"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0ea11ceaf76696d3c"
                         },
                         "ap-south-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0177601a7e4e0f237"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0df8d5863d530ec53"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-02acaf802ebcfdfde"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0afe00382fc6aee29"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0e6468aaaa04de1cd"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0366b0e5c600369b8"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0c2a8976c6ca9b33e"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-03a5b8d1287311695"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-01f4f4b5745312ce6"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-059d21dddae6b541e"
                         },
                         "ca-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-02d68b74489172ac6"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-03337c51efe902db3"
                         },
                         "eu-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-04d3750b706767b83"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0de26fd9943db2d33"
                         },
                         "eu-central-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0ae263e89f90f2b46"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-09420c8b1778eaf5a"
                         },
                         "eu-north-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-075649311ad04e4e3"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-072b0048bb8eb4c9f"
                         },
                         "eu-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0995d70238507ce18"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-02bb74b11dd6ac4b3"
                         },
                         "eu-south-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-04cf181f9f6eca624"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0f7f4468e3d2824b0"
                         },
                         "eu-west-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0688e6123cff4199c"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-07a153e794d08d71f"
                         },
                         "eu-west-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0a4dd3e46ac011ec4"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-026db242db3dc8af6"
                         },
                         "eu-west-3": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-03d10fa543d50bcf3"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0e1d1d1c836f117d9"
                         },
                         "il-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-08cf65ee282088362"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-073b90bfbcee50f91"
                         },
                         "me-central-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0aa447a43d4babf6f"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-01bb7abb86062e3c0"
                         },
                         "me-south-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-03ceb3dfffd8ee064"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0a602698baeea7128"
                         },
                         "sa-east-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0171764c02dc6c76b"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-006b1e302db41c064"
                         },
                         "us-east-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-083a735d0245929cd"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-03936e50359910ea6"
                         },
                         "us-east-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-015cdcda72748d3b2"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0ab4e92f3817274ab"
                         },
                         "us-west-1": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-00e1b69d489feea68"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0af71e6a20294e517"
                         },
                         "us-west-2": {
-                            "release": "38.20230722.3.0",
-                            "image": "ami-0170f39c0014e6a54"
+                            "release": "38.20230806.3.0",
+                            "image": "ami-0bcf9c89280ef797f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230722-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230806-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230722.3.0",
+                    "release": "38.20230806.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9f96cb3b94d71c03e44549b547054da630bbaa032fe96bbed16fb654c2d5ae19"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:14d59f2e0332716c89652ab776ec426b003ca36bf445db46e9c61d3a029c1335"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-08-08T18:34:23Z",
+        "last-modified": "2023-08-22T18:29:02Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c4330232a46383d1e0320e22d014dc7aab5889e19f71053ddcada571edfb320b",
-                                "uncompressed-sha256": "fa56f88e652e7e981f6deb3ebcd0bbafcddf8f6b6bb078c36f0a0b168b49da5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b1b945b724e72f7c35195fb1e757bc1fbc41cf67cefbbc0674202c5e83359118",
+                                "uncompressed-sha256": "de3a29cd94f0c44d891b404e5623e1fb7a3c6df5e2fef07add539526167bb4f2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "10d4775792b1f220193c0770cf3f615895a6bf0807004097e45c61aa2526effe",
-                                "uncompressed-sha256": "b2b4a32c64fb05cc08b5f66a4f4410612efdfef3bdc0415223f5e92d68f4fa04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "238861899506fd9faa6a37e3bcce08140b9e22e9aa26272f292e59a1019135d8",
+                                "uncompressed-sha256": "5b8d44ab175a07d4d49394f30a88ce7ef0c0ba00c2cc3ae78a77c5fa1527a65b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "fdd41ead5f3dc0579a1281bb372f71bedc91f837b668211ed4f203d434a3e0e4",
-                                "uncompressed-sha256": "9fada854eeefa11405c7c97aa0b0036b62b3026dca85ee752f8a5bd85dfab8b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "fba27c2c29ce1341b65a02a2bf4363d6a9ed0f54cdf1209906d62754782f4fbd",
+                                "uncompressed-sha256": "b956afc1e5b3da2ecc982cd15b879c93d8d6ff8deb6cc76090523804caa6b33a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3c98718c8681154229f34fe3d965a6e613f0b1c4303fe48d90f21be41c2a30ae",
-                                "uncompressed-sha256": "d38163c4b99bbd504d827054346bc3759ee4d1be918cf9c7d1a370dd436c5a6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "120b552522709351059d9e79ceb6ca474593c017aa9e63498a128efb219e618f",
+                                "uncompressed-sha256": "686403d3b523b56e7cd4c7a0297b3f96247f161d8c713bbc726a84f51f8cee68"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live.aarch64.iso.sig",
-                                "sha256": "8f80062dbc029d42b54b46bd9d4de52b16c27142764c33cd0a77729947ec9238"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live.aarch64.iso.sig",
+                                "sha256": "1fdacc9954b230b9cd109c5a67e62d2a1f2b65d68a5ea777d39f3e1c6e3e317e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-kernel-aarch64.sig",
-                                "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-kernel-aarch64.sig",
+                                "sha256": "ba9026ee27f6a3d4f37d34f493ac488895926358d5ca2c7e03119381b4cacd66"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1e6923cf515cdeba5346d4a0a4f2b3f1eaa473d9b50b9a170ef0c682284312d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "02688cd5e0396bb516b46656d620fe418f8c76afce80a87edb52ee60cafb10cc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "4c87c163a22a6b333d9f94e4009f2725390cb25c8d4cccde668af0d8db79bfa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "15c02ca0efaed97556e447846957859aa7132b776e4f12f3ffa9e7c401ba218e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4f129091ba027742dd57b8c87dde92b7b27e6a01188e848ca9639f190b09aa6e",
-                                "uncompressed-sha256": "f3869f3568a7f8d7ac910f7f6b95f0fde460e5c6d4ac01aaa5660f5b4dcb09d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5558c387be907fd492b58fc59a929431b7bd14550c4775bd6d8afa78126b84c6",
+                                "uncompressed-sha256": "9e4393ab182e3ace0c45e556f978e073be0c205cd2363d5a0c4a286a525c2c30"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "cf7a44850c267a368dfec89e9c6222ba75ce4ec279f11eb62f09ecbe0adeb9fe",
-                                "uncompressed-sha256": "dfeb44ee1384476ef61f4c3cec18b4a0b7b57168a80207dfea3e7d689c9a4605"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c245aba63c313e91f7325eed9aba5b7512e0e560b7e0f3a1d17fd26f61d3a478",
+                                "uncompressed-sha256": "3cbbd687a3bf9f8268b0119078533233b83fa681dd2ca7d37777a1568d5d7e95"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/aarch64/fedora-coreos-38.20230806.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6d88d88f28ea10409c280358fd220672a9042419e2176102a379e49133bb8e88",
-                                "uncompressed-sha256": "5c04a042a23c17059a115852d787c6a68026a6d07c8bd5db71fa134aaf72d6d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ad29d2411e58bf616dc7603d576c4ed486026420296d90415894c9695844a65f",
+                                "uncompressed-sha256": "492a304781a9c123e04eabbde1f03f296f0bef19ff0ea2cbb243f9215b6648a2"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0e3755ec7f7cb1d40"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0aefb2c82037db758"
                         },
                         "ap-east-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-08cbdb9ff38195cc3"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-09ba9f9d1b41f9d46"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0a65731524b9eeea3"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0b82d924ee12f215d"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0153c74e61edcac0e"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-05eb323d49a6472d7"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0b1b4ba1c3cf480e5"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0c07b057522e29438"
                         },
                         "ap-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-09e0637664318612c"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-09702ecb71b600868"
                         },
                         "ap-south-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0ab28e6d3e132cc48"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0b254b2c478876bcc"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-054c2b6337db0e9ec"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-00c32717999a0562c"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-03b9e9315499414b2"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0fadf78398e6a3c12"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-09fcc10dfe676fd3f"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0c22496dd3e84e0d8"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-07f992189b88224af"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-01cdea20fd6cd5f3f"
                         },
                         "ca-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0433b795091aaf4b8"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-095a191e79523037e"
                         },
                         "eu-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0724654014d5fddb0"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-02a2ad545388e0531"
                         },
                         "eu-central-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-03918beedae34eda4"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0efb09aee26198f20"
                         },
                         "eu-north-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-09e35885f0590c6bf"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-06e6ec3e98f1450fb"
                         },
                         "eu-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-00872514a535cfca3"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0389eab2f9e825f97"
                         },
                         "eu-south-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0171902c81b1df9d4"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0f7979daa2923193c"
                         },
                         "eu-west-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0e399874831164df6"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-046590a73be729d86"
                         },
                         "eu-west-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0cb5ffd3b14fe9b93"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0876a99578a147bbd"
                         },
                         "eu-west-3": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0e9223ef3e37824b2"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0891bb99c3bc418ff"
                         },
                         "il-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0d7adf078977b7ed6"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-06ab1394c26848ac3"
                         },
                         "me-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-057227aa8edb88e8a"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0a3c2dbda3b5984e0"
                         },
                         "me-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-046fc2003a3ea6505"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0b3edf7c28d8c8b6f"
                         },
                         "sa-east-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0fa79514cdebc17a6"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-03c7639f113a6d210"
                         },
                         "us-east-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-04e5a9107c59e9700"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-046ca4cd975e69a92"
                         },
                         "us-east-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-08de29d214495f76e"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0225c9602d2415fcb"
                         },
                         "us-west-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-06f24be6aeb0f47e6"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0031988e60f3b598f"
                         },
                         "us-west-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0fb7bd219fc782fdd"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-004f5bb7ccbdbe7b9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20230806-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230819-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c1cf357cd60a6805b4326e834b8f6ef0c41ea4cc90b208866e8f2bcbd94f8b9e",
-                                "uncompressed-sha256": "56f55c4e805075728247a7edb8fadfde78afc18feb065eae139a633cc5154c6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "d74c1635e3b12b3ded974ca4e3dba2a050c4109d69884cf225b76ad3ccd7c3d8",
+                                "uncompressed-sha256": "1ae40fb919372b7dd60c7579bb894706a459705cff726c0edee1d1d8b0f60e52"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live.ppc64le.iso.sig",
-                                "sha256": "2be9fac4e7c057b062aa1863f79a2210eae2a46393b7b6e7a9e6bf0986b9ce5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live.ppc64le.iso.sig",
+                                "sha256": "415e290d059d8c7e0be2dec494d7b4b0e9dd646b4aa953e9914e61cd9a0eb133"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "0b427366e3121d50864102fbab7ed00654da6f0b8c12974ad5d75602685e91cf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "179eaa65e88b65f2e534e06831ff55d898f571cfce4b81ecdb487abd7b58d590"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5a75c7df64618cd2673dd45fecfe867941a574ee93b0cf617487c8203819ced7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f89f80519841731f277b559dc8364637135836ec0965f1350009ad7f5b3bd70d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "00f8853f19edfff96c4a4dc98abadeb0e708e5c1f963b8cb0998b91b892485db"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "06e9784de945af6999c68b8751b8cc98c06c14d728c54721b3a2aeef04ccd686",
-                                "uncompressed-sha256": "a417fb0ace4d9eb7e0c3193c5404b94bc62ec34d36b6de2ef70dbc90c0b30d58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6731219fd14bba195a9328fdded8472650bca10174158a44076b27904de544e1",
+                                "uncompressed-sha256": "140355f63e7e2734c710ad3ae8d77495245f1f794f76c7745628ac96040e136a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "c14e1fcae48eeb777b392cf3b563c9888f71bc00b8dc2c35b6787e102a4651d2",
-                                "uncompressed-sha256": "08d1478a0cb28fc69d420e1e478e7f9f6ade84d0566fc45ffb4a4eb2f6eac78e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0f65608c747aa195608c8346d92d10846326f9e926639ee30937a8d729edf15d",
+                                "uncompressed-sha256": "d0932362a7ee964e1d631b566fc25351c1c41e435903705010d3834c7992bf79"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "87d1a55a1c04a6ec8b14a2cfaf5889b31da83d9d29cd572d425d45e2e1931c3d",
-                                "uncompressed-sha256": "620405f6ba178a0c2d68a1e9f7f1efef390e34692e37f3bd94b8aad147edc14d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "7f9bfd7b496165a1d5275dcc2e3b3bc60cbabc9394cb1e700b2a1bdef53bbb18",
+                                "uncompressed-sha256": "3de1de82b1aac7e8c0d96bdedf627289ee5390704a67e68e461964f134050222"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/ppc64le/fedora-coreos-38.20230806.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c588100d95996fc63d8564db3a854772a81bb901deffa04e19b352475b70d3cf",
-                                "uncompressed-sha256": "27c51ee347893bad8065c633a42bdad375c2b71c484fc1c10ef734f34fed7525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4dfe6dad0a1581a42c605c5be2d52cad1303d850c5dda5dfe3fd2c477ba2d166",
+                                "uncompressed-sha256": "5db6e8806d55e1d7131b38801cae204c4c96b40088025f466848afbc59de4dfa"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6723e067050f3d8b4b5547eb2a4a6bbb13137f430e67e54e0d5e9d166ec38e25",
-                                "uncompressed-sha256": "12d43bb561410f42e9a42e98ea767ccb64049b567ed661280098f887a8375a1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "eb17348cab0636037e5a1a8c502c70096120d132a978649af8a9f866b8418559",
+                                "uncompressed-sha256": "113802cc54b203210dd8800bc96af477125883a43fd60f7ad2e55b926d0c3cb9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "29db939859c026725717f5104f001193b140e84f57be19bfc9d1b389f037c686",
-                                "uncompressed-sha256": "1ae5b9abe3cd4b5e143e52198dfbde9ec40a5cf25a100f84528fa77d03951c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c7a024cb03f0276afdac7956db1508da444ed201d5ea0f36e8e559018e61909a",
+                                "uncompressed-sha256": "959730f81f9cd71818b27c59e9f5fa8b66c5bed2a2abe405764f1ae301180c20"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live.s390x.iso.sig",
-                                "sha256": "13d23f181817da0fefcf091530282e5d006f5588db1deb01881d33793666e871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live.s390x.iso.sig",
+                                "sha256": "f339502ef8fc346201c2cab49afecfa63173b2bca79ae1dbc0c945d45aee7799"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-kernel-s390x.sig",
-                                "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-kernel-s390x.sig",
+                                "sha256": "d73c2dd854f81ac24587d8e7752395fbe51d8cddf775a70208e0d5161956da19"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c21e74ffb880b7f2728f7dd54f7db103f7f653bf4cfc160024114ff22e1fd7fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ee2787010338ed1b62864ad4a69115bd367eac411bf17c6cd6e82263ad5346ae"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "eb403279b19889e31d5d226b1f8e0137a205a5d8ccb053536a730d801ff43c4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ec43ace886cfaeafb0273733c93923dba67cf3f2b3e2ccc573f9212188fa3778"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "c6d4a5c12e36ee9d61ea72ee75bd846e8b474cffa84fd1d6a8e29b8af3bc3fc4",
-                                "uncompressed-sha256": "7b35a8ba906f1f9fc1754a4740b3ca8cdab064a2ba5a4aff1e9fdbb3defedbcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e3bf17d4ecea2ebf5e42be637818b32226773f5574c71602ff1d3da08a7f0758",
+                                "uncompressed-sha256": "a3dd057ccb536dcb67a0839e57de7fa18bd6526655fdce9c4afc627f40d1c06f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2a3a2ab95bd4b9b046ecf78bb5b7f68d3b0ab0e05f7499cece05c55a0b27e297",
-                                "uncompressed-sha256": "f77dba9da2b83b06cb6e2a83fee8305ed1407e3c2fc99085300b401f9a0006a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "508e12f22b8d2645d5b235727ff09535a4df0aba19bf1488f53888cd97bd38f1",
+                                "uncompressed-sha256": "2a6b3ffa3e62b839c0e710d39784ec28fdf1354d98ff1734e242c390767f1c54"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/s390x/fedora-coreos-38.20230806.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "52b3c1508082aad82d98f213098758992fc391544106a0e641f43729dad65be5",
-                                "uncompressed-sha256": "0c31ced9a0a8cf065dfcc427e58f54f24ad059568b6377f9888a4386f1120e91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3c6cf725fe8423a37a4f9850c671c20feaa1c783652fd45a854f29cc5d3223a1",
+                                "uncompressed-sha256": "92866fb2799ff40ac1cf5cc8229f5c9ce89b196fc53d85ad1cf263ed7d13b529"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6b2342b38ccbea608ad1e7b1841a666de095627356773bd5a9e985993a984ee6",
-                                "uncompressed-sha256": "767c3ca0a3e090d5da574a1f2e56b37adab361285643b4666f35a563ea19e3ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "15356414127028c957c6072416aff652204aace563ac0840839d3ec40f1f4997",
+                                "uncompressed-sha256": "c37a5fa6b85ded07e320f6c7c0fd28726933361d648afe50de32aca2cdd5ae79"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8ab52a527558fb8a47d87e71f909ef453a15c8b2605019cc6bd990d48d01bf5a",
-                                "uncompressed-sha256": "7558a035837eda6e5e7e4a7dcf8be87565918aa5fea43fcde7a8556e220d4927"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1605687e9c6557c1e2026144484b080df92bdff951d36f0f00340887b01a4c19",
+                                "uncompressed-sha256": "f82413c5178cad14c754075e79cb54d90f3ad83f8a76ae5325aca0f20b236626"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a15faf9848a82be6fb99b8b25e98b2425f548462eb197955cdc79d94c30f598e",
-                                "uncompressed-sha256": "f338a95aefc88be9d3f71589ac0e31336f67ec0f2d97eafa17ca0ace9095c80f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "834597734a4cf3e3f9d27469d81a7da3db008e98a954af2ac9fcee6c62bc7b0e",
+                                "uncompressed-sha256": "c820115d96760760529e1cd1ebe5be50168ffc5e859d367e9ff220d785c91f3b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "deb0b51bf5ca373adaa6e1f8e7887a4079d48d19bbd18f097cf347123b51b244",
-                                "uncompressed-sha256": "0f05b690c1ae13383cc2004a17cff378f3c03598a4d3d58270c181c19004f5b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "74818c525718fa5f64c5c469cb0f15ee54cea70b1720421ac7e3591e79b3b6b4",
+                                "uncompressed-sha256": "1aeafdc03b1c3ff93907f6fab528c5dce59d1c1485aa7426de4a1a2fecc66cb5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "26457349f09bab56a321137cb5d3c9d72a984074b3d36e74107e874773f712ab",
-                                "uncompressed-sha256": "0cdd4f16103345e3c7f1ec940978df62be50a0f8310b962138992c5b3937b4cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4f98b20354a952460a07aba846128cbebd254c2ea7529fee35016aa88b545feb",
+                                "uncompressed-sha256": "2bd29c418db2d4f4646fc678302916c621c93db1dfab9b859563ccdb30bf7df4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a3d4ec8fabbea40c3425bdda71c57da8b739f933383f39cf4877d01ae8e207ee",
-                                "uncompressed-sha256": "14e1264860d726ec40f11788a3e385f5be3b343c499f2a82676d7932b42f89c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b56235a200005602821a5f0b3d32220c84aa96b81ad6585fa385f923bf1c4cf8",
+                                "uncompressed-sha256": "ddfe6bf96c1e0704e4b3cc200ccbb2fd293323a0747550a0df570443ff42f5c7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f79141c404262356e813b86d6fd96ea0c88000c3778dae62e0a4dfd3ab8a186f",
-                                "uncompressed-sha256": "2161e170ec958bf9f52c1dec36f079cadc69f5a404e426032e16c8b66d51f078"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5b0febf557d91bcf7bdff9dbc16791065c250e30dce28c790539c81deb59e587",
+                                "uncompressed-sha256": "2dfce0fd2ab9dc976b660664264d3c7ada2f948ea92ac3bc3adca771df1ebca7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "023f98804f71a1d0781df4a6e31a86d57da6e09ed7f6904466234e9bda871bbd",
-                                "uncompressed-sha256": "33946097cfdcfed320f078e4f9d557c0b9f1af5c12c4373a26e9b02ecf13ed67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "d892e8a8bedeb0adefce6e60914ff1bcfdd5cd493ebcaf49b751eedb7925e390",
+                                "uncompressed-sha256": "bba1a021a37223f7bd4390ed68cc5445cc7fce49584ff80587a1cf547a0b0702"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f487b9b2b7120c3ec2ba6e2ee3652fd5fd6fb38775729d6b051fc6649c605165",
-                                "uncompressed-sha256": "cac2e5360a0a437b7b3c7eb18270ae4848a25041f15daca14e898a8bdcef278f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "45ba7db1d8d387f2699b6e9dd796fc6bf26434c88f419f3ad480e92c07618b32",
+                                "uncompressed-sha256": "8a5cb6bb1269585dee4667f4348c3c4794b98894a73cd5a2051a339c171144b8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "fc9823fabfcc901cecb8950ecccadef3dd922710bf4068585832b3c82cfb486a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6ba8afbf8486ca4bc6ffb35f53c3acb316cc24ba4a82af4460ecb7ddbcada300"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8073f774d19361ec7b15ab957e09c2c3fabe2235362ed43e15aaf144e975a636",
-                                "uncompressed-sha256": "56a0c5be6a3f1f72b7ebe684c92e33616d4d3425e726bc257cdd1f18364f275a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "37270860038c3a143b53503dcccd788261d0c211ca1cfa91a1015857b7ea59d0",
+                                "uncompressed-sha256": "2088284734d285b87c48811a42edab0a56cedbe8420272798fa67e936af40dec"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live.x86_64.iso.sig",
-                                "sha256": "c27e7aac3db4fef9207220bc92eefe3707debabe6d77abcbb3cdecd1503c246d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live.x86_64.iso.sig",
+                                "sha256": "383dd4a7a5864708813b3bf9ee8a2b3c3539e74ebf55ea88d84e11be044e5d43"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-kernel-x86_64.sig",
-                                "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ecf92904e2df6ea872fef9cf07702eb876f5131fdc0d0e09ad54c6a8456618fa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7b48c435a4ffd7f6603be0279823f6e98ab6e035d00692adad1613b430c145c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "42dcf3d8333f310767cf86719d0d807f7696dcac344548d1905ae73f714710da"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "8479f544d19e6860db2c0c7d12b6d717079198bd86950c88c3c5e07e227ac88c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c4f979ae551043975673a4c5d1e9eae4bdd5e7c0db5d39e187e696a19a2b2725"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1240985b4a7b2ccf1587aecf855c0befd3ac95e92b363356893c6b821fc3091a",
-                                "uncompressed-sha256": "96214cc94c79f6d185d12fcc968e61c8ddf9576538160c6123efd687c837fa4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a45755aca52450afd1e5a5e1517e7589d93954a93bc77501973be06cce0da24b",
+                                "uncompressed-sha256": "27b203baddeb95dac07e2f8ea31034e7c150543cdbfaf7ae2f1cee43032a89cd"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "055fc0045ee39aca5336667e26f9dc39fe1add5d1026bda16d95b45d69a22f2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "5bf8ab9e493228395e64bdfb56a0590b1798330bcd5355c04f2225778e7fdd52"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "824d0c355463eff7e8f1a4607949f88c398886c5041b84ee224905ec7ce7e216",
-                                "uncompressed-sha256": "51da48aca8940f07a6689a869327999e045b8ac719b959067212ed236bd1154a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "329e5ddbc8261857533aa1a27ace6a94157efc951751ea89cc72a576cfb4ba22",
+                                "uncompressed-sha256": "2339b93c953a7449d20eae7146293e10b1f18cfddb9bf46b442467ad946e3655"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6acc38edcf7ba035fab3ae05303743b36fe1003b628658c6d9a0df690ab29f28",
-                                "uncompressed-sha256": "24c6ceabe854f328a6d9bbcc27833e79de403e23f2eb09840ecc3fcb2a807c40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b131d829880109e9b69228729910775d7c229a2c6c3a9ae3aff02b673af1396c",
+                                "uncompressed-sha256": "4c2f661d4d8c894aa1fb45c51c988126da0df68525737e856f96c53579f1effa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a80636eb853eb57d038040589670a46bc0b4826232a5fb5959523e5e0fd9f965"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f8a94e03006b9b4baa8576a96ef7da22a3d0a73255a2d6b6b1a59c70f5f5cd55"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "fdd8daa65a01d211cbe9f95cc8d8807e81bb56401b4068b1bab97edaae618f1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "0159a632459c2cb62ae3d78182283738343a3b173b57f882a2e7bd2e797ee5a9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230806.2.0/x86_64/fedora-coreos-38.20230806.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5de5380a73e2ba3dd211a069820e5b0aa6344b6ddb82e9ecf585b9ce3f01843e",
-                                "uncompressed-sha256": "41a766f1105f7ff6bcb025151d29bfdc61670547dcde49529e9b61342070400f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1270e477c2c4886eeff301f58510f7341aab0c689da415c2b20ba6411b3ba8da",
+                                "uncompressed-sha256": "94e68f61db50a5b3abb44b22dd3dd9a7c13b2a0bbb8ba50aa11048714de899a2"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0f72aac5bffd65e84"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-089d94096cd895e41"
                         },
                         "ap-east-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-02dbe69dc2ecb8106"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0d847e6cdeb5a6e32"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-07b27fe3a69091249"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0744228d8db6647dc"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-017c5afd5aaf5253e"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-039dc410f566286e8"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-089b044c231e647b9"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-07bab3cabd1eeb365"
                         },
                         "ap-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0fcfb06d20554e171"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-06974ae6a5b14710a"
                         },
                         "ap-south-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0ee6aaee921b50a97"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0ff9a8e617d30af1d"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0ca9f81a41a6ed86f"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-091862f51a7e3989f"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-011793208ade39903"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-003e86509fa14df8e"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0c22f181a7a1864b5"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-02d563ee4e1cb3862"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0ab9bfb9a8fe77a16"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0fe354914a3b87f4c"
                         },
                         "ca-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0127a215c083dc891"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-04af965f3dd219f66"
                         },
                         "eu-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-075699d73ba0c3afa"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0a9ec481e06e4147a"
                         },
                         "eu-central-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-001fa0f517b1342e9"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-03dfd0e1017878ad4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0f1ae7d4d969678f8"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0573389716431fad0"
                         },
                         "eu-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-03f9fa58cbbf6ea9d"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0a954ad925380ba59"
                         },
                         "eu-south-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0b59f0b8eb39f66f9"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-018760f9654f5106e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0469c71b89f8b5889"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-056d455acfa1c74ae"
                         },
                         "eu-west-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-034d4a970e7d0970c"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-00fe57c61c82f1818"
                         },
                         "eu-west-3": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-053937becbcf85b23"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-094fb4f308ba73da5"
                         },
                         "il-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-03f813965b9a9a2e1"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-049ab1ad4bfcb1ade"
                         },
                         "me-central-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-07f072b83cd15d0e8"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-04813d3ad4ddfa931"
                         },
                         "me-south-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0a4d6e95c24a5c1d4"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0d555d0af8a875712"
                         },
                         "sa-east-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0197e1128db318c69"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-000f4260b6427e92a"
                         },
                         "us-east-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0952a723fe06cb5ea"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0e2acf77c0f926a06"
                         },
                         "us-east-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-0826d37aa70bd75b8"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-09af6eecc184b76f0"
                         },
                         "us-west-1": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-05fbad89d9fb83f05"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-009ae82b3f72c59dd"
                         },
                         "us-west-2": {
-                            "release": "38.20230806.2.0",
-                            "image": "ami-03c2fd02a9b71de34"
+                            "release": "38.20230819.2.0",
+                            "image": "ami-0880a237960151aff"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230806-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230819-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230806.2.0",
+                    "release": "38.20230819.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:68cde352544cecb9f2772a10229344b3b86da13f4a30e065e42eee93551ec410"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1cd2a91f3b9139e2e472f02ea69c87466a8302051aaf0474457e6da16cef1b57"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-08-08T18:34:24Z"
+    "last-modified": "2023-08-22T18:29:04Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230722.1.0",
+      "version": "38.20230806.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230806.1.0",
+      "version": "38.20230819.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1691589600,
+          "start_epoch": 1692730800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-08-08T18:34:23Z"
+    "last-modified": "2023-08-22T18:29:02Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230709.3.0",
+      "version": "38.20230722.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230722.3.0",
+      "version": "38.20230806.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1691589600,
+          "start_epoch": 1692730800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-08-08T18:34:23Z"
+    "last-modified": "2023-08-22T18:29:03Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230722.2.1",
+      "version": "38.20230806.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230806.2.0",
+      "version": "38.20230819.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1691589600,
+          "start_epoch": 1692730800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).