### PR TITLE
Roll out stable 38.20230902.3.0, testing 38.20230918.2.0, next 39.20230916.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-09-11T16:39:04Z",
+        "last-modified": "2023-09-19T13:20:50Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "918e6a3c020220b3b85aa96c5b862a791706b512f5f93ba2503b6da1209da900",
-                                "uncompressed-sha256": "7efec496c704549e79002db90685f6084294f0a6afb97b98050d52dd614adeac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "10461357735adb0640f266e20c75cf75914b0ce0aaab984ac1fcd0b79ebe3bf7",
+                                "uncompressed-sha256": "3d3dc91498790f81dda8c324f374c185f6f1a217babbe2df7c021098ec44fcae"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b98f9ad759b89077c256846d9eaa8b1eaefc210d6b8e078c8d3f4128ae7dc62d",
-                                "uncompressed-sha256": "f450dfbd23cdb544182158e6181c826bc623f9da7dbc31ad10f2e1989096e9d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0f2673aa2228099eaec05e5f0423963c98f2f1de7215dd9d2ce9ef42259a8132",
+                                "uncompressed-sha256": "61f267683e75e3ada7d02fd7063a141c2711b79b2a9d525a9e01999a9d1e3e97"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2ca20014195f8a3a12e7849af9adaaa8f599d91bbade58627d34434bd5593923",
-                                "uncompressed-sha256": "338d834b4f34f3b5f3b17519b978dddf634ffe3b6c781bfc7493bee64dbbd29b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "ce094fbdba0ae12b01b1614d0f1e14cc338c353fd1066fc032f293b89f09bfd3",
+                                "uncompressed-sha256": "6d718b148de6b5829a504e63d49ccfcd3986eb026db313684ed2139546b6f0b5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "60ec54515e26488471c8e81bb9770bc655f0de98e8a665cb4e0b3349cf49519b",
-                                "uncompressed-sha256": "67da43797b55de2a79edd61cce6dc7544f26af527940dd39ab4328176dd694a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "43e66976130eb4139fe693735fe98839734d1f85fc28fc56afeb9d0ccd360769",
+                                "uncompressed-sha256": "92003a8dc2f3d478388f93cb5a97c3ab4c738bb34d481a3b76a88690a12b5fa4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live.aarch64.iso.sig",
-                                "sha256": "752c6bbd07bfa96d4a4f20d5e526a928902caf2852da3860461dab4a149757c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live.aarch64.iso.sig",
+                                "sha256": "b9dcbb377c4d782ce8838fdb854ee162506e7254f6d883060d96c95e068c6d73"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live-kernel-aarch64.sig",
-                                "sha256": "6720c00d3427f0c61daab399f7e9cefe0945380ca92ce27ff5ff48e7b341aae5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live-kernel-aarch64.sig",
+                                "sha256": "1bc192144ace5e6037368040374dda13270b62c8874261ea9ab592667382658a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "581b6ef5049b0dc4dc4b14c4a594e0174fc0df3191b11971fb351489b5591d2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "01bd044d79961658380b57909ba903c462241ad9328f8f3095ab91f8bf4e11a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "30540e457480597d3716b366814c2b34b304abe5ed97e9fdc7b3f244d936b12b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "957e2a69d3c5ce858bcfe70254241d900f96d74bcf02905c94d2e71ad6bfc2b5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "7310de19632aeb8734ac5e2d3fe1730b64d35894759c4d1e92971cb9ee3fbf29",
-                                "uncompressed-sha256": "7844c78fc5f383f7ec348447e74e9f3c5d1d889bbfdd2ee1ec9b170e0130d66f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "dad2bf14b1005d1c45cd266c4287dccced98d1a7c3c4ac78b34bfcf87b2eec6c",
+                                "uncompressed-sha256": "ba90908878d82631c6d0285decf70dbf6e14156ba333b46103850c65f21361c6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7a2a50a72f868bde2ba2c05342546accbaa286ef4dd1619be30a4a27b842ec31",
-                                "uncompressed-sha256": "731b361a78f3924115b5dad1594d231d01fb5489f93b2a63dc84cf181aeaec33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6b23ea67aee29e0403bd7f85a52deb381efbc21f044c8183a8385510c76fabda",
+                                "uncompressed-sha256": "8de22bf78ef560fe0dd801f848e58fb2eba62a2aade568d7d4d990a616783752"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/aarch64/fedora-coreos-38.20230902.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "3c6a2b6b824d60a65131486fe71f34f212dddec8b2f052354f4ac5572d269ccd",
-                                "uncompressed-sha256": "a1e21e9e76985b334443bd413bade7da6e6ac2ab78dd59dc23f197f613a74d54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/aarch64/fedora-coreos-39.20230916.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "089de06c8c2c5e21a92f9db6b5f43862686a98839f3d669c4fcaa18d3ec3f3a2",
+                                "uncompressed-sha256": "51b7682b10d31ffe14405fcc0566686661872920943958c09c89293c128f3b6a"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-00c3b962e3ae1e442"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-09817b9f3c090169f"
                         },
                         "ap-east-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cba44b6c8b0cbed8"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-029b4582976fbb2ea"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0e0d6fb79caecba13"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-082729487255b5161"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0717150363cbae323"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0cfb32d094507fbcc"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0fd878a0bdfd13236"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0f34506c3558d1a71"
                         },
                         "ap-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0fae50cd3454d44db"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0104658564f3234f0"
                         },
                         "ap-south-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-082e34472566b9a5a"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0cf09c895f23b6ea5"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-02e932bf436358bed"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-09cc9070ab2ee41e6"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-07927f6f09e102a4c"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0ebef069cb046cd10"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-06290fcfd2ec69923"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-066a27f4cc0983397"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0d66f518310bc8761"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-07f6fed1de7d3c361"
                         },
                         "ca-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cc6d51b7e5dbf81a"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-05aec7def03d4d535"
                         },
                         "eu-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-08a631c677f70cfa9"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0f63a9ddfee32236f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-069215f905269d58f"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-074ce5d48dd44ec0f"
                         },
                         "eu-north-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-02946bea502ec54bb"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-00a25562050eebbf3"
                         },
                         "eu-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0b35a5536368ee45f"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-02d50ecb820a4bf5b"
                         },
                         "eu-south-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0f1732249773a72b9"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0c0c8a15b0aba56bb"
                         },
                         "eu-west-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0ac3492aaa941344e"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0d3a74d227ec8bf03"
                         },
                         "eu-west-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0edbb39b7dac3cf7c"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0c50626088b19b33d"
                         },
                         "eu-west-3": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cff20fab136932af"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-01fed224e534d46c2"
                         },
                         "il-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-05c9a7b7fab2e2647"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0d00ad586b09a12b8"
                         },
                         "me-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-022a0dd3ec288b443"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0ce2f8dbdddba47ef"
                         },
                         "me-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-099c762b36752d494"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-08d964108bee18afd"
                         },
                         "sa-east-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-02294cf1d8f280c5e"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0788d4ed59c05c2eb"
                         },
                         "us-east-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-01e7ed398b2bdb4ff"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-02136fd7a3edcbfab"
                         },
                         "us-east-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0f862f3a4a5ae16e0"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-038ca84b42768b91f"
                         },
                         "us-west-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-08643ee39fcd0bcde"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-05ec6dbd51ffb8746"
                         },
                         "us-west-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-08cb7ced1e835b8df"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-06b8c8fa7bf9e5c70"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-38-20230902-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20230916-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ef5fe4d30efdda40798212c761d3ffb3b39aa0f83b16c42da8a56d1a9559d5c1",
