### PR TITLE
Roll out stable 38.20230918.3.0

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-09-19T13:20:47Z",
+        "last-modified": "2023-10-04T18:18:37Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5ebe05102b092af79542ea953d3f1e96dd675903866c5f5273de5e5699260bcb",
-                                "uncompressed-sha256": "c6a50efa1b265999d4f0eb3834bf49c6ca4903ae119bc41ab51cd6d1ae57acec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8a92d3b47af5414009a064f8e5090c815987fe683bee562b2907095abd46c5e8",
+                                "uncompressed-sha256": "97b2044061d39fbd204451b6ec87713d706d40c62cf736a51a75e5f4d6545a95"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0ddac1ae86e064aab655fcceb542b9f71568340fd09698cb390e846e5fcf04d3",
-                                "uncompressed-sha256": "9c0ee968afa8634dff5a062686a37b9fb68ee8f2e50c881c2f4f90cc5e5f9066"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "cce02778d9ddcbac25922ba137514531b20a7d69aee02d487eaa90798fc35e8a",
+                                "uncompressed-sha256": "504f38207e03a89de3272010c10236425eddbbda66a77c29cb2167900a91799c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "185616dc08f6c5d976ad5b50acbffbea6c6d626c93c2d71eb4f3ea7f0c3174de",
-                                "uncompressed-sha256": "35a33c2ba6954260e3b001deef808fa34706c8d53e77e4b69e636c15460fc73a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c654505502e0575eaaa8938c3c30977d6f35ba6ea1f2b0011d768a53ce5c156a",
+                                "uncompressed-sha256": "3d01a1160f8ffb6ac334dfcb7681a9dea4c2d9524f439252ebe5198cf8bc8311"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "02278822d21ac74201869f1924141479fc6d680bd500285bf85efe571d310880",
-                                "uncompressed-sha256": "a95f4f14c2e2c0dc7f6efb90263963d5a304729b80a8fb5497ccb45a98571803"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "661e3742cb1c356e6920d4e010b8fd57786496b49f4d52121542d6a090d1c250",
+                                "uncompressed-sha256": "414da351ab20265bb3af3a7a32657deafe54c30c6cbd818c5003cf9010619922"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live.aarch64.iso.sig",
-                                "sha256": "ad20c8bf79ed8eb4f443d3501bf34b5bd0f76789b9eeb76e02e6e5d96e499d7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live.aarch64.iso.sig",
+                                "sha256": "f035da6ec6118e549e2c1b90b97859c9b7e59870e2f9d848ea321334185ce711"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-kernel-aarch64.sig",
                                 "sha256": "6720c00d3427f0c61daab399f7e9cefe0945380ca92ce27ff5ff48e7b341aae5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8f51eec7059732cbad7031bf29e5a2c9a2d3457ebcef040ccaee56f17b7f8094"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "b44053f3ef80bb6b51d37ad11591c0a72f531739926e8f925ef7be2e808c6bdf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "bc2ac765fc57415cc16cb6faabe0d7f7ea15e1840ee460be043698926ce7cb86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "de24e6872009795e75a2224c9cd6b12939b198d09f4b91c4d4272c2f3ccd98c5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "1edbc8d01e24f6c55f244e4c818ced8a78478a44455d78dda0bb71b795c9513b",
