### PR TITLE
workflows/rollout: try updated create-pull-request action

### DIFF
--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -120,7 +120,7 @@ jobs:
           echo "BRANCH_NAME=${branch_name}" >> ${GITHUB_ENV}
           echo "ROLLOUT_DESC=${rollout_desc}" >> ${GITHUB_ENV}
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v4.2.3
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
           branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
We're currently seeing an issue where the create-pull-request is running into an error:

```
2023-09-05T16:41:46.6206079Z ##[group]Create or update the pull request
2023-09-05T16:41:46.6209875Z Attempting creation of pull request
2023-09-05T16:41:49.1514174Z ##[error]invalid json response body at https://api.github.com/repos/coreos/fedora-coreos-streams/pulls reason: Unexpected end of JSON input
```

Let's try to use the latest version to see if that helps.