### PR TITLE
Roll out stable 38.20230819.3.0, testing 38.20230902.2.0, next 38.20230902.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-08-22T18:29:03Z",
+        "last-modified": "2023-09-05T17:46:06Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8a683863a50f9dde645229b19d77a224d176066661094ae5d696401e220805f8",
-                                "uncompressed-sha256": "f7383956b0cf4b4ebdf729755a0efb9ec38b31e9eb2fa6feb52940e1116235c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "94b90993179ac21ac04832e580cd8c23d29273660ab8f6b4fff839d1258245ea",
+                                "uncompressed-sha256": "ce6ce9f17663d6df48a0439b6573fb99b44cb66ba91962705b6dc77a4b2e0966"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "344c69207430baa7d641d027a5014b16520d9b795519d598e7e1cf49ac7b9288",
-                                "uncompressed-sha256": "457d4bcd3e71d604f75914e0b10844cd06370b8ba5adade3f062ace0c833a8d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8f2d906cc68bd0e74dbc9a079e73e91d4eb6e765d610ea036b3a9c7c7f6a30dd",
+                                "uncompressed-sha256": "5d887befe954095bdf62393cc661f57da238fd05af47f987e160d3246bf44c65"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "c1d0690e8a1df0e703d96468e5ff2b34f58dafe96520a01bd784dd2af5b5a6dc",
-                                "uncompressed-sha256": "115169b4b131d4751a89f43f1ae658d57cb11322793f607b4291138bcebcae6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "84c9eaf02097b872f4643078161fef93ee07fa748a9961da928b9491e6dc1e0c",
+                                "uncompressed-sha256": "fd31739f6c4a1ee54fada3d14171f2bdaf2cbc1c6f6b0d2847e0917257c0d9b0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7c727805dc34d64ba2f8e0d32d67144e0ecaa4af99e77274225767886686a412",
-                                "uncompressed-sha256": "78de802d88e814218daae156b291d7d5753016990728405994973ca1b525d7a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "cc281bddd55af38eb9dfd0f9c78558d37f55b874cc61fd1d8dfcbfc89a342998",
+                                "uncompressed-sha256": "2945553b8a24ea7876a45e2f1934f89e7c64c963f20155580f2ae8ef5a9689cf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live.aarch64.iso.sig",
-                                "sha256": "0a8a8fb5f9210ddbe1194ca1f77f930f4a79250fc03f79613c6efa3b11cf5ba3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live.aarch64.iso.sig",
+                                "sha256": "9d26f030066c9fdc5a87c2f6d38b7c91183a3ee271177bfaadf5b94a3bf00482"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-kernel-aarch64.sig",
-                                "sha256": "ba9026ee27f6a3d4f37d34f493ac488895926358d5ca2c7e03119381b4cacd66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live-kernel-aarch64.sig",
+                                "sha256": "6db828ed5e633b64ce66f3f6822e2895e4dc0cfb54bc4d080d075970d1c0028b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "91af528d7c4e97f2fa5842b4b06290ad155df370e74efe5da6c7540111259312"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5b3fa1dd01f7c3a274829e129c644438438d4352e26d0951ab6e2f6041f6c35d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a74a2eb005af7bd7ff5c1d615f1abb56adb1dfd7c0020dd4be022045a46b0c51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6b4e5e3932d10f3d573e8315cd05f57a69f71ca17ddd4a6b5fa3fd2773586ceb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "bae6563b26d4ff38ebb2833841da917a78ad8b87e46e171a152c024ac1774b19",
-                                "uncompressed-sha256": "fd4d0d5da4c672b73fb92927db113bf3fc44522a5f8542be399d72f2bbf71a70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e12ce38dab350a2c0c412a32a1042791f6231535573628ae7215fb59898a9d2e",
+                                "uncompressed-sha256": "b2046fca14983bd415412795e3681d3bc3421aeade27dc061bfa3e5ba0b75b81"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8c479240c134b11f7f5b1686dd615e57650c18fb32b8aa15e0b0e4891f3bd70e",
-                                "uncompressed-sha256": "0abc0a9c098bafa9da341c86fe93c75daa248f52c4983a3fabb26fcae276cb75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ac3c97e5f26fe0b1dffb0b0ed7f4a56a8d73f4089f5d5337284155935711b028",
+                                "uncompressed-sha256": "c20efdccacc6591ee692b0978e5e359aea11797cf59f335612300e410c61e667"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/aarch64/fedora-coreos-38.20230819.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e96a4252122110cb2d464ec67a083b0d3d846003cfd3663f91b0c79585efe5b2",
-                                "uncompressed-sha256": "4d5900a756e5411d0364dc305dfd720dad590501e1937ef2685162c53d2111f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/aarch64/fedora-coreos-38.20230902.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b6612ced3063249f259a50d64daeebca97db1a9c923383048a6245029b062686",
+                                "uncompressed-sha256": "2a86fb499b3fd85fdf0547793cf6ee515f0eb9c2398e9b2794ef68bc23c5fb0c"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-06d96004cb3ee4ab1"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0e391c671401bbf54"
                         },
                         "ap-east-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0021fa5ab71114ba7"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-050351c24bb8372bc"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-039ddbacdac7472f7"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-016adce3cd01561fe"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0fe46185a97248d2f"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0aa7136991589daa3"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-06bc8450a0eb56dcd"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0cf6206d791837f5b"
                         },
                         "ap-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-06921407cae78b349"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0f3c606fd2b28c9c4"
                         },
                         "ap-south-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-09db90b555cb2bd6d"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0e52537291a82c780"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0437be10dea621544"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-01db7a65bf2e81cd2"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-02646e705766e7af5"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0126a48f42c33e389"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0bd3121acce29df92"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0c3fe1d458f242281"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0d6655ed6f8e72ef2"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-068c1be342656ab29"
                         },
                         "ca-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-01b61ac984e783c5c"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-05c05ef53795d6be6"
                         },
                         "eu-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0875babf890b51d5f"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-016e4f3f991b562e0"
                         },
                         "eu-central-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-02d2b93d77193d147"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0f2e39bfb19ae4f21"
                         },
                         "eu-north-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-00df78804b8a3a1c1"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-09a67dd4c0b571842"
                         },
                         "eu-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0ebcad96155c99c09"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0a1b570f240ded568"
                         },
                         "eu-south-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-02bfbbfb1862638ab"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0464d50e10d732bed"
                         },
                         "eu-west-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-07640761212ecac13"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-080845b154bc96e39"
                         },
                         "eu-west-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-01ba12d6aceddd4dd"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-08f8a7d21b67d0afc"
                         },
                         "eu-west-3": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-03dd6bba5232469eb"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-01ecfdd8c26165912"
                         },
                         "il-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0e94a510e6ef075c7"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-085393f4b219f0b96"
                         },
                         "me-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0d86aca7073847db9"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-034e7279b6856b317"
                         },
                         "me-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0c1ae3a26660b1cf1"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-017b3cb9de3ebcb86"
                         },
                         "sa-east-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-084776463ed8de082"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-085f1b5f1e9f59f29"
                         },
                         "us-east-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0fdf8488e66560943"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-09ab77d23f514c2f8"
                         },
                         "us-east-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-04e09c7f6ce699c70"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0480d7dbab2f3765d"
                         },
                         "us-west-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-02537e927b57f30be"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0ea1d9e8e7b951b38"
                         },
                         "us-west-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0dfe7b935beb342fd"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-026a064d18ead09fc"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-38-20230819-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230902-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "40aafda1aafe1a4e6c5cc55cbc7ba7056ba39f9a574368a8edf6c815a4671193",
