### PR TITLE
Roll out stable 38.20230918.3.2, next 39.20231006.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-10-05T04:07:55Z",
+        "last-modified": "2023-10-10T14:00:09Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9058da83ab103b4f8e0e25edacc3c5acb22acb262f8113aa4bb2966bece64227",
-                                "uncompressed-sha256": "ec21f7f70a5194cc42a08a12299af299a50bab208b006d45dae81d21888153fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "cf13838a209ae127ef421d9258879da4fd2e85c36e1233442bdfae26fae16c7c",
+                                "uncompressed-sha256": "e9c8700f625796c4b065533d4ea2f0ee1efb744bc3802af40fe8cc29333c9fda"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a2016f9d89548aca0c312757cdf370922a563b7e24fe6aa68016a373036da538",
-                                "uncompressed-sha256": "7001e3d24d1be819916a33eb032e9f1bdeb50b3fa87fbdc4e8b5974c8e97eda8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "e4d57c8b02d45ede005a8daca6ea92257794d19d9177713771318201efa14647",
+                                "uncompressed-sha256": "92ec0d45e0a20bac69c8e47b4d415c54f456f3904989de7076d51307f7f336cf"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "6f59defbcb79bf55debbef4e1ed5569838fb5687e23f64ad4d84fd1338aead61",
-                                "uncompressed-sha256": "91cd4d50e3437fc765f9ca1d40738a2ff1b2edf4592fefcf4b85dcafb04ac7e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "10c246d1856f90938a649241d90778935ef78c41059539fb113b521768e3fb5b",
+                                "uncompressed-sha256": "4cf93ce6d2ae20a416f79a893f12f2c13a56c0799d2873b991f99cd517fba3e8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7c7ee237ffc3ed7163e087f08b7d1e98886e31766fe60b6a86adca98f0d84d76",
-                                "uncompressed-sha256": "15c1cfe958a9c770496abc8c23fa7bc0dbfdcd6d28f17b06544627bdd42118e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e1eae7db0bd2a5f8b01c46b3c40df6c367e72aac0e996c0cd138b348d129183d",
+                                "uncompressed-sha256": "d6fa8d9eb473bb0e6a7fcc539ee6bb8edcab48393b314bcb975154f980895bd7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live.aarch64.iso.sig",
-                                "sha256": "338d7ac64a5f831674d832a6ee83673f2f7e4b92c3a5a17b422ecf5cb431053f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live.aarch64.iso.sig",
+                                "sha256": "ad470ffcc5995f0bc0a2f40b83c504acab45768fbfdd34dda3702752683b6d2c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-kernel-aarch64.sig",
                                 "sha256": "e77ac23b7c4954c2d2e710865098bdfeda72cdf9f9039243f1bba30fcc65d75e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "45cb740abccc2c3d6d1e28ca96a6ec9dda55c198e151c2370a3783f78d41a85f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "824d9badd18417c5f7f7a8af09a22719ac673f3c4ccc3ff864b262854a50b7f0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "f2356996f89b05356f54cc6f6fcba1ed12c223b2c121c57460a56a6147795d65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "81af205e62549cc01aab7ce759ca5ec82988f41f7e7bff92fc267cb9ad3a0ddc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "4ff1dcc78e3644287b63db79691cdd4aa1b872e37842e712e3535c6aeb7e6bb0",
-                                "uncompressed-sha256": "81e85a0e7b6bb39d5684933d005a96c90e6cf26afcb68897c20402b4e29d1935"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "fcd65891d977f4b195b6c3fde44d5f4032c34b50a09684922cf4bc2083d8b995",
+                                "uncompressed-sha256": "64b4b0503fe546cbb3c3d49c2396a8787670a4e17869f45e2c35f96346eba0e8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a2a1e241d13a855854e45602e77cbb46a541aa1f0543138d3ea3ca67d63d6e42",
-                                "uncompressed-sha256": "6220d0ac08863eb7212e0d3a887011f96c9a4b937e8daaa2d6ef4e31beb7658e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "caf8a3d3605d3b39df79bfbedf3790d1e6e2b991e32ce14bc1cba68516927525",
+                                "uncompressed-sha256": "7d328b5e16c42cf76a3e81710ab92b08167708181e9e308c307f8c0d0325fd55"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/aarch64/fedora-coreos-39.20231002.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "dfda40e918587d779d8743acccfa81ca5e8b7d936939fb4d07be090111a44d3a",
-                                "uncompressed-sha256": "5c29ebee01225b9acf779be223d47b412cd7e155b00bc24986d8c60f1af81ca5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "44ffbccdaffbfefe3d9fb6ed771820283dcbde07867d5aeb5df7c3ac64bd6259",
+                                "uncompressed-sha256": "304f8e4326fe340825a222adb817df3d302272b977146916c7e39c7ded5cc3b8"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-067d0cf57d66d229c"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0dc360cccbc497b87"
                         },
                         "ap-east-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-05d9274620af70784"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0513279059036d745"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0a20753c11710797a"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0138963b7bcfa997f"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-041911cd46cca8185"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0a7a9b96623e9cedc"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0d35a805176b7de8c"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-000d86ba8edd37f2d"
                         },
                         "ap-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-00e6107b503f320bf"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-08ed5b574a2ebd2b8"
                         },
                         "ap-south-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0d651192e019d1b43"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0767b714e99819838"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0d695cba81a4c420b"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-07289a9e81abe07b8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-083ae457df5e2b60e"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0ad1706114261dd40"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-06a8e7cd851c82681"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-06cd3a6f35df877d4"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-08193ad1c6b4b3fd9"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-021ea8bdf006049fd"
                         },
                         "ca-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0b269f69c107abb11"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-02c3234b61fef9438"
                         },
                         "eu-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0db88ff5ae860fb93"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0b77df33910a36cdf"
                         },
                         "eu-central-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-03d380ee72b551eae"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0873686015438d4c5"
                         },
                         "eu-north-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0c3e116cccff9fe3a"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0420e68a2f363a14b"
                         },
                         "eu-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-08347eaaf6db01235"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0ae9e023ee7b47688"
                         },
                         "eu-south-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-090e632399a687570"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-07df1edc036571445"
                         },
                         "eu-west-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0d97a59e44fed7e55"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-06a276c578e02f16d"
                         },
                         "eu-west-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0e769fc89223c41ce"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-084f879f23bc07fc5"
                         },
                         "eu-west-3": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-09eab23cc0784aa86"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-04cff852e7340e378"
                         },
                         "il-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-095db0c4b50d6b71c"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-09c77f0c5a53aed70"
                         },
                         "me-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-030c982bbf2e82e9c"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0213c188e171f820f"
                         },
                         "me-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-04fbb0b763ba2f947"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-072f71df559d0e933"
                         },
                         "sa-east-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0ef5820a4bdf39c04"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0d8616680e1865d3d"
                         },
                         "us-east-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0f4b5b62407969db3"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-02b78519d11c6b274"
                         },
                         "us-east-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-093928b8f1bdbf0da"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-03b51f459c4224dcf"
                         },
                         "us-west-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0a25771c95f792eac"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0677998ef2e374ab7"
                         },
                         "us-west-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0ee5f9fad916d0534"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0a485cd4044a51308"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231002-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231006-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "85f6af6903a41e451094eb5900f80e09c50efdd43641df837eed8f4163afeafb",