-                                "uncompressed-sha256": "cf9dcd350d5f7555bfa7881333b1cfe1c69de91e52583c448f2a8b748b405821"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e5f4378e8754b3f0411c654370b4787bf704c34d96cd208e0f835ad1bea73990",
+                                "uncompressed-sha256": "be21cc172bc73f10a324bff94db79d68c686d31475e480bff0a30eb6552b51c8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live.ppc64le.iso.sig",
-                                "sha256": "d983e5fbac8720a8b808b8ff685e7614de161a32dfa5c751f68c40a1f4c49055"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live.ppc64le.iso.sig",
+                                "sha256": "4b2a9418da2ca1139b05ad16c4005c16f17014e25c146edbc0d26cd19d707a5d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "60ee5e19f2c9a4cd3b9b29d86474dcb9bc182a60e0d6ed5431d448c98e1453a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live-kernel-ppc64le.sig",
+                                "sha256": "c231fb75f57ed5cac249c68a6de71038475f0d8e8a89d4b0fd1ee1f2fef6de10"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2f818864816147f47131afcc83f2f3b8dd139a488266a59bdcd079f0ef3f927f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7415f445052e75f01874c2bc9409339db104f6ba400731ae2a497763f76f5df3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d507118260b72f4da4c8d933f6e47bc819acd083e09425160427c019a3096993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e8d2281f9f9d0e073f6a650e2ee359b76f798559083da84f41ac0ad714d46204"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "7f0992d55a1d5140d43dcff6be2ecdd823c59b54fa354b81370945c25800bf09",
-                                "uncompressed-sha256": "284b48c4708c64227ef0f76429d9a7a8b74bce4bd2ff8ca5504343e4a5ab2088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "36b4a12b69c4bd1baaf86c8556e51586fba167b8e920d02fd2c0ae335a9f9804",
+                                "uncompressed-sha256": "c4faba38edd47f18a3875e1471121d44b4bf5cb3707b1b1dfc5703fa28f3f28b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "84ae066e56e7de8388fea7381059eea4567baf766c081b9adb2624e300b45e42",
-                                "uncompressed-sha256": "7d7c42045d28bed05efa5c9d710603b5babc68819975b73727da8ab6fa1df07d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e175b75960385a94b8ced32c9be5715a24b8d84a7247cd7b8964719b4bf91b69",
+                                "uncompressed-sha256": "86b7c8690aa4f449feab60d207baba252e86eb7b7f94a48158d97aa113432a05"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "992d0ae8b65c3b9d69f6ad1eeb60ed4b90fda1ba5616faa61f9fa04606f907e3",
-                                "uncompressed-sha256": "ec0b0e1a8416cf0c8b2e967fc9846d93af7fe67d349b7fe83e1781740b46246c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2f992fa7b499c5228f918ec01031434651d0817c19449b26120501f13b4524e9",
+                                "uncompressed-sha256": "dbbda7570ba79143941dd155078138f0b60183130f2930343c6165b58c43aa37"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/ppc64le/fedora-coreos-38.20230902.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c6c2bb1a365ff5094de392aa5ca4fe7ddb5c6f2ff3842256458fd5a75a17258f",
-                                "uncompressed-sha256": "94f093142c15fd98131e7f5e162db50caafde13a89829db9c8fec8ccb45aaaee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/ppc64le/fedora-coreos-39.20230916.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a100a07f819882aede791d51848e2a621511cb68015cbc5464af65eefd75132f",
+                                "uncompressed-sha256": "5dd816d14a6fb4b260e5503132bfcb9c32a8202efe657e6a3c46094f748e86be"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a35416c8d6b80008844e2cde08de8376b5b56d4a88927bb1bbd962692ffacc5e",
-                                "uncompressed-sha256": "0c456cb00b9f8340f7ef72fb511349ac10dfa916f6cbf4e35ee555a8b37c4286"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cb71aebcc192140bba50a90eff4af3dd8aae274735d26de5a9ae9ee9d5b09d44",
+                                "uncompressed-sha256": "9534dc1a797c26028e1d6c459f41b6bffdaad0453012aecff8ffea90c3c61dbb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "9a401db0838771c74083e243a0890181b7a1a4a40659c84e4f7357a16f779bb4",
-                                "uncompressed-sha256": "ccfe6c7a52ab0c11d9256450f1bf95f9702074df92f4a3678219a001cf3b5cad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "731abf2d17233481eb3378eedfc5ae3a8fc2d73a4f6fe80e8413faabc966bee1",
+                                "uncompressed-sha256": "d9e5a9a27d063fd728ef37747c702c329383c8a71f69220c82d968f9302a42d2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live.s390x.iso.sig",
-                                "sha256": "bcad8184068c7e0df88593bbe68f6cd50a13889af139e7cb72e953bf1ac620b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live.s390x.iso.sig",
+                                "sha256": "b1f70090102fc3adc26debc9ab4da7d511c25670bcc54039ed5774cc4c568068"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live-kernel-s390x.sig",
-                                "sha256": "25ddda8298326c51f22e049e25e896cfaf45f9675895cc10e1563892f8ea0260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live-kernel-s390x.sig",
+                                "sha256": "6f538059ec55df75656952520b2179e7e895550cf8b9d498554c87dd8524274b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "4c18b1263c48f39b13b459bc31cdf97e9801006549f619987d3b8dee6cabb572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "9c8948f36af8d528b68736cb6b410792160066eb7fdeb6db90dc1a9de79193df"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "cf845d66fae5bfa88d11fd32c52c39977fbf61d382d75df2aa55c673f0e63761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "31b1dbc47342a47eb942474b66361e64c85dcc1d54e5bc4ed170f86de83ac88a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "0e7a1d1c019d03419293c687b9bdca7b87527c2fcc3276fd27061997a94c7404",
-                                "uncompressed-sha256": "0ca0ec344c14e9dc5ba6b4c0c8efa24ee3c673796815e4d20e0c053bcdd83147"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "b726ba4241c251c964041b9001820493f67fbe3975cdbd8233eec0e4b96658f0",
+                                "uncompressed-sha256": "f7e78c13a4f40b84c34ad46c83af07fa4e285524bc56da6933e2623e0b1e842f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6feda220d264a4fee6a7c8a835d8bed83841fb46d7cce2e236d61c7ce440284c",
-                                "uncompressed-sha256": "ad611e6c3c3dd725714b0753af5089060ded47fd9e046d8b3259513d4dd3d7a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1f1e54c4b3f2a5bd27a57e0fda02f31974f5db3f9f53893507a28952336f001f",
+                                "uncompressed-sha256": "4920752aa6fdb95e94565f60befd685d7a25ce49e3245b936dc35f08f2cb1085"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/s390x/fedora-coreos-38.20230902.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "532066e923074557384c9e6e588c9c1b970d6deb5e2f52dceb4163bc078c3bd6",
-                                "uncompressed-sha256": "73ddf07a71e0bcc4b851bd775ffa45a2c0561ee71410fd6777d1795b223561ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/s390x/fedora-coreos-39.20230916.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7da86ddc426404f1751fd9eb8addba8852f44b71371c1f9bfb686ace32eb0c60",
+                                "uncompressed-sha256": "98870bb15cc19093f7f9b5e004b04c7f554ff5da3fd4b2380221cca7218c0711"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2b730d5fd45dacd50fd465e6a29b0acb093d191a7c0fdbbc00a011d79dd044ed",
-                                "uncompressed-sha256": "b8872753005bc754c58af47430c906fc5b13e65561baeabcb1c9d59ee1474a96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6cb7d6688dc340863d0341022e47c8fa02ce63c2fdb88eb11283e24754062a1e",
+                                "uncompressed-sha256": "6ab86b685e82bff1d5bd3fa4686b6df66a5c4607e5a915dd90b33fada2192132"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "aec23ac483474f8085bd8e5e1bf0e4b4ddd7c16745c3a6ba64f7b078befb505a",
-                                "uncompressed-sha256": "54564b03aa393a21152d6d2f419abf90816a47252342dd260177acbb7cc0b2c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "41f71c555ed434792be72472cdfe926b9beed6290ac7649d02b73a801330ed38",
+                                "uncompressed-sha256": "48c0a5ecad7b07db9343525ce085329d6d85a644c9aae785a32603724981d701"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b970d90918170d1586ef76aadad858ccb1ec173858ea2231c3aaa5f581d51a6b",
-                                "uncompressed-sha256": "f9384d7b55440fdb56274da6876148d2944f4da2240cb71b9168c039a065603b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4e8b7b2c62195c28d918137730eb855cd042fb288b70bb50d74e935f480b5246",
+                                "uncompressed-sha256": "94f6adc37e8dbb71baa8e11b6f23cc3a9022928452770884e80aced643633a0d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "bc4caf4d5f96f6a36293cfd1ea27d3b34bd9376369437b9225b57fedcd61385d",
-                                "uncompressed-sha256": "d3ead30faea910b6f54e76ad48f45d97b5f21fc2ea6f2c0bdbd671f199f64269"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e0f514e2656dc22b3c150a5f4c4090d4afab214cae68227c1eb629c359910b55",
+                                "uncompressed-sha256": "b3e364268c7fa8f267cb5470f7cf0c57e30d99c282d4f61f775c7e503c3a1035"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "38d343b0a82af894223698a555043b0c20f7c57016cfd0bcb57c7998e2368d33",
-                                "uncompressed-sha256": "408be438c4fa7c4e6f031ce0b46ac22748b6858b5883864428e17f42c01197b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "6129100f0716ebf54e675efd2643c7956bcc36f8f02c2fb3f16de4c28abf5593",
+                                "uncompressed-sha256": "dd84cdc0b7acaed7325b1b3da8c6f074d7425f5a3f5019e97f6b50c245a875a2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1ad43a36286a5723d62595863cbc2a0a371428f00d860453e798e998b0e08c75",
-                                "uncompressed-sha256": "5d7ccf0f32229e3d00725ceeb4af691668fa13f6fa0517c5b91d3414fabed3bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "54956d58eec7c1d5ac05d8c596a715b500d1e0a326656ed27240df57a0901555",
+                                "uncompressed-sha256": "e7f8bb8bdab27f26d76e19992d6ac3bd00dd7af2a9e1408200d2972dc22e74d5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "95505acb7993a95c436a008a49c7225dc3452b54bba994f7c9390686ba0ef39a",
-                                "uncompressed-sha256": "9ba3fb26a47cf95061b13f2a664fd33e2fc121be2a92f273232034f5d514eceb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9aa218db7295f4f12acd89ac679894ab3ed679099af7aebbc46f03c49aeb5a24",
+                                "uncompressed-sha256": "862681cfa49b6fde6896096a6d26bf3550db848249c9f92800e3a3e4042e67aa"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ee30a54b000572b9dd30097720d72ac65800a3590a1108ca67adb023f6a5c526",
-                                "uncompressed-sha256": "d3a5b41bdcba5a30718c8190e0e85c8162d825283fa9b2b86135870fae9ee5fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e789778b152e3be08c07e9b676342a0f40c0b3dcdd349a8206ccca929624424a",
+                                "uncompressed-sha256": "d4af6efc68b8e2f99b1b0bce108787b7de2f3f452acddd8e1e329b5de99c1b2c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4d64111a264e37797b327cbaf87f3849723cbc3847492a66572c552c0b824a47",
-                                "uncompressed-sha256": "b03a0fb1c93dbb1ff8b016dc569afe840695d6b9181cc20b28da970884e2a29b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b8d437abf6fd37257de73939f7ea367f89f0c8de4faf8c70e7aea3b8680f272e",
+                                "uncompressed-sha256": "cbea4606fca50f50c31de2fe84fb052d80f86691427fdef9ea7e79b5c91b0f20"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b6708052ca568370ae43da120189e0528f8b051fb3a5872d43eff05a735d81cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "0ae913e735989c8cd1ef9aceb513de544840b67fb6e37e39799dd428d7da38f1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7551e3dd971b1c8c3f1fb6de1ffb199c7df0c84cb2c427268eb34578b71d9f98",
-                                "uncompressed-sha256": "4eca91f15998e1aebe3bc2bb4b1efab65c826efc97c9bf5634d1b00024971b2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1066ebb413b49fe32967b84f8423cd90c6e582875c34833c8e357a25b75bd620",
+                                "uncompressed-sha256": "51c149e2d79ddc73c9f40503758839c2aafe15f066e2ed3d68c3ad157ca9c6e1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live.x86_64.iso.sig",
-                                "sha256": "63dd01765f6e58830a019cb3bd2c39cf46139484715cfe21d2f03dd956686d91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live.x86_64.iso.sig",
+                                "sha256": "8b2eff1c4a432ad7a729ad74df48ab3a33c06a0828c641ebd41dda7e556a8246"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live-kernel-x86_64.sig",
-                                "sha256": "923ac8fffec0e776c0250432b867da0199ffb7da40300fda602bd6be1938ca92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live-kernel-x86_64.sig",
+                                "sha256": "cfaca46244ecb78181f11c915d6bb71c9feba318d8b2d975bf826906270f0244"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b67c62150051953177fa90da9fea5bb519e1b0b78a4e6ef51ea7791a35fcaa58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b881d16f0c80d3f39ff302eb3426a5e88a3662d2a619da7692f85d46baf680d7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "9e7511890e23a4d9854106fbfc3791186787e9e3781f281fe0877237648f7392"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "077c43f5e1630e349eb8c8e47490db1d92592505c061e210863cd8cf8f4dd8ab"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "29295240f9f8cc930e155d71668fe083ab6b4302d9fd530ed58570e830f073a9",
-                                "uncompressed-sha256": "f811bf0cf35c716cef8b4b87fcecbf9806152427ffed3c1765927889e0c1e87e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "31176e263e868a6435f626212e05c4f6a6ee94ab63205097dc1e61a8820e03d2",
+                                "uncompressed-sha256": "7951bc3d16d02afb512247a559c0af5a96a9df4b6d775aa5febb05c1c9f5969a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "09c13a915b81b4f569fcd3898452d43219940650757355522dd817e091f99d5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "212268db656dc996a0d503369a5bfc81a4c1bb24e2e88e1cddc812986ae5d406"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "cb32a619321cc2506120a08101197fb4fd7ec7111e9aacf653396db243763eae",
-                                "uncompressed-sha256": "73dfb360e630152a5f8cf2607de5f588fd4d675e64ac1e6ae2ef6a63615e215b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7642fe51babecb0ed85dd4173da3ea697ceb9cc4140db2d56d0975b8d45df1f2",
+                                "uncompressed-sha256": "de3f478671e072016aeb09b9fd6e77f8e29ec94907f213b6fbc747f795674486"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b0ff6cf2b026430e9303af12dd47d7f751cd8ec83fb3634692e766f9f876e0ce",
-                                "uncompressed-sha256": "b0f84e0f864116d3c09658e630e16dbdf4cf205727334a21917aaa684d9c82ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "bad73feef4fa3d952d15db6dc2027d85ec0d22f2375b286a1c527bae7c2a6781",
+                                "uncompressed-sha256": "179bd0632d3ea088fff74f67643de5a1337763f0610ffd4d0b8f5b0ce6744b21"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "389d416a84706eb22733150f7a5265ab03a93b1abc2cbbb35468ca9987a56791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "e8602fe2f354d97d76fa9ce10bd65fea457e5d6d566ba86fa4ac6950d5cf988c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "45085de80424ac4c405e744cde33a9622944f2a79c7f3702b5a133f4fc029b1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "6f6a22be72bb0a6a36b1e35d000d5a22f7a55b22dbea0a6e0807da26773254f6"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/38.20230902.1.1/x86_64/fedora-coreos-38.20230902.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "eff49f686cd45987d0a2027b6687010a849afa6a3ab9c49ce607f4c13f261df5",
-                                "uncompressed-sha256": "2c3fb071058f6fd2984ad953b2bd13f644a2ef5fb508c43fa0082612e7322038"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20230916.1.1/x86_64/fedora-coreos-39.20230916.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ae96e9b03f37965fde5f10160960179fe734f3eaa11b664106320ceb52e2fb9d",
+                                "uncompressed-sha256": "66950f2555960dfa45bfe9a31252ef7158b549871eb17275791f910de8b211c8"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-03639babbeb305e08"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0b89107b6a33f622f"
                         },
                         "ap-east-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cfeb073061e6c45b"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0a2cec87cad50e050"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0b7e6d6518def49ed"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0996328fba1b3c92c"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0185a7b002aa6f2c7"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0aa4d56f085a99180"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-02e1015a79221a0ea"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-01cea375f063a36e2"
                         },
                         "ap-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0be9e3a21d6a43b07"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-04b28d488e5e9ae52"
                         },
                         "ap-south-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-090c249e07a03d6cc"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0eeb8d96fee2ec821"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0dec386c0ca9f70f9"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0c612ea7048988be6"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0bc61918b3ed04b6b"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0440ed720933f8de4"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0c3588a586d547682"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0dc31b62b6b55d069"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-019227dc74c162ad4"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0c63d3b3120e05679"
                         },
                         "ca-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-039f16b984e3c1504"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-04d64ce9568d522d5"
                         },
                         "eu-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-00f962e8527a07b94"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0caf9f2ba8f9d7b37"
                         },
                         "eu-central-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-01128856e76e0c5ac"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-065f3b14c85270d17"
                         },
                         "eu-north-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-057bec8d59e5b589b"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0afcfc7c9bc131ccf"
                         },
                         "eu-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0ffe543bbb63d258d"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-088f0f8ef9812d49f"
                         },
                         "eu-south-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-038398649498fea81"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-071eb34a7e9d60194"
                         },
                         "eu-west-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cc1e8e22f05e98c1"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0733204e296a0398c"
                         },
                         "eu-west-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-003bf93b24c8f3224"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0ddf9f21e96c564ec"
                         },
                         "eu-west-3": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0f7dc2b67653f94f2"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0e0cbe12c69da6039"
                         },
                         "il-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cd7434090b8e25f2"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-08537d6beeeb5e6a5"
                         },
                         "me-central-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0dd25a780a131f24f"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-087d1c7ede448b50f"
                         },
                         "me-south-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-00deb125f62a36f35"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0e448d117e6abd3a6"
                         },
                         "sa-east-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0d46c83be241b396e"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0cb4896c54e197ea1"
                         },
                         "us-east-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-086157a933476db8c"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0032341b3a646f5a2"
                         },
                         "us-east-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-03163bab8364582eb"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0fc9f3ddd432e5cb8"
                         },
                         "us-west-1": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-08c0dd8bb4e0f9373"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0b11dbc3796464c8c"
                         },
                         "us-west-2": {
-                            "release": "38.20230902.1.1",
-                            "image": "ami-0cb4fc3dbe49af34d"
+                            "release": "39.20230916.1.1",
+                            "image": "ami-0b1698a2515224254"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-38-20230902-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20230916-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230902.1.1",
+                    "release": "39.20230916.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6bb6deb9639720d2a6ae954599074b06e4cca5a628ad3c9b3291c26464450030"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8497dd983c365fc8a62bb45ccbe25b01a96ebf97e0534aba884324ad9210770d"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-09-05T17:46:03Z",
+        "last-modified": "2023-09-19T13:20:47Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "628b1178fa0d3e769fba47269452f2ceb6edfdf3661bd32d676c3228a0c8a4ee",
-                                "uncompressed-sha256": "ac601a4e74fccf52b98262cbbd0e7d72e5395916a4375be79f9c7a7fd51e1589"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5ebe05102b092af79542ea953d3f1e96dd675903866c5f5273de5e5699260bcb",
+                                "uncompressed-sha256": "c6a50efa1b265999d4f0eb3834bf49c6ca4903ae119bc41ab51cd6d1ae57acec"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "843845657191d3ad4b3574e69682bf15aa6bf7ced258d99fc615c73abe4d0661",
-                                "uncompressed-sha256": "b1d03ad03c832bb6df9c7b7112509993b8db192cd1489257ab267944aeb5b86e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0ddac1ae86e064aab655fcceb542b9f71568340fd09698cb390e846e5fcf04d3",
+                                "uncompressed-sha256": "9c0ee968afa8634dff5a062686a37b9fb68ee8f2e50c881c2f4f90cc5e5f9066"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0f6776090cba908fa49cf71d860a2e4c81a7f86d1e58ee2e26fbeb582916286d",
-                                "uncompressed-sha256": "dcb71bcc2f112c22ede1680fecebca3e4ac2db1480713d9349f1048110be6ac4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "185616dc08f6c5d976ad5b50acbffbea6c6d626c93c2d71eb4f3ea7f0c3174de",
+                                "uncompressed-sha256": "35a33c2ba6954260e3b001deef808fa34706c8d53e77e4b69e636c15460fc73a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "562759cb29fc001992a380fbe300046e3d614dd4d076e79f2dd0013c330133d3",
-                                "uncompressed-sha256": "28e8cd79316551a5320cf8cbe203e91354ee1b0022e1d92eed5a71652b31d262"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "02278822d21ac74201869f1924141479fc6d680bd500285bf85efe571d310880",
+                                "uncompressed-sha256": "a95f4f14c2e2c0dc7f6efb90263963d5a304729b80a8fb5497ccb45a98571803"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live.aarch64.iso.sig",
-                                "sha256": "dd89240a6e937e864ff976c0ae9a714bfea9ab145c89943c20f7b0361c541b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live.aarch64.iso.sig",
+                                "sha256": "ad20c8bf79ed8eb4f443d3501bf34b5bd0f76789b9eeb76e02e6e5d96e499d7c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-kernel-aarch64.sig",
-                                "sha256": "1f92481a05c278b9cd7b3c84fe90ae798d2663fd497e96bd55775b32959b0f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-kernel-aarch64.sig",
+                                "sha256": "6720c00d3427f0c61daab399f7e9cefe0945380ca92ce27ff5ff48e7b341aae5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "fc0c10affb7401922b62ec8185808ec3d1953a358ebe7d3ea222c756c940db17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8f51eec7059732cbad7031bf29e5a2c9a2d3457ebcef040ccaee56f17b7f8094"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d54ae691eba85c3cbd0be8eb78efc1bc5aba74b7dc5ffe166530ee6d760447a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "bc2ac765fc57415cc16cb6faabe0d7f7ea15e1840ee460be043698926ce7cb86"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4930d0331d5232fdbaacbb82ed319f0a5f86bc4765e6ef966066b2662cde2209",
-                                "uncompressed-sha256": "03247bb612dc248eededf7c5b253a2b81a3e1437bb4f6e68e9533626ee2050a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "1edbc8d01e24f6c55f244e4c818ced8a78478a44455d78dda0bb71b795c9513b",
+                                "uncompressed-sha256": "5d49437c1df3943fd21c88da3562285287203a6db8ff1bcb2009cdcc886eb62e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "801ca5101b247061772e83546f225977acee3b32d598edc66ef37a4da7511a39",
-                                "uncompressed-sha256": "15748565270694dae017cd609bb3ca7ee22e2baa8fb9112e6929011e6a068816"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3b86583e9ab62101ab0600cbcb74b106e59f9155f8c563192cfd3e57eba7eeca",
+                                "uncompressed-sha256": "f625bc58094609de12fffc2f9c76bc511c413a71f2b5964d8e5b607c568a0dcd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/aarch64/fedora-coreos-38.20230819.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "412ff2d87f7c24efc944d1cf198f3142905675635b568f2dff273c77796aa51f",
-                                "uncompressed-sha256": "5813c3f983d8799e4d3715c109fd31d0556f79b9285d48b393bb459af541d866"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7a4143e4aef7346944ae5a0d0cc4bd996a41c1f9e12989dcdfa31a80c8e1cc27",
+                                "uncompressed-sha256": "c8f1e91f232dfd936661b8747ffe98bb170f35ea6a81ff492b3ca371cc211bcc"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0e7de2967b9948fe2"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0a76449d077358c41"
                         },
                         "ap-east-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-059b4d938cd6af773"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-00511d27907bc9547"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0421af6d1d374e86e"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0ef7fb44cc5f9d356"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-024d2484db2805377"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0f1a5cecb982890dc"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-020bcd0304c8ef6bb"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-065fe709951974dcf"
                         },
                         "ap-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0c9fc60b1a57735a3"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-067559144468b210e"
                         },
                         "ap-south-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-081d9c4ed02a774bb"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-06442d69bf278f9e1"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-03da0708b4c14247c"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0776b5836e5106179"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-06a97df26239e2744"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0b84c7f114cb37c33"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-02a4f1d2eb40b041f"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-095611520b99a19a5"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0d716650759cac7bd"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0b1d34bd72b86b5dc"
                         },
                         "ca-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0f42ed6db21778aed"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-04a986901da1bc72e"
                         },
                         "eu-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-04d5e15f458f4a7c4"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0bccb2c3497171351"
                         },
                         "eu-central-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-033b99bfaa77c7bd3"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0e371e17df43f0414"
                         },
                         "eu-north-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0d47d82eb643eeafb"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0a78b4c3ac2511f26"
                         },
                         "eu-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-05e3ff825b7e7ddd9"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-020ce985e621cae20"
                         },
                         "eu-south-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0adf4a11b64d2abc9"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-03f9d90f2174d490a"
                         },
                         "eu-west-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-027f82b528a1544e3"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0005f001dbf391e4c"
                         },
                         "eu-west-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0b02f8ad58d819d53"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0bcec8a3e6103452a"
                         },
                         "eu-west-3": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0a2118c6b7ecdf59b"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-02990a310403e8b42"
                         },
                         "il-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0e6ec1cdc8679eb49"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-04a77e8ea8b7cca0b"
                         },
                         "me-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0a902be4f0ad3bec4"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-067c37ac8b10228e0"
                         },
                         "me-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-07c938cf1c94a52fe"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-097d9b5f12f34809b"
                         },
                         "sa-east-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-00adec82c96c7caf9"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-07b2bb8329504b0b6"
                         },
                         "us-east-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-09781c4235b52419e"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0efa797a1031e4ac1"
                         },
                         "us-east-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-00989cc1614b2a9be"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-03844f60f62520b2b"
                         },
                         "us-west-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-04d9003223c5c51ea"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-01cc2f6080b71e8f1"
                         },
                         "us-west-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-04855cd021156df0a"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0ef24426a108d1b49"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230819-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230902-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3d2ef13391d5229c576a8208ea8b5de2230a337d109c27b76b31b131bd5bedf9",