-                                "uncompressed-sha256": "205e42e84b399e92d680f1a1c0ce3de9608d4e30d90e428347723fba2337309d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "faac22c5e1d9d1b56e07dbb34fec6d847c0b9fbc8e36b5b4cd121a61e19cb4d7",
+                                "uncompressed-sha256": "77ed2c3ded9185f271fd750d2374b5d5d33f1f293fbb0ca8fe2143b08c040958"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live.ppc64le.iso.sig",
-                                "sha256": "0dc791e25e0ae75dd0669590462c68c67bb6a037e7a266a9c61398a8fad50260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live.ppc64le.iso.sig",
+                                "sha256": "c19da5ee3ce88eb92e0e3e0a22a46343d3448d688685933b798305543522d932"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "0b427366e3121d50864102fbab7ed00654da6f0b8c12974ad5d75602685e91cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "7e8c4133188709f48aa7f0a523ee215d67c2cb6e6a162e9b50e889ae3477a6f0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "bb672a270c1b8a77703ce71a7918014428abd6c0cecd78b7bf1ba297f6a3a4af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "a0d979b4b51bcfee19c0a70975771185d9a939f3629aa624e41c81d7b7f07655"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c7440b4697062c4009794d9ce04bf19b465274e55c89bcbe628f18cfbe1bd5f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b69a8ec56bea141a0546843551f10ba800e01fee2e374574c7e5ab7d7ca2aae5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "fd1f5f79592d97ea746a78c4e858fce38e14a6e7dfd0e0895063bcf68cfc0dcb",
-                                "uncompressed-sha256": "38cf67ef2f64165680d9f6cedc793357778cc51f75c7d95d2ea0907705794793"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "d07175dea3f8ed80f32f1c48d9234ae509354032c9ec335d2662037245896627",
+                                "uncompressed-sha256": "739db48c6b4b74ebf191cb979d55bdeadbce2a9dc3fcfdc955814c456a886d55"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e110c4edf4033459a7fadee9998950568f1f1512a8a4085f9cf4a99742d1b66e",
-                                "uncompressed-sha256": "1ec9dafcff18717deeac057b69c9581f2d568666f21888b96dc688ec3b022cfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1b71cb32c6c26a431ef8138e88fc7392a3112d54e6ac8b899ac06a51690b34d5",
+                                "uncompressed-sha256": "c72ba27a6f7cde221e7bb1e03c500f7536b76fe8cd275eaf36e18afb065f0f56"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d15a84aa5a6bcd30f9e3b2c86b5221842f965baf60dc8c53360667f3774b1b62",
-                                "uncompressed-sha256": "ea5512d351327ebd710a607172e8031caf111a03dd63f6f3c59e6e01a4d1d801"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "489b0e682b507e96e9ebdde185422a5823e863494cc62fe6c7aecac370fdd3a3",
+                                "uncompressed-sha256": "2459bd8b810b1dfef9a103df55ccdf668e1ee1af7c646b245acec53511abd7b1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/ppc64le/fedora-coreos-38.20230819.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "10b57150bc0572644be705fe1f783679a760582b381248709a752726fffaf42c",
-                                "uncompressed-sha256": "c790527bb371d77ff7cf02888191d3d20c6f5d28c3734fb1d352c621064d0437"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/ppc64le/fedora-coreos-38.20230902.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "62ce065e5151331df471619b9ee08f65ad818ca40e3ca60d2c22fb220151c9bd",
+                                "uncompressed-sha256": "6786b95d844ea5ad60fe37c3a767f78f30a78efb4ee26a813fe99bfb3b8f3c7d"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7860b61a940bcb5ec7214fa32a65ce76a47a969ac0c54008d126cccfc9c9ddba",
-                                "uncompressed-sha256": "956a655a3df288d2762e32ce1e9dfc037b747a8c21f807b3fbe766ed9fb00c1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6f07090154b2ace57c97558ab177414085d6bc2a185b420bf56801fc80d47e03",
+                                "uncompressed-sha256": "ea6cf094d5a55a6a07851ccad73efb0ba0f5e5b9b5b407ab5e1059caa01c5132"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "08abe6c4764a266e715a58de961b9cc452d50dab0b31231c87d750a2a641d3c2",
-                                "uncompressed-sha256": "82e5adb2eab5a114b88a27ebe8f784de4bed8992efa2b5e1e09119f284ad8d1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "039ba0a9bc4013ad4d5f707ec3fa111372a9a4f00e3c414fff149fee0a9d1a58",
+                                "uncompressed-sha256": "b2380d644f0324f5ac921f403497f7a95577cf5435e38809ef170ec109d7dfa1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live.s390x.iso.sig",
-                                "sha256": "b9b31bacb9241e0b87260cf9880e7e241c14396434a7b1e84f1756f3f31a9ade"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live.s390x.iso.sig",
+                                "sha256": "b334cc90a5d539453b7adc7f0efe17dc51e4d7a48d4a96e0c6988aef91824d84"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-kernel-s390x.sig",
-                                "sha256": "d73c2dd854f81ac24587d8e7752395fbe51d8cddf775a70208e0d5161956da19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live-kernel-s390x.sig",
+                                "sha256": "a14f414ee1358a2f0c5c9af78f3f70bbd5527d4b12051aa7219e4892c98bded0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ae0ae8526395cf076846ee4681ec018cc1d4ab1cc0d9c91b485d29db49d082a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3108af78f59e45302b17a78149821d62b17e17206b7af59b921275cc93ef99c0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6708c14471bfb9e4eeb78fdbcc2ed70ac0858e512754bf3a67fc9c3ab60767e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7ecc834e678d0fb056884fc7775770b56d6edc8f5e4d358d5fdc24bf04629a7c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a0451e32ba9da45c3cb4a029fb956ba6460f075ddee532005df90c8276405259",
-                                "uncompressed-sha256": "d718333962d1a121c0575b1d48a0816dc028da500681f02700cb476bbebbc9b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "24261cf948f528f0c4ce9a53ed51965a83f1dd6a39512fc9ce3aa6bf3b3aa2ea",
+                                "uncompressed-sha256": "40c155e9255e5da1f4b22e79e0311b2693201b1a0442474c67464b9521e767f0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b96f3bc8234c8343f87bb2f842377b66b189ddeb6df6efc2f6ba9cbad8ce64e5",
-                                "uncompressed-sha256": "f991f25119c8a123ef1c2babb268d7fcf1026b9826af5180362b49445f990a3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "cba071d4927ea3a25db90709ff3599afab02623b59718c580115f6c4ed3766ed",
+                                "uncompressed-sha256": "7b7131a3793279156916cb83186e1dc3331711a6b1cff7eae0270cd9a74c0656"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/s390x/fedora-coreos-38.20230819.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6a8e10d9e3a4dd79fe2720d3a631c78df32ac381cc41fdb05e6a6d3d98a30f3f",
-                                "uncompressed-sha256": "b009f630463642aebdca49b14c40ff4c9c04c33d4ab5e8c109f4a047b9d24ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/s390x/fedora-coreos-38.20230902.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "51e87c8f9e43ec1ca4622f588474c6164e663105e98e9506d3584f1ae9824e8f",
+                                "uncompressed-sha256": "1bcba3fb9eca72ba34e3e525cc492a024c424ca6cf743ade864c5a3e3a0b4666"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ba9d9e2b76dd4c06accd9e8cbc80bed65620d5a8967a36a74bfbeeefd46fb581",
-                                "uncompressed-sha256": "6126c55a319613ca571858676e30b7d3824554fe6bbc1cfda78d2206be7bff80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "72713f5f36c74c1499276322f64c2aedf2b14a224d381ef51a865c8e07b88e96",
+                                "uncompressed-sha256": "96904ee23bc9876886fd1216376776fd5ba687709362d528d742ce985eaa8bcc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "02731a0db625cb32f1f5b872cc146d8af74adec8055213493a2f83ac27b42bc5",
-                                "uncompressed-sha256": "9fbe96fb2cdbe11a317daca697f0c436da2976e06f704406ef44ce6304eefeed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3c85b2aa2afdeff5e664f21e419d58c1f89774ea5f123210f354c9eeddc05169",
+                                "uncompressed-sha256": "030532b520405b1888fb8aff9807ef90c76c2bb0abd4a346c499ea0281e1a69c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "66852437f6832b8a99bce3297535e505a564ac18b87bfca1a6ac8fd8027cfad9",
-                                "uncompressed-sha256": "d4a592ab5e3cd57833571900266a3c79e98c21d87a404904627220a40ce69ca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5cdf0a2218d84ff54b66e28011b4158717900b4513ca7dc63727ca2abf5bc261",
+                                "uncompressed-sha256": "ee28e71321c75cf5ae4c1b2c20127324271678185586ea5e897ac83486f7101f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "746817517e02a30f3e1c3d1653fbecb630c385b41b271cc5d6fc85453eb42a90",
-                                "uncompressed-sha256": "1fa07d6d901be44919e5d7d720f053427b9add0eede2a1ac3467afe1ab70ee8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4b8479126a8b34897c348ad84a9b53a2cbbb8e033e605c852ccce2c8053b07dc",
+                                "uncompressed-sha256": "dfbde1b662cdfc3fc966247cef636665352f85167790d3fe224898e9b71ac629"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1601e55c4d25797527db83025ff358956dfcba34214552ff5aeb729dfbc14d1a",
-                                "uncompressed-sha256": "6352032fb779ade48f93675e4e32aaf84457977d50cbf95cde83dd2be0415cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "fb91e337181f5b7669d529ffb9aa1fcf1ddfaecbf5f14d293b28dfd77fe029dc",
+                                "uncompressed-sha256": "dc6a3c95b4eb28826f6b9e34ed90484b6990784f72bea9dc077ea885a2fd7d1e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "89801d4a3902e78cf495d4843c8b21fbb39be20ab69559c03a59269944508d1e",
-                                "uncompressed-sha256": "0cec7d0768d1e6b6b97ceadc559a26a7ca960ea06d3b24d8813c6c2fd96bf486"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "cd89c608015b4a0768f8f01993160cb622a5042da44ef2c3b5a948511a5ea4f1",
+                                "uncompressed-sha256": "32f422807e9826cd28dbb3aa90bd5aad1be8d65cbe6657031bb6a7032d94690a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "aeadb0262f8b3d144fe9e1938e3ed1631b80298f295f644cab8218a0726c2aee",
-                                "uncompressed-sha256": "041e1756ff89b669e2920849308a8d69af25ae6fb69452f93a7fa93cc5aca061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1b3c71bb2dc3199ed2b1650a197fdf014abba490c57270fbfb8e14b35b3f5535",
+                                "uncompressed-sha256": "eb73e6750ddf798a009f69350f1a7b9cf7a225236282f9f3dbe173c205fee8e7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "459b29cc81055424b0dc54202fdae88831951f619f4f7472e977d5d640281b43",
-                                "uncompressed-sha256": "defa2e45975d1025ced7cca6d6ae8d5e3a7aed577016781813a2ad0b6d04b0e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "a2f2efd2e3f7f45182a8ab851c014ada507873314abfd6360074ba4c3b1c6ccb",
+                                "uncompressed-sha256": "9c72e04f43e3def4879e36ae62f1ef52039da0010d53b3f72c3b7b9c921981d4"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "dd764eb470616b65d50675d619fea41007f67f3a4c16bfe242c5dc226c59aee7",
-                                "uncompressed-sha256": "18b3b432a5b31147bd49d45394c6c0775b5074ba95e6ac63139b40ddc3a031cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "73e4385d2aef8d3887d4777c8ed20f4557c70b5dc29fee8dbeffb1d83a6560c0",
+                                "uncompressed-sha256": "069c037d8550b68445c08130d3383fd779424c2eeae237e3bc806aeb2a2a3a15"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a3e34b6e676c080071db608790de59724c25678bb4aa887101bdea856eb7d96a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d7dae02d0609efb41eff70e74b4ac8a6b8373363b797e876e78c0d566495af7f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "326aae3a93676191ac9d263e39d2348499453b5825ee0a55b9b4bafc2a3ee5f1",
-                                "uncompressed-sha256": "1dcc2351641cce0b9242970d290d0ad31360b523b76cebfee518c4a32f0e9938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9f1e28eddb2280d59a5add7d0066bfea0c5de78e35c60ff6e6fa4bdc985c89af",
+                                "uncompressed-sha256": "d9fba12199677cd0505fbf84aae8b51851b55b59c5ec69f0ea948e8efe013370"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live.x86_64.iso.sig",
-                                "sha256": "eab6d063c9123aa83fa8c87a47335c0eaba05733979b5d22904597c7815b8f65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live.x86_64.iso.sig",
+                                "sha256": "1ca7cd8bc29e608893671cc6783961d8cf74e5a7d77931b64c9ec5433578cb84"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-kernel-x86_64.sig",
-                                "sha256": "ecf92904e2df6ea872fef9cf07702eb876f5131fdc0d0e09ad54c6a8456618fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live-kernel-x86_64.sig",
+                                "sha256": "3d8ff5351fd600c0028494a656952ce6757dbbbf70429344e16ecf25a01c1eb7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "83f9d25521bb255022fcb875e05779f40915b5a1c6b6bd4aa7c1043ebabe03f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "28676c3de7cdcf19e68fb9f8398fff8b72ac6c7cbfdc7ad14ae054998d256f50"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "388aa8718c895e5425c664e28363517d5dc16f0f274c9738c7750c70639f36f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8a8118f5d034f5b40e47bf9ba8f14e24b4ca698cd0a2094b287b6f92beff9fbb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c088eac8747313a641622ddea77ef6f55aa38b3cc3671fc0ba2a7bc61ade4563",
-                                "uncompressed-sha256": "0a1e4fa815df5b5b85b3b9088abb5063c82165cd8b9818b759500b07e9d8f93b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "141cdad21d030b5e2148977f139aefa38bb0e7e3282f19a6e849d4bd1d8d2816",
+                                "uncompressed-sha256": "e81a65d1caf8940b057150693faeb084952d49630695bdb4ff7d6c71c816be6c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b916e857a8a14fa0927c3ce05c94def25ba11a6bec97f9e290299abff0eaf18a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "5d72457c501f282d59346b715b4d074cf8f2f39ab7faaa798f086df78bfdf032"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "102b84f0dccc5d2f1de8ae9a5ee79637f07f8aad7547fb3630bced541139d3b0",
-                                "uncompressed-sha256": "9aeb247d24d1a986aedfbee71be5d9bffc33e6b8beb2b90208ae4fef8f7d32a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "fb5df45e02a535cc5d850c1f4ff8c581f68004acaa8e0a65dc986db26bb18831",
+                                "uncompressed-sha256": "ce629725f03bc2e4cb33e46eb139414c9016b45504b3863cee22acfdaca7d576"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ea362f44eaa145c24cb5c37b5ad39631db2574b502145aabd4b889a9a065be21",
-                                "uncompressed-sha256": "0bd325ae4f2e41a5178dc2d99565d80b80ea40bb9067719055cb1189bad2b06e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "15fd2d388c84dc18713c71c18374b408b82fe803ef76373c0e3cca16fb65d9a3",
+                                "uncompressed-sha256": "ba901e44484c762e8d13c4ca197964b53c49196270bdc6ae4227bdf136c582dc"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "2a737b7c20f1ce7e7ba41177fa50444b436816ecdeea7434d13dfa5e5e55612c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "917b9c10e25cbf3ae02717d6f6d842f1fc416081860f25b058683a78198f6639"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "5aa6f73e5ecf99644a5601191c3a9cee681132f4f9589dc3b82a4ceb11b8c0da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "64b6ea0f0747b3380ba1fa54ef28807b96d307246aaa645631f8350cf779ad64"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230819.1.0/x86_64/fedora-coreos-38.20230819.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "40b98d39b12c832c4d7ff0d6733f2814d73a8f2bce6db1b4d3b94747d4ebf6cc",
-                                "uncompressed-sha256": "e6760d5be3e7c17a3669c81d9744f22f3190a8f3d4fd4a070a12681695c6fca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.0/x86_64/fedora-coreos-38.20230902.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "00d38817fdb9d7324671860502130fe3010f0830bda7868c8ca4d02d53b4e25b",
+                                "uncompressed-sha256": "7304344ca7dacdd3baa6fb1b2350ece0e28caa7ef540d0463bd965db49664d57"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-004cd58047681a9b4"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0360855e6309fa1e6"
                         },
                         "ap-east-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0e9a9a7f57ca750fc"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0f029608cb87acb69"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0343aa22179ac2767"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-03e2f2e77e4fbb810"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0734cd31472bafb85"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-01322ce0bec8e3b57"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0b870b79f923fd3aa"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0f88208ab022c82c4"
                         },
                         "ap-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-00dbe525256cc9ab3"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0abcd9b72c77aec96"
                         },
                         "ap-south-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0a6ba615edcab0dcf"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0f8e6ae801e0aa0ed"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0edd453598ee74ed4"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0c177b442f8cfd6d4"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0f1a11240dea9873a"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-092dbd5e0071acc54"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0a575141ba5ed63c3"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-016ef141c6e3ce131"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-074ca2e691cb07193"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0fe4a44b24f19042b"
                         },
                         "ca-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0b6a3b8ca21c9c144"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-07a95934053caf23c"
                         },
                         "eu-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-01730e24981df715c"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-065f75f84081aeb78"
                         },
                         "eu-central-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0259e7f89e1351116"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0231e38e953f55355"
                         },
                         "eu-north-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0acb7af6cb144a794"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-084ba8f90b381299b"
                         },
                         "eu-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-05e9d3035762b909f"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0ff042c8e561954d3"
                         },
                         "eu-south-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0e118f28721af9a31"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-095fe9b4fedd7c674"
                         },
                         "eu-west-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0b22f81b6aa0e061a"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-016aba1d25dd4c5a3"
                         },
                         "eu-west-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0708c0fcd0ab987c5"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0890657997b8d0f11"
                         },
                         "eu-west-3": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0a8feacde3c925480"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0d6774e4e92d70b92"
                         },
                         "il-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-041a247b18d42e9d9"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-04b9e9995e9aeca3e"
                         },
                         "me-central-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0f7721a05a691f774"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-08f4b3594e531149c"
                         },
                         "me-south-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-03fd226b840f76659"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0cb189d659bce6986"
                         },
                         "sa-east-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0a49ea395d8ddcf03"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0d9a9acffac665c8e"
                         },
                         "us-east-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0d20ac32c2c7d4a28"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0a7ac32c45e2f6875"
                         },
                         "us-east-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-0d9e553f1d87e4184"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-019367be34476a86e"
                         },
                         "us-west-1": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-05fa1985806819560"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-0b5fb3004d538f886"
                         },
                         "us-west-2": {
-                            "release": "38.20230819.1.0",
-                            "image": "ami-056314a2a02067342"
+                            "release": "38.20230902.1.0",
+                            "image": "ami-03e60d2acd2f4e282"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230819-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230902-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230819.1.0",
+                    "release": "38.20230902.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6fef84324bc13415a89fc8e4d1366562b2412f086f86085a039593c8ee8f7ac4"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ff78c0965faba9d865197ae12e41795eb1717794fee6bc27467741c4da0da6a5"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-08-22T18:29:01Z",
+        "last-modified": "2023-09-05T17:46:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1714d8ef458ecb62149ea43ae882bb0932e9dd995564e62225bd6c1f40035f44",
-                                "uncompressed-sha256": "d64d7361c0f21af2aaec92d071824d62d194d9e5bd2e49e3dfc5ac8134819e8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "628b1178fa0d3e769fba47269452f2ceb6edfdf3661bd32d676c3228a0c8a4ee",
+                                "uncompressed-sha256": "ac601a4e74fccf52b98262cbbd0e7d72e5395916a4375be79f9c7a7fd51e1589"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cb7890593ea9811fb746dda0325373547a1e5982ba442baff58b86228226eb76",
-                                "uncompressed-sha256": "84b5f64aaef175ceb404fbc069e23b7e68f0d2c2d02486649ea195da85efaaf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "843845657191d3ad4b3574e69682bf15aa6bf7ced258d99fc615c73abe4d0661",
+                                "uncompressed-sha256": "b1d03ad03c832bb6df9c7b7112509993b8db192cd1489257ab267944aeb5b86e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2b5df874026e9b1d05e2beda20c565ebd926b059a0f17e3e0fc135df0b18980d",
-                                "uncompressed-sha256": "86da4f5a2264c2c4c941e583801d5f42e824241da904935764a8872c34a82d3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0f6776090cba908fa49cf71d860a2e4c81a7f86d1e58ee2e26fbeb582916286d",
+                                "uncompressed-sha256": "dcb71bcc2f112c22ede1680fecebca3e4ac2db1480713d9349f1048110be6ac4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "dc6a7e759d096fe9fb57b63f51d4eae31239da3cc53b8b410fd8f55d9cbc9b0a",
-                                "uncompressed-sha256": "87c7c1629d2969fd7455aa36541f9afc15d947fd35a65c5bd574180cf111db10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "562759cb29fc001992a380fbe300046e3d614dd4d076e79f2dd0013c330133d3",
+                                "uncompressed-sha256": "28e8cd79316551a5320cf8cbe203e91354ee1b0022e1d92eed5a71652b31d262"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live.aarch64.iso.sig",
-                                "sha256": "57c18395b40796572eadda36eb8495bce4a120e15157c36a0a3f5ec0c48da6b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live.aarch64.iso.sig",
+                                "sha256": "dd89240a6e937e864ff976c0ae9a714bfea9ab145c89943c20f7b0361c541b8b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-kernel-aarch64.sig",
                                 "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "86d78e3921b4b9793fac9108a5ce2f4e0b9d0a8406bdf1860c2cde49015552f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "fc0c10affb7401922b62ec8185808ec3d1953a358ebe7d3ea222c756c940db17"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c38f7f3378e6e21268066f61c34af1b03cd1d7b1ec7cf71d6a7fd5710fc9bf8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d54ae691eba85c3cbd0be8eb78efc1bc5aba74b7dc5ffe166530ee6d760447a0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "e07df477c3c1909541acba4e8e8e3608ee1fa8b2f1e50c414dc3d87e341ffb7c",
-                                "uncompressed-sha256": "16abc9c2adf19ca2c72a912305e58fdd595cbe8dbba0f8e913a6846ed643fc88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "4930d0331d5232fdbaacbb82ed319f0a5f86bc4765e6ef966066b2662cde2209",
+                                "uncompressed-sha256": "03247bb612dc248eededf7c5b253a2b81a3e1437bb4f6e68e9533626ee2050a2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "796e8cfa5165fdc020d858181dc3ae0aac8019e0829e1c0812b5153c17d983c8",
-                                "uncompressed-sha256": "2b8eef5eb294cad5b8653f2ad3533cf77ae37ac023b3c3f371362574a0dd048b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "801ca5101b247061772e83546f225977acee3b32d598edc66ef37a4da7511a39",
+                                "uncompressed-sha256": "15748565270694dae017cd609bb3ca7ee22e2baa8fb9112e6929011e6a068816"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/aarch64/fedora-coreos-38.20230806.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "17adba525527f6235d2819488269adebb6594d0d22cfa3e8ba31795571f43863",
-                                "uncompressed-sha256": "8ca5eea802d653382a861189ff752d7afd3c5fb401d4a45164b37ee674535763"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "412ff2d87f7c24efc944d1cf198f3142905675635b568f2dff273c77796aa51f",
+                                "uncompressed-sha256": "5813c3f983d8799e4d3715c109fd31d0556f79b9285d48b393bb459af541d866"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0bb75d130b38ab37a"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0e7de2967b9948fe2"
                         },
                         "ap-east-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-069be3627758158bb"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-059b4d938cd6af773"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-04393e0a61c6eaa4a"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0421af6d1d374e86e"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0d87b8f5c15303c4c"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-024d2484db2805377"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-082bb2197af25e50f"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-020bcd0304c8ef6bb"
                         },
                         "ap-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0855ed6c20cc6ceb3"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0c9fc60b1a57735a3"
                         },
                         "ap-south-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-04644028ea4643a73"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-081d9c4ed02a774bb"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-08b02bbacc7a72ad3"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-03da0708b4c14247c"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0f535956a46580fcc"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-06a97df26239e2744"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-01b0f55ddd61eeacb"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-02a4f1d2eb40b041f"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0a4220c9413e90a84"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0d716650759cac7bd"
                         },
                         "ca-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-06afe0f5dad6e6570"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0f42ed6db21778aed"
                         },
                         "eu-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-066fbfc14654cfcd5"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-04d5e15f458f4a7c4"
                         },
                         "eu-central-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-05c89668815a2047f"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-033b99bfaa77c7bd3"
                         },
                         "eu-north-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0a8234553a6e41323"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0d47d82eb643eeafb"
                         },
                         "eu-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-01362b1118bc10ba0"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-05e3ff825b7e7ddd9"
                         },
                         "eu-south-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0e9840bcb36ec6cda"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0adf4a11b64d2abc9"
                         },
                         "eu-west-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0d899494dcc619c6c"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-027f82b528a1544e3"
                         },
                         "eu-west-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-03d0f67ddbb49e547"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0b02f8ad58d819d53"
                         },
                         "eu-west-3": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0980f8b43fec4950a"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0a2118c6b7ecdf59b"
                         },
                         "il-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0f2cfebeecd244e48"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0e6ec1cdc8679eb49"
                         },
                         "me-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0086d65b481ee78ce"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0a902be4f0ad3bec4"
                         },
                         "me-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-001e551c948f123cf"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-07c938cf1c94a52fe"
                         },
                         "sa-east-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0f298e70e0ae153c3"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-00adec82c96c7caf9"
                         },
                         "us-east-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0429e7b3ee561f625"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-09781c4235b52419e"
                         },
                         "us-east-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-068284c85603d7e8a"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-00989cc1614b2a9be"
                         },
                         "us-west-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0badd0e9b86e1c6ac"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-04d9003223c5c51ea"
                         },
                         "us-west-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0a8ba63e7bef50c78"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-04855cd021156df0a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230806-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230819-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "64b0a13ccd6d41292cae3931069296e0906ac339dd3cb9aca7b50bc3bf817d62",