-                                "uncompressed-sha256": "5d49437c1df3943fd21c88da3562285287203a6db8ff1bcb2009cdcc886eb62e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "88d4c73ee7f5a6ff0825d0bcbb0116563d4d8de5928af528fbf950d4400cb3b0",
+                                "uncompressed-sha256": "b680518ad5c6fa58839acffcff9f6f917d7f5f0b290f11952691984fbfe85138"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3b86583e9ab62101ab0600cbcb74b106e59f9155f8c563192cfd3e57eba7eeca",
-                                "uncompressed-sha256": "f625bc58094609de12fffc2f9c76bc511c413a71f2b5964d8e5b607c568a0dcd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e65e81da70c2de21766650732fe8cbb6894b582a679a6609249227a0a4ac67cf",
+                                "uncompressed-sha256": "5fb7caf4d6c487fa778163ab03fe87ba7c0a7998441f5d7d7e6702c39df2c2e0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/aarch64/fedora-coreos-38.20230902.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7a4143e4aef7346944ae5a0d0cc4bd996a41c1f9e12989dcdfa31a80c8e1cc27",
-                                "uncompressed-sha256": "c8f1e91f232dfd936661b8747ffe98bb170f35ea6a81ff492b3ca371cc211bcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9",
+                                "uncompressed-sha256": "cccb0563fc48289b2321b991a8fa926aa83c50b15f89b38d4862b3455a3a202d"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0a76449d077358c41"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-032b7cd50facd0e5a"
                         },
                         "ap-east-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-00511d27907bc9547"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0d825269befebc21a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0ef7fb44cc5f9d356"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0b50a66440f2c1f4a"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0f1a5cecb982890dc"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-081785b1b76ada7ac"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-065fe709951974dcf"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0227e319c461494f2"
                         },
                         "ap-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-067559144468b210e"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0b155aa41cacff8f4"
                         },
                         "ap-south-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-06442d69bf278f9e1"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0d4327ddf1b103608"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0776b5836e5106179"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0377cee92bef16890"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0b84c7f114cb37c33"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-003a7cae4f45b190b"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-095611520b99a19a5"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-027323ef570a63656"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0b1d34bd72b86b5dc"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0189bc72ebc74dea6"
                         },
                         "ca-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-04a986901da1bc72e"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-05101588475eacc4a"
                         },
                         "eu-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0bccb2c3497171351"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-034fec08fd2d4308f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0e371e17df43f0414"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0b7f65bc0da311412"
                         },
                         "eu-north-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0a78b4c3ac2511f26"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0feae78d4105b72d3"
                         },
                         "eu-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-020ce985e621cae20"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-02e4fa689b89a0198"
                         },
                         "eu-south-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-03f9d90f2174d490a"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-03ea53c19faab545a"
                         },
                         "eu-west-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0005f001dbf391e4c"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0f8abb990761c72a2"
                         },
                         "eu-west-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0bcec8a3e6103452a"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0c66d4e56cda9c0bf"
                         },
                         "eu-west-3": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-02990a310403e8b42"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-09f82bff6cdc11adf"
                         },
                         "il-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-04a77e8ea8b7cca0b"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-085aa34481c50d7a6"
                         },
                         "me-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-067c37ac8b10228e0"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0379bacaddc0b7d55"
                         },
                         "me-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-097d9b5f12f34809b"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0d62d1657a54d6af6"
                         },
                         "sa-east-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-07b2bb8329504b0b6"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0739991b4dd5204d3"
                         },
                         "us-east-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0efa797a1031e4ac1"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0e3c173aec94143bb"
                         },
                         "us-east-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-03844f60f62520b2b"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-06847f12bf323b92d"
                         },
                         "us-west-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-01cc2f6080b71e8f1"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0a24ae560a6ff0036"
                         },
                         "us-west-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0ef24426a108d1b49"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-033d2bd4397b35c10"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230902-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230918-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "08c929573e18f571a2cb7d4c2100e13214825059289c7a05f32f553a754ba845",
-                                "uncompressed-sha256": "eeda9650dfe51ba2bb7d24192739fe6000c0239e547862013fc7fcaed2036415"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "628c402076f7f154ac488a735a927ab50254901d3c0c4a1c5cd25b7ab528d8c2",
+                                "uncompressed-sha256": "2f628e1b09725b6edcde0e52f81abde905f23183c073b50da54e74740ad83890"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live.ppc64le.iso.sig",
-                                "sha256": "3daeb46c18549cd7cbe42c88513ec7d3b070c0cd2324f600810f36664937306c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live.ppc64le.iso.sig",
+                                "sha256": "406e38038159c36f95eab9f98c6b7beb4dc288482aea86f0b608526df8460126"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-kernel-ppc64le.sig",
                                 "sha256": "60ee5e19f2c9a4cd3b9b29d86474dcb9bc182a60e0d6ed5431d448c98e1453a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "340b4a1f508718a382d52239bd375c6cee849da88b90ec9c2add9794df6027de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "18aeac141acc07b9e513629d612f5147e64666ddd41465726520e44893d372fc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "217eab22d51cb3290474d522e80d14fb9b6d779d1fe0fa91a2ebbd211bac1e4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "feca37212c627ba56313aef681577c474eb10b353c2cf927b8c812c22229e5cf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f14dcb0fa19d8473c12e5bed5787f74502b560389ee8acd1f398f27436755fbc",