-                                "uncompressed-sha256": "4ded5499c416c66633f085294a0d5d23b268cfbb3e7d4cc84999521d63fd15e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "08c929573e18f571a2cb7d4c2100e13214825059289c7a05f32f553a754ba845",
+                                "uncompressed-sha256": "eeda9650dfe51ba2bb7d24192739fe6000c0239e547862013fc7fcaed2036415"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live.ppc64le.iso.sig",
-                                "sha256": "fb862775870cf16760d6b3c9cf7222b55e446ad0da7380f9f904d9c10703f992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live.ppc64le.iso.sig",
+                                "sha256": "3daeb46c18549cd7cbe42c88513ec7d3b070c0cd2324f600810f36664937306c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "c21d33cf1a4cbfad3652a3acc0967b038b2616a44a6e3c9f6414d67877fa9b92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "60ee5e19f2c9a4cd3b9b29d86474dcb9bc182a60e0d6ed5431d448c98e1453a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "38e53757b2c990699091abd70d61f1b12358c896e20f1f356c5cd38ba465f92c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "340b4a1f508718a382d52239bd375c6cee849da88b90ec9c2add9794df6027de"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "462a7c5732c83eadcf1f68b2b83793a0e7f0dcee223a46d158e77b2520cbe923"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "217eab22d51cb3290474d522e80d14fb9b6d779d1fe0fa91a2ebbd211bac1e4a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "bf8fbd5ed16247d4e015284f0d6a9185d29a3a70d7cd0dd967036053d9787a11",
-                                "uncompressed-sha256": "2474d11ad170287419f38b2cb5320976f70c1fc7c962294e31ff3a6187c57bcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "f14dcb0fa19d8473c12e5bed5787f74502b560389ee8acd1f398f27436755fbc",
+                                "uncompressed-sha256": "01a3f5939da45457c5223d2ee9d08f43c2d7e1f03988e9533359420bd29f124e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "85f7a654c1d09b18a54da8c03e112fa8b0a0fd2dca49b5aaf6f9778adeb8188f",
-                                "uncompressed-sha256": "d3f11f0d1ca39bd6768e15f0375905657b1a541abf38964687e058a9b33500d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f143f442799310b72db1a8b8f3a12713ed7da7b26c3ce662d5e3c18062e919fa",
+                                "uncompressed-sha256": "f6a2067c527ec6dcc0fa01cd722651aa187c9befebf8a7be8d07e6dbfca66a8b"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "da3e428e68c18162e25885d5809765a0dade62757ba3919a12d0fb780a991e8a",
-                                "uncompressed-sha256": "9fa19b0de90bf7aeb1eda9ef3e47fe33f18a414bc470eeedb0520790d834a00e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "57a9893e260697187f2fbb9694e268ea68dee99ef84be637f712ef0b76bd180f",
+                                "uncompressed-sha256": "7aa0ce9644e0b6335d0fe86b4e89d7ed97e1125784dfcf8612a955c2e7070853"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/ppc64le/fedora-coreos-38.20230819.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5f9fd811bed34f4a3c3d1344e3b00bf8467967e191c762a66dc03011c1ab6c8e",
-                                "uncompressed-sha256": "ac1d4dba2757ee206afc790ddb4f2833dea9cc166813e49414e61d700a561ec4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bfd772effc9cd8ca19ac837c98f7a1e04263d974853f36b4ebf64450f1191306",
+                                "uncompressed-sha256": "4d0144d84d58ca6d82939aff4e431a198ba913c1307985c5bd75f9d19518d5a4"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "30ccf5d6a82124b1b8af0ced5011bee5d133a0dc3bc9efef3ccbed26cbf7391f",
-                                "uncompressed-sha256": "5f5b5a12ed77a9d76391abc4f1405374e5e30e4cc39f3ea5c4b717830b64c1bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8979aa9e00c9f5b4f10e0087a3cdfdf6f93973583b814e6b55db500a27ae6179",
+                                "uncompressed-sha256": "ad7f550444bff300a7a861f86de3d180e4278205a64309fc75933c12f7056b96"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "31d1efabf9234fd68bd96c050519bb3af18af6ca7279b0fa0dd68b0a4d3db247",
-                                "uncompressed-sha256": "c7f7ed656510737f75d843a965fb5cc0aeec9375fa5c2fcc40358dbfd26e698a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "41b522d60cb5db74d0fb8f320ef712ed12af1447610e5ee10fd67a7ede0405ad",
+                                "uncompressed-sha256": "45af2ecb887992b1b68e748822cb2dbd27da65f1b9a383513d735413ea78ae93"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live.s390x.iso.sig",
-                                "sha256": "afb8748adbcd20bb3dc10c06fb47e6f15c94804e8e7dab990e47640d801691a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live.s390x.iso.sig",
+                                "sha256": "712c20cc5e502f784f5f620b224345b22d30fa47089fb01c593d6302b067a596"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-kernel-s390x.sig",
-                                "sha256": "cf3b28bb417590dfeacbb5a253aa43578ff2f914acc21b2ad22f4bb93f7cd332"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-kernel-s390x.sig",
+                                "sha256": "25ddda8298326c51f22e049e25e896cfaf45f9675895cc10e1563892f8ea0260"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "d6ab0a8a3fc0b215c7c3341354aed6fb7adc03a71a68265543e6ca8eb6e197b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d4249981633f92eae5bd7aa40ce92f1873daa90ff5414722240ab9586ce67062"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cf3867303ce651e8306b44f4fc1871b1e2940840d7383cced89acc49fdd24637"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "8f5ef1ee314a0445431e99259658fdc6e879ecd78a3ebc2a7d630dbebe00430e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e6b656ece1fdcd4880dfcfe3f03acd846b5e50f7ffff690c843190406a9bfbd4",
-                                "uncompressed-sha256": "b9ffa4db1a58b5e8aaa9a806666fd1b06f6397eeb4c033b2986b547c21b54b9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "424e0dd084ea821766cfc1264a50e7e988993dc4e3cfebbea427b9178ddf3bd0",
+                                "uncompressed-sha256": "ba41745d7d19d1d0f47cb9b8ced74622db3583682452723f9c4d83487cd4b91b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4c77efc84358ec2db6d6b705b5e7e47aee0cd1fa2e229a740d9b07ab7b2816bb",
-                                "uncompressed-sha256": "775bbb7e83a24e5db1fcc4452f692edfb8c0254023d53ed2bc2812bce1671671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4cf8e70db33f90d5ef79bb81157751ad2aa8352d666169a4c83db628682814ae",
+                                "uncompressed-sha256": "775d22a41241e91a8d2e4caa191258430113c99cc401a41589968bc8aa23aaf8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/s390x/fedora-coreos-38.20230819.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6cabdef6e2efaaeb2b2d083f1ac5367020136b7a553cace2948e3a1e36a59018",
-                                "uncompressed-sha256": "20397cbe45f989d3296aef52839c3925c715358cc562a8abe87c92e101eb8222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3d1214e95a1d713759052d93bec189f2b354b42497ee3ce0710a94aab91a9db6",
+                                "uncompressed-sha256": "a438d2c198530db2b8c6c8c7a045e159d8820dfe1388ec31ba4b32df1881ed66"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3b2ea3541bfcccac89864e5e4aa6d7eb2db099cc9ab1feb64480bbddc97a1620",
-                                "uncompressed-sha256": "8b6033acf3ba9a07ee429e1949c08ee4f928ebad54086cfd1cfebc6a7ab9e636"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a77fb7e978f6825f0e19d606198ac035267560c835b9c585127051b90e1a4dc7",
+                                "uncompressed-sha256": "d59f301689dcc66671bd2ae886e9ae70ee97b49ac47d8d89864e2d6db24b3c37"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a5ca1edf0bf435dddf04518674fe9f1f2eb11bf88747c9e3a2d11968d93ea121",
-                                "uncompressed-sha256": "ac68c1cff3435fc36a4a874371af3255010728d669aa6ba0e886c4de0cb9a933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "46072c2c1af2f13f48de5eb7377cc9a6bbfad00c561edf0494be57f6a305bdae",
+                                "uncompressed-sha256": "e93bf51b5a56dbfdb839e2cbfa0e5f2b345ecb792c5c05d214252894ae95d3bc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "68e394e6760340795e849a6f327bb86b3d43e9b0e3945db0f972d67c22ea6a64",
-                                "uncompressed-sha256": "6dfb16c24c6089c008f6591979a9774aecd35081ff73a13b0dfac71911da1ff2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "24196115e320141e8201b67915dadd7218758da745a8c2459a7910fa68e7cde6",
+                                "uncompressed-sha256": "b8539afc4a6d8763dac3586e97584548c0dc1d5cb8b94814ddaa7cff4e0367b7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9a82afb65bf0097354892cd8b20a45c62f7c18cdcff3063f86054bff7ce86775",
-                                "uncompressed-sha256": "91cb530b099a93d87589f5465225885062b6d9365e096783cf91d776530a32b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8b5bff885a587009048efe9aaf6934e90729e86f97785cf4104292a459672f63",
+                                "uncompressed-sha256": "4990c4f4874767a940d0cc8ee3f9005d74a4bbef237825053695bf64b5f17fae"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9126eceb8db0560328c33a2e5c35afd6e56fbf2861eb2d433176c0d247107c76",
-                                "uncompressed-sha256": "2b1f91d76c8e6f3d1d983d8dc704e198700d28c6820b91c0f7f96821e3149c9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "052a6f3d99616156dce17c2ffc6e941a39378b7b5d1409d9f86cf513982c87e6",
+                                "uncompressed-sha256": "78a92f72de630274cf5e1a4d8c9597b506017a9c383469fb1c5688033faa5656"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2bb47c62e0cea052ac48dd0629c0afc798e44a79c24640643df9539931c543e9",
-                                "uncompressed-sha256": "5043f9ff3953b6de86b58409e926d7a6c57ffc3c8d0c056bd7d9d6e75508973e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f73bd8d60460224811dcd1d73b650c96c01b296045c6ca547cece03709df787e",
+                                "uncompressed-sha256": "12c89dc4d648d11740fa06bd4bc5a1ee80057a2c49557ca7e111cde81fb99126"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ebb9f0765af124a6dd12cb7abbf00c4b020eb4a255a452f0a6fdee0a5d806d23",
-                                "uncompressed-sha256": "b30da62da08df182d07359b8d9bf28b64d36af0aeab4412694cc0a36252f5637"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "068058a1631b5898122dd6e263fd822416446249ec0258bb97fea7d83f407011",
+                                "uncompressed-sha256": "a325741c41f0e5a279795264959789a44b2535fe1741ecccdf915882d5e1f523"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "fb02632cc8ef3d984bbb04cf3bcf2a3031620b293db91e536f40a871412b9ad6",
-                                "uncompressed-sha256": "c69ba3f37def33853722b9cbd7b5d4edcdcc95337c99b2b4f0762534034ae2cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "9ac9922b44203e2eda93328baa5b64f653f8d584f6bdffd027fe619fd4778a51",
+                                "uncompressed-sha256": "4d7414bf0341cf16dd91d9fcfdf737dd1a3a93f5881ded78421b362381c3db90"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3b1a3e8d18b1c17456eb95d73a10f42511bc7e3ba0fb3a95211c56cfcd8cbdda",
-                                "uncompressed-sha256": "c4ab039e41e171a6d3517ff25d693b4be6c175d47a37222dfa1cf053d52e0785"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "831ea9d1b08a6f937f0f850a83b646877a349472e6d66525486d01429cb6ed3b",
+                                "uncompressed-sha256": "a594ae24ebd91a4f781544a2ded060315400031988b2bf43d60cc1b976c3a0e1"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "15931ae34158359c527d87589b96f77eef4369d78a4dba1038b730cea77aeae2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e570a05ec5145c14faa88d802f59cd3ac90f5135820d78ad1a3fe0f7ff4ede11"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4199bd77482c1afcfc6d9d27e9e7c280d9d659f6402d7b1e75eee8c175610d87",
-                                "uncompressed-sha256": "87cc9df2d0101a0756816caca7edebdf75b2df8ce42325de78f1fd4693fc527a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5c273f9bd697236ac3a6e251a3c97b0d6c69cb896dbe222f358e95eddd3b1ef9",
+                                "uncompressed-sha256": "83385aaeb7eb281eeadfd032429aa79656978fd1a7494f85007018d67c1d9614"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live.x86_64.iso.sig",
-                                "sha256": "64d7ec18c67803f40c0783585d1a8986e21dc2b0f49508584ef825ed34785fe6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live.x86_64.iso.sig",
+                                "sha256": "bc972cdee047113ed2af3a68c9b18d0f8a6fd12ddc87d6d030a7e10061c07ea4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-kernel-x86_64.sig",
-                                "sha256": "04e1ca1dc31a84ab650eea07d2786be772394bc64965f90332d0dab2042c25cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-kernel-x86_64.sig",
+                                "sha256": "923ac8fffec0e776c0250432b867da0199ffb7da40300fda602bd6be1938ca92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a94780046d54c80b5ab03ed84704a578dc060d7ba76977912d3b8d88d3b66992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a0c3c74f1fc260561e149cd43c2dd440bb14ee773ce62e3dd050275a2ecc1fd2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "7dd9489a793619a30715374cb66711d08ae82813552ac62fca53dedd816e6ac6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d860c506ac2ec0252df8d3973292c2b64bfe01fae1177998505674ac28cc22d8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f9b8816a5a13cc7bc8b3443babb9496e0aa922abf3447b155820e4d762901f09",
-                                "uncompressed-sha256": "42ae4ac58d392e952d806b07c075fc835a305e3129760219e63872050a39f91c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "44d5737e67326b750db5bf6640c4e8d6ba5dee1a4f0d612dd1419563c2d71e53",
+                                "uncompressed-sha256": "6f92fe84018df8fc39b1bece4490efda5fa646fdc2b40214c729178fb025aa4f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ce0b309d2e2d2dc8f85f97f325a1e7ca94526878ae54c65006a3b5f529dbacab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c3bc6a1aeacff562b9be05b1a00b5696a8078381178a9021f83889e2412d0d47"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e1eec662bd3c14767bc10c89d60388a85dff75b5af9391c7fd45603c5f99f942",
-                                "uncompressed-sha256": "cc3d8b824e1c338f77319f689f10a876c4ea541aad70a1e901237df1f21dbad4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3246ce14dbca4457e926a5f1a562213c0f16b36f0239c3893d42bf4ea0fafc9d",
+                                "uncompressed-sha256": "ea624c634d89f52f28e216bad025775dfdafe0394cb8886ab197506090e98ade"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "854fc18ba1379e457c227dc4294eadafbbb2f8e5e067154fa551c2de52f52b58",
-                                "uncompressed-sha256": "7e6d2c100391d2c9308ac54cd781db54a917881cd369b29f706f7db04c2ff264"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "09ab10a13330307baefb71e6fcf9f07ce93799aad9ec25185bf59deb3d6c1eb7",
+                                "uncompressed-sha256": "0652ff522a1cc87270c5fb0879cdd73f55815055ce9c30616d7a53d793baf48b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5984decd4ced902e4077a154c26a054ca690fea9f66ca225836e862b1ec253f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f37d08fd0d5a3844c466be79e5006a7f560009b902152b4f850b461f8c3317b9"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "76f37fb76b272c0ed5069c72e99f6fab61b9fbb98cbd6cf9ea0e4dc9a29fc8a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "c9b5e73aa32f26c403de0b0ff95460fe33e881158054f917c637a75fe275c426"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230819.3.0/x86_64/fedora-coreos-38.20230819.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6c2e1cb9dc82a2140e21dc2b44a540600d60683a88349eabd306f4cff9847584",
-                                "uncompressed-sha256": "c4b3b304fdd301f2710c27b5985488b8f02d6c26806cf7bc5589c6b50f397b54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9cba2a53a6e1261f6017ad379b59a76d5898696be0c00aba26525dc93161ef9b",
+                                "uncompressed-sha256": "666ffda64226c2c2048556b7b523832faa9d4a27a411a8534c9282b3cf527d86"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0985c480dcf474251"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-005fe3f3e0dfa986d"
                         },
                         "ap-east-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0207c3eaa294c00a1"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-011a19312a876e978"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0d0cad40fe35830ba"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-077110f14516cfe46"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0f3fb503c2fc37d79"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-040c882582ab20d1c"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0c0bc2fec4c969455"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-03e15ca924e832832"
                         },
                         "ap-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0ad388bbed8299365"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-03ac7e0261dce2afa"
                         },
                         "ap-south-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0b4d302d2a2150e94"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-033cf6438ff237917"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0e9b65a58f243f199"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-028adf5e39c07c8f6"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0b53f6297d6570219"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0e6c07ae16dbd291a"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-01c9020881cdc9e6b"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-03c0b9d98e7d5fbf4"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0df36258042cadf03"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-024d6e612c94a6189"
                         },
                         "ca-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0fc6e359912d20146"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0ca3a1080ec9ba3c7"
                         },
                         "eu-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-01c166ecb7969fff4"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0de2a354cc3f07369"
                         },
                         "eu-central-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-00af662618de94e74"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0e4d645ad17c3c76d"
                         },
                         "eu-north-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-083033f66b497c20f"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0336fe4b6fe4d9cd7"
                         },
                         "eu-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0e36adbe943a3673c"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-05c6bcca53531c234"
                         },
                         "eu-south-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-035f5b5f3d7686e73"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0689d7606c720893a"
                         },
                         "eu-west-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-07eac55d1b8f93e5d"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-024ff0b2898335d13"
                         },
                         "eu-west-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-02bd8cad3428d2335"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0969b9a0e124b83e2"
                         },
                         "eu-west-3": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0376de1c3bf960c1e"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-09774876bddcd1818"
                         },
                         "il-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0e7c3507eadd53c97"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-075ddc315da827d5c"
                         },
                         "me-central-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-02e9f26a9fd9c46c8"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-09532ed72ee770d03"
                         },
                         "me-south-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0380a51f57736d4f8"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0a29a2cc03ab02b29"
                         },
                         "sa-east-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0e85fec968c3b23f8"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0938275a2329eadae"
                         },
                         "us-east-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0a79e259cea5778d7"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-09c0fbf68bfd6baaa"
                         },
                         "us-east-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0378c7af96510a6fe"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-05b507cec472e39e8"
                         },
                         "us-west-1": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-0c9c8732c08f5ec5c"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0d4535fe92f17d561"
                         },
                         "us-west-2": {
-                            "release": "38.20230819.3.0",
-                            "image": "ami-007038e2ec3a8525d"
+                            "release": "38.20230902.3.0",
+                            "image": "ami-0bffbb9997ae3e0c9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230819-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230902-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230819.3.0",
+                    "release": "38.20230902.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0bb7d6038fcb3d834fb62264d412b4cf1bbf9d2ea8c75bf5b1df38e46882a8f5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c99dd6c3a624df79225432cded9ae8c9b8528b66722622a574cf13bfd1b6e05e"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-09-11T16:39:01Z",
+        "last-modified": "2023-09-19T13:20:49Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8c1538d0d3501ab0ee767659411acb682af4858729733930682900af6f891b76",
-                                "uncompressed-sha256": "80a31f910e46fe175b0ebc781c5edd54e0c5eb265e9d2e789f28889ec682c016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2e5ba8eaccd8ccaab5fbc3a5ca0748d948e1575b9d9a9909a0b7cbe11a0fb639",
+                                "uncompressed-sha256": "e2f732b051379c35ecc8912f2327fe03c2fd361cbc7f878e976a06205778128a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "bcf25e0dbd62d1b03aabba4c3968c40bf14ac3db511f912d98b7b164f1146b4c",
-                                "uncompressed-sha256": "5736efa489d56780adb9e0077d66037607775d6de6f6b31f502f4ede1f764a9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c78059d24423662c8c6cd8a6652606a7504eefb4733d7f8d17d2dc04185e372e",
+                                "uncompressed-sha256": "3da390db817a4ffd380076997b7e441fa72ed8df81ee5d9c2bd03c584d1c54f3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "aa586f4ed072f7e65e7f30562ee1868ea3599dc0f58817b9267178f5dc36c02c",
-                                "uncompressed-sha256": "e5382a39e922a7e8fa507cf83f024f15595053346ffb3d16fc27a4534d371f7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "822ec33f4dd0a2f2a30b4d89f0cd71e11ca331781e52560c262f6c795fd8dc60",
+                                "uncompressed-sha256": "698d9a21394ae2d255be73f7300fe80045efdf0e2afa62ee6c50dba4ae2df06e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2d8a41653481bdc0ecaed2316f23ca0565c9c4b8ed2592d52c80b607abcfce25",
-                                "uncompressed-sha256": "5975485cbd9072fa367470d00e856ddea5fdd75d8d924974524e52d25a37d933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "be66d13a9086629c2e447f94d3c1f2e5e54ec8bf5630c21427dff5dccb25cacb",
+                                "uncompressed-sha256": "f053ea5c30188f41f0ec2bd6c4abfdf988c4df29d402e3b0df09d547b5f154b8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live.aarch64.iso.sig",
-                                "sha256": "83e0acc3155f5cff9a0348875bf89edf67bc80cacd62b4eeeb018e59d33bf475"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live.aarch64.iso.sig",
+                                "sha256": "d0048868bfc6cfcf65d0037eecfe7341727bbcd6a03a3163f1f33b18d5eaece2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live-kernel-aarch64.sig",
                                 "sha256": "6720c00d3427f0c61daab399f7e9cefe0945380ca92ce27ff5ff48e7b341aae5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "ec8e1fbe349736bf33635e8ba6a4c575792a029186cb99de105a26591103d0c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "12f32b5bb1adc990ad5b696daac43fc5f3ec271b7e4130bdbda8df342d494b6d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "df8f686a7789ae7b148d62fceb50664a0c6024dea60a7a27a8a71d76c9f46f5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "b55e15e2bd783eb9c7fe8e0184652d623cb078a55e44de80a1c964f2710efbe3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "8426837aee2aefdb68cd9a1b1ddd715d4acc4ccd2e528b302a0dc62b686017db",
-                                "uncompressed-sha256": "e335caebd3832ffea2150c444731cff71d6864a8c4797b362527c43edd9c7b51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "519a37b26456a348cb9f991530c3f63829a2bd9f1627e653a2d6557b33128d54",
+                                "uncompressed-sha256": "22de2760f5ea0550fd6628a6f8f1d193fe188960599d8df2d16884505b2ddbb2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "369109a4da29437003ca96efd870c76b0590f3b24ee7ce746108c924c3f76580",
-                                "uncompressed-sha256": "7585ef0942237799e2ef820aca408dadc57ec4e0b5fc5ae2feb7f1f1e0293bec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c5638706578661844a09cfa8155b79f5cca2a308dc534f01663cd49a077fc60f",
+                                "uncompressed-sha256": "48f9de3de200d13e04470cf99263c9b88b6911b26dd3ea2be9b7c0aa8172870f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/aarch64/fedora-coreos-38.20230902.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "29da271663c661e244da048d2d1a23d70e8d7cd3075ab75fae97aa51d50bcf20",
-                                "uncompressed-sha256": "de50670c386f814eb2f124d6a87730137666e203c489f13d1f8926d9c2839c55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/aarch64/fedora-coreos-38.20230918.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ed9a9733d0c83436c593cda643dd73e1cd747a6ddaa9c9f24b0d73e865a2f3c9",
+                                "uncompressed-sha256": "4b2143dfba8563543739090a58dbd4b7ac38c1d9ad3b9a5a0a677512c9e358c6"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0d57b43b3c40c2227"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-090c3501a9cea7618"
                         },
                         "ap-east-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0f8edaea9e478beb8"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0be018ecbb9249c14"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-01b29823066a10409"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0046a503a97f5457a"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-05d76cea108259f1c"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0d3ef88b998011695"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-00c89e0c4c2fdde2c"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0360a4c545f48cc12"
                         },
                         "ap-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-046102f2e738f0bbe"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-076821774a45ee292"
                         },
                         "ap-south-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0e074057c5c588017"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0af674d3ad9691ee3"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0b2544f34acaa90a7"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0c783a1283e0e8840"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-064523f44060b704a"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0853936880cc1c603"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-07c0d6a02f68d03f4"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0efb61e22d72cdecc"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-06b1c4ccc65339d79"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-097fcb5941684427e"
                         },
                         "ca-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0174d148c74d2dc8f"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-02e73c9fc7f25152b"
                         },
                         "eu-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0026419f465a088c8"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-07ed83a8e8067cd16"
                         },
                         "eu-central-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0ed44a724fd925580"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0311bfa9883b4ccf0"
                         },
                         "eu-north-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0bb9d4af64c70fdcf"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-08a2ba30c508b1333"
                         },
                         "eu-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0eb8c0b8597edaa71"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-003dba2b1875f7539"
                         },
                         "eu-south-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0681322b299733510"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-01fd64192947008bc"
                         },
                         "eu-west-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0a06d078d49df2c72"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-02352ebaa016574be"
                         },
                         "eu-west-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0b6a1ea01e88605a3"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0b57e3979dd503c66"
                         },
                         "eu-west-3": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-01f38f846d0b5a2a1"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-085439e16cd84e4cd"
                         },
                         "il-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-060bcae9d394b5417"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0402daea1669376eb"
                         },
                         "me-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-083965bc3f2b3568a"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0a0acedc9bf198c04"
                         },
                         "me-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0f78c3a81e231200d"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-017777614dfc7f005"
                         },
                         "sa-east-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-01dcdbe28659a8c55"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-05615a00c880e8afd"
                         },
                         "us-east-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0d384a71eab794fa5"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0f9ae945c5c08d7fb"
                         },
                         "us-east-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-009d49346e4038938"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0974e35e9946e6859"
                         },
                         "us-west-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0812c7ec2ad119173"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-03246b434b0561422"
                         },
                         "us-west-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-033835c4ab9b6faf7"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0f953d243f0455e8c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20230902-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230918-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "925924416d96237034262a4e94f2b45879499a3342bc7fb80244b1130df6b500",