-                                "uncompressed-sha256": "82ed335fce1200c44114cc6d3b79a8e3f4406e85ac7b0871cbecb70305e3e99e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3d2ef13391d5229c576a8208ea8b5de2230a337d109c27b76b31b131bd5bedf9",
+                                "uncompressed-sha256": "4ded5499c416c66633f085294a0d5d23b268cfbb3e7d4cc84999521d63fd15e4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live.ppc64le.iso.sig",
-                                "sha256": "f032eb4320453ea55c0e2dcdffa3e19c29c76512fa2c68e1208f88530fef8d51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live.ppc64le.iso.sig",
+                                "sha256": "fb862775870cf16760d6b3c9cf7222b55e446ad0da7380f9f904d9c10703f992"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-kernel-ppc64le.sig",
                                 "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "c54d8afbd13e7f758e45e9f1e6349542abdf825d5a0a9dd7c37e5d3b003158b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "38e53757b2c990699091abd70d61f1b12358c896e20f1f356c5cd38ba465f92c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0982cc06f195f83550a8d0465177bd1dfd91c38b5488d147501f3bc667615877"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "462a7c5732c83eadcf1f68b2b83793a0e7f0dcee223a46d158e77b2520cbe923"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "8326d275bc3878121952ccfe89efa8f48bd8e80f2aaa6c2f56df1f356cbbe778",