-                                "uncompressed-sha256": "01a3f5939da45457c5223d2ee9d08f43c2d7e1f03988e9533359420bd29f124e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1d56e47c4b556dd84fd8739f0611364e073c7a45fa58b1dfa8986d10196d077a",
+                                "uncompressed-sha256": "e5d471ff1c04bc6db0a11e74200ef913cdcce5594a5a41985b20b1a7fb9bd7ac"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f143f442799310b72db1a8b8f3a12713ed7da7b26c3ce662d5e3c18062e919fa",
-                                "uncompressed-sha256": "f6a2067c527ec6dcc0fa01cd722651aa187c9befebf8a7be8d07e6dbfca66a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "bc5cbac753b63001fd92982f5fb66230ece03dbe0aff09efae9d1748e485a035",
+                                "uncompressed-sha256": "c7e50b24e93e74ae3b0cb0f695b74a227e6d6ede336d64438550c1f5fdad156d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "57a9893e260697187f2fbb9694e268ea68dee99ef84be637f712ef0b76bd180f",
-                                "uncompressed-sha256": "7aa0ce9644e0b6335d0fe86b4e89d7ed97e1125784dfcf8612a955c2e7070853"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f1904efba7c9cdbf14486a0293229007820c287aa5eb99992c590dac1c8ef2f1",
+                                "uncompressed-sha256": "dababc67dfea3d8dd005f18a312359737d14e2a877bb0d45fede0e3eba3344ff"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/ppc64le/fedora-coreos-38.20230902.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bfd772effc9cd8ca19ac837c98f7a1e04263d974853f36b4ebf64450f1191306",
-                                "uncompressed-sha256": "4d0144d84d58ca6d82939aff4e431a198ba913c1307985c5bd75f9d19518d5a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d9761ec65bb1d6d8767556b6651fefd1258d8aa0406f18063fbce9b32ba79ed4",
+                                "uncompressed-sha256": "717844e1533fddc23342a1bd2752b33b532cdf3462cdcbc9606adf721dcfb641"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8979aa9e00c9f5b4f10e0087a3cdfdf6f93973583b814e6b55db500a27ae6179",
-                                "uncompressed-sha256": "ad7f550444bff300a7a861f86de3d180e4278205a64309fc75933c12f7056b96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "bcd95532930bf6ad29e95e23ff237076a116229c316f559c2eb7e20354496a87",
+                                "uncompressed-sha256": "99735df0f35ab97c70a0a4d6f7c98514cd7f2ac84e14e51f4a9bb6d03cfd68f5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "41b522d60cb5db74d0fb8f320ef712ed12af1447610e5ee10fd67a7ede0405ad",
-                                "uncompressed-sha256": "45af2ecb887992b1b68e748822cb2dbd27da65f1b9a383513d735413ea78ae93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "13168259d66bfda419ed4e54c810afac08554041521cac436ac747e080dd50b5",
+                                "uncompressed-sha256": "faa1e6f6f078ba1cad30c3f9993f0f711203f63f449b85bacecdbcf69d1f328c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live.s390x.iso.sig",
-                                "sha256": "712c20cc5e502f784f5f620b224345b22d30fa47089fb01c593d6302b067a596"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live.s390x.iso.sig",
+                                "sha256": "65fd161b10f6b543550307326879432ccd90371b057067e7875694c858f3a874"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-kernel-s390x.sig",
                                 "sha256": "25ddda8298326c51f22e049e25e896cfaf45f9675895cc10e1563892f8ea0260"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "d4249981633f92eae5bd7aa40ce92f1873daa90ff5414722240ab9586ce67062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "0d580f098fa06ead1a48667b4d9c157f1257eb62972c9e65578ec63409146d9e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "8f5ef1ee314a0445431e99259658fdc6e879ecd78a3ebc2a7d630dbebe00430e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f10eff36627fcee1eee976e4cce00b9889fd5068c39e7b56e69a5dbe6509b138"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "424e0dd084ea821766cfc1264a50e7e988993dc4e3cfebbea427b9178ddf3bd0",