-                                "uncompressed-sha256": "c3b6d85307ab08639571cd10ce24ec6f06cfd05a46452261f0eda31d230947d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "13047b67665c2dcc1e468617d1dbe6f1d222d3a4c88152d98de8df4d070b8c92",
+                                "uncompressed-sha256": "73f8732baa6c3dae01bf1bccc588ecb4ff06f8873957533af4013bf6f042f20a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live.ppc64le.iso.sig",
-                                "sha256": "e58041aa9fea5875bd98aef56c3bc16e5fa56b9421904d7b607ebe1d8f1530ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live.ppc64le.iso.sig",
+                                "sha256": "4cb295c08a8f23983a15e264584b3d27fc3dc9febabbc0bc4ae7a7205396dae2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live-kernel-ppc64le.sig",
                                 "sha256": "60ee5e19f2c9a4cd3b9b29d86474dcb9bc182a60e0d6ed5431d448c98e1453a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "dca80cc864b58eb2ba56ab4cc14354d7f8a9ff3a1611705a5f2c2226e3319243"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e064106aacb623d001fa956dbed16c8be4bd590572477d098f0ef5790f69bfc1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c75d2f5c19a7b8a86fc4983b17ff66fab6a3dc19c7e5ae3622322638653e7767"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9dae56205f4830c7b991fafdec984fb912836aa9ebe87bc0bfec6a8c57a87f70"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6ca274f0853c54d62105b9929f6ca1a64098e133189c92b1ddde0808dc342416",