-                                "uncompressed-sha256": "2043fbd10396f979f788b4e75ded99d13781d86a6b61537297754b92a0a3efd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "bf8fbd5ed16247d4e015284f0d6a9185d29a3a70d7cd0dd967036053d9787a11",
+                                "uncompressed-sha256": "2474d11ad170287419f38b2cb5320976f70c1fc7c962294e31ff3a6187c57bcc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0a8d8da43a383cf8507d81ddb182cc3d39e9ccdca21a66539adbeeb6444864e2",
-                                "uncompressed-sha256": "cd8ae08d4b31c82644b87c3af978552489eadc00052cec451ed35302865c99d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "85f7a654c1d09b18a54da8c03e112fa8b0a0fd2dca49b5aaf6f9778adeb8188f",
+                                "uncompressed-sha256": "d3f11f0d1ca39bd6768e15f0375905657b1a541abf38964687e058a9b33500d1"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "eec9140e0807288fea6ae43d76c4a384f76fc964fc1307ccd04cb494be694d6e",
-                                "uncompressed-sha256": "624c0a080a7d10d54a5c949e2789db928704ece7dbc39bc7c0967cce65f7fe26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "da3e428e68c18162e25885d5809765a0dade62757ba3919a12d0fb780a991e8a",
+                                "uncompressed-sha256": "9fa19b0de90bf7aeb1eda9ef3e47fe33f18a414bc470eeedb0520790d834a00e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/ppc64le/fedora-coreos-38.20230806.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "77d13792051d2bed417828494e8388595e33cec1648cc76ee1de0b086fe471af",
-                                "uncompressed-sha256": "4692644a5a818303393e624d62b7e4b1774a499c7edf85dcedfc8177e8bdc641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5f9fd811bed34f4a3c3d1344e3b00bf8467967e191c762a66dc03011c1ab6c8e",
+                                "uncompressed-sha256": "ac1d4dba2757ee206afc790ddb4f2833dea9cc166813e49414e61d700a561ec4"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ba4bc19196f897c0df732dfe85c17a617b629da65b9bfd4859abd7273049e42f",
-                                "uncompressed-sha256": "2bb29f98f8ffe313db206632cc647cb9ed4836aa18bfb82d2809158135235bc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "30ccf5d6a82124b1b8af0ced5011bee5d133a0dc3bc9efef3ccbed26cbf7391f",
+                                "uncompressed-sha256": "5f5b5a12ed77a9d76391abc4f1405374e5e30e4cc39f3ea5c4b717830b64c1bd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d106c8d912a6f4c1674faec324b0a256c3337ade1df716b22f1b80e4fad69079",
-                                "uncompressed-sha256": "f74c242dae885b28a2bee2541f71393ba9f072fc54de4c4d0fadd559545e9285"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "31d1efabf9234fd68bd96c050519bb3af18af6ca7279b0fa0dd68b0a4d3db247",
+                                "uncompressed-sha256": "c7f7ed656510737f75d843a965fb5cc0aeec9375fa5c2fcc40358dbfd26e698a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live.s390x.iso.sig",
-                                "sha256": "e1c4acd88b23e548fc12d1ca2ec36b72e1446817c0bbfa833df9e8809c7e86cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live.s390x.iso.sig",
+                                "sha256": "afb8748adbcd20bb3dc10c06fb47e6f15c94804e8e7dab990e47640d801691a4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-kernel-s390x.sig",
                                 "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "42f394416efdda2e713f3fc29962cb9a6e3416e5ac251df271e67520a0e59308"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d6ab0a8a3fc0b215c7c3341354aed6fb7adc03a71a68265543e6ca8eb6e197b3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "112a4f48d356d4b420d8d024b77d011e240082a650b06eb2a558ace2833637b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "cf3867303ce651e8306b44f4fc1871b1e2940840d7383cced89acc49fdd24637"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a1c6b90ba9860e4f4e5ad5dcca480ce05e38953a2b50f94e8e47d777ab8c62b2",