-                                "uncompressed-sha256": "6d46889a135ad8fd5e021d1d924cb5271eebdf0fd17477fc2909d09798a53c34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "31231c357b93e1e34ef67e107feac2d7fd2525861392d5fe329b7be3d99ce7c0",
+                                "uncompressed-sha256": "f61f3783f0a05862c5c3e08be2f5f0bffc5dd9fc6a67a710b33344b982d539b2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live.ppc64le.iso.sig",
-                                "sha256": "de96c7189e62e9241b0a28be5e7b46bc779928738caecf36757944fd9bcbd29d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live.ppc64le.iso.sig",
+                                "sha256": "089d91944f97f329d05122c1ddb21fab705595846167be6bc33e8161e6a025e0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-kernel-ppc64le.sig",
                                 "sha256": "efb9ba2504e36eaa1ff816d2b918758fa5e77da957555546fedc7d94a5d36ad1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "fe0d3be4635b41e011349716d506701b2b0d6e24d80819b30335b6f7134b2ad7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b06a6cebf1e8ae0bd180e1ea1c00a80184c2d7436e821cdbc28adbea47a0f9e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "39ac1c013c2a0c873e4ebdb34433665315fa65b378f85cefc857622957b2a2ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "cc32fe0ca5ec126a00c2b04b28446628aeb8ee83800565f39dea53951ec90021"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "2e96be9947009387902f9171b555b4c4f263d6374e309bee105f7ea5f72c9106",
-                                "uncompressed-sha256": "c4109b3a78cceb94f8bbe4e60a95aef81e809160695cb1d43b38f0f1c1dfd221"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3323683c4ff97d28a88838d77ed5a976a767ba2d3e0f35b9314c41fc5c788f7d",
+                                "uncompressed-sha256": "9fac51e6caa0b6b670aaa5940e6f31ad80584a3c6072e110ba059cc8ecfbeb97"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0bb4048a644f5b6934aacdd7d077d87c7079e484a2f9d7846e2f9321580bed47",
-                                "uncompressed-sha256": "1cc4db8cc2c86a5ac641e882d9b5cd4e0c71f80b476dc2658015578f0328a4e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "20608c032ea1fee60b1af335f717ec2855fe8cb613bf112b233d45133cf58eb7",
+                                "uncompressed-sha256": "2d3be577cdd8634b937f55bc7be30781eff8fec0f5a0c69c4e5a645c9416ade8"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d13a4be30edaf8ff34f71c202fd83bb8577246970e0de1f17fdfd2a94dccd185",
-                                "uncompressed-sha256": "424a5c1fca0575e01b3cbb26f81a81b2bcb6611db91e995b6874ef8a8b8fde1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "facd2481f3ef3939ad3fa2f860390897d4a55cb947a4de95d3a1694925a16ebd",
+                                "uncompressed-sha256": "cc81ffe0e86f83f393c0fbd78cb6ce9cfc51e17caf72e50fbd8bda53a6692a1f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/ppc64le/fedora-coreos-39.20231002.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "945f9d9678d7a25341f0c576e3b0ba09dc1f913a09c9d7c853bfc85dd7b1b3fe",
-                                "uncompressed-sha256": "1c3bcee6cf33520ee0bd9e62a448f0cd20320a5368fc4ef74c1f3b58706c2d95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "96221a18f18734fcf12a3f6b4a21fcaf39dcfe6c737cdbf88a410f2d716183a9",
+                                "uncompressed-sha256": "e8091df2569d225276c26e026dfc8b92800dd3bcaa24fec11d154c20dce1cad5"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "5e3ff0e69aa5482e16284647b2225f047bdeb32c22e7b68ba4effd2eae816f73",
-                                "uncompressed-sha256": "99cb8401e01be595a6d41030b02495aed6b4a6fbb314df84507754d6cbe03055"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "56d33de7cc1eeecbe72409d38fa3d85bf4fc7255ad1d492ff19717137bd15a96",
+                                "uncompressed-sha256": "c212185f827814ee9e5a3f4e09c328dccf772ab5652927492c16c4caaf5bc7d9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "20d15593853e056350b74c9346ebd41b26efa29d2be85c501a5b94c036f372a5",
-                                "uncompressed-sha256": "ad7560ae132154ede94279a7af8ec5768662666a86b8c1a7de6407edb2d5a561"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "89ddb3cd7f89370cb6e7d48988227bebc422600e29e3643fe7b21b2c19bbd5cd",
+                                "uncompressed-sha256": "fd05f8cf6d2fc4c066d5cab5e504ee566ee59417534a6a2f568f64b20dabec9d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live.s390x.iso.sig",
-                                "sha256": "3696e76617a42995902b1b36ec88488c4c706193f23e22b116fb21bb3b9a490d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live.s390x.iso.sig",
+                                "sha256": "dbd356793d9bf8421d734fd53907c123cd9531ae1ac3d895e7ffec47626dcb2f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-kernel-s390x.sig",
                                 "sha256": "8310a3da29b17e6076ab10cead79d2a80b3beeaf1f17ff058567ef6e3d79d342"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "53d9a6a1a18fc5cbfc25ecea879edd9e07d55c2263b34859f6b2b21368d46986"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "1e843ae407dddb206866c62596e5d974a5aac872c9659f3637ad5eacc96d6b12"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "b01a242c9013f9b574ed024c6e4612a2fc3004bbbf14e5adb71e41f5f0760e25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b250ee4500511c2ad3e3b65855da0f637a2219f05c4790ffb57c4b6874da2857"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "95b07b0da282d2fca9b31b3d847c391730275c266cfb0427a6a11f45a4187b83",