-                                "uncompressed-sha256": "e0bac4bd64a872eba2e3781d9c645948877e8f58885a1b79c55bfd1c6d12a1e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0b69610f3a4c7f41c608dadc3d2cb3af7b5b59b92d7c6ab319af9e91f24e2312",
+                                "uncompressed-sha256": "21a0e94330d153c7027def65856d6ee280a0229236e67a91b46009878f2397db"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2fc412a1beac43e8723087aa9742b15c46e370799261b2c5f0507a3c8dcced7d",
-                                "uncompressed-sha256": "b0bdab6ce127b14f5a736c4cea0d97a119cdb4ce6c340bb1ac463f28ce457545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "3541336c2184b43ecfc6979bf9924a7bd5abb6b37426b41ef066353cd88d31b3",
+                                "uncompressed-sha256": "05b39ba31838739469f3904d4d7d1e847f0d9f502a3b8c17d3db8c86e69a14b9"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4419677f13f95cfe6bd03623b704b28bcf5f8d6d3e20781e4b436aa34a0cd5c5",
-                                "uncompressed-sha256": "fd699ad7dccd96619da4fa92ff2e82361d58522b9d5fc7998c8b695728b06ec6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "171fae820db0ae67d639964ffd016fbfe3b4e48170c6c064991f6e920acfc6bc",
+                                "uncompressed-sha256": "63c2786aa95258ec4ec32346bbe09b9240a6fe3628b772ea4a8cd667f54e7f04"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/ppc64le/fedora-coreos-38.20230902.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "036d2821b9856b4a9322f233eee6a1be2698bf2ab90f996d9a257c6cc0824952",
-                                "uncompressed-sha256": "51246be91b2b1501b25353f0c789e3469c0c082f810194b9e8c6d808626d41ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/ppc64le/fedora-coreos-38.20230918.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "86300a5dd45eacb54987db913571d1bc2595f868bca5ada600a0aa8db19387df",
+                                "uncompressed-sha256": "a3910579002bffef902b49bbafb54a0a62644c2c36313b240a1dad95be7bc34e"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7e61a16dd6809c30ba7993179bdd854d30fb145397ed4f972262079525554df4",
-                                "uncompressed-sha256": "a40645e9ffdf50a7e0e5f1dd2dfee657ae8e28c2bc1eec77840e664ab8ae6ee6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "2a19b8d72d98ad44b13afa7e36bed0b6ad1ffab0f91051009a65b6a68971f0b0",
+                                "uncompressed-sha256": "8c3ba68c24f0eef5b62b50cf8e62c6d78bc94f017b793c965183bac57c4b8333"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f24b9b4a9a6635877828dbbc0f5ec5172d36071b66dd17f8e0f2132c2d10a626",
-                                "uncompressed-sha256": "629a965dc2cae61b91c082a03aecabcf3bce2e954cbf096c9942d79e8cff508c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e8e9da6a88ae110a12e7fcafec319769961af546af63b732096c8cd4d7d69149",
+                                "uncompressed-sha256": "f58bd53d215f162ed65a3c2b084e6befa1336f63d9484339750270ed4d46d4cb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live.s390x.iso.sig",
-                                "sha256": "330fd3ab405c3ecddcb0e242ed5359dfa190b97d85ec21e1ce990bded1c455e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live.s390x.iso.sig",
+                                "sha256": "50248169652487f72abcd8eedbf70454652e96c1dd0edb31fd18668989bc083c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live-kernel-s390x.sig",
                                 "sha256": "25ddda8298326c51f22e049e25e896cfaf45f9675895cc10e1563892f8ea0260"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "d97c323caece9ee1f7a045c6863a5198e3807899b7e27cadca05e619804dbc90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8071d5d7fb26c0ef744520c19f258358086a1fefd4d37ec8d90e31c71bc0dfc8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "4a6c95f0f6b5310e13dae9696733589a54b4b34391bd8e9905ad360d829db6ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6e59bbbb5279e03c2346d2cba35e8e1c22fcf7ac85500a3148840d0cfee15a8d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "fc846ee56e4365a64c35559cee50be175d0e144c66c69a6ccb51d598b805ec89",