-                                "uncompressed-sha256": "82dce0b27e5888d53f472e805e95e2ec4ad6093c04fd8c7591909e0417862314"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e6b656ece1fdcd4880dfcfe3f03acd846b5e50f7ffff690c843190406a9bfbd4",
+                                "uncompressed-sha256": "b9ffa4db1a58b5e8aaa9a806666fd1b06f6397eeb4c033b2986b547c21b54b9f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8f24453646f2a9478782bcb5e4a6a4779282636d9046ee337c323546abdf11a3",
-                                "uncompressed-sha256": "e588d6954661d7eca67bf0d72bda9830b706fa23115c0238eb8bf9b1cfdbce5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4c77efc84358ec2db6d6b705b5e7e47aee0cd1fa2e229a740d9b07ab7b2816bb",
+                                "uncompressed-sha256": "775bbb7e83a24e5db1fcc4452f692edfb8c0254023d53ed2bc2812bce1671671"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/s390x/fedora-coreos-38.20230806.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "97ff6c751611b3ff88432535c82107cc766d92f02174013f2015dbdca152c559",
-                                "uncompressed-sha256": "6b2ece5417704b11d3b67da630ea2c3c5df9a23c327fb96a581b2d970a07287f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6cabdef6e2efaaeb2b2d083f1ac5367020136b7a553cace2948e3a1e36a59018",
+                                "uncompressed-sha256": "20397cbe45f989d3296aef52839c3925c715358cc562a8abe87c92e101eb8222"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5c876aa07dce24942fd9e051d9d536f6ecfbbc57e5d6c499c11756e93243039f",
-                                "uncompressed-sha256": "4da096e34864ad0b4530cc8616a07d9a16f01f7a13e09d367858500059dc3224"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3b2ea3541bfcccac89864e5e4aa6d7eb2db099cc9ab1feb64480bbddc97a1620",
+                                "uncompressed-sha256": "8b6033acf3ba9a07ee429e1949c08ee4f928ebad54086cfd1cfebc6a7ab9e636"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9f7ba8ee2c9f398cce59fc20fce40fa18bba59d44215f9d29280c304596b9af3",
-                                "uncompressed-sha256": "33b57e4e8a583ddfe88f18d7c1c1ea7868583e302b34869cc24ee75b11ef484c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a5ca1edf0bf435dddf04518674fe9f1f2eb11bf88747c9e3a2d11968d93ea121",
+                                "uncompressed-sha256": "ac68c1cff3435fc36a4a874371af3255010728d669aa6ba0e886c4de0cb9a933"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b070c059fb2f9dc6d38646a3320455d3d20ab2401b90df26cf621ffa79876457",
-                                "uncompressed-sha256": "fdac53eef74fc888fc1d5b12702f3711d1606b90581d33aff1013726505c767b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "68e394e6760340795e849a6f327bb86b3d43e9b0e3945db0f972d67c22ea6a64",
+                                "uncompressed-sha256": "6dfb16c24c6089c008f6591979a9774aecd35081ff73a13b0dfac71911da1ff2"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e70e27c34dd46146dc2b526b58819f9e3262488cbf7f4e2e58068418e33c0299",
-                                "uncompressed-sha256": "a0c3413cd7c2ddf322348041bf8813d30f1b7868905c2252f1e2f5f6ceec6cf3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "9a82afb65bf0097354892cd8b20a45c62f7c18cdcff3063f86054bff7ce86775",
+                                "uncompressed-sha256": "91cb530b099a93d87589f5465225885062b6d9365e096783cf91d776530a32b0"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f21cdfb85b3174c7647033ed42f42d31c52bc609f9a089569e510a35e206e951",
-                                "uncompressed-sha256": "f9b97f71752ab93a9468a08bad5b070a1feec908840a2f0764f7a2c3a53d302f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9126eceb8db0560328c33a2e5c35afd6e56fbf2861eb2d433176c0d247107c76",
+                                "uncompressed-sha256": "2b1f91d76c8e6f3d1d983d8dc704e198700d28c6820b91c0f7f96821e3149c9a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a025669433cdb657fd68b42666488a242680b67b61c0f736011b1598c2668ccd",
-                                "uncompressed-sha256": "385c57a3f97d1d71740570a6de37188b1fee71dac545f5eaa53588f202244784"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2bb47c62e0cea052ac48dd0629c0afc798e44a79c24640643df9539931c543e9",
+                                "uncompressed-sha256": "5043f9ff3953b6de86b58409e926d7a6c57ffc3c8d0c056bd7d9d6e75508973e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d022e2e6b127eed89f00f1afac5889ade714c5ff45152b6805d569bf6c98864d",
-                                "uncompressed-sha256": "152540eb6fbee931e21439cc2d80a6cc210f676e3e4db216484689a2a3546b45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ebb9f0765af124a6dd12cb7abbf00c4b020eb4a255a452f0a6fdee0a5d806d23",
+                                "uncompressed-sha256": "b30da62da08df182d07359b8d9bf28b64d36af0aeab4412694cc0a36252f5637"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "75c3f86838d0ad39caf01b6873c1bfb4a5591dc8304602a281fe8a4c6465e022",
-                                "uncompressed-sha256": "bbc6f59c05213d27528e4e04d6b295c87037dbf1e5f4294e8b951821678a6d59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "fb02632cc8ef3d984bbb04cf3bcf2a3031620b293db91e536f40a871412b9ad6",
+                                "uncompressed-sha256": "c69ba3f37def33853722b9cbd7b5d4edcdcc95337c99b2b4f0762534034ae2cd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3e1df0b0d9554d812bbfe2326e9f5574b9bf0d626077947a5c47132df1621dc2",
-                                "uncompressed-sha256": "5de0c26ce6d196ef2f241e53ac2fa5736f96ac7ede4b2011a313fab3143cb3ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3b1a3e8d18b1c17456eb95d73a10f42511bc7e3ba0fb3a95211c56cfcd8cbdda",
+                                "uncompressed-sha256": "c4ab039e41e171a6d3517ff25d693b4be6c175d47a37222dfa1cf053d52e0785"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "64da9fd61b5fe853851fb15956dab14390229fe9425cc969897505910c7f8531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "15931ae34158359c527d87589b96f77eef4369d78a4dba1038b730cea77aeae2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5d97b8ecaa57d62bac3d8a538ada00c79afd48e205578b13f2cdf016feb773e2",
-                                "uncompressed-sha256": "aa55ff950724ed5feee6b66080453fbf8a757e72e505bd176f5986447795d9dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4199bd77482c1afcfc6d9d27e9e7c280d9d659f6402d7b1e75eee8c175610d87",
+                                "uncompressed-sha256": "87cc9df2d0101a0756816caca7edebdf75b2df8ce42325de78f1fd4693fc527a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live.x86_64.iso.sig",
-                                "sha256": "4305aa0f7fb9f32a4c4b2559086311200db94e1ef0b5d4c7897424119074fdad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live.x86_64.iso.sig",
+                                "sha256": "64d7ec18c67803f40c0783585d1a8986e21dc2b0f49508584ef825ed34785fe6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-kernel-x86_64.sig",
                                 "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ce80e86da7cc1b51ce62dc87a6b152a9b2863b6289bafc07edbbda28d7b28d57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a94780046d54c80b5ab03ed84704a578dc060d7ba76977912d3b8d88d3b66992"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d75315a83a7da1ab17a7f74aa06ddc23bcfa0adc13881890df052f4a7b098d27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7dd9489a793619a30715374cb66711d08ae82813552ac62fca53dedd816e6ac6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "442b02d43c42c79c73859ec6049415b22ca3e69af4edc23a35d4c3dd18bed953",