-                                "uncompressed-sha256": "c6d5bdc3b2b6d93d020e19a1e24d7f40b0c887b7a9b5550c4e6bab239c9b2f2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "f8dec4a6ec30f92c03d6cf39a35d5993540d4c5450afc8b7d870e0c55fdbd1c9",
+                                "uncompressed-sha256": "bb2274cf3c09bc4b3994c16fcd765269f16fb0215def8ec892535d0c4a5cc13b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2b3abcb1dcf70af7e6d60692a13deb43086b03d2efa9dd79b71217e7d6813e04",
-                                "uncompressed-sha256": "c0a620295287f928a029d535e4f3abb31733a2796e51ba293cf5fd22209fab27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "79c2872211ce0a702cc6a31f7f89a9e9992ef286862801d946f76f4eb033532d",
+                                "uncompressed-sha256": "e4bb808407991694e5cb1d6c389916b104469f77c1fb14a250f1c676c7444cbb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/s390x/fedora-coreos-39.20231002.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "50492d77954447c807abacfcdbdc972aaed1d97282dfc00e3c25eb56af363950",
-                                "uncompressed-sha256": "d647ea3745dd7f606bcfccd473c07710fc074bb639ba9909f06263217a0ea13c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "1e630d73a92201e27c2976c8e020ed2324e9e0f612082f36698d047e0a7008e7",
+                                "uncompressed-sha256": "30be75bd5bc50806fbe53c35a24a1bba9d63d0810ed039e841cc818d86381325"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4468ccef03065f67b02e96550a9e4fbbde9ac7889c734678f9de6b078a24d128",
-                                "uncompressed-sha256": "065b8dcbe955c9880c5fa429774cdb409642d2cd3d72dc8db711523b59dd78cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7b3fb12bce2196ef10fed7a41776a0394f91e1f37f418e7cd522cbc40e51017f",
+                                "uncompressed-sha256": "8ae7935a7dd714981b7318b0a78ebb46fe0e8cf169cedabcddf4eab33feab644"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "eeb3b403455817d61060ba867c21f5bbab070fa943b3ea537ecf4fde110ec0cb",
-                                "uncompressed-sha256": "f361785150d1acc4601ac1cab4abe6eb7baecf16766b431e6a99df863623fb69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d0079083cc38b52e516bb41ea9bd05bc990711cfde945b4fc32461f5309e66dc",
+                                "uncompressed-sha256": "47504e68eb90a978ed1b5a85b2f2b22d14c278d4543e911956aa03c4875dd0ab"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b15e3c01c6bd5d9d55a4e208a4585552717adecefafdfc0be2faeb2df3dfd80d",
-                                "uncompressed-sha256": "900f9ba9b2cf4cbd0c6d162e6e06b4e192b7aa9fc7403825ca8e3de12277c2ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1d6ba9f390b25d162aafe2ac01a986b3df52360769affc1b97a3ff88f07986a5",
+                                "uncompressed-sha256": "4f206615a7d136ea4061f901c38a14c18caf5f12c5ead58b9b85f4d0f8a577f1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1b446fc33d99ec084aef0f28c9f79259c2d5e1a7b4f0393830c5d0d11856f80b",
-                                "uncompressed-sha256": "52702f6d26a2357bde6f5106310c238e37d35f8a2b5a72904cba5298aee2029d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "9c4b19866e20424619262f54c7fdf6cae92bad78d85db6c99ec77c0a70450a40",
+                                "uncompressed-sha256": "32c5baea17e2a111a98506acc6ee118ebfdcade0c207e22aa09d99c1f4e1e2ca"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "6faf2515c5e74708591cc79df784fa790af678cb98a793ec0e496c72ddef07a1",
-                                "uncompressed-sha256": "c31e5796f19014b60f177c627d38c8a670c7b44ebaf0b3a40417a674b3b420b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bf84263f7935e5205092d4f2fc9b58320793bae1afe5835452286b19eb04823a",
+                                "uncompressed-sha256": "9e6287744a81ab1a0b922a1bd01d59fb143a9558e2c95dc932de71107241256b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a8d23e8f24d586404a7c40dbbc4d5c095c990e20be33a2e07536e06cd9a99f52",
-                                "uncompressed-sha256": "3b6a493858fc4c187b578c6371c72eddb312d668af89d5384b5024aadc3d39ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4822159bd115e11e6f00a0d6b934bb6b9551e9463844d32a60b320e9af45228a",
+                                "uncompressed-sha256": "1890ff5ebd9a44d09f9fabb91ec13e36cf8c54d95e50b03d651b375a3844a231"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3c474eafcf4057805d9461f4e71d23106dfa176b50ff2396b99269c0aa81b6d8",
-                                "uncompressed-sha256": "f05312d097331761b246f34bbf3ed1c7ffcafa8359e434dbfafd4f3f8343aa64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a5eccb6fc3c837bdb451b1e0cfd01e18fbeadf1d16ce194d6712ca5ada0f2089",
+                                "uncompressed-sha256": "cb4ccc82fba8dc6af9a3a57735df62cbff9902cb975bc1396b6cd03071cacc04"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "204fcc507b6a9c5dd9cc45a96ecb955dd32a49184aae68def2f9b4c20fd0257c",
-                                "uncompressed-sha256": "28a4d2b958a24dc4d7f7719553514968a061eb0a36953b6207b67d7284b6a88d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c79bbfe87000aafb6f3af83507b34e7d417a3ee9de4e08ff5a7cf87ee74f6cd0",
+                                "uncompressed-sha256": "95d8dca8b451ba5676a69ab33d8fecb207b7019f6c85dea2d01b7ad0ba44d52b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "adca12e1b715b7c76f709e2e4ba841c8ac59302136a867eeabe580b395cdc71b",
-                                "uncompressed-sha256": "d551824ecc4dc50f5a60c65925cf076377ba42345bde1e3cf99bf725b6e3a3f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cce3051a8efa13443ae20f95dea06376311350e44bdb0687b1b7fcf4788e376d",
+                                "uncompressed-sha256": "f37477ba9119df25754b721562ce487abb7ce8003e3d48a6112f621f35ca6a66"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "73d39efa05c9bf4049c90799d821ceacaf639057a82a983dc7201bfc1be59357"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c590ddb8c95f4bc5bbc36c95637caecf63b8b1a1c69a0761456c8384c67a209b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "35e387bd01c1eac02ed2e63d81a7fa60ae58220bad55f3e3f7c107ca7a60c7a3",
-                                "uncompressed-sha256": "5d19df54349434a6cabb3e61e3430fa2728536765ceec81d8b6e03590d94006d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0aa92e6513a15669a46806c02ddfae918d24ffdf010ea61e8c85b40729f1cd33",
+                                "uncompressed-sha256": "dfafb2eafca99f067dc0925970ef2a0d98ea45bdce23ac2f6a8ff1c4b9771cb5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live.x86_64.iso.sig",
-                                "sha256": "70b3ef460f4d8e15a31e3c7baeb65f06b4c058cc00b41c563d4ad0cba9108f3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live.x86_64.iso.sig",
+                                "sha256": "701fb74f1762a1ebd37961b0f4ee686cbba0a7b6da05d0713013ba1409f47950"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-kernel-x86_64.sig",
                                 "sha256": "e2dc5040b4dd3a2a2d1396d3789106305ea49157bdffa796eb8df218fc380b57"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "cce8d2aac87f44f3ae1f27aa8ce64ff4b7a9a7ad18d1263ead4d6fad3e051aa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "2630a11dd882e4f0815ad178ec2b1dab6939332817afb54f1487d4baa8dda639"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "00e5d6a7c7d7e5048cf48bcb69dbd756b3d67bfb87d48bfc04c5d1831ca5ee41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "64be041a044bd6e49556bccc2a2db4b64cca86748172465ed504bcf5b9868188"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "10582d93fc890961e80951bc05fb26d4e3522d2900099062bf174622bbbd867a",