-                                "uncompressed-sha256": "55ccaf3a5579bf56f1773b92fd0b5356f8dd3cf59032e599a716c95fe79df81f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "0283d30faef75b4f44c502efe1d4fe917a851d5d3acd37d54af610b91dad31cb",
+                                "uncompressed-sha256": "e8d85df2dca42c4e4c0e20167dedf2909c9667f2091552f1e755c27453dc8cd6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5ba46f0ea20dedac5845832814cf7d432d0d96bbf62ee30205668bcc9e02a5f9",
-                                "uncompressed-sha256": "a21987e249c2192932c2f4ccb54909762b696c5c107c91adb4af2a879d21df17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7b2c49705ecef4f1d970ec81a469fc74a8a0d3c8553fa735e08bf3791a6d173e",
+                                "uncompressed-sha256": "47ec6dd5f3df57333b5114abf392fd1f258fa3a570471cceb2a5bf1b23c0141f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/s390x/fedora-coreos-38.20230902.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9c11cf45bcee273acae5478aae719b7dbc8f4d00308c19cdcb12d48ffd32d15b",
-                                "uncompressed-sha256": "c23992900f174df43b27cb32011a5162c090374e1ab27aa1a5da7e697b844a0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/s390x/fedora-coreos-38.20230918.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "587ae00942e4adda0b6950b2d64278f2445104cba40fd62e0215ea4e3f441637",
+                                "uncompressed-sha256": "bf2a18b58acf4351b5ff33ba75ebaef1354f852bbbf23cf2bd7c4ef28951a5ac"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d6d90e029c6db263cc8982df8c32169a68473bfc7c67c095abc76ac7e182d7ca",
-                                "uncompressed-sha256": "017f6055394ffbaef128bcf607f0abc225add3603a55d13d1fdbfa30a9ee2909"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8bb35f187e272ffc8c6563c6220c40bf2eaf4a9b5c35eae40d59e7ed9370e59f",
+                                "uncompressed-sha256": "b3a9affc18354596e2f1f4c0ce8413678bd5c3b424b89b4c2a2153b8593c5fda"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e545263bd53d3f3a9ea5cab086093f9dfc07cf425b27038f4dd3c4ebe582b094",
-                                "uncompressed-sha256": "83b4015b833ac896de99beb9f81bb42e2ad9c1181bd1c2565bc70746105f05f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3b77025bec4f948f2a366a15a519a481edf6846c6f9026d670c94cbdf5a5e027",
+                                "uncompressed-sha256": "1c47d4e6176175bec95c6df991526aee7779dc0d4a54594d895ad6b8c2d3d8cb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b79ce606b3717ba2500dcc3940c71605c5cc6e1cfd2aaf2e845c34dc0417fdfb",
-                                "uncompressed-sha256": "579bc0f2fdddcf55ca13130823d7b35b35910e0272086c725e6127245a33efd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "84bf40201c6350403145b4d6bc80a317053ee1435f23f7f7bcb417792bc52672",
+                                "uncompressed-sha256": "e359b4f3e3acec84040f6a6ececd83867cb385763ee770b4ad48a0e47c00a3b7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ce818e2eea2ef37d2a2e88f5dcd045e470ea7a07fd781cf6b113ef630eb14e53",
-                                "uncompressed-sha256": "7ccd652f82d304e14e2a9b9cb004810113b6e0f92896c9df3ae8795d3de9b779"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "632c096a3881955d5404c7101faa54c336541c47c60d9da1231af421d49bc0e5",
+                                "uncompressed-sha256": "eace2b2fc49f4c3362293922471d8ab17962e63a46336f66bf5bd3f95e2a6523"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0b6aee6603c44f334275b9d1ff826adc4a1710a99632715d1cd0278f417cb0e7",
-                                "uncompressed-sha256": "34398f3323b5c2ac9befc5cc4963446e592fa2c07a7c67008714c89472503302"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a29b4d53b03cf27db55aa5e3362e464e5c665a358dfba56f9f7350635783b242",
+                                "uncompressed-sha256": "aef9b68526bfafa53c81f149c7b084ab0074e8d41cf7cb46c292c87364659590"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e4aac88f63358f6c87a860a539523bbc70290bf1b44e9eb6f8500f6129d3f618",
-                                "uncompressed-sha256": "e01b4c38583dc508b465302cadf8ca035771cc1c7d20edb4e0f2d7b1221b8866"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c5a8e53e1cf3ba5949a3ebe7cd55b909e5dddcd1943edc7831ad72273caf3b8b",
+                                "uncompressed-sha256": "95a5bcac0e7b75fbf5c2eb70a9a26bc1c8a0e83cef0c582c786084a6f84684e3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2498f0704a443ab2b978653061b5ca2028c427fe87bdb57615961caf72f73373",
-                                "uncompressed-sha256": "165cbcc14d092190f50bb0297ef96bcd8a538a28ee2b685c8fd00f3541a9248f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e8778ee423e3059d9e9b461c317bd6bd96519ca0ee397e528be626c21f9461c6",
+                                "uncompressed-sha256": "c04b5daa204187ff3f7c9a458ce7e3408e27e39c57f6f261347a3b5ac0483dd1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "29345881bfc8745193392044fc91bd6ae913473c7e036f0d64628f1097492434",
-                                "uncompressed-sha256": "a2bc351a3d481747c8b158eecb0a1b19cca57e8b77fdd0d0691d1d11b6a07b6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e3626dad267acd1082e4712f403be515f0adb68941359aa6cd806749326c5335",
+                                "uncompressed-sha256": "57375b6bb09f8c90aa3d81ac47a306edb0ead5e36ce77c26b08d8f3cf1c30b7f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "07ec4540352027d0b5b3a69ac6fd5a9c4d709e107dd4191289aa5e47fb313a92",
-                                "uncompressed-sha256": "872ba425725d49484649d116965cce0bd3ea080a662dabf73fc4159b1744e018"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "88f585f513f83673ad08412fe9629b58de2f2072d25c9ce16181e5e116d24155",
+                                "uncompressed-sha256": "ff92a4bd0799f211aea47242d250e2216096d07554086f71cc7f4981243847d1"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "9b19f6a0f24aade4275b5cec5af5d440285c40267d91092464eeeae3a009883d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "27cb79b5cfd386c3f0cf8c806da2109a31a237eda8b6b9e80d9b0ffee71548aa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6b9264745e158a1c9e0963746b89a32b8056b210fe495c74203643e1daef941a",
-                                "uncompressed-sha256": "211cec0e246ab20c5e063f462d30429cde2cd9fbd959387245e48aa10a20e670"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "711787e4c57ae5cab58d00a486d561f1fd2d910eb4c6f783814d03e86fec6c2e",
+                                "uncompressed-sha256": "1203b6df2fa07e2e446978ca9804d6d844fd055da648a896c9b79868c95110c1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live.x86_64.iso.sig",
-                                "sha256": "1c8479d9862c827a82ac53a558e137d59c3b430d6fa238559d67f384bb50201a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live.x86_64.iso.sig",
+                                "sha256": "68b3d9a997d6e00f9dc68da462e9aae5959901b3864a0bd3abda11b81b4dacef"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live-kernel-x86_64.sig",
                                 "sha256": "923ac8fffec0e776c0250432b867da0199ffb7da40300fda602bd6be1938ca92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "2d01660a990d091d8070ce4efafb4d60c8f989d947c727e2a37c4772d84a1b8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "51f2c5c8bad79e16d2b4dc1d94c5646d48b77a3d38cf9b6bd7fd6ab6b5bc9cec"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "07f9b558bbb35ef825f664847111d0cc72a0d40c80bb5a60f2751818cb04ca16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3ce84d53e358778e2143182eddcbab21c07d29bf50c830575895b98e6dff4dc6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "ef3d40bf180561e8dc2ab576f934699277ab886137e78c64b3b21c1b0bb39e47",