-                                "uncompressed-sha256": "ba41745d7d19d1d0f47cb9b8ced74622db3583682452723f9c4d83487cd4b91b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "5e976af8b0c42ca211ada51d9f7e4d8b898bb27373cf0dc743a9bc502086418e",
+                                "uncompressed-sha256": "d314cbaafd345cbfd51fc755384b2e8862b8a6109b9fd11a399b845278ba586b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4cf8e70db33f90d5ef79bb81157751ad2aa8352d666169a4c83db628682814ae",
-                                "uncompressed-sha256": "775d22a41241e91a8d2e4caa191258430113c99cc401a41589968bc8aa23aaf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e86ac0adb4cf572d1e2097423841c6e6fd318503bb0aab9690bc68f84f67c8a8",
+                                "uncompressed-sha256": "30fca5d51232180d23a20c1b723c3e875a5c2d47e51141aec04c3cc3393dddec"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/s390x/fedora-coreos-38.20230902.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3d1214e95a1d713759052d93bec189f2b354b42497ee3ce0710a94aab91a9db6",
-                                "uncompressed-sha256": "a438d2c198530db2b8c6c8c7a045e159d8820dfe1388ec31ba4b32df1881ed66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "13cf327ba0cbd17dc0ebab2849cc7ecd3b4e5e29981a505634fad50701017e4c",
+                                "uncompressed-sha256": "430b70c1c268ead7614be9c9d1562f4935958772891093ab0c3467fc5890efd1"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a77fb7e978f6825f0e19d606198ac035267560c835b9c585127051b90e1a4dc7",
-                                "uncompressed-sha256": "d59f301689dcc66671bd2ae886e9ae70ee97b49ac47d8d89864e2d6db24b3c37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8bbeee1e3a0ef2d1df6d324e014ab7af75515e1eef0025aac472362426c26819",
+                                "uncompressed-sha256": "dbc791bd31649837df1a1ab3bc8c264d1d743a74f305ecac306763226fb0219e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "46072c2c1af2f13f48de5eb7377cc9a6bbfad00c561edf0494be57f6a305bdae",
-                                "uncompressed-sha256": "e93bf51b5a56dbfdb839e2cbfa0e5f2b345ecb792c5c05d214252894ae95d3bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d71ff8baa0731f485bd25aacd4df10fbb7f7920ad2e884a217c269ae3f0c8395",
+                                "uncompressed-sha256": "52cb73d96bc28d123b4de605c66bd1d7cd82789290b2c3e4214fd30a736ed5b2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "24196115e320141e8201b67915dadd7218758da745a8c2459a7910fa68e7cde6",
-                                "uncompressed-sha256": "b8539afc4a6d8763dac3586e97584548c0dc1d5cb8b94814ddaa7cff4e0367b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6ccf4fb3d037db8d1a7c7dc6148d0c86563febbca23baf40d6af0a1a78e8cc00",
+                                "uncompressed-sha256": "0171439b211f194d44f3fea1cb95a448c5d84b797b5891c8c2667d2c40fbeba7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8b5bff885a587009048efe9aaf6934e90729e86f97785cf4104292a459672f63",
-                                "uncompressed-sha256": "4990c4f4874767a940d0cc8ee3f9005d74a4bbef237825053695bf64b5f17fae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a8ebea6dbcecd4452d4792643e65483197d7a4712fdad25fa476edb8ed1300ab",
+                                "uncompressed-sha256": "f6250cdfce1da2e81afa28ff8152045fc0e83e7d45f0353f78af974b23718b75"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "052a6f3d99616156dce17c2ffc6e941a39378b7b5d1409d9f86cf513982c87e6",
-                                "uncompressed-sha256": "78a92f72de630274cf5e1a4d8c9597b506017a9c383469fb1c5688033faa5656"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "fe295196cac332a8188bf37c73d7bcccdb5d7c234cd07208c4905b413a3318f0",
+                                "uncompressed-sha256": "f69b9764d99b1625f1af089b4ad6c74fa96188b4b16fca053f946cdbdf3064d0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f73bd8d60460224811dcd1d73b650c96c01b296045c6ca547cece03709df787e",
-                                "uncompressed-sha256": "12c89dc4d648d11740fa06bd4bc5a1ee80057a2c49557ca7e111cde81fb99126"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "82b949b90ad157d288deaa8989f718c2a1e797ec4ef6af09538c4acf6e893222",
+                                "uncompressed-sha256": "99b9a34bc933e23f6ef41081a45e3a6e042ba7065786f71e62fda8d0ca4418ff"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "068058a1631b5898122dd6e263fd822416446249ec0258bb97fea7d83f407011",
-                                "uncompressed-sha256": "a325741c41f0e5a279795264959789a44b2535fe1741ecccdf915882d5e1f523"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "431bd32f1315032647df6cee147ff3a0387c8b54a55d068a439bca2bbda22e23",
+                                "uncompressed-sha256": "f7d1659bffbb5f594fc4fcffcaabb04c206b5e4ed4a43d4cd674aed7107870da"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9ac9922b44203e2eda93328baa5b64f653f8d584f6bdffd027fe619fd4778a51",
-                                "uncompressed-sha256": "4d7414bf0341cf16dd91d9fcfdf737dd1a3a93f5881ded78421b362381c3db90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c754a9658f58986ec2680c1529e5d8f7740bd671cd8eaf91f81cf7a401754525",
+                                "uncompressed-sha256": "3becd25a60241d6dd895345ae833b53481407f009db2a55ead027f70f719c464"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "831ea9d1b08a6f937f0f850a83b646877a349472e6d66525486d01429cb6ed3b",
-                                "uncompressed-sha256": "a594ae24ebd91a4f781544a2ded060315400031988b2bf43d60cc1b976c3a0e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d3dd5b4b23aadeb01b9f70990381960df4fccb0433d6043f6ad7c950ff222180",
+                                "uncompressed-sha256": "c4447e363382f7c8888387fc405a58b8ab6fede48af7de3ad49aa6c69ddcc346"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e570a05ec5145c14faa88d802f59cd3ac90f5135820d78ad1a3fe0f7ff4ede11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ce02fd78bb358f5d1a140611cc2234d43d6bced9e664f80c702789ecd093b6c8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5c273f9bd697236ac3a6e251a3c97b0d6c69cb896dbe222f358e95eddd3b1ef9",
-                                "uncompressed-sha256": "83385aaeb7eb281eeadfd032429aa79656978fd1a7494f85007018d67c1d9614"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1400efc09a251c338d08577aea2c02a955ea0e47b3e092521e61672674ffa1cb",
+                                "uncompressed-sha256": "2eadd19900bc2104d76dfe5a2b1ab7c05e5269d9ed55bb553f216554a525b7fe"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live.x86_64.iso.sig",
-                                "sha256": "bc972cdee047113ed2af3a68c9b18d0f8a6fd12ddc87d6d030a7e10061c07ea4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live.x86_64.iso.sig",
+                                "sha256": "41c954a561fe3d8e4235b02335cb5f0a88eaca09ca2cd06417e0470c1c2d87aa"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-kernel-x86_64.sig",
                                 "sha256": "923ac8fffec0e776c0250432b867da0199ffb7da40300fda602bd6be1938ca92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a0c3c74f1fc260561e149cd43c2dd440bb14ee773ce62e3dd050275a2ecc1fd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "fa332340548cfc7898d52c5de732b4c0834130381300c29413e8d857241c7290"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d860c506ac2ec0252df8d3973292c2b64bfe01fae1177998505674ac28cc22d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "a6198ba1c09ff12d43308801767fdcc78d42346d41391fdfb27c4e3fb8bf1f23"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "44d5737e67326b750db5bf6640c4e8d6ba5dee1a4f0d612dd1419563c2d71e53",