-                                "uncompressed-sha256": "cdb26ff4035b004a7b93bd14cb2ca68a934e7f6548b6b64d15abb410e13747e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f578833ea2f855da47df30538e61ce64403745e181f44d4524d55e3858de8876",
+                                "uncompressed-sha256": "14da6a0687a0a4b25b931599c90c0bf47a84e1789e90675b6fff5f7e55ab6ef6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "38fcfe51e10b051b26a42547412574a1b649cbddd95193d775b54481e6fa7438"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0d0b497cf2f09892c2986700f0e7ee9966ce0c4addf47794a3b9414534b914b0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a82444b7f4422871df99913bc604d476282ca85689ab36f4c21a3d6e8c8c5910",
-                                "uncompressed-sha256": "4caeb46bbde69639f99b25861b74547a9cbf45a7e42322a9477dbc74b0d130b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b6d8cfc2b91947fe3e9567bf8d76d5661ccb055ad6400cd86c47249b99fd369c",
+                                "uncompressed-sha256": "30b216103d330cc3fd81283c94552004e3bbb3c4806d4fcdd3f2488aabe3430c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fa4065a08923f2e19bfe203ddb0701480186a400f38f4a2a47aeb00391ff0dfa",
-                                "uncompressed-sha256": "1dc7ff2be2645500c6b9dfaddbd8d71debfe10d4da80914ff6058fb0dafff8d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e1e3d323f6690142d5f675776974a0760319095380e4abda2cb2462972616a75",
+                                "uncompressed-sha256": "dd00b734382e025c88a2dc1db1d704f5b47f66000ddb56bb01fbdaac53ea033b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "4d2a6bf6f9333b7b6c90a14ad3231360de17b4181a37f5472a450a1b1478b09c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "72ae53fbe491c0cedac762b97f0423dc77d9344306a4341a14332233c7c19737"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "cad874868c49e685ae419289282fb07fdd8c3b1069f408bba98fd547f2461355"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "7363d29fb4e27d0893681f652600af40b82f78c3b715fc9d5642fa042c1a1d94"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231002.1.1/x86_64/fedora-coreos-39.20231002.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d7b92f0ad661b91bc815242d800752dcce25ee9e314390ade85b19739884c255",
-                                "uncompressed-sha256": "bf21561b60d27d32224d2443faba69103af044d4dbea7f5e5a24991d0c11a832"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "dc7754303c66abc202ee90b21cac49e86152d612c84065e99ee333518a7a2319",
+                                "uncompressed-sha256": "8abf9360b80e14e7d6490b9745ba1398144d1a3a1b4f3771540bf791550d2f8a"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0cad1ff3f2cf17caf"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-07f8e35529148605a"
                         },
                         "ap-east-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-06e84fc66cf2d4e76"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0af6f14da07a3ae2e"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0eab26a15b071b579"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-003c3fa437836dd19"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0f0e9e8a824c40eb3"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-00b71ce5104942ca0"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-00093dae80f43914e"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0bae55fdede9ecb9a"
                         },
                         "ap-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-09856165d83659814"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0688bf4953fe2e642"
                         },
                         "ap-south-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-042e731b74bfe3940"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-039ae12e0613c8112"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-071072a6d00cedb5d"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-05a98137859f096e6"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0f84859f5e00f843f"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0dd9730d3be37cb8c"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0901d409d0c669e8e"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0df6152a84b6433a0"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-00eec664baaab3e83"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-05dbd92768edaf23f"
                         },
                         "ca-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0c8708f11a389480c"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-01f677475bfb11401"
                         },
                         "eu-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0085efe5524914054"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-010ec213d37ef01b3"
                         },
                         "eu-central-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-071d044ae1b75c41e"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0c459d5bf6d5cfbca"
                         },
                         "eu-north-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-09bf81c755cbda2d8"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-03cc4c73f9ce02059"
                         },
                         "eu-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-036b01f2719409920"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0afd167de53199d04"
                         },
                         "eu-south-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0a0d4423eb8206997"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0745328a04533108d"
                         },
                         "eu-west-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-09d0a2224d2895ecb"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0d8a9dd35bdd1d22b"
                         },
                         "eu-west-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-09b43d01c0fb3fa8f"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-05f199616210a27f6"
                         },
                         "eu-west-3": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0390066294a96a925"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0b8e16315e5c85ac0"
                         },
                         "il-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-03ea7d79b1c4db914"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0b54dd351a75897f2"
                         },
                         "me-central-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0e409a340f0dbb012"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0e2217f0119454ffd"
                         },
                         "me-south-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0752c619192ddc43b"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0a9edc5c444d44423"
                         },
                         "sa-east-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0c01923a16a0e96dd"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-008d1737f02f69d44"
                         },
                         "us-east-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-0fb0d455828af7b4e"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0b0d29e0cf68cca94"
                         },
                         "us-east-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-05f34626d44bcb896"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0e2434261de510aaa"
                         },
                         "us-west-1": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-07b653d82033f9681"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0333fae4112a26ea1"
                         },
                         "us-west-2": {
-                            "release": "39.20231002.1.1",
-                            "image": "ami-01ebec60fa28fefa7"
+                            "release": "39.20231006.1.0",
+                            "image": "ami-0970cca9285284e02"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231002-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231006-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231002.1.1",
+                    "release": "39.20231006.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1d79234f39707531be35a9d9a2a51c0373b148ca63dda9f964d6ea5140716066"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4bcfdda492747e049bca06fd2b7a7621700c0c92cf6525bdacc807b3e7b8f26e"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-10-04T18:18:37Z",
+        "last-modified": "2023-10-10T14:00:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8a92d3b47af5414009a064f8e5090c815987fe683bee562b2907095abd46c5e8",
-                                "uncompressed-sha256": "97b2044061d39fbd204451b6ec87713d706d40c62cf736a51a75e5f4d6545a95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "93138945c31366c30378005a4149af92d0806bcf646a4fc112e026f9f659ade3",
+                                "uncompressed-sha256": "432f75ee47bd77587fe7b9156204e5d03a4df9855af79bfbe02db852895ad459"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cce02778d9ddcbac25922ba137514531b20a7d69aee02d487eaa90798fc35e8a",
-                                "uncompressed-sha256": "504f38207e03a89de3272010c10236425eddbbda66a77c29cb2167900a91799c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "6abc0008491929195cdabd53807bc0064f0080fc2092d8e26f5e33270f6066bc",
+                                "uncompressed-sha256": "f862eba9536fb483ae2a4899fe57aaa30c1ab5eec177f6414ddec2cb59fce82f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "c654505502e0575eaaa8938c3c30977d6f35ba6ea1f2b0011d768a53ce5c156a",
-                                "uncompressed-sha256": "3d01a1160f8ffb6ac334dfcb7681a9dea4c2d9524f439252ebe5198cf8bc8311"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "ad6523d267bb34a162919370c48316932c98c95393e8f0c39656c495a66ef92e",
+                                "uncompressed-sha256": "8b4730727f169f24e310d4e78d0d1e80f1bebe740f24ec5ad8099ae0187e7ccd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "661e3742cb1c356e6920d4e010b8fd57786496b49f4d52121542d6a090d1c250",
-                                "uncompressed-sha256": "414da351ab20265bb3af3a7a32657deafe54c30c6cbd818c5003cf9010619922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3c29b7de618e5a06b36d4cb783a3f42fe0bb3c9362318f52f2c41d888c13517a",
+                                "uncompressed-sha256": "e9dcba4404445aaffe81e8bfdcbc0f590ab1f400384bce5219e7a1a2b9b21181"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live.aarch64.iso.sig",
-                                "sha256": "f035da6ec6118e549e2c1b90b97859c9b7e59870e2f9d848ea321334185ce711"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live.aarch64.iso.sig",
+                                "sha256": "ff50582810ae4abbb413d8bd73acac7ee4aa383d33b32e021b846df2705c98c3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-kernel-aarch64.sig",
                                 "sha256": "6720c00d3427f0c61daab399f7e9cefe0945380ca92ce27ff5ff48e7b341aae5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "b44053f3ef80bb6b51d37ad11591c0a72f531739926e8f925ef7be2e808c6bdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "753f9e07b04dec60458b5552d79503757d4e406d3f18451c42c8627fa0619e06"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "de24e6872009795e75a2224c9cd6b12939b198d09f4b91c4d4272c2f3ccd98c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "3c0a4fdbd4ae2b5ed4e0f9d86e031ca699c59a9a92a9720f9f6fe689d165829e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "88d4c73ee7f5a6ff0825d0bcbb0116563d4d8de5928af528fbf950d4400cb3b0",
-                                "uncompressed-sha256": "b680518ad5c6fa58839acffcff9f6f917d7f5f0b290f11952691984fbfe85138"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "d70ff2b59f98b17e1602910f2ad525d1e7dceb10b38258421998a42fbf5d32b5",
+                                "uncompressed-sha256": "465351aa7d514bcbd7b005a34f1633816440c68e34843cc3d5ab484a6c8e417c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e65e81da70c2de21766650732fe8cbb6894b582a679a6609249227a0a4ac67cf",
-                                "uncompressed-sha256": "5fb7caf4d6c487fa778163ab03fe87ba7c0a7998441f5d7d7e6702c39df2c2e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c85990e5b5dabd0c0d1bfb2f97a569b7e059124677c3a05c573ac8cff229c72f",
+                                "uncompressed-sha256": "9b9b767a201c606cf75be9d5111aef50d0ed211c8c68a09707b4e98e69d4aac9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/aarch64/fedora-coreos-38.20230918.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "432b5af49f56fcf6d2ed9046ee7b3654adb6345203d69fa14fe8d37b72b79eb9",
-                                "uncompressed-sha256": "cccb0563fc48289b2321b991a8fa926aa83c50b15f89b38d4862b3455a3a202d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9b5ae2a1f499b112a9d1dffb7f1da3ad60c3cb863be85e71cc252b83241674d0",
+                                "uncompressed-sha256": "ce4b349e4fe5ba51818a98bf2fc6462d0660cd7ff8141f65a40f8372d475d044"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-032b7cd50facd0e5a"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-07337c53da2fe79a2"
                         },
                         "ap-east-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0d825269befebc21a"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-025c18286be6c85ca"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0b50a66440f2c1f4a"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-048427d64e8278fa5"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-081785b1b76ada7ac"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d8bc48ed50b6709a"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0227e319c461494f2"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-08fbc4b28cb470ff4"
                         },
                         "ap-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0b155aa41cacff8f4"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0f2e9591793fcc3d4"
                         },
                         "ap-south-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0d4327ddf1b103608"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d58a601f06c40bad"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0377cee92bef16890"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0afcf4ae29e3b7170"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-003a7cae4f45b190b"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-03ee98728193a8373"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-027323ef570a63656"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0b5e399223430ac91"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0189bc72ebc74dea6"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0ab6e322dccb2fa62"
                         },
                         "ca-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-05101588475eacc4a"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-074dbab78caa78632"
                         },
                         "eu-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-034fec08fd2d4308f"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-09a59414b2c8a34b6"
                         },
                         "eu-central-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0b7f65bc0da311412"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0e38205e49ea559ac"
                         },
                         "eu-north-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0feae78d4105b72d3"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0cdd00784ed2c4115"
                         },
                         "eu-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-02e4fa689b89a0198"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0139a2f4a14268f43"
                         },
                         "eu-south-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-03ea53c19faab545a"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0df0a906cd825c2a2"
                         },
                         "eu-west-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0f8abb990761c72a2"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-025b6691f17bf02fe"
                         },
                         "eu-west-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0c66d4e56cda9c0bf"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0c27c34e6bfeb5eba"
                         },
                         "eu-west-3": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-09f82bff6cdc11adf"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-056271add45b1d4bb"
                         },
                         "il-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-085aa34481c50d7a6"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d8ce913e6ac6a4fa"
                         },
                         "me-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0379bacaddc0b7d55"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-09d4cc28c1ab4b100"
                         },
                         "me-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0d62d1657a54d6af6"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-06c173ecf0cc5c30d"
                         },
                         "sa-east-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0739991b4dd5204d3"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0acf020041998e667"
                         },
                         "us-east-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0e3c173aec94143bb"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-00ae3b65c54549827"
                         },
                         "us-east-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-06847f12bf323b92d"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0625b0946e4e3532b"
                         },
                         "us-west-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0a24ae560a6ff0036"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-04e23410568e42734"
                         },
                         "us-west-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-033d2bd4397b35c10"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0b8567a30d424d1ab"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230918-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20230918-3-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "628c402076f7f154ac488a735a927ab50254901d3c0c4a1c5cd25b7ab528d8c2",