-                                "uncompressed-sha256": "a6711fd709712d63e4b24ed66bd9649ff5a3d32dac93d8575bbb46afcd88f4be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f9b8816a5a13cc7bc8b3443babb9496e0aa922abf3447b155820e4d762901f09",
+                                "uncompressed-sha256": "42ae4ac58d392e952d806b07c075fc835a305e3129760219e63872050a39f91c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "de2717d8099023c15d065a25f1d62bf1795b0f02289e82fbe2c4e9a14a93fb05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ce0b309d2e2d2dc8f85f97f325a1e7ca94526878ae54c65006a3b5f529dbacab"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8f76f70ff645edc35fb29817cb20b9cf2e1ab46efc9d75a37257a6689f128cd9",
-                                "uncompressed-sha256": "1e7ca33cc0afda45b51587709575244daac050856d820e527e481f46689d5b5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e1eec662bd3c14767bc10c89d60388a85dff75b5af9391c7fd45603c5f99f942",
+                                "uncompressed-sha256": "cc3d8b824e1c338f77319f689f10a876c4ea541aad70a1e901237df1f21dbad4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "63e13b12fc147a38cfc7c40ecaaa373ba32134a9ea4fe74890a3b6f828554ca0",
-                                "uncompressed-sha256": "b1561741399a8f1354e207572efd403d5f7b1a409f7ca159c824e3b579ad33d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "854fc18ba1379e457c227dc4294eadafbbb2f8e5e067154fa551c2de52f52b58",
+                                "uncompressed-sha256": "7e6d2c100391d2c9308ac54cd781db54a917881cd369b29f706f7db04c2ff264"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "eada8aa451ef363b6b16ae145f962586259ffa4c3179d20204483eaf6f841ecf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5984decd4ced902e4077a154c26a054ca690fea9f66ca225836e862b1ec253f4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "6d7d1ecf24ca451fb675d51e2abeaeae93d6220812c5f6f65f4a46b999eef35a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "76f37fb76b272c0ed5069c72e99f6fab61b9fbb98cbd6cf9ea0e4dc9a29fc8a1"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230806.3.0/x86_64/fedora-coreos-38.20230806.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a078df213207a72c94a217a148fd84a8b82696543cfb98087d2f772cb74cc8ae",
-                                "uncompressed-sha256": "9ca1312f84e1438eed31a14b198f46688bc3070d2e29fb39fe1f7eb050177e27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6c2e1cb9dc82a2140e21dc2b44a540600d60683a88349eabd306f4cff9847584",
+                                "uncompressed-sha256": "c4b3b304fdd301f2710c27b5985488b8f02d6c26806cf7bc5589c6b50f397b54"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-08466b5c2a92f41ce"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0985c480dcf474251"
                         },
                         "ap-east-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0868c51a597245ba5"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0207c3eaa294c00a1"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0a835dbeaed3f9f5c"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0d0cad40fe35830ba"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0d9218df8d07f76ed"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0f3fb503c2fc37d79"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-092234a0ed3b0faca"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0c0bc2fec4c969455"
                         },
                         "ap-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0ea11ceaf76696d3c"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0ad388bbed8299365"
                         },
                         "ap-south-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0df8d5863d530ec53"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0b4d302d2a2150e94"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0afe00382fc6aee29"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0e9b65a58f243f199"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0366b0e5c600369b8"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0b53f6297d6570219"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-03a5b8d1287311695"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-01c9020881cdc9e6b"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-059d21dddae6b541e"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0df36258042cadf03"
                         },
                         "ca-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-03337c51efe902db3"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0fc6e359912d20146"
                         },
                         "eu-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0de26fd9943db2d33"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-01c166ecb7969fff4"
                         },
                         "eu-central-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-09420c8b1778eaf5a"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-00af662618de94e74"
                         },
                         "eu-north-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-072b0048bb8eb4c9f"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-083033f66b497c20f"
                         },
                         "eu-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-02bb74b11dd6ac4b3"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0e36adbe943a3673c"
                         },
                         "eu-south-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0f7f4468e3d2824b0"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-035f5b5f3d7686e73"
                         },
                         "eu-west-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-07a153e794d08d71f"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-07eac55d1b8f93e5d"
                         },
                         "eu-west-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-026db242db3dc8af6"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-02bd8cad3428d2335"
                         },
                         "eu-west-3": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0e1d1d1c836f117d9"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0376de1c3bf960c1e"
                         },
                         "il-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-073b90bfbcee50f91"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0e7c3507eadd53c97"
                         },
                         "me-central-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-01bb7abb86062e3c0"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-02e9f26a9fd9c46c8"
                         },
                         "me-south-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0a602698baeea7128"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0380a51f57736d4f8"
                         },
                         "sa-east-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-006b1e302db41c064"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0e85fec968c3b23f8"
                         },
                         "us-east-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-03936e50359910ea6"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0a79e259cea5778d7"
                         },
                         "us-east-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0ab4e92f3817274ab"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0378c7af96510a6fe"
                         },
                         "us-west-1": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0af71e6a20294e517"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-0c9c8732c08f5ec5c"
                         },
                         "us-west-2": {
-                            "release": "38.20230806.3.0",
-                            "image": "ami-0bcf9c89280ef797f"
+                            "release": "38.20230819.3.0",
+                            "image": "ami-007038e2ec3a8525d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230806-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230819-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230806.3.0",
+                    "release": "38.20230819.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:14d59f2e0332716c89652ab776ec426b003ca36bf445db46e9c61d3a029c1335"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0bb7d6038fcb3d834fb62264d412b4cf1bbf9d2ea8c75bf5b1df38e46882a8f5"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-08-22T18:29:02Z",
+        "last-modified": "2023-09-05T17:46:05Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b1b945b724e72f7c35195fb1e757bc1fbc41cf67cefbbc0674202c5e83359118",
-                                "uncompressed-sha256": "de3a29cd94f0c44d891b404e5623e1fb7a3c6df5e2fef07add539526167bb4f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "6b51738ef9a7e707662c60eecc5b6816fcf361e93acf2ccf58ac3bf850a719de",
+                                "uncompressed-sha256": "f560f2314d0f2cb4ecc716757dc3038d2c83bfe41ef55d41d0936bbfc6e00f22"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "238861899506fd9faa6a37e3bcce08140b9e22e9aa26272f292e59a1019135d8",
-                                "uncompressed-sha256": "5b8d44ab175a07d4d49394f30a88ce7ef0c0ba00c2cc3ae78a77c5fa1527a65b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5913512c2aa64bb07ceadca76c4c618ab48d9a30260f93b6a9f5d98c05790ed4",
+                                "uncompressed-sha256": "d38ecc5a287e4171b6a954ae503ab4dc441a19f8cb3f8b673cf775dd9178d0a7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "fba27c2c29ce1341b65a02a2bf4363d6a9ed0f54cdf1209906d62754782f4fbd",
-                                "uncompressed-sha256": "b956afc1e5b3da2ecc982cd15b879c93d8d6ff8deb6cc76090523804caa6b33a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "70ef84deadaff8252bdcb24ee605722cf74c63ff16f79c8b10a13ad485b1e962",
+                                "uncompressed-sha256": "66a52430ade4a3e73dd756f60bcb5c32c2e752203954de3ed1436b8b36106bbd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "120b552522709351059d9e79ceb6ca474593c017aa9e63498a128efb219e618f",
-                                "uncompressed-sha256": "686403d3b523b56e7cd4c7a0297b3f96247f161d8c713bbc726a84f51f8cee68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8e7ee1237b8cf78d400e8698dcb8e631e0114337614bb51d8be3bf1af0c2c352",
+                                "uncompressed-sha256": "a732b6bba8e5306bb2526470d5276e942e9591c46907e751d732412d86a16186"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live.aarch64.iso.sig",
-                                "sha256": "1fdacc9954b230b9cd109c5a67e62d2a1f2b65d68a5ea777d39f3e1c6e3e317e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live.aarch64.iso.sig",
+                                "sha256": "571f5e609874338bcbe2c9e5c81e7efe90b9877ca68df5ca9edae2d40c576ad1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-kernel-aarch64.sig",
-                                "sha256": "ba9026ee27f6a3d4f37d34f493ac488895926358d5ca2c7e03119381b4cacd66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live-kernel-aarch64.sig",
+                                "sha256": "6db828ed5e633b64ce66f3f6822e2895e4dc0cfb54bc4d080d075970d1c0028b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "02688cd5e0396bb516b46656d620fe418f8c76afce80a87edb52ee60cafb10cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "749cfa1bfaab78e03abe6e5bfce4624957a69e342e61c56715d1536a20ffd0c0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "15c02ca0efaed97556e447846957859aa7132b776e4f12f3ffa9e7c401ba218e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6ed4400a61c2f1c489d84755315f30f5db1aeb09916ae465c94ee310e614cc6b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5558c387be907fd492b58fc59a929431b7bd14550c4775bd6d8afa78126b84c6",
-                                "uncompressed-sha256": "9e4393ab182e3ace0c45e556f978e073be0c205cd2363d5a0c4a286a525c2c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7590935e7667607b5b209ef0e870e489fdbbabb18566fd72c01a45356c1ded81",
+                                "uncompressed-sha256": "d7ac6680d60abb605bfe3f5e5483c71d573b851f7ed1dd0e0d40e67d4ab796d9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c245aba63c313e91f7325eed9aba5b7512e0e560b7e0f3a1d17fd26f61d3a478",
-                                "uncompressed-sha256": "3cbbd687a3bf9f8268b0119078533233b83fa681dd2ca7d37777a1568d5d7e95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b317bff204ced699a2bc50f1712c916bad52186820e136b508f259a52d424caf",
+                                "uncompressed-sha256": "0c0ebaa8e45230536d7f08a14ff6a736abed094ec656bb98aeffab19f1e6b4d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/aarch64/fedora-coreos-38.20230819.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ad29d2411e58bf616dc7603d576c4ed486026420296d90415894c9695844a65f",
-                                "uncompressed-sha256": "492a304781a9c123e04eabbde1f03f296f0bef19ff0ea2cbb243f9215b6648a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/aarch64/fedora-coreos-38.20230902.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "07fcc2dced0c5ad5a6dc8e7597455a61f806b26a6585d1b26c713774e23d17da",
+                                "uncompressed-sha256": "24cc7fe29e64e84f818bcbb97439df3c2c4832ba182f6b2425021183d3b1558e"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0aefb2c82037db758"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0651cd0856b471b9a"
                         },
                         "ap-east-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-09ba9f9d1b41f9d46"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0253706b8d70eba49"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0b82d924ee12f215d"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0eb506dafec3eee08"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-05eb323d49a6472d7"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-036cfb91ae77d0ffc"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0c07b057522e29438"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-03ccd54c6ae5afde3"
                         },
                         "ap-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-09702ecb71b600868"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0eb4ec5745a048c8e"
                         },
                         "ap-south-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0b254b2c478876bcc"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0ab04c82344ab497b"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-00c32717999a0562c"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-09d5e19f7ca599688"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0fadf78398e6a3c12"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0b786dbbf745897ae"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0c22496dd3e84e0d8"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0e58fda687a73088c"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-01cdea20fd6cd5f3f"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-02ecb35a213296b08"
                         },
                         "ca-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-095a191e79523037e"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-06094f9e3547bf6da"
                         },
                         "eu-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-02a2ad545388e0531"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-04a937f3a837e7404"
                         },
                         "eu-central-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0efb09aee26198f20"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-038f941ad369f811d"
                         },
                         "eu-north-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-06e6ec3e98f1450fb"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-01bcef50f67998f44"
                         },
                         "eu-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0389eab2f9e825f97"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-04cafcbc33ec83826"
                         },
                         "eu-south-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0f7979daa2923193c"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0af4ec7fcca31ca0e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-046590a73be729d86"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-004f14ceaaabe958a"
                         },
                         "eu-west-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0876a99578a147bbd"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0a98da958223d4313"
                         },
                         "eu-west-3": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0891bb99c3bc418ff"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0b4efedeb039da5fe"
                         },
                         "il-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-06ab1394c26848ac3"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0e229f67b5bde9c25"
                         },
                         "me-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0a3c2dbda3b5984e0"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-009b0071b7c5641d0"
                         },
                         "me-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0b3edf7c28d8c8b6f"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0910c1eaf37c7bc70"
                         },
                         "sa-east-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-03c7639f113a6d210"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0be838d863a93459f"
                         },
                         "us-east-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-046ca4cd975e69a92"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-00c4bbe74caf61c94"
                         },
                         "us-east-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0225c9602d2415fcb"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0629117de880fc0eb"
                         },
                         "us-west-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0031988e60f3b598f"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0c4a307da3f1c015a"
                         },
                         "us-west-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-004f5bb7ccbdbe7b9"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0f92099710d350576"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20230819-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230902-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "d74c1635e3b12b3ded974ca4e3dba2a050c4109d69884cf225b76ad3ccd7c3d8",