-                                "uncompressed-sha256": "6f92fe84018df8fc39b1bece4490efda5fa646fdc2b40214c729178fb025aa4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "778ebcba0f597e8457cb86879d2964e5f73edc266c516256a58ae5b1945915a9",
+                                "uncompressed-sha256": "73baccc3c3dba8dd328291bb9c5f795307a4c36b6d10848d5e7953d6011accaa"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c3bc6a1aeacff562b9be05b1a00b5696a8078381178a9021f83889e2412d0d47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "bc5e314f9284fedb6ad0a049d5d45f12fb3b28679dcb015b6f44bee0587d20ee"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3246ce14dbca4457e926a5f1a562213c0f16b36f0239c3893d42bf4ea0fafc9d",
-                                "uncompressed-sha256": "ea624c634d89f52f28e216bad025775dfdafe0394cb8886ab197506090e98ade"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "824ca0f2d1947e0e4182d9aaa9bf486002d394652cdf2682edb2ab95ec73f66c",
+                                "uncompressed-sha256": "50499a0965ec8c80ca04b9a16acca370e4d53637ff1e09c3994bb5183259afcb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "09ab10a13330307baefb71e6fcf9f07ce93799aad9ec25185bf59deb3d6c1eb7",
-                                "uncompressed-sha256": "0652ff522a1cc87270c5fb0879cdd73f55815055ce9c30616d7a53d793baf48b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "52d98121563a61fdab6924a8e3190bc1cbf7775942d8a8046f9ef2a689ed7aa0",
+                                "uncompressed-sha256": "b12ca08216348f4e2c0968cc6b5506e6327f1bc89841e0e9f3155185c8ec217e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f37d08fd0d5a3844c466be79e5006a7f560009b902152b4f850b461f8c3317b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c188f6467394ede3c1effb4dc55fe1756faf36e6fba48be44969edcbed52cc81"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "c9b5e73aa32f26c403de0b0ff95460fe33e881158054f917c637a75fe275c426"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "5e70c9307ba353181c86805f9be8fa56c516795a1becc6ad27fda5005a3be57c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230902.3.0/x86_64/fedora-coreos-38.20230902.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9cba2a53a6e1261f6017ad379b59a76d5898696be0c00aba26525dc93161ef9b",
-                                "uncompressed-sha256": "666ffda64226c2c2048556b7b523832faa9d4a27a411a8534c9282b3cf527d86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8fb942bad8df8cc930da4eb729f31b2d8f7406ba4a4fe080d6c8e0c22975be0f",
+                                "uncompressed-sha256": "11caac4af38a8fc2f7d9805c1357de6a12c64d67fccd82c61d4822ac54b05f01"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-005fe3f3e0dfa986d"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0635472eea3206ea1"
                         },
                         "ap-east-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-011a19312a876e978"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0cb17dd6b2dde740a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-077110f14516cfe46"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0f3a851628c62d95f"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-040c882582ab20d1c"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-03d63b7c01e34d67f"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-03e15ca924e832832"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0309080452404f866"
                         },
                         "ap-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-03ac7e0261dce2afa"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-03a57eee9b6f6c7e0"
                         },
                         "ap-south-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-033cf6438ff237917"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0d694deac61cc0968"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-028adf5e39c07c8f6"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-025c3e510bbca3ef4"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0e6c07ae16dbd291a"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0f359127e88b1dc00"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-03c0b9d98e7d5fbf4"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-05594d4713eecafb1"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-024d6e612c94a6189"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0fa09928d7c608a8f"
                         },
                         "ca-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0ca3a1080ec9ba3c7"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0b420215dfea83046"
                         },
                         "eu-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0de2a354cc3f07369"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-003df8d5ee47d3a95"
                         },
                         "eu-central-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0e4d645ad17c3c76d"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-08c2a52a0d6fe8800"
                         },
                         "eu-north-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0336fe4b6fe4d9cd7"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-011c5b8300321ec61"
                         },
                         "eu-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-05c6bcca53531c234"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0fbcb1c1d677cdbdc"
                         },
                         "eu-south-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0689d7606c720893a"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-029a0ad6b8b6b747d"
                         },
                         "eu-west-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-024ff0b2898335d13"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-000aa36383fc9d104"
                         },
                         "eu-west-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0969b9a0e124b83e2"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-063f568d6cbb9d5e2"
                         },
                         "eu-west-3": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-09774876bddcd1818"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0e7523991e41bbd92"
                         },
                         "il-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-075ddc315da827d5c"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0c9cb7858cedbd6c4"
                         },
                         "me-central-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-09532ed72ee770d03"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-012455c58e703b5fa"
                         },
                         "me-south-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0a29a2cc03ab02b29"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0a475a021e2d07374"
                         },
                         "sa-east-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0938275a2329eadae"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-00ac1129ec1741e20"
                         },
                         "us-east-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-09c0fbf68bfd6baaa"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-0764cd71059587de2"
                         },
                         "us-east-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-05b507cec472e39e8"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-03c51f514ec6a3d09"
                         },
                         "us-west-1": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0d4535fe92f17d561"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-01ecff683d8cb1f78"
                         },
                         "us-west-2": {
-                            "release": "38.20230902.3.0",
-                            "image": "ami-0bffbb9997ae3e0c9"
+                            "release": "38.20230918.3.0",
+                            "image": "ami-071d77afdc4233d40"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230902-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230918-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230902.3.0",
+                    "release": "38.20230918.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c99dd6c3a624df79225432cded9ae8c9b8528b66722622a574cf13bfd1b6e05e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fb208e11fd5485d288c68e9e622ee16375ddbff712cfe8da24b516579063b5c8"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-09-19T13:20:49Z"
+    "last-modified": "2023-10-04T18:18:39Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230819.3.0",
+      "version": "38.20230902.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230902.3.0",
+      "version": "38.20230918.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1695218400,
+          "start_epoch": 1696445100,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).