-                                "uncompressed-sha256": "2f628e1b09725b6edcde0e52f81abde905f23183c073b50da54e74740ad83890"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "4bd5c9599ff7723dcd2bc768258c591bed69ccab34e2d81648eb10a4c6be2026",
+                                "uncompressed-sha256": "84b3b855edd5f13b499c34254f884a12a806011f4246313ad6327704d8d193bd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live.ppc64le.iso.sig",
-                                "sha256": "406e38038159c36f95eab9f98c6b7beb4dc288482aea86f0b608526df8460126"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live.ppc64le.iso.sig",
+                                "sha256": "71d0a0153c626026ae1af2d6c46b82802e5423d2d4fd92df87eb626793ea1021"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-kernel-ppc64le.sig",
                                 "sha256": "60ee5e19f2c9a4cd3b9b29d86474dcb9bc182a60e0d6ed5431d448c98e1453a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "18aeac141acc07b9e513629d612f5147e64666ddd41465726520e44893d372fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e4458e30537fe78d4db1c155a1233a79a5112cb31674ee7615d8f43730e109b0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "feca37212c627ba56313aef681577c474eb10b353c2cf927b8c812c22229e5cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a1ca63f8f6717d6dc39262a66248004b9905f4e81ad54b2b1fcb6aceb0118d07"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1d56e47c4b556dd84fd8739f0611364e073c7a45fa58b1dfa8986d10196d077a",