-                                "uncompressed-sha256": "549b68c90a9d0566f6b565425b21402bb53b3c8284eea6a6fb2640ce486cccff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "df0b34d5d79587a77ec544c12f3970e49080f8beaa4d7b89971b57abbbb21000",
+                                "uncompressed-sha256": "92416e5d9e4c6650782129976984831b4024b8292f77c2216d0fe159745608aa"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3ec9552741e6a8523ae2378b4f01a1b9c585325fe95545ded7951cb904d3c3e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "77759627485f42cf6b951b4e31804a56dfe4517becf499731c8299de0461d64a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f36a37c8220192c51958b8b8dfc53a4aaf626326e4056e8aa863c7be1928c48d",
-                                "uncompressed-sha256": "f1cff427ced7597298506eb18285bf29a85c36c69811740dd213462bacc17de1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "55863a78e1977439efad3ba665109bf21e13cb97abfcb4a8ba0cec61df1d4965",
+                                "uncompressed-sha256": "aedbff67cd42aea58c581ce9497615b0aea10550f18a98877c4399aa1e3f2e09"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "71ea471dadb79673a890f9f53a0ea40c747a4caa70a3f42dc560017ab6e8ee9a",
-                                "uncompressed-sha256": "1bea2af0ebf640b4932b63e6256cf4ab90bbdb2bf4788b4658f69efe753b549f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "006f6af4b3a5f02c0933df01ceb1c17659afd1eb1e4751d8fa177610c9a2ea45",
+                                "uncompressed-sha256": "fd7948f006b5debfd0ef517ca3690fa00ad79a79de84b34c33028f93c50475dd"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "241fb1d101ee7d9a5620d8b0fbde4753e2d3c08c60f63de7f9dc55d39892b1a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "19c0d68fe25d597a2b20632a5f0223405dcbac9bf02798dac752dba9b8218181"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "c8abce50bf6f04e7477d976f97e439c1f86c751d4105d7ae04254ab3dc502178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "1318c1f1b236359b23b4176269243ac6db81ce98022ebdf7e10fbc808b638bf9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230902.2.1/x86_64/fedora-coreos-38.20230902.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dc704e3572aa9fbc7e3dbe4cef31738000b46148ff75b00cad29e3a52a67707c",
-                                "uncompressed-sha256": "454d8a6905140e1ddb1f6d7c1cc94cc990b29926f7563314b6c5988efb10d411"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20230918.2.0/x86_64/fedora-coreos-38.20230918.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b92eb82430c33c3db44551836de579327b2c54bea97e88dcfa0029a657eef393",
+                                "uncompressed-sha256": "db2a94c077ca208263db92acb141710aa346068ee3f338110ed24c6705c2a6fb"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-060126a8e0483b6e6"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-083d619ab2cde5bbc"
                         },
                         "ap-east-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-03f9e4bf2f5a62165"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0d2aa6dcc865c3a1a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-033cb1209e1bdf658"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-037bcdfe8bef2107e"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0568d9de1166216ad"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-06af663e0564cf0f6"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-017cc73146694761a"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0693143ddb7d8cca2"
                         },
                         "ap-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0afd0df2f624279d7"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-077098ff16b6967fd"
                         },
                         "ap-south-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0d87072bc4ef140a2"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0085d064d5b4b8ab9"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-06167ff4cd07cb244"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0df266f5c9cd263b5"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-05bd41ed8b0756f4e"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-04a7493b7d606df08"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-08a747e612cd177f0"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0463adf52e0a2e2dd"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-08755f301f4771006"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0abd12739ccdfff7d"
                         },
                         "ca-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0e4f7d7593459eea6"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0e5abb819b5ed5fc1"
                         },
                         "eu-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0677e90dabfe8289d"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-01f547f6d075fab75"
                         },
                         "eu-central-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-052d73622ca7ab481"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-07d2cb90194d2ad89"
                         },
                         "eu-north-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-00b80974073df9ca2"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0947eef9e7224ac4d"
                         },
                         "eu-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-052a1910eb6272ebb"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-00e2fc84cd5213951"
                         },
                         "eu-south-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-022ff7d42fbef2864"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-05b0f141990e0374e"
                         },
                         "eu-west-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-005d7ce2881772474"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-00ffd1cc687c344ea"
                         },
                         "eu-west-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0b3a83b046fd4297b"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-03fe480acfb7a89bf"
                         },
                         "eu-west-3": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-043252370d3c54ae6"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0a92e5447f5e1d6bd"
                         },
                         "il-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0ec09e84990f33e5f"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-03ab3affe558f32a0"
                         },
                         "me-central-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-03394d99253d1b07c"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0f1e5527bd3aa4ae5"
                         },
                         "me-south-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-062b5c00c23bd8181"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0cde7fd6a93a72df3"
                         },
                         "sa-east-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0945e180de227f917"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0aa17b752d472305f"
                         },
                         "us-east-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-063af423114eb126a"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-06a9005cfbb705871"
                         },
                         "us-east-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-0b926518226f6b8ba"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-08dafdd356f38c7c6"
                         },
                         "us-west-1": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-04b117a9ad31e1076"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0740f006c37260cd8"
                         },
                         "us-west-2": {
-                            "release": "38.20230902.2.1",
-                            "image": "ami-08d08fa84a80e93a4"
+                            "release": "38.20230918.2.0",
+                            "image": "ami-0f6fa057bb170cee3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20230902-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230918-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230902.2.1",
+                    "release": "38.20230918.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8268132ab2c061949e596fde19e5f4b288321e3ce235a2ede7f1bdef527a3ebd"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:66e07a57ac56128b83aae321a5f5884ce14c5efba80684fcf14fe9bfcb51c568"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -87,6 +87,9 @@
     {
       "version": "38.20230902.1.1",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "start_percentage": 1.0
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-09-11T16:39:05Z"
+    "last-modified": "2023-09-19T13:20:50Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "38.20230902.1.0",
+      "version": "38.20230902.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "38.20230902.1.1",
+      "version": "39.20230916.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1694455200,
+          "start_epoch": 1695218400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-09-05T17:46:04Z"
+    "last-modified": "2023-09-19T13:20:49Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230806.3.0",
+      "version": "38.20230819.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230819.3.0",
+      "version": "38.20230902.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1693940400,
+          "start_epoch": 1695218400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-09-11T16:39:03Z"
+    "last-modified": "2023-09-19T13:20:50Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230902.2.0",
+      "version": "38.20230902.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20230902.2.1",
+      "version": "38.20230918.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1694455200,
+          "start_epoch": 1695218400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).