### PR TITLE
updates/next: pause f39 rollout

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -94,16 +94,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "39.20230916.1.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1695218400,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
The new moby-engine can't start containers, at least on FCOS:

https://github.com/coreos/fedora-coreos-tracker/issues/1578

Pause the rollout until we find out more.