-                                "uncompressed-sha256": "e5d471ff1c04bc6db0a11e74200ef913cdcce5594a5a41985b20b1a7fb9bd7ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "95aff7015c38b7e50b8fa62e89e896538e882f47d72830fc2e572d947d5e3af8",
+                                "uncompressed-sha256": "1a511324827c0f1ed356af99f18499218cdc8ab021f27326462298ae3352ae04"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "bc5cbac753b63001fd92982f5fb66230ece03dbe0aff09efae9d1748e485a035",
-                                "uncompressed-sha256": "c7e50b24e93e74ae3b0cb0f695b74a227e6d6ede336d64438550c1f5fdad156d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "d60f29a945669bdbd1a739f0488f8be4e69befdd2d05c1c31468d9a03908bd4d",
+                                "uncompressed-sha256": "4c1227cce678f0e9a11748122255a2ca14d6c0d6a89209abb78e4e39daff326f"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f1904efba7c9cdbf14486a0293229007820c287aa5eb99992c590dac1c8ef2f1",
-                                "uncompressed-sha256": "dababc67dfea3d8dd005f18a312359737d14e2a877bb0d45fede0e3eba3344ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ed1787ef1abbc514cbd4a71234984e43df83bbb14019dd7f560a9a2a3ee8e331",
+                                "uncompressed-sha256": "2f3547b64623ec37f8ea3b660c957baa9a2fa4e5766de40a9f6a668da227132f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/ppc64le/fedora-coreos-38.20230918.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d9761ec65bb1d6d8767556b6651fefd1258d8aa0406f18063fbce9b32ba79ed4",
-                                "uncompressed-sha256": "717844e1533fddc23342a1bd2752b33b532cdf3462cdcbc9606adf721dcfb641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "25f44fc60f2858836365e955b87b11e3b5a2a694b6523497cd05fdf77049d5ef",
+                                "uncompressed-sha256": "03ce085189018c434e1f014e4c9b2b4fa7b3ce1a05acb0c1b0d9b7dbaffce8f0"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "bcd95532930bf6ad29e95e23ff237076a116229c316f559c2eb7e20354496a87",
-                                "uncompressed-sha256": "99735df0f35ab97c70a0a4d6f7c98514cd7f2ac84e14e51f4a9bb6d03cfd68f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5acc63e3ce47c701c6c88408dade86dc6a754fa14a7f5fbfaa8250df1988e572",
+                                "uncompressed-sha256": "c1ef3ef191e34e06fec818edfb222dcb0f3ec41e039946e46a7fe04571ca3764"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "13168259d66bfda419ed4e54c810afac08554041521cac436ac747e080dd50b5",
-                                "uncompressed-sha256": "faa1e6f6f078ba1cad30c3f9993f0f711203f63f449b85bacecdbcf69d1f328c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "14955d0d62d7ccdaf335e8229bb1f6b3fd4575c6f583e4a2807ae5480de2816d",
+                                "uncompressed-sha256": "99162f6cd9de60eb708fc25c5fa98ce85d53f7be161d543a423fe30d9304abcf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live.s390x.iso.sig",
-                                "sha256": "65fd161b10f6b543550307326879432ccd90371b057067e7875694c858f3a874"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live.s390x.iso.sig",
+                                "sha256": "defa38685ab4a39880c9de5d75ad0ac962f3d5ab37e95910547ee6310579e20f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-kernel-s390x.sig",
                                 "sha256": "25ddda8298326c51f22e049e25e896cfaf45f9675895cc10e1563892f8ea0260"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "0d580f098fa06ead1a48667b4d9c157f1257eb62972c9e65578ec63409146d9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-initramfs.s390x.img.sig",