-                                "uncompressed-sha256": "1ae40fb919372b7dd60c7579bb894706a459705cff726c0edee1d1d8b0f60e52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0ff3db85e7d5a939baedf741ad8643b4bac62540ec782a2fa9351e39609f4145",
+                                "uncompressed-sha256": "1bee38c67dda513e07a43a73608e14ee52b46461de638bf1e108c73ce7eeefdf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live.ppc64le.iso.sig",
-                                "sha256": "415e290d059d8c7e0be2dec494d7b4b0e9dd646b4aa953e9914e61cd9a0eb133"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live.ppc64le.iso.sig",
+                                "sha256": "32adb7367edd97c4895e1eba30bedc646077735556bb394d5ebc2aa354a0ec61"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "0b427366e3121d50864102fbab7ed00654da6f0b8c12974ad5d75602685e91cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "7e8c4133188709f48aa7f0a523ee215d67c2cb6e6a162e9b50e889ae3477a6f0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5a75c7df64618cd2673dd45fecfe867941a574ee93b0cf617487c8203819ced7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8cd9833716b0385d3307049e10bb910b88c58ada9f11692a5f11dc3ccd421b0b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "00f8853f19edfff96c4a4dc98abadeb0e708e5c1f963b8cb0998b91b892485db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1f561d3446a39705637ba09eb72084499afb68390e6d5eb42c2ecd42fea24605"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6731219fd14bba195a9328fdded8472650bca10174158a44076b27904de544e1",
-                                "uncompressed-sha256": "140355f63e7e2734c710ad3ae8d77495245f1f794f76c7745628ac96040e136a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a6aac29b8db5821597f1ab15608e9e85bbe8da40388741c92e5cc98cade01ded",
+                                "uncompressed-sha256": "186cdb66f6bd4444bb94bd6a7b4be09abc1816c659beb0cee2931c5ddec3d68b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0f65608c747aa195608c8346d92d10846326f9e926639ee30937a8d729edf15d",
-                                "uncompressed-sha256": "d0932362a7ee964e1d631b566fc25351c1c41e435903705010d3834c7992bf79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "690e76ddd52a648a51f1d762016e57f00d3284815a25483a24ef70c51079c8b6",
+                                "uncompressed-sha256": "81f4b3f1f2481cd16c29405f1572b1c016eebca0f24aa7b8018dc534fbd2eb7d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "7f9bfd7b496165a1d5275dcc2e3b3bc60cbabc9394cb1e700b2a1bdef53bbb18",
-                                "uncompressed-sha256": "3de1de82b1aac7e8c0d96bdedf627289ee5390704a67e68e461964f134050222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ae69a61bcf2d2a53ef740d0ed2a11829ee1feb1ab2d79487fb41bf58511ce36f",
+                                "uncompressed-sha256": "d907a56fe8b9a143ffdf61f1a7642efdd0cc6554b3e2c9c44ac2b1a18be92eb5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/ppc64le/fedora-coreos-38.20230819.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4dfe6dad0a1581a42c605c5be2d52cad1303d850c5dda5dfe3fd2c477ba2d166",
-                                "uncompressed-sha256": "5db6e8806d55e1d7131b38801cae204c4c96b40088025f466848afbc59de4dfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/ppc64le/fedora-coreos-38.20230902.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "857fbccbfe985a8e495941b417b8aba48355877df10c9268ed64d32ff3134889",
+                                "uncompressed-sha256": "b7f1370fbbcb440c6cb2275cd9f4127847899a60d19012075ef7bd7bdb1b9201"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "eb17348cab0636037e5a1a8c502c70096120d132a978649af8a9f866b8418559",
-                                "uncompressed-sha256": "113802cc54b203210dd8800bc96af477125883a43fd60f7ad2e55b926d0c3cb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3456071594cf22875a185e6976a6551a6c352e2671ff9de7058725d7e1038528",
+                                "uncompressed-sha256": "6c7ea924f549b4ff246cbcafdd715662e4c9881b4f8b4499204d79a494b629bb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c7a024cb03f0276afdac7956db1508da444ed201d5ea0f36e8e559018e61909a",
-                                "uncompressed-sha256": "959730f81f9cd71818b27c59e9f5fa8b66c5bed2a2abe405764f1ae301180c20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "46ca14922297854f75dff142e31276b2be8cb3f6fb346b1e92543597450ed1f3",
+                                "uncompressed-sha256": "05a3963c84d67cce01e03fb630dc1c119acf8b332f1ef0e945d3c35a485afca0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live.s390x.iso.sig",
-                                "sha256": "f339502ef8fc346201c2cab49afecfa63173b2bca79ae1dbc0c945d45aee7799"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live.s390x.iso.sig",
+                                "sha256": "f7c77f06356171306f0404a05a13d1609fbc00fa6b2c5cefdbe0d3e4ecd280cc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-kernel-s390x.sig",
-                                "sha256": "d73c2dd854f81ac24587d8e7752395fbe51d8cddf775a70208e0d5161956da19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live-kernel-s390x.sig",
+                                "sha256": "a14f414ee1358a2f0c5c9af78f3f70bbd5527d4b12051aa7219e4892c98bded0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ee2787010338ed1b62864ad4a69115bd367eac411bf17c6cd6e82263ad5346ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8a1bb62ac90ebb5cbf89328a23efbf96840f4911095b30e4c9c580b558170b04"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ec43ace886cfaeafb0273733c93923dba67cf3f2b3e2ccc573f9212188fa3778"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "769f57bd4af0fbe633f354579b66140de4fba553605b820e7e5167caeeb0a479"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e3bf17d4ecea2ebf5e42be637818b32226773f5574c71602ff1d3da08a7f0758",
-                                "uncompressed-sha256": "a3dd057ccb536dcb67a0839e57de7fa18bd6526655fdce9c4afc627f40d1c06f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "998f3784e75fd8edb0532cae3f4832b7189f126793f3db1cd9fe689e20c1a424",
+                                "uncompressed-sha256": "b133c11930c17c3c332a783e91e9600fbe7f05725b26c5416afb3ecefae9963e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "508e12f22b8d2645d5b235727ff09535a4df0aba19bf1488f53888cd97bd38f1",
-                                "uncompressed-sha256": "2a6b3ffa3e62b839c0e710d39784ec28fdf1354d98ff1734e242c390767f1c54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3b8d41cbf029f91cc216cb1794deb823ef47fc31c635876d4781e5d770df0b32",
+                                "uncompressed-sha256": "8538c41ba0c38c4f0292bf7d3823a1b0b4b2114ab2b7b6138a9a3c1281674ea7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/s390x/fedora-coreos-38.20230819.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3c6cf725fe8423a37a4f9850c671c20feaa1c783652fd45a854f29cc5d3223a1",
-                                "uncompressed-sha256": "92866fb2799ff40ac1cf5cc8229f5c9ce89b196fc53d85ad1cf263ed7d13b529"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/s390x/fedora-coreos-38.20230902.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5909b8f9306b60ce6820ef5e187f9aa0fd9417ab890a4fffd085c88f13881851",
+                                "uncompressed-sha256": "b8083a378aa08e9fb95c4a6903ca043394c905bb58c09cf9fa99101842183b0a"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "15356414127028c957c6072416aff652204aace563ac0840839d3ec40f1f4997",
-                                "uncompressed-sha256": "c37a5fa6b85ded07e320f6c7c0fd28726933361d648afe50de32aca2cdd5ae79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "65c77902633448ba23ca0a335a9b98c143a32b87718e0ca2687b3d543cb83200",
+                                "uncompressed-sha256": "c10255ba1aa7e180470a1bf7ed6fd2e8767d3d0f46f2dc6d2a9b7f7894fe8835"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1605687e9c6557c1e2026144484b080df92bdff951d36f0f00340887b01a4c19",
-                                "uncompressed-sha256": "f82413c5178cad14c754075e79cb54d90f3ad83f8a76ae5325aca0f20b236626"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b8d27f849e83ffed0c3db8ac2f7858cb7b580af9a25f74cb22a875a64246f50f",
+                                "uncompressed-sha256": "e5fcb3466d78d6a97d9977e2c9b137844c9f0f74c11918aa199d7fa68566b50d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "834597734a4cf3e3f9d27469d81a7da3db008e98a954af2ac9fcee6c62bc7b0e",
-                                "uncompressed-sha256": "c820115d96760760529e1cd1ebe5be50168ffc5e859d367e9ff220d785c91f3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3199820e93ac1855ae51991b3bae266e60baa67982e6015a389f269273d8b587",
+                                "uncompressed-sha256": "6fcc9083ddc27744b0c2c6b7c85d60a15b18e3072f0f43cf4db17a347d74f900"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "74818c525718fa5f64c5c469cb0f15ee54cea70b1720421ac7e3591e79b3b6b4",
-                                "uncompressed-sha256": "1aeafdc03b1c3ff93907f6fab528c5dce59d1c1485aa7426de4a1a2fecc66cb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b0892f7eed661e69e2fffa6ecca1ad44e49c94f045e1416cb2314aaf37595630",
+                                "uncompressed-sha256": "2526d17aea7b39b7a9f43da8a2b28748744c9f5579e076b46a1227ab63962c55"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4f98b20354a952460a07aba846128cbebd254c2ea7529fee35016aa88b545feb",
-                                "uncompressed-sha256": "2bd29c418db2d4f4646fc678302916c621c93db1dfab9b859563ccdb30bf7df4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4ce00e746410173269e9c1664bf632a79c985e433bb4c3a8423e7c1b2d601fae",
+                                "uncompressed-sha256": "1b76c1d9884e95a89c3474304fba9ba0461886ffd70c4218f432bcae8e86aa11"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b56235a200005602821a5f0b3d32220c84aa96b81ad6585fa385f923bf1c4cf8",
-                                "uncompressed-sha256": "ddfe6bf96c1e0704e4b3cc200ccbb2fd293323a0747550a0df570443ff42f5c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "500781698c6dc105b47f74a2b5371a935fa956f6496a335a2e32c849c3293d75",
+                                "uncompressed-sha256": "f5a2c10b11555452d684cb10ce0a6c67258cc355a62b64fabb004892738ded93"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5b0febf557d91bcf7bdff9dbc16791065c250e30dce28c790539c81deb59e587",
-                                "uncompressed-sha256": "2dfce0fd2ab9dc976b660664264d3c7ada2f948ea92ac3bc3adca771df1ebca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "28c3dc42f152aa78107b6c5c97bb2d7e96acb3896fefeda77d1ad4faa0500a3a",
+                                "uncompressed-sha256": "11d8b3d7e58baa16668bfc47a03bc82afae6a2896175390dd6b44d49b68ac479"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d892e8a8bedeb0adefce6e60914ff1bcfdd5cd493ebcaf49b751eedb7925e390",
-                                "uncompressed-sha256": "bba1a021a37223f7bd4390ed68cc5445cc7fce49584ff80587a1cf547a0b0702"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "531e2393169c7afe6c9f1bf4cd9c1be0e406f2d60f0013acdd8465d1b65fa4e8",
+                                "uncompressed-sha256": "adf617fde3d95d73330168f9c9e0c2d6436ee1487d7566147aed410af14a5fdf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "45ba7db1d8d387f2699b6e9dd796fc6bf26434c88f419f3ad480e92c07618b32",
-                                "uncompressed-sha256": "8a5cb6bb1269585dee4667f4348c3c4794b98894a73cd5a2051a339c171144b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c927f2887c96e4710b2e04543b6674e169012626639fbb773b00db9d6c80f981",
+                                "uncompressed-sha256": "adbfba54d91f709f30697cf99ccf49d21bfebfd1194074a1cbeca595cec2d9fe"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6ba8afbf8486ca4bc6ffb35f53c3acb316cc24ba4a82af4460ecb7ddbcada300"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5522a5792207fa3ec0cb748e2fdc127dbefbbdb2fbc2941dff56e028f9bd1f68"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "37270860038c3a143b53503dcccd788261d0c211ca1cfa91a1015857b7ea59d0",
-                                "uncompressed-sha256": "2088284734d285b87c48811a42edab0a56cedbe8420272798fa67e936af40dec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "73fa48410a7a9d1bb921ab2140df6d19cfa7f0640ff043f830eed2791d07ba98",
+                                "uncompressed-sha256": "eb99622d697593b1d411fda43027d4cdb25d357d44f2c93f5f861f14afdfdbbf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live.x86_64.iso.sig",
-                                "sha256": "383dd4a7a5864708813b3bf9ee8a2b3c3539e74ebf55ea88d84e11be044e5d43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live.x86_64.iso.sig",
+                                "sha256": "1346cd00dc382214ab35196a046cfd81c108c4e11f4f1efc0deabb78312e5db5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-kernel-x86_64.sig",
-                                "sha256": "ecf92904e2df6ea872fef9cf07702eb876f5131fdc0d0e09ad54c6a8456618fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live-kernel-x86_64.sig",
+                                "sha256": "3d8ff5351fd600c0028494a656952ce6757dbbbf70429344e16ecf25a01c1eb7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "42dcf3d8333f310767cf86719d0d807f7696dcac344548d1905ae73f714710da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "639e849cb6ca763afe6053a518fa9b3b14db87717ba3ae3fe2b494537b61a737"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c4f979ae551043975673a4c5d1e9eae4bdd5e7c0db5d39e187e696a19a2b2725"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3787c02f3d82086a4fbee7dd945f023bbfcb65b322baddc850db72aabb280496"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a45755aca52450afd1e5a5e1517e7589d93954a93bc77501973be06cce0da24b",
-                                "uncompressed-sha256": "27b203baddeb95dac07e2f8ea31034e7c150543cdbfaf7ae2f1cee43032a89cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "023b92e3b380e63b5235bfeeb8704b0e5a2a7ad1da507c06e2a0298b00c82e4a",
+                                "uncompressed-sha256": "2093b6299dbb62833e191d1f45ad58f3188eea38d9fbe72aba457d67d104c528"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "5bf8ab9e493228395e64bdfb56a0590b1798330bcd5355c04f2225778e7fdd52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d6829fc5e445c07ca4809756581dc8c9f913c686091159226868bfa9bc02b0f9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "329e5ddbc8261857533aa1a27ace6a94157efc951751ea89cc72a576cfb4ba22",
-                                "uncompressed-sha256": "2339b93c953a7449d20eae7146293e10b1f18cfddb9bf46b442467ad946e3655"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cad05eb77b23cd54b79582ab6eb74cbf9dd3f1d3590cd89ef80dbc832e5ce2eb",
+                                "uncompressed-sha256": "58a1246d72d8241bf2f193f765167dd3066160b8fd03a1d6b9723f6c8cb094a0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b131d829880109e9b69228729910775d7c229a2c6c3a9ae3aff02b673af1396c",
-                                "uncompressed-sha256": "4c2f661d4d8c894aa1fb45c51c988126da0df68525737e856f96c53579f1effa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6b60d00c8d4771cea84d701f42536ca761e082697b1b53ba38c69e867d32f896",
+                                "uncompressed-sha256": "68e832ca8f6a0309f8d29d97f7ca9bad6c401b0397da21b1644a6052407487d4"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f8a94e03006b9b4baa8576a96ef7da22a3d0a73255a2d6b6b1a59c70f5f5cd55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7c86587af2962d199c53bc0579f4def0f321ff2d29f99cc470bdf288464a0273"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "0159a632459c2cb62ae3d78182283738343a3b173b57f882a2e7bd2e797ee5a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "30facc3e629b30f2431628349c439cc06c4bd2a34f3aacf2becc89141909f163"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230819.2.0/x86_64/fedora-coreos-38.20230819.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1270e477c2c4886eeff301f58510f7341aab0c689da415c2b20ba6411b3ba8da",
-                                "uncompressed-sha256": "94e68f61db50a5b3abb44b22dd3dd9a7c13b2a0bbb8ba50aa11048714de899a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.0/x86_64/fedora-coreos-38.20230902.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1d36488beb1d6ae4ec6ccf2f83dba5db8fa359a2a4acfc7a410362454ea5408c",
+                                "uncompressed-sha256": "e9271e136b8d004b1345f8d9b035c39db4314e8b9f03ac5ea669b955684f81e7"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-089d94096cd895e41"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0e8699cf919e75639"
                         },
                         "ap-east-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0d847e6cdeb5a6e32"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-041b32b3cb6c31c5d"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0744228d8db6647dc"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-00198244ba26c0dde"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-039dc410f566286e8"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-00b3db99435940f00"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-07bab3cabd1eeb365"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0754d1d4ffe3cf6d9"
                         },
                         "ap-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-06974ae6a5b14710a"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-01b7d1e45c861d7d5"
                         },
                         "ap-south-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0ff9a8e617d30af1d"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0db497fa0339d0957"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-091862f51a7e3989f"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0e5199200f5e00ccc"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-003e86509fa14df8e"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0f44d04fd075927d7"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-02d563ee4e1cb3862"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0ce9dffa3253d1795"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0fe354914a3b87f4c"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-02bf3eb9895161858"
                         },
                         "ca-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-04af965f3dd219f66"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0f9bc62c8adf62142"
                         },
                         "eu-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0a9ec481e06e4147a"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-03f30612a86e45412"
                         },
                         "eu-central-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-03dfd0e1017878ad4"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0a684bde5b4526c8e"
                         },
                         "eu-north-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0573389716431fad0"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-086e9f481169b6163"
                         },
                         "eu-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0a954ad925380ba59"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-09768aad578e3bec1"
                         },
                         "eu-south-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-018760f9654f5106e"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-034206e4f5da1ee1c"
                         },
                         "eu-west-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-056d455acfa1c74ae"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-04583689233c58acf"
                         },
                         "eu-west-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-00fe57c61c82f1818"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0ce375e414d8eebe6"
                         },
                         "eu-west-3": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-094fb4f308ba73da5"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-05538d38b0e9fd74f"
                         },
                         "il-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-049ab1ad4bfcb1ade"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0fefd71062103c6e2"
                         },
                         "me-central-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-04813d3ad4ddfa931"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-01e0c7885a83af30e"
                         },
                         "me-south-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0d555d0af8a875712"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0d2467f6770fe7368"
                         },
                         "sa-east-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-000f4260b6427e92a"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0a40c9a3c1fa06baf"
                         },
                         "us-east-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0e2acf77c0f926a06"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0f8a206d412d73361"
                         },
                         "us-east-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-09af6eecc184b76f0"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-07c57227686b4ace4"
                         },
                         "us-west-1": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-009ae82b3f72c59dd"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-0b55ecc935d772dcd"
                         },
                         "us-west-2": {
-                            "release": "38.20230819.2.0",
-                            "image": "ami-0880a237960151aff"
+                            "release": "38.20230902.2.0",
+                            "image": "ami-04da2f63e64b14d06"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230819-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230902-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230819.2.0",
+                    "release": "38.20230902.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1cd2a91f3b9139e2e472f02ea69c87466a8302051aaf0474457e6da16cef1b57"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:214ee760713c973ec5e0bc500e836c1a8b1c5ca778bdd90610431a51fa70e82b"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-08-22T18:29:04Z"
+    "last-modified": "2023-09-05T17:46:07Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230806.1.0",
+      "version": "38.20230819.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230819.1.0",
+      "version": "38.20230902.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1692730800,
+          "start_epoch": 1693940400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-08-22T18:29:02Z"
+    "last-modified": "2023-09-05T17:46:04Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230722.3.0",
+      "version": "38.20230806.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230806.3.0",
+      "version": "38.20230819.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1692730800,
+          "start_epoch": 1693940400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-08-22T18:29:03Z"
+    "last-modified": "2023-09-05T17:46:06Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230806.2.0",
+      "version": "38.20230819.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230819.2.0",
+      "version": "38.20230902.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1692730800,
+          "start_epoch": 1693940400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).