+                                "sha256": "98a8140f4d74f65fa2f69d5b636594a68b72b8a2bcfe39192338c7231964ccf7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f10eff36627fcee1eee976e4cce00b9889fd5068c39e7b56e69a5dbe6509b138"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-rootfs.s390x.img.sig",
+                                "sha256": "8324f7d8753363a3f8308c2ec56c65c90abe3dca91910e478734a3f964d91042"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "5e976af8b0c42ca211ada51d9f7e4d8b898bb27373cf0dc743a9bc502086418e",
-                                "uncompressed-sha256": "d314cbaafd345cbfd51fc755384b2e8862b8a6109b9fd11a399b845278ba586b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal.s390x.raw.xz.sig",
+                                "sha256": "2b6afeb34970b3b640e1c63f470b9781a45d43e9ae017ead14419d19471d8d9a",
+                                "uncompressed-sha256": "59acf267d631daee5e50c73c6dfb9bf377670c0c2dce7ebb7c2c5d3a059a04ae"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e86ac0adb4cf572d1e2097423841c6e6fd318503bb0aab9690bc68f84f67c8a8",
-                                "uncompressed-sha256": "30fca5d51232180d23a20c1b723c3e875a5c2d47e51141aec04c3cc3393dddec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5d46ff6046a94ac0d93ad2be9018ef5b9702e892d10f6bf48e614bb60d88ee66",
+                                "uncompressed-sha256": "537afcc9e38516cdc04469884ab84dc3528dee528de32536dc3fc51ce985132e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/s390x/fedora-coreos-38.20230918.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "13cf327ba0cbd17dc0ebab2849cc7ecd3b4e5e29981a505634fad50701017e4c",
-                                "uncompressed-sha256": "430b70c1c268ead7614be9c9d1562f4935958772891093ab0c3467fc5890efd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d93322af0e67116b54226a1c9d0b6aa460a617925f0803dcc2abea83c8d6b8e5",
+                                "uncompressed-sha256": "8aa305c0c4f71140aa8529874ea01953d0c604f91c6d42e3c049fe233772e3bd"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8bbeee1e3a0ef2d1df6d324e014ab7af75515e1eef0025aac472362426c26819",
-                                "uncompressed-sha256": "dbc791bd31649837df1a1ab3bc8c264d1d743a74f305ecac306763226fb0219e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "540189857b3405a5fa70d433fd776f17c545fd088eee7569c435316b62677f04",
+                                "uncompressed-sha256": "5baf4cea3a5fa3c6fe82dbe194a398548223d4211d6cb6c704dda9eaed09b2a5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d71ff8baa0731f485bd25aacd4df10fbb7f7920ad2e884a217c269ae3f0c8395",
-                                "uncompressed-sha256": "52cb73d96bc28d123b4de605c66bd1d7cd82789290b2c3e4214fd30a736ed5b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d369afd0ce505805167f98d36fac22313de38b161c0aad429bd5ce347743be15",
+                                "uncompressed-sha256": "330e048010b51c33997edce7da397d75632435b4e757af61336ddfc2fbc1f56a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6ccf4fb3d037db8d1a7c7dc6148d0c86563febbca23baf40d6af0a1a78e8cc00",
-                                "uncompressed-sha256": "0171439b211f194d44f3fea1cb95a448c5d84b797b5891c8c2667d2c40fbeba7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7c7a2031f50e3a8fb17cfd51e4c34a3cf0fc38876d5b33427fbfe664cab71358",
+                                "uncompressed-sha256": "91a1ff9f5bacb5d3706b3a0c2111597c6699f7ed1c195dfbea3a65bfa2aa8d94"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a8ebea6dbcecd4452d4792643e65483197d7a4712fdad25fa476edb8ed1300ab",
-                                "uncompressed-sha256": "f6250cdfce1da2e81afa28ff8152045fc0e83e7d45f0353f78af974b23718b75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "aba72d4c2b25f489f5e306cd037c484a9cab0ba692ab631cd4c533fe8116f51b",
+                                "uncompressed-sha256": "d2d40ee35cde60a3f270867a2f37bcf59d659e5a41e1a29c1555a1b3fe2b2c92"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "fe295196cac332a8188bf37c73d7bcccdb5d7c234cd07208c4905b413a3318f0",
-                                "uncompressed-sha256": "f69b9764d99b1625f1af089b4ad6c74fa96188b4b16fca053f946cdbdf3064d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e5ac4d38faec01fdf1257a76f5721f3b94e86bb186453490579e00b1cb9f5c1d",
+                                "uncompressed-sha256": "21582a257b95c648d73d52d10f211965d65b01f6238f1c897ecbfcd00dafb40e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "82b949b90ad157d288deaa8989f718c2a1e797ec4ef6af09538c4acf6e893222",
-                                "uncompressed-sha256": "99b9a34bc933e23f6ef41081a45e3a6e042ba7065786f71e62fda8d0ca4418ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e1000d602538b202522e0526524b6eef73abad3b70916efadfbea3ad67b1e050",
+                                "uncompressed-sha256": "6fd3f45702d1df8e21489f25cbce2c9119a2ac1283eb20204201b72fad1b2038"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "431bd32f1315032647df6cee147ff3a0387c8b54a55d068a439bca2bbda22e23",
-                                "uncompressed-sha256": "f7d1659bffbb5f594fc4fcffcaabb04c206b5e4ed4a43d4cd674aed7107870da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "38fc9a4017450899aed283c14f25a1652a1f22036b592da19aed33f9467fd051",
+                                "uncompressed-sha256": "9421674469d6d0dea1eadddab6898bf731d934ced28e5946e8bc556c89ab694f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "c754a9658f58986ec2680c1529e5d8f7740bd671cd8eaf91f81cf7a401754525",
-                                "uncompressed-sha256": "3becd25a60241d6dd895345ae833b53481407f009db2a55ead027f70f719c464"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "52046e8048601ff1f5b9981e1a26266156b3cfcb239d6919321333ae52cb3acb",
+                                "uncompressed-sha256": "7e4e607bca92589af7ae12178ded029442d7d6f1f07af6d86e621b8a43d45733"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d3dd5b4b23aadeb01b9f70990381960df4fccb0433d6043f6ad7c950ff222180",
-                                "uncompressed-sha256": "c4447e363382f7c8888387fc405a58b8ab6fede48af7de3ad49aa6c69ddcc346"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f0be0ceb92f2bf402e9b0f11a5f28afc68fd6ba3d6154eefc8ec0a578c16862a",
+                                "uncompressed-sha256": "f76d09d4291437fbdb57204a97cfed97332ff1267feea63c1ae900e89cce36e0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ce02fd78bb358f5d1a140611cc2234d43d6bced9e664f80c702789ecd093b6c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e208600746d1325de51f11f7d2567c6158084c32d0500e5af50e7ef8f51af465"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1400efc09a251c338d08577aea2c02a955ea0e47b3e092521e61672674ffa1cb",
-                                "uncompressed-sha256": "2eadd19900bc2104d76dfe5a2b1ab7c05e5269d9ed55bb553f216554a525b7fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f31f09497d5e1d830f3f84a270301cd55a1cf8113118920705724654f39dad8a",
+                                "uncompressed-sha256": "59d5c19456beeb5eaf3ef4df6a7006033117ae196315678bcbfd7a51cc2fd675"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live.x86_64.iso.sig",
-                                "sha256": "41c954a561fe3d8e4235b02335cb5f0a88eaca09ca2cd06417e0470c1c2d87aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live.x86_64.iso.sig",
+                                "sha256": "e8f5d83dd31432535efc6d3e307e0b9d499ac6c445fb2c4bcd43c6795d47f54a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-kernel-x86_64.sig",
                                 "sha256": "923ac8fffec0e776c0250432b867da0199ffb7da40300fda602bd6be1938ca92"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "fa332340548cfc7898d52c5de732b4c0834130381300c29413e8d857241c7290"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "afb6cce0a8f36f72b2825ae512a7ab46dedd6d8bed865edea0986d5e942187ef"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a6198ba1c09ff12d43308801767fdcc78d42346d41391fdfb27c4e3fb8bf1f23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "1df8e889b40c835795a58e94e4ebc66d0001df59ad12fd1bafa723f8a9f324a3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "778ebcba0f597e8457cb86879d2964e5f73edc266c516256a58ae5b1945915a9",
-                                "uncompressed-sha256": "73baccc3c3dba8dd328291bb9c5f795307a4c36b6d10848d5e7953d6011accaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "e4dfe894c89362d4e02e3f259b54e771f089261abe1684c04b9463a2608719db",
+                                "uncompressed-sha256": "6ff36cdd80065cc1e3348c4e6d802b01a6914ac4387e4fedf09963ee807892d1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "bc5e314f9284fedb6ad0a049d5d45f12fb3b28679dcb015b6f44bee0587d20ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d517592fd32c6c1cdd6d108efab977fa8b8ad4185df2261382c17c06d206b31b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "824ca0f2d1947e0e4182d9aaa9bf486002d394652cdf2682edb2ab95ec73f66c",
-                                "uncompressed-sha256": "50499a0965ec8c80ca04b9a16acca370e4d53637ff1e09c3994bb5183259afcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "16d609f17bb1c0f772ca8c9e7aabb49f8f2d9a50c2326d29ca68979912377491",
+                                "uncompressed-sha256": "6eff43918411669cccf8a2c8ddab0a1f0aad5945bc06fcf5db770939489e59ab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "52d98121563a61fdab6924a8e3190bc1cbf7775942d8a8046f9ef2a689ed7aa0",
-                                "uncompressed-sha256": "b12ca08216348f4e2c0968cc6b5506e6327f1bc89841e0e9f3155185c8ec217e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "31011034432bd11a3ef5cc85f1765ed5ab675188b5e15b485122e90f17b123b6",
+                                "uncompressed-sha256": "153c07de0ef0f7406896ad82b14be505d0fdc1bfba7d0509e7183d5a400a5d96"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c188f6467394ede3c1effb4dc55fe1756faf36e6fba48be44969edcbed52cc81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "b9c6ce542333d414f9008e6feb5d34d3ded398249e9ba2e62eb30b67a085af41"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "5e70c9307ba353181c86805f9be8fa56c516795a1becc6ad27fda5005a3be57c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "644ebcf45ce39a1188448c1faa10e073163bb4b10e354fb79b2f39e1d69b0b9a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.0/x86_64/fedora-coreos-38.20230918.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8fb942bad8df8cc930da4eb729f31b2d8f7406ba4a4fe080d6c8e0c22975be0f",
-                                "uncompressed-sha256": "11caac4af38a8fc2f7d9805c1357de6a12c64d67fccd82c61d4822ac54b05f01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e4fbab45c69bec3845ba5cb445a6f5a383dd853557670c51a825d460a5fb4554",
+                                "uncompressed-sha256": "9bb48feff1025e4aa69df391f26b09e62d09dbb918aa02021bdc36175fa56ca0"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0635472eea3206ea1"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-065437c051370c44f"
                         },
                         "ap-east-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0cb17dd6b2dde740a"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d7cabca15d0188a8"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0f3a851628c62d95f"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-04b4a7b3dc902c749"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-03d63b7c01e34d67f"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0db3f16615ee0fb6a"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0309080452404f866"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-025bab6544b34e570"
                         },
                         "ap-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-03a57eee9b6f6c7e0"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0047d5ecb844e3691"
                         },
                         "ap-south-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0d694deac61cc0968"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0da851144996bb499"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-025c3e510bbca3ef4"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0fcca80375a7f0a52"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0f359127e88b1dc00"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0bf95628e1d3a9670"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-05594d4713eecafb1"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-04fade0c2a9a29a3f"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0fa09928d7c608a8f"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-094c41871220c9f8e"
                         },
                         "ca-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0b420215dfea83046"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0ba6d30296e0aaccb"
                         },
                         "eu-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-003df8d5ee47d3a95"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-06265981883982e6f"
                         },
                         "eu-central-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-08c2a52a0d6fe8800"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-006d0e49984fb13ff"
                         },
                         "eu-north-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-011c5b8300321ec61"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d7a68c9f78de73a3"
                         },
                         "eu-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0fbcb1c1d677cdbdc"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0a27fea9039315252"
                         },
                         "eu-south-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-029a0ad6b8b6b747d"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-082360313a509e4a6"
                         },
                         "eu-west-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-000aa36383fc9d104"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-07ed8a2eac547603d"
                         },
                         "eu-west-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-063f568d6cbb9d5e2"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-097be233c78403c65"
                         },
                         "eu-west-3": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0e7523991e41bbd92"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0aafef2a84eeac2fc"
                         },
                         "il-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0c9cb7858cedbd6c4"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0e7a9fa237debe057"
                         },
                         "me-central-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-012455c58e703b5fa"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-07fcc5474ad6324f9"
                         },
                         "me-south-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0a475a021e2d07374"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d4296d96ccbb3f91"
                         },
                         "sa-east-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-00ac1129ec1741e20"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-009c2e9ef554bdb1f"
                         },
                         "us-east-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-0764cd71059587de2"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0d8d8150576293a30"
                         },
                         "us-east-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-03c51f514ec6a3d09"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-06919c5c51ba98191"
                         },
                         "us-west-1": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-01ecff683d8cb1f78"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-0ddfedc82cd7e6a69"
                         },
                         "us-west-2": {
-                            "release": "38.20230918.3.0",
-                            "image": "ami-071d77afdc4233d40"
+                            "release": "38.20230918.3.2",
+                            "image": "ami-08918bf79c6a165c0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230918-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20230918-3-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230918.3.0",
+                    "release": "38.20230918.3.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fb208e11fd5485d288c68e9e622ee16375ddbff712cfe8da24b516579063b5c8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1f9650de0992f6675217ffada2ac1cca973434c95a217ddd87057417cb82a6cf"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-10-05T04:07:56Z"
+    "last-modified": "2023-10-10T14:00:10Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20230916.1.2",
+      "version": "39.20231002.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231002.1.1",
+      "version": "39.20231006.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1696514400,
+          "duration_minutes": 2880,
+          "start_epoch": 1696951800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-10-04T18:18:39Z"
+    "last-modified": "2023-10-10T14:00:09Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230902.3.0",
+      "version": "38.20230918.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230918.3.0",
+      "version": "38.20230918.3.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1696445100,
+          "start_epoch": 1696951800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).