### PR TITLE
Roll out stable 38.20231002.3.1, testing 38.20231014.2.0, next 39.20231016.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-10-10T14:00:09Z",
+        "last-modified": "2023-10-18T14:27:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "cf13838a209ae127ef421d9258879da4fd2e85c36e1233442bdfae26fae16c7c",
-                                "uncompressed-sha256": "e9c8700f625796c4b065533d4ea2f0ee1efb744bc3802af40fe8cc29333c9fda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c6df5a9c30107aee4d0812f564c37302f14daa61573352c87e4abe9d84ba824f",
+                                "uncompressed-sha256": "5e95d2d759473da6dbdddd2a0238e35998ffb85e6c95c3192f0fbcbe416153dd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e4d57c8b02d45ede005a8daca6ea92257794d19d9177713771318201efa14647",
-                                "uncompressed-sha256": "92ec0d45e0a20bac69c8e47b4d415c54f456f3904989de7076d51307f7f336cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "f1740d09f248456ee7811dd1a88791d62b199ddabb3f086bb5d7db9dc747dc90",
+                                "uncompressed-sha256": "0185d35accfe75e8937b41d878d7442bedd1a5be28954b5f536a5a29a0694132"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "10c246d1856f90938a649241d90778935ef78c41059539fb113b521768e3fb5b",
-                                "uncompressed-sha256": "4cf93ce6d2ae20a416f79a893f12f2c13a56c0799d2873b991f99cd517fba3e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a6790544232725d9d8dd99523724be3964c1df35e21605a4f1ccfd33f0051685",
+                                "uncompressed-sha256": "11a30d84c193be62b18b981d7e9ab0089cda5c0b2364299e6afc31347f3049a6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e1eae7db0bd2a5f8b01c46b3c40df6c367e72aac0e996c0cd138b348d129183d",
-                                "uncompressed-sha256": "d6fa8d9eb473bb0e6a7fcc539ee6bb8edcab48393b314bcb975154f980895bd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7f520bc8e26c651514c3941e57a6febcf2cf357c05ce4d87bd5468f9127d6805",
+                                "uncompressed-sha256": "825aa9388c1712659baa60c9ac28a24b4b024982d20bd2a42288bf94e6071332"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live.aarch64.iso.sig",
-                                "sha256": "ad470ffcc5995f0bc0a2f40b83c504acab45768fbfdd34dda3702752683b6d2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live.aarch64.iso.sig",
+                                "sha256": "1f46b9fea40195046f3143f26a4551274348c0553525b7168a98f8c7270d5789"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-kernel-aarch64.sig",
-                                "sha256": "e77ac23b7c4954c2d2e710865098bdfeda72cdf9f9039243f1bba30fcc65d75e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live-kernel-aarch64.sig",
+                                "sha256": "52246027427a8b5d6b214332ef3ff01a0df157ef076b4c493b13426572442454"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "824d9badd18417c5f7f7a8af09a22719ac673f3c4ccc3ff864b262854a50b7f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "980d10ac9f0114e58a3e07851954ff3f901d240f1852ac3ac29f279fc187ed6d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "81af205e62549cc01aab7ce759ca5ec82988f41f7e7bff92fc267cb9ad3a0ddc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "34f05dc2d02bb7cff55b426277841734a3e9689ace744acdb837606030339fde"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "fcd65891d977f4b195b6c3fde44d5f4032c34b50a09684922cf4bc2083d8b995",
-                                "uncompressed-sha256": "64b4b0503fe546cbb3c3d49c2396a8787670a4e17869f45e2c35f96346eba0e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "32241d8671e1d18b861888a8a8c1aebd046b424f1a323fe4fd92d6baa6487e6e",
+                                "uncompressed-sha256": "81c264fccd97cff62ed2ea564e5dfc25e02411d151d8c222840b2dd703d72466"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "caf8a3d3605d3b39df79bfbedf3790d1e6e2b991e32ce14bc1cba68516927525",
-                                "uncompressed-sha256": "7d328b5e16c42cf76a3e81710ab92b08167708181e9e308c307f8c0d0325fd55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d65dc1ad1435bac35832c0cac88981f58a8feb564ae16f9f6c0fd42b43165e16",
+                                "uncompressed-sha256": "80a3b662b9c955ff7e700e31568a8a75e25f01eabdc93dbf4ea8ab7d98ca6f9e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/aarch64/fedora-coreos-39.20231006.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "44ffbccdaffbfefe3d9fb6ed771820283dcbde07867d5aeb5df7c3ac64bd6259",
-                                "uncompressed-sha256": "304f8e4326fe340825a222adb817df3d302272b977146916c7e39c7ded5cc3b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/aarch64/fedora-coreos-39.20231016.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6f6b651860278b8adfc5f7beb572dcee0b263c0648af49f31e0b579251fd5fe9",
+                                "uncompressed-sha256": "cb744276f451e80f7781e3bc81d4ee66814f352f6f0a3ea702f8c1984759d1ca"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0dc360cccbc497b87"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-000e1bd28d6af8969"
                         },
                         "ap-east-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0513279059036d745"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0fa99439610ce7e9e"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0138963b7bcfa997f"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0782ff435cb1ae14d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0a7a9b96623e9cedc"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-08eaa9684bc2eede6"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-000d86ba8edd37f2d"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-07ae02f443238704b"
                         },
                         "ap-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-08ed5b574a2ebd2b8"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0d973aa843187bc6e"
                         },
                         "ap-south-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0767b714e99819838"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-050179d63b6f0f8a0"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-07289a9e81abe07b8"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0100912f91828ffa8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0ad1706114261dd40"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-041c25ca8b742d365"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-06cd3a6f35df877d4"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-09d01db925c109a4a"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-021ea8bdf006049fd"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0e57c2fca7c13d6ce"
                         },
                         "ca-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-02c3234b61fef9438"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0ce394a09e71b2fba"
                         },
                         "eu-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0b77df33910a36cdf"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-05271cfc47c99c9cb"
                         },
                         "eu-central-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0873686015438d4c5"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-02c699694b480f278"
                         },
                         "eu-north-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0420e68a2f363a14b"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0cf0b9e73c580ba53"
                         },
                         "eu-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0ae9e023ee7b47688"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0085b710dfa690184"
                         },
                         "eu-south-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-07df1edc036571445"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-09d7f6232e27d65f3"
                         },
                         "eu-west-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-06a276c578e02f16d"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-06f42085ca945e785"
                         },
                         "eu-west-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-084f879f23bc07fc5"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0d730dbb1e8b611ad"
                         },
                         "eu-west-3": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-04cff852e7340e378"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0cf2900ea70d49ba0"
                         },
                         "il-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-09c77f0c5a53aed70"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-029f71126597fb455"
                         },
                         "me-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0213c188e171f820f"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-07003dbef35c94c53"
                         },
                         "me-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-072f71df559d0e933"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0baa4dcc8973958b1"
                         },
                         "sa-east-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0d8616680e1865d3d"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0805a1223c65286d6"
                         },
                         "us-east-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-02b78519d11c6b274"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-014d4b2fc6430bc23"
                         },
                         "us-east-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-03b51f459c4224dcf"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0a432c51435315db7"
                         },
                         "us-west-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0677998ef2e374ab7"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0a631ebb3fa32a927"
                         },
                         "us-west-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0a485cd4044a51308"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-00b2ed6981e899307"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231006-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231016-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "31231c357b93e1e34ef67e107feac2d7fd2525861392d5fe329b7be3d99ce7c0",
-                                "uncompressed-sha256": "f61f3783f0a05862c5c3e08be2f5f0bffc5dd9fc6a67a710b33344b982d539b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "4dedf4851d7f7a6b956041cea8a4c04e77aac5ce477aa2c08b2c0518ff0eda25",
+                                "uncompressed-sha256": "5eb5ca8ed5070e7042b55c04d84592bc1669441059d9162aa7dcdf5cae6edbe0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live.ppc64le.iso.sig",
-                                "sha256": "089d91944f97f329d05122c1ddb21fab705595846167be6bc33e8161e6a025e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live.ppc64le.iso.sig",
+                                "sha256": "4c7a5a5eec0a79161830e2e3ba3dfccd956a999ce39e2cd52fd785a55de5b90b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "efb9ba2504e36eaa1ff816d2b918758fa5e77da957555546fedc7d94a5d36ad1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "6d77658130a7de1dd014ae14d7983c27f8ba1a61fa02e8d9064afdb8519e7e96"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b06a6cebf1e8ae0bd180e1ea1c00a80184c2d7436e821cdbc28adbea47a0f9e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1fc5df5e8cacce6c0a8031e7604b846b05816dcaba577c55e59049579c789345"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "cc32fe0ca5ec126a00c2b04b28446628aeb8ee83800565f39dea53951ec90021"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "2df4f5f0e5a3ee5e242b4518a0cff9da306158c98e9a656ca2616974d1743a15"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3323683c4ff97d28a88838d77ed5a976a767ba2d3e0f35b9314c41fc5c788f7d",
-                                "uncompressed-sha256": "9fac51e6caa0b6b670aaa5940e6f31ad80584a3c6072e110ba059cc8ecfbeb97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "fc1bd699001b7ddc30f84182097979b592955dea18cf34bc01ef14e3d2d85f3c",
+                                "uncompressed-sha256": "e8e077b1d97b661fba8e911f88c953e330a875dd523f70c2a5d08fdfa6ce17de"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "20608c032ea1fee60b1af335f717ec2855fe8cb613bf112b233d45133cf58eb7",
-                                "uncompressed-sha256": "2d3be577cdd8634b937f55bc7be30781eff8fec0f5a0c69c4e5a645c9416ade8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "eb5064dc180824ca4954982e330fc41be49dd5420f44b1085dd76d236b5658ae",
+                                "uncompressed-sha256": "2736af8726d87416e6e4961450db93a07ddd7ecefb832c3b6e139ea7a016df62"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "facd2481f3ef3939ad3fa2f860390897d4a55cb947a4de95d3a1694925a16ebd",
-                                "uncompressed-sha256": "cc81ffe0e86f83f393c0fbd78cb6ce9cfc51e17caf72e50fbd8bda53a6692a1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5718f21a47dc7c75da9eb54c5b12f372c051e3fccc0912a526ea334fabc0aa12",
+                                "uncompressed-sha256": "ed099273dcfc50a9f72fedced74e653def4e56dc74bb04d6251ec8862d3f851c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/ppc64le/fedora-coreos-39.20231006.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "96221a18f18734fcf12a3f6b4a21fcaf39dcfe6c737cdbf88a410f2d716183a9",
-                                "uncompressed-sha256": "e8091df2569d225276c26e026dfc8b92800dd3bcaa24fec11d154c20dce1cad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/ppc64le/fedora-coreos-39.20231016.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "fbb91b404082a94f422db3824f8c10345a6df673af1d6985585cb71169a0454e",
+                                "uncompressed-sha256": "285b50f3c2db3f1cda256cfbd1b84f460e7da7c2d7d44ba7302298d9f558c90a"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "56d33de7cc1eeecbe72409d38fa3d85bf4fc7255ad1d492ff19717137bd15a96",
-                                "uncompressed-sha256": "c212185f827814ee9e5a3f4e09c328dccf772ab5652927492c16c4caaf5bc7d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "64963d5362535c1f11ce5805b00047ec0dfa4d78fdba36112bb57f73d1b7e782",
+                                "uncompressed-sha256": "1641156187114073ab38034e2f8d39fc71345823e788b85cd5205730570acfbf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "89ddb3cd7f89370cb6e7d48988227bebc422600e29e3643fe7b21b2c19bbd5cd",
-                                "uncompressed-sha256": "fd05f8cf6d2fc4c066d5cab5e504ee566ee59417534a6a2f568f64b20dabec9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3fe6d98cf6c1582fd223af2382034dc4ca4b18b377fcf8436bb8dbf0c8ca9538",
+                                "uncompressed-sha256": "da7790334fefab334135149392df68ccc1c3fcd0bc87b90a02b9b7f9627d9b14"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live.s390x.iso.sig",
-                                "sha256": "dbd356793d9bf8421d734fd53907c123cd9531ae1ac3d895e7ffec47626dcb2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live.s390x.iso.sig",
+                                "sha256": "2553422545ebe57931b5784be04301689d417624523819cc4b1cda197e4b345d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-kernel-s390x.sig",
-                                "sha256": "8310a3da29b17e6076ab10cead79d2a80b3beeaf1f17ff058567ef6e3d79d342"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live-kernel-s390x.sig",
+                                "sha256": "42b8928653e16ea0e19aa40bc56f683945ec52dd89b0102e6c405c8421185e00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "1e843ae407dddb206866c62596e5d974a5aac872c9659f3637ad5eacc96d6b12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "2d1d160f0243fac6ddd4d6d4b03531b0a0af8f6c8dbbaf1bfa71aa502a8a59a7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b250ee4500511c2ad3e3b65855da0f637a2219f05c4790ffb57c4b6874da2857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f519b6f749af72f0aeb670571b9b8f01b22ceb9bb1c20aa39f9fb68fc67fa2b6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f8dec4a6ec30f92c03d6cf39a35d5993540d4c5450afc8b7d870e0c55fdbd1c9",
-                                "uncompressed-sha256": "bb2274cf3c09bc4b3994c16fcd765269f16fb0215def8ec892535d0c4a5cc13b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6761ab5eedff8d0fb2b2d6d851e45b79abe258c2e965badd459842f0cd889800",
+                                "uncompressed-sha256": "30c30a4d2d738543f38554fd08b0b0c74e5bc34c02f8a91ad7f2a78d89ae2bd1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "79c2872211ce0a702cc6a31f7f89a9e9992ef286862801d946f76f4eb033532d",
-                                "uncompressed-sha256": "e4bb808407991694e5cb1d6c389916b104469f77c1fb14a250f1c676c7444cbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ed01c257f82d049b6c35e03cfd09edc551304b8234df3f93a2d5f28cfe9488e7",
+                                "uncompressed-sha256": "44d2da9511c7824d02b3a2b763ae5a5a00f07fab1e9394ca2764edcee2777f80"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/s390x/fedora-coreos-39.20231006.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "1e630d73a92201e27c2976c8e020ed2324e9e0f612082f36698d047e0a7008e7",
-                                "uncompressed-sha256": "30be75bd5bc50806fbe53c35a24a1bba9d63d0810ed039e841cc818d86381325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/s390x/fedora-coreos-39.20231016.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "69fc865c3f9f66f5d0f81abe6a7b6139b5a7b5421b03fad7efeddca9667cead7",
+                                "uncompressed-sha256": "2f0d49b3b083d377a24f679a0c0f79d65399ef5c09f36b12264f6151a77078ab"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7b3fb12bce2196ef10fed7a41776a0394f91e1f37f418e7cd522cbc40e51017f",
-                                "uncompressed-sha256": "8ae7935a7dd714981b7318b0a78ebb46fe0e8cf169cedabcddf4eab33feab644"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "becf115841d22fd00d1a3ba58e5b0654d2f28266475bc1a1043c3a273e8e0d42",
+                                "uncompressed-sha256": "6391aed95d7958533a0e4555978a031cc51c40b2bf83cac6ca415c58ca6ecc50"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d0079083cc38b52e516bb41ea9bd05bc990711cfde945b4fc32461f5309e66dc",
-                                "uncompressed-sha256": "47504e68eb90a978ed1b5a85b2f2b22d14c278d4543e911956aa03c4875dd0ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d14b9ebf88b04755e68c5def3d8aad72ad26170a7ccf583366f18bb5008e9e9d",
+                                "uncompressed-sha256": "9526a1759fe713b1037d391fbf4448d3a1e074af134adff3164f6813cfffb3dd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1d6ba9f390b25d162aafe2ac01a986b3df52360769affc1b97a3ff88f07986a5",
-                                "uncompressed-sha256": "4f206615a7d136ea4061f901c38a14c18caf5f12c5ead58b9b85f4d0f8a577f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6db5b81d7b9d02b2f4fd8c60c5b4767537d3e02ae0705e0ba04a201dd2c75c54",
+                                "uncompressed-sha256": "7e2c5bb186aaf22afc43fb7ea3999dd8c6f609ac58b597a92ef20deda6e2f911"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9c4b19866e20424619262f54c7fdf6cae92bad78d85db6c99ec77c0a70450a40",
-                                "uncompressed-sha256": "32c5baea17e2a111a98506acc6ee118ebfdcade0c207e22aa09d99c1f4e1e2ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "36a8bf8535dce6769b1330c87339bf4a2c4587cbc41c066d230e86b85627309c",
+                                "uncompressed-sha256": "451dab67309c3a0ee495677f44bec2e38c02b177fb675b9709610771933a4fa8"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bf84263f7935e5205092d4f2fc9b58320793bae1afe5835452286b19eb04823a",
-                                "uncompressed-sha256": "9e6287744a81ab1a0b922a1bd01d59fb143a9558e2c95dc932de71107241256b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b5c9fec91833b00562f8f5bc93230dc08c0ad204b3da7f26950f8e3b017a30f2",
+                                "uncompressed-sha256": "97d35cd37cc5cdd34366f902385d7bea68a76b35826f23fa1f7c9bdcd27fd881"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4822159bd115e11e6f00a0d6b934bb6b9551e9463844d32a60b320e9af45228a",
-                                "uncompressed-sha256": "1890ff5ebd9a44d09f9fabb91ec13e36cf8c54d95e50b03d651b375a3844a231"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b6825787a10df5e13cf6e41bab4d26e2cd61f0414dd965ade732006f80705fb4",
+                                "uncompressed-sha256": "f27c8ea215eb432d936da9a507a8bee76ba23cb667d048c1475367176d103de5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a5eccb6fc3c837bdb451b1e0cfd01e18fbeadf1d16ce194d6712ca5ada0f2089",
-                                "uncompressed-sha256": "cb4ccc82fba8dc6af9a3a57735df62cbff9902cb975bc1396b6cd03071cacc04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a879067720eb0113baf42de487b799b164e132e174175fd408895edad8b34fd3",
+                                "uncompressed-sha256": "67cce720f78efd6aa8e951cded1fe09c5765d91f9bf9f7c7995d2eec950717b2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "c79bbfe87000aafb6f3af83507b34e7d417a3ee9de4e08ff5a7cf87ee74f6cd0",
-                                "uncompressed-sha256": "95d8dca8b451ba5676a69ab33d8fecb207b7019f6c85dea2d01b7ad0ba44d52b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "f508c4fa77b53e3bcbbc6884489e6eeb8bdb48d92f651e48bd39daf50214239f",
+                                "uncompressed-sha256": "f2648ba9ac25fc82b8097537312050b23de1d7f51e185590facc2ebec8f75001"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "cce3051a8efa13443ae20f95dea06376311350e44bdb0687b1b7fcf4788e376d",
-                                "uncompressed-sha256": "f37477ba9119df25754b721562ce487abb7ce8003e3d48a6112f621f35ca6a66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "36ff8696d88520bd4ea6c3a84ce01d18415f8d78c74d24deba6d5acd4a71b25a",
+                                "uncompressed-sha256": "6e46206f98ecd3808e7acc32be599b2ac07b9a775b3a03cb20898bf34211c885"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c590ddb8c95f4bc5bbc36c95637caecf63b8b1a1c69a0761456c8384c67a209b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "41994414b8d380a3007d230de94b9086dc26d56c196af5001c4b4e146e4bfce9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0aa92e6513a15669a46806c02ddfae918d24ffdf010ea61e8c85b40729f1cd33",
-                                "uncompressed-sha256": "dfafb2eafca99f067dc0925970ef2a0d98ea45bdce23ac2f6a8ff1c4b9771cb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d9adf6af42a97ee103f8af5d07f22206d1b2524391e3cb64e112f21278139a98",
+                                "uncompressed-sha256": "86adc6cc3ff36b38233d733e886971301452386759e0453d551816769c9cc332"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live.x86_64.iso.sig",
-                                "sha256": "701fb74f1762a1ebd37961b0f4ee686cbba0a7b6da05d0713013ba1409f47950"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live.x86_64.iso.sig",
+                                "sha256": "dfbc0c5fcea83b0042e7ab373996481f4c9d435a25798fa934c0237c4f93abac"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-kernel-x86_64.sig",
-                                "sha256": "e2dc5040b4dd3a2a2d1396d3789106305ea49157bdffa796eb8df218fc380b57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live-kernel-x86_64.sig",
+                                "sha256": "5f2ef0de47f8d79d5ee9bf8b0ee6d5ba4d987c2f9a16b8b511a7c69e53931fe3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "2630a11dd882e4f0815ad178ec2b1dab6939332817afb54f1487d4baa8dda639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "44181973dd02c7fe3af3e246733fad05cef6879289cf2717919dfb522b7057ea"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "64be041a044bd6e49556bccc2a2db4b64cca86748172465ed504bcf5b9868188"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "70c440940555ae0174cd006951af7bd4a0b611f968f566fcbd6800908b62c0c5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f578833ea2f855da47df30538e61ce64403745e181f44d4524d55e3858de8876",
-                                "uncompressed-sha256": "14da6a0687a0a4b25b931599c90c0bf47a84e1789e90675b6fff5f7e55ab6ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5cd183192329bc2ab9e60a56002f48340056f96f57e83f16bb0271e85d244a38",
+                                "uncompressed-sha256": "891a9018cb5159faad6ec6794546011092350be2dc52408a128205fc9a73e6a5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0d0b497cf2f09892c2986700f0e7ee9966ce0c4addf47794a3b9414534b914b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9aab73e729390697da5687c74f3946a55dd5aae1159519acd1640f1ce1c8539a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b6d8cfc2b91947fe3e9567bf8d76d5661ccb055ad6400cd86c47249b99fd369c",
-                                "uncompressed-sha256": "30b216103d330cc3fd81283c94552004e3bbb3c4806d4fcdd3f2488aabe3430c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "987026d16f9f92f4ea3d1d2d080db988dc4a381f4c27bc2fe0ee2149239e69d3",
+                                "uncompressed-sha256": "dc4b8108de011a49c92bc9f408167ddb567a6170f365dbab07fcfe855fe22c63"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e1e3d323f6690142d5f675776974a0760319095380e4abda2cb2462972616a75",
-                                "uncompressed-sha256": "dd00b734382e025c88a2dc1db1d704f5b47f66000ddb56bb01fbdaac53ea033b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "cf5b17da2867a78f3cea20322247e69eae65f61f38feb8bcf0cffa5e59bba4b8",
+                                "uncompressed-sha256": "b5f2bfaa5c17df0f965e61e45edd13bbf5a89fc7ef78771aa796b9b15965f0c1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "72ae53fbe491c0cedac762b97f0423dc77d9344306a4341a14332233c7c19737"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f3ec6df0deb53a4639aa3afa16f8d41c694ea6f5a4f1111f4bfd677ce48c5612"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "7363d29fb4e27d0893681f652600af40b82f78c3b715fc9d5642fa042c1a1d94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "ada86f191a7c433e54590f215d8a45c0bf9b637c9b84bcfd82e92befb6dda514"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231006.1.0/x86_64/fedora-coreos-39.20231006.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dc7754303c66abc202ee90b21cac49e86152d612c84065e99ee333518a7a2319",
-                                "uncompressed-sha256": "8abf9360b80e14e7d6490b9745ba1398144d1a3a1b4f3771540bf791550d2f8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231016.1.0/x86_64/fedora-coreos-39.20231016.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "210a2135612250f3fa2140ac1f5c69da2c37785fc2573b4c2b131abff1498733",
+                                "uncompressed-sha256": "0f4748db1839b1a54c6a9d3b9401051d505e8fc23c40c03aa6571349a932ec2b"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-07f8e35529148605a"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-09dee08074ae6e2c8"
                         },
                         "ap-east-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0af6f14da07a3ae2e"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0a46d55cc5eddbb59"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-003c3fa437836dd19"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0c5c1fdcf91f6015d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-00b71ce5104942ca0"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0c7e04143e562dfc6"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0bae55fdede9ecb9a"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-04176adf7b6ffcb4e"
                         },
                         "ap-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0688bf4953fe2e642"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-049c83e564b2f552a"
                         },
                         "ap-south-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-039ae12e0613c8112"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-089306bb1f3002413"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-05a98137859f096e6"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-089217bfeb101dad6"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0dd9730d3be37cb8c"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-07bf4ea3c487f3694"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0df6152a84b6433a0"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0e63fe09a86e32890"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-05dbd92768edaf23f"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0ca652d77748728ff"
                         },
                         "ca-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-01f677475bfb11401"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0e264e992d684abd4"
                         },
                         "eu-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-010ec213d37ef01b3"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-045a169f20282897a"
                         },
                         "eu-central-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0c459d5bf6d5cfbca"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-047612a1ed47bb683"
                         },
                         "eu-north-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-03cc4c73f9ce02059"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-000465ebd056d3377"
                         },
                         "eu-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0afd167de53199d04"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-04fd4bd48908aaf97"
                         },
                         "eu-south-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0745328a04533108d"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-093c3da0577b4b3bf"
                         },
                         "eu-west-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0d8a9dd35bdd1d22b"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-08a515c6991d5be00"
                         },
                         "eu-west-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-05f199616210a27f6"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0b3329a270542206e"
                         },
                         "eu-west-3": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0b8e16315e5c85ac0"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0cd36fcd1ac70c2ec"
                         },
                         "il-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0b54dd351a75897f2"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-00fce0119b692d673"
                         },
                         "me-central-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0e2217f0119454ffd"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-013ebb7ab03564427"
                         },
                         "me-south-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0a9edc5c444d44423"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0dc80704e4a9b80bd"
                         },
                         "sa-east-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-008d1737f02f69d44"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0f474d7216d4ddda4"
                         },
                         "us-east-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0b0d29e0cf68cca94"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0e801cda402c2d958"
                         },
                         "us-east-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0e2434261de510aaa"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-074fe84a2209d6569"
                         },
                         "us-west-1": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0333fae4112a26ea1"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0bed662d90e64e548"
                         },
                         "us-west-2": {
-                            "release": "39.20231006.1.0",
-                            "image": "ami-0970cca9285284e02"
+                            "release": "39.20231016.1.0",
+                            "image": "ami-0e5ea2cd98f255d19"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231006-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231016-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231006.1.0",
+                    "release": "39.20231016.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4bcfdda492747e049bca06fd2b7a7621700c0c92cf6525bdacc807b3e7b8f26e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e801341d58b0c9432d94932d4f5742d5e48a2dfbe518bee32230171e06725150"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-10-10T14:00:07Z",
+        "last-modified": "2023-10-18T14:26:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "93138945c31366c30378005a4149af92d0806bcf646a4fc112e026f9f659ade3",
-                                "uncompressed-sha256": "432f75ee47bd77587fe7b9156204e5d03a4df9855af79bfbe02db852895ad459"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c7b72d2be0f3be32f6265e58fccfbdd8663982c72cc6c5049cdc8a3a7e2e12c1",
+                                "uncompressed-sha256": "b9aeea96f55cfa6e3de37b66cd6e38594731be1f8d7f3bf0b3798433c672e55b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "6abc0008491929195cdabd53807bc0064f0080fc2092d8e26f5e33270f6066bc",
-                                "uncompressed-sha256": "f862eba9536fb483ae2a4899fe57aaa30c1ab5eec177f6414ddec2cb59fce82f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ef9db358e8506bd1c7af16557a3a9dea6d9f197483f6a1bf2aa0da29b84512aa",
+                                "uncompressed-sha256": "6c409464132ac8eb84609174c7cde04fd5de4c12b28442b2a7b1c126fa38aac7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ad6523d267bb34a162919370c48316932c98c95393e8f0c39656c495a66ef92e",
-                                "uncompressed-sha256": "8b4730727f169f24e310d4e78d0d1e80f1bebe740f24ec5ad8099ae0187e7ccd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3814fdc10230febcacf483616cf424664c7bb0350d2c2570b7ecda464def0319",
+                                "uncompressed-sha256": "e90a293b9b42539d54e7a68e2915c3b4df14edd02f1a14c31425543ae37b35d2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3c29b7de618e5a06b36d4cb783a3f42fe0bb3c9362318f52f2c41d888c13517a",
-                                "uncompressed-sha256": "e9dcba4404445aaffe81e8bfdcbc0f590ab1f400384bce5219e7a1a2b9b21181"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "9030b580d43d0a0df5725c5e591ce9532091c52143d00c439229bf6ef55e7fd5",
+                                "uncompressed-sha256": "521207203ac9571eb09766cd8454546e22fad4e7f4716cb74acbdf90f2415095"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live.aarch64.iso.sig",
-                                "sha256": "ff50582810ae4abbb413d8bd73acac7ee4aa383d33b32e021b846df2705c98c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live.aarch64.iso.sig",
+                                "sha256": "56d308e67638a430784e4fde39d375c60058a4bad401a1110b6a4669ecce0983"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-kernel-aarch64.sig",
-                                "sha256": "6720c00d3427f0c61daab399f7e9cefe0945380ca92ce27ff5ff48e7b341aae5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-kernel-aarch64.sig",
+                                "sha256": "5a8d3f044f8ab56cada5820da8400321bb44ec9797a9848edbacb8c45d5ed298"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "753f9e07b04dec60458b5552d79503757d4e406d3f18451c42c8627fa0619e06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "c9296ce3958fa69df8e03d1e430882eadfedd4e8ce2ec03ba21e088b603e90b0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "3c0a4fdbd4ae2b5ed4e0f9d86e031ca699c59a9a92a9720f9f6fe689d165829e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "6f5e7aedba658dd0cdf60d0bb6cf153be0838eb60f8dfa74429bc5d981c07dc0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "d70ff2b59f98b17e1602910f2ad525d1e7dceb10b38258421998a42fbf5d32b5",
-                                "uncompressed-sha256": "465351aa7d514bcbd7b005a34f1633816440c68e34843cc3d5ab484a6c8e417c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "58a855d7f5ec0c13c56abe73b4518604cd99c2ea97b9301e08ccc1071e4ef880",
+                                "uncompressed-sha256": "a870acedfe8e8543fa3a44fe0446f10823359e79d94dd4fb515af1188ce6da54"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c85990e5b5dabd0c0d1bfb2f97a569b7e059124677c3a05c573ac8cff229c72f",
-                                "uncompressed-sha256": "9b9b767a201c606cf75be9d5111aef50d0ed211c8c68a09707b4e98e69d4aac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "84f3b2a4d9da03e0c7484ebb2d103bdcf9bcdd5d05ed6c42cd124657289aab91",
+                                "uncompressed-sha256": "455a3f7d5e15f79ed8a6042b7af0d19a3a8bb3ede5908cefb2a47605b676f14b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/aarch64/fedora-coreos-38.20230918.3.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9b5ae2a1f499b112a9d1dffb7f1da3ad60c3cb863be85e71cc252b83241674d0",
-                                "uncompressed-sha256": "ce4b349e4fe5ba51818a98bf2fc6462d0660cd7ff8141f65a40f8372d475d044"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6051c5c2332d7a51f014a77b7804a9d01e0ef8792dc68c130484976107481e11",
+                                "uncompressed-sha256": "5beba76aef4e87044c32d7170bb61ab6b559d74bb99a510677cb38ce48144d7e"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-07337c53da2fe79a2"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-044c5837e0c79897e"
                         },
                         "ap-east-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-025c18286be6c85ca"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-033db5509657620dc"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-048427d64e8278fa5"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0d1ffd32c25a27693"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d8bc48ed50b6709a"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-059b90cd95aff1a2f"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-08fbc4b28cb470ff4"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0b94bdb4ec2eae6d7"
                         },
                         "ap-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0f2e9591793fcc3d4"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-008efbdbcc40d8726"
                         },
                         "ap-south-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d58a601f06c40bad"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0bc0c41ab3613df9d"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0afcf4ae29e3b7170"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0504691c505bca141"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-03ee98728193a8373"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e718a58e26d23b95"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0b5e399223430ac91"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-05a9b5634f8e96d2e"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0ab6e322dccb2fa62"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-00404bb428d3c8f47"
                         },
                         "ca-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-074dbab78caa78632"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0bccc2b3385ac435e"
                         },
                         "eu-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-09a59414b2c8a34b6"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-09b6088a67bc9d35a"
                         },
                         "eu-central-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0e38205e49ea559ac"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e428d3c5724a4c28"
                         },
                         "eu-north-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0cdd00784ed2c4115"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0c280a723564a60d5"
                         },
                         "eu-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0139a2f4a14268f43"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-039b0f6caf897e252"
                         },
                         "eu-south-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0df0a906cd825c2a2"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-050f1f0316b655c7f"
                         },
                         "eu-west-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-025b6691f17bf02fe"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-03f64e7fa748c3186"
                         },
                         "eu-west-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0c27c34e6bfeb5eba"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0b4d30328483d3253"
                         },
                         "eu-west-3": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-056271add45b1d4bb"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0a932a3e22c7fe286"
                         },
                         "il-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d8ce913e6ac6a4fa"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e7cc2df48976d0fb"
                         },
                         "me-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-09d4cc28c1ab4b100"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0ad2f6ec8b909c21d"
                         },
                         "me-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-06c173ecf0cc5c30d"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-01a8c060067c75f4a"
                         },
                         "sa-east-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0acf020041998e667"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-07fe2ff62a61cf7b7"
                         },
                         "us-east-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-00ae3b65c54549827"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-027c7dc302e55c11e"
                         },
                         "us-east-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0625b0946e4e3532b"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0cd4265eb62f71834"
                         },
                         "us-west-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-04e23410568e42734"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0b56c24530e694a1f"
                         },
                         "us-west-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0b8567a30d424d1ab"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-06b667f6f9c774e36"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20230918-3-2-gcp-aarch64"
+                    "name": "fedora-coreos-38-20231002-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "4bd5c9599ff7723dcd2bc768258c591bed69ccab34e2d81648eb10a4c6be2026",
-                                "uncompressed-sha256": "84b3b855edd5f13b499c34254f884a12a806011f4246313ad6327704d8d193bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "15edb2ea3fe1aa7a41ea6573307219821f0d4fabff639f690dfd5c3328a8680b",
+                                "uncompressed-sha256": "4f3a8054764f136232cc38ccd30f646d9013bac51bd1df36b014f2fb0f7e5b0e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live.ppc64le.iso.sig",
-                                "sha256": "71d0a0153c626026ae1af2d6c46b82802e5423d2d4fd92df87eb626793ea1021"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live.ppc64le.iso.sig",
+                                "sha256": "6dceb4cc320288ff6dba6b030797afdd55ec818b9590879da9f488e41e622167"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-kernel-ppc64le.sig",
-                                "sha256": "60ee5e19f2c9a4cd3b9b29d86474dcb9bc182a60e0d6ed5431d448c98e1453a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-kernel-ppc64le.sig",
+                                "sha256": "3cb685061328c9f7fe7536c67bc375978a3349f4b0d7a6145e5450dc7a824202"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e4458e30537fe78d4db1c155a1233a79a5112cb31674ee7615d8f43730e109b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9264aba911efeca5b76e5c3764ed8365a4d4ddc671cd1ff2cfca3eacc33509fd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a1ca63f8f6717d6dc39262a66248004b9905f4e81ad54b2b1fcb6aceb0118d07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "aea85c746569a2490f07ff85ca1f0b14e3f525c375841095b70b34e140cd94bb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "95aff7015c38b7e50b8fa62e89e896538e882f47d72830fc2e572d947d5e3af8",
-                                "uncompressed-sha256": "1a511324827c0f1ed356af99f18499218cdc8ab021f27326462298ae3352ae04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "263bc65796c2b80973aeb376b79876b2869449c3b10e0f78f0a66a205c535b85",
+                                "uncompressed-sha256": "413054a6c23d7ce3a1e761c7a055882fe5651468b0fa23b132b31608580eb859"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d60f29a945669bdbd1a739f0488f8be4e69befdd2d05c1c31468d9a03908bd4d",
-                                "uncompressed-sha256": "4c1227cce678f0e9a11748122255a2ca14d6c0d6a89209abb78e4e39daff326f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "dddc2384f5b5fdd31d9b2c792057906acd7fc7ca19a57797dbad2bda24501d50",
+                                "uncompressed-sha256": "823746727d4cb8b0a69d6620e8b47ed7a725d0bdb1c0afd5133302c13e40ec28"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ed1787ef1abbc514cbd4a71234984e43df83bbb14019dd7f560a9a2a3ee8e331",
-                                "uncompressed-sha256": "2f3547b64623ec37f8ea3b660c957baa9a2fa4e5766de40a9f6a668da227132f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "fef07fe4fea252b10cdf782d0383c1a3e4ebbe2d6bc33ef562d059aee1a1d3bd",
+                                "uncompressed-sha256": "a65f620434c301b2708222e3b0006fabc40335a8285e6d96270ed48e37728bec"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/ppc64le/fedora-coreos-38.20230918.3.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "25f44fc60f2858836365e955b87b11e3b5a2a694b6523497cd05fdf77049d5ef",
-                                "uncompressed-sha256": "03ce085189018c434e1f014e4c9b2b4fa7b3ce1a05acb0c1b0d9b7dbaffce8f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9f656189441f26d791b1f39f0be03cf25d694ad1da1b9ebf876d2e418d4b84e2",
+                                "uncompressed-sha256": "0f256d2775dbfc010c8dbc16aa2f57b1d9bf6f976a0352198f4810e8892d56c8"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "5acc63e3ce47c701c6c88408dade86dc6a754fa14a7f5fbfaa8250df1988e572",
-                                "uncompressed-sha256": "c1ef3ef191e34e06fec818edfb222dcb0f3ec41e039946e46a7fe04571ca3764"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "f17f0e2611dfd6ae44e05922f0c4f76b787981040eba9a54fc302cc12b27cd3a",
+                                "uncompressed-sha256": "25f9d370ac19d7cb5184f8f09b73ae6b000a4884648bd91b5d051a7005b1b1b8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "14955d0d62d7ccdaf335e8229bb1f6b3fd4575c6f583e4a2807ae5480de2816d",
-                                "uncompressed-sha256": "99162f6cd9de60eb708fc25c5fa98ce85d53f7be161d543a423fe30d9304abcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "487ea5455c691d4f1c020abfc498d5a1b89acd384e07d4b2a0cbb4c972aaf00c",
+                                "uncompressed-sha256": "19ccf84f2d772ff27bcffe964c99adabbe799b8beddd59bb62df187900747874"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live.s390x.iso.sig",
-                                "sha256": "defa38685ab4a39880c9de5d75ad0ac962f3d5ab37e95910547ee6310579e20f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live.s390x.iso.sig",
+                                "sha256": "b81ab4453d43b1b0fc8387c942a211515e0d868f8e30b7a384e3997438d61ac7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-kernel-s390x.sig",
-                                "sha256": "25ddda8298326c51f22e049e25e896cfaf45f9675895cc10e1563892f8ea0260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-kernel-s390x.sig",
+                                "sha256": "29d81e2de06f9158ff9a10dde5030e39d6754629ded5d52b68d7f2b7b6154796"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-initramfs.s390x.img.sig",
-                                "sha256": "98a8140f4d74f65fa2f69d5b636594a68b72b8a2bcfe39192338c7231964ccf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "a9eaca40448343d0156701d3dde8c8d9c02f11b8b7a32b648ac14eaf229824fe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-live-rootfs.s390x.img.sig",
-                                "sha256": "8324f7d8753363a3f8308c2ec56c65c90abe3dca91910e478734a3f964d91042"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "858f6762c4c037cf7ef05b20f6f237f82c685c22d39e3d01454926347f4d9bee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-metal.s390x.raw.xz.sig",
-                                "sha256": "2b6afeb34970b3b640e1c63f470b9781a45d43e9ae017ead14419d19471d8d9a",
-                                "uncompressed-sha256": "59acf267d631daee5e50c73c6dfb9bf377670c0c2dce7ebb7c2c5d3a059a04ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "0cd5c3338b47d5c5cc96b244f38e5ab7e15f9edc6af189da393c4346ccafcc60",
+                                "uncompressed-sha256": "e8a01387fa4608c9fcd15d992e6249c40fa9b1fc3eca9916584132659797e7f1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5d46ff6046a94ac0d93ad2be9018ef5b9702e892d10f6bf48e614bb60d88ee66",
-                                "uncompressed-sha256": "537afcc9e38516cdc04469884ab84dc3528dee528de32536dc3fc51ce985132e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1ba4adfce696e1b1a43a121c1a3e5001577881fc5eb9971410a8d4fd48e72393",
+                                "uncompressed-sha256": "53ae1daa3e8b024ce0f74377d416424a8a659bfe9a485416e4eb39261eb1bd7d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/s390x/fedora-coreos-38.20230918.3.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d93322af0e67116b54226a1c9d0b6aa460a617925f0803dcc2abea83c8d6b8e5",
-                                "uncompressed-sha256": "8aa305c0c4f71140aa8529874ea01953d0c604f91c6d42e3c049fe233772e3bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "94fad78df24d3b775361f61b7b877dd52a79ee77c40e2a5a1da3facd76b2cac9",
+                                "uncompressed-sha256": "ce5139e1dfe6f83eb037b2a9673de42305c6cac02bac5fa93b8fb07c92dfe48d"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "540189857b3405a5fa70d433fd776f17c545fd088eee7569c435316b62677f04",
-                                "uncompressed-sha256": "5baf4cea3a5fa3c6fe82dbe194a398548223d4211d6cb6c704dda9eaed09b2a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0c09668a71258ce86daf4732da94e4eea4a6fe40d489c7f24a57c808c10d813e",
+                                "uncompressed-sha256": "f3635087bff2be70f74a9dabd5d5d3b16d9f7439a3ddd061410f07a622166f22"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d369afd0ce505805167f98d36fac22313de38b161c0aad429bd5ce347743be15",
-                                "uncompressed-sha256": "330e048010b51c33997edce7da397d75632435b4e757af61336ddfc2fbc1f56a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a3f424a058c1603fe9d6d93e8b4150d2e9351dbfb19cdc40c051e42471e1d977",
+                                "uncompressed-sha256": "1552db0c4ab8180ab24937feb8d9788b8d7b40a2b2c3dd1d6e625ff5953677cd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7c7a2031f50e3a8fb17cfd51e4c34a3cf0fc38876d5b33427fbfe664cab71358",
-                                "uncompressed-sha256": "91a1ff9f5bacb5d3706b3a0c2111597c6699f7ed1c195dfbea3a65bfa2aa8d94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a29b2eadb552015387c48ec63af352234fd5077b58b1e3ae993f1946544050c9",
+                                "uncompressed-sha256": "5e45f955ba5b528b92f68a4381b7c1772c6607a905a9a0568a8abd2853ecfd1e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "aba72d4c2b25f489f5e306cd037c484a9cab0ba692ab631cd4c533fe8116f51b",
-                                "uncompressed-sha256": "d2d40ee35cde60a3f270867a2f37bcf59d659e5a41e1a29c1555a1b3fe2b2c92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1c0f3df14928884efd46c377ad18f1dfb1190a1a274a35688055dc36a7f08f18",
+                                "uncompressed-sha256": "110d45deed79dfcbaf9f95362a913f19f6fea03df10b35a977b04e90751dfce4"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e5ac4d38faec01fdf1257a76f5721f3b94e86bb186453490579e00b1cb9f5c1d",
-                                "uncompressed-sha256": "21582a257b95c648d73d52d10f211965d65b01f6238f1c897ecbfcd00dafb40e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "038b06f4153f7e441629741ba06782b166d2893b1f7f0c73d41cbce7e196fdd7",
+                                "uncompressed-sha256": "5b11abcd177989e082ad2e1b1c5e618cdbcbd084901834f464ca233d0f2eb30a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e1000d602538b202522e0526524b6eef73abad3b70916efadfbea3ad67b1e050",
-                                "uncompressed-sha256": "6fd3f45702d1df8e21489f25cbce2c9119a2ac1283eb20204201b72fad1b2038"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "52303a7de83b6ef9307c48b38282c2579b490a5ba1c43cc0f4df3df00cfd16a0",
+                                "uncompressed-sha256": "d6e3936475105ca331b4adc2078701579ce132c3de1df04316e67bd3546f2ecd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "38fc9a4017450899aed283c14f25a1652a1f22036b592da19aed33f9467fd051",
-                                "uncompressed-sha256": "9421674469d6d0dea1eadddab6898bf731d934ced28e5946e8bc556c89ab694f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "811b4f7fe01626ffd7a6646601920f0b5b899b7733d6b400440efb5fa338c0f1",
+                                "uncompressed-sha256": "986ff3a601079cb3d57abd662b83498975e9271c5313cf8127e45c39832a40e2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "52046e8048601ff1f5b9981e1a26266156b3cfcb239d6919321333ae52cb3acb",
-                                "uncompressed-sha256": "7e4e607bca92589af7ae12178ded029442d7d6f1f07af6d86e621b8a43d45733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "36ad86fcea2355f691431809d41737a008c1f55385a25247ae4032887a18ac76",
+                                "uncompressed-sha256": "cad811971867eb7ebd650f80faa83e75520469a454559f435451af82203b835a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f0be0ceb92f2bf402e9b0f11a5f28afc68fd6ba3d6154eefc8ec0a578c16862a",
-                                "uncompressed-sha256": "f76d09d4291437fbdb57204a97cfed97332ff1267feea63c1ae900e89cce36e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b083a39904a57b9a8423ab1444706f5db0999d9d35e75544381213def6529a2b",
+                                "uncompressed-sha256": "6827ae1b52f17252971d328e6a2e5881603007c5e1b0e41c6f14a05038b9bb8e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e208600746d1325de51f11f7d2567c6158084c32d0500e5af50e7ef8f51af465"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f4b6bd50140581c2479b1838c3ce76012aca05b880b2f26a70668820b72d5d56"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f31f09497d5e1d830f3f84a270301cd55a1cf8113118920705724654f39dad8a",
-                                "uncompressed-sha256": "59d5c19456beeb5eaf3ef4df6a7006033117ae196315678bcbfd7a51cc2fd675"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5d1250fbadefc9b787e45201a464825b62f2817b544be82adeddbc0b43c29339",
+                                "uncompressed-sha256": "6597a3b7e9ae53d3a0af6b603f933e60a055af3abe90f93ec6679ebdc063c023"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live.x86_64.iso.sig",
-                                "sha256": "e8f5d83dd31432535efc6d3e307e0b9d499ac6c445fb2c4bcd43c6795d47f54a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live.x86_64.iso.sig",
+                                "sha256": "d7839771d1810176f71e8b998d23d60eb580c941914264b5f5dec35798ac7503"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-kernel-x86_64.sig",
-                                "sha256": "923ac8fffec0e776c0250432b867da0199ffb7da40300fda602bd6be1938ca92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-kernel-x86_64.sig",
+                                "sha256": "af72f61a3571dca6515182320b37afedf881d5c51e1c2b07be39f227849d8bd8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "afb6cce0a8f36f72b2825ae512a7ab46dedd6d8bed865edea0986d5e942187ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "e602806b53e09a898079eaf5e216cc610dde19e8a3f8fb6598aae02286203cd7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "1df8e889b40c835795a58e94e4ebc66d0001df59ad12fd1bafa723f8a9f324a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b80c63e56bdf19a42d0a6aa8062577ac5dd6cad7cff7e47aa2cc5d1d589589ee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "e4dfe894c89362d4e02e3f259b54e771f089261abe1684c04b9463a2608719db",
-                                "uncompressed-sha256": "6ff36cdd80065cc1e3348c4e6d802b01a6914ac4387e4fedf09963ee807892d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "8517c69cd578406d93a0b8d36ccba1b330acf2c2fdef8654ed374eaa8ddc114e",
+                                "uncompressed-sha256": "79720f5c6bf72a683828ccf4acfa7c7e98bda3634faf0400a66953bc4cc2bb7f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d517592fd32c6c1cdd6d108efab977fa8b8ad4185df2261382c17c06d206b31b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "23778bf59e0e25a5a62b7450a6f71e633e3ead92303defeb13e4fc97592d1a14"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "16d609f17bb1c0f772ca8c9e7aabb49f8f2d9a50c2326d29ca68979912377491",
-                                "uncompressed-sha256": "6eff43918411669cccf8a2c8ddab0a1f0aad5945bc06fcf5db770939489e59ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9f1ee492b27c5b0c3f00b2373849eed2af2ccc5c7b5a6c934ebe351684634be2",
+                                "uncompressed-sha256": "e6e00dfd8b3a626fdc2f3ef68880cf66d040e48e8d9184c364bf1897e8594738"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "31011034432bd11a3ef5cc85f1765ed5ab675188b5e15b485122e90f17b123b6",
-                                "uncompressed-sha256": "153c07de0ef0f7406896ad82b14be505d0fdc1bfba7d0509e7183d5a400a5d96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "bd34a9becc532bdc5d80e2a03378c24334302cd0e6626ca98a771a00695770bb",
+                                "uncompressed-sha256": "a508cdaf6045bcdbe7b1b34c74ca40e13d21bdffb42e69b3d5dcdb19015ea82a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "b9c6ce542333d414f9008e6feb5d34d3ded398249e9ba2e62eb30b67a085af41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "89f3ebc9a35af4d01572d6658c913fe720e8f3315974ca5f16cebd38b453e04f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "644ebcf45ce39a1188448c1faa10e073163bb4b10e354fb79b2f39e1d69b0b9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "cded1c7030c0edeb5c660946e50b57e5f901c3060684669710f38b3e98d79f82"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20230918.3.2/x86_64/fedora-coreos-38.20230918.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e4fbab45c69bec3845ba5cb445a6f5a383dd853557670c51a825d460a5fb4554",
-                                "uncompressed-sha256": "9bb48feff1025e4aa69df391f26b09e62d09dbb918aa02021bdc36175fa56ca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "83c51f20915451e31ea4043f6b2fa734a2f2b487f2b9eed4fb4a3d544cd9ec4d",
+                                "uncompressed-sha256": "5a04e78fbfab83254adc051fc7dcd8ddfedd4d0860b76a871ef1db26829ad2fd"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-065437c051370c44f"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0720932b5c7d84c57"
                         },
                         "ap-east-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d7cabca15d0188a8"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0bed057fd762ff5e0"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-04b4a7b3dc902c749"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-08b791df633d18b93"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0db3f16615ee0fb6a"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0fbe831e7fdb92b01"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-025bab6544b34e570"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e45bac6bf3944629"
                         },
                         "ap-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0047d5ecb844e3691"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-07d883513706ce7d2"
                         },
                         "ap-south-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0da851144996bb499"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e0dd1012510e851d"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0fcca80375a7f0a52"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e90b354807b9b5d1"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0bf95628e1d3a9670"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-073d341030dcfbb20"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-04fade0c2a9a29a3f"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-012a496f6190d9b65"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-094c41871220c9f8e"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-09381b0f94c557578"
                         },
                         "ca-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0ba6d30296e0aaccb"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0564962451c797744"
                         },
                         "eu-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-06265981883982e6f"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-05a372c9a4cb6f6d8"
                         },
                         "eu-central-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-006d0e49984fb13ff"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-022019216c02770d4"
                         },
                         "eu-north-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d7a68c9f78de73a3"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0710a7e0dffb99463"
                         },
                         "eu-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0a27fea9039315252"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0da8f818327f6d64d"
                         },
                         "eu-south-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-082360313a509e4a6"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-03bfb04a97f30d793"
                         },
                         "eu-west-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-07ed8a2eac547603d"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0c08f78ede249af29"
                         },
                         "eu-west-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-097be233c78403c65"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0dc5ab23fbf367aa2"
                         },
                         "eu-west-3": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0aafef2a84eeac2fc"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-08b3a0285907eb922"
                         },
                         "il-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0e7a9fa237debe057"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0d3154d9b03966180"
                         },
                         "me-central-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-07fcc5474ad6324f9"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-006060f80fea0ca2a"
                         },
                         "me-south-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d4296d96ccbb3f91"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0e807582954151545"
                         },
                         "sa-east-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-009c2e9ef554bdb1f"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0f29554a793778d5e"
                         },
                         "us-east-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0d8d8150576293a30"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-089899354cd079d56"
                         },
                         "us-east-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-06919c5c51ba98191"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-03f92dea0f13a7a05"
                         },
                         "us-west-1": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-0ddfedc82cd7e6a69"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0a410f6b124de378f"
                         },
                         "us-west-2": {
-                            "release": "38.20230918.3.2",
-                            "image": "ami-08918bf79c6a165c0"
+                            "release": "38.20231002.3.1",
+                            "image": "ami-0910d8aeb8134f493"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20230918-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-38-20231002-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20230918.3.2",
+                    "release": "38.20231002.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1f9650de0992f6675217ffada2ac1cca973434c95a217ddd87057417cb82a6cf"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7ba3408b6008e1b182af167d439fac93c04ff5a8d2d72782bb45fd8562ac3e6d"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-10-05T04:07:54Z",
+        "last-modified": "2023-10-18T14:26:59Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "81caacf0d7006a59b7c02ad18a9951da1f931b0b2cd88bffc6e22c502b462d80",
-                                "uncompressed-sha256": "252614d8ebe8896caf1104e516156274abc2d3b535efa0ec5167ee4410092a3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d977f7990be3e3641c49050d37ffd3d7c46af2e7497f54d64a864a414c699407",
+                                "uncompressed-sha256": "162785d5f1bea038380e28182ca8e24e94d0db4d37b21972197b63c101a0ecc2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b3a8238596080d7a1116a52e1fc807481770ffb4d6a13deda67028ce35f988ce",
-                                "uncompressed-sha256": "59cd14ae3b6307b758e0c46f8f9c0f2ed0a731cba87f24967b461c95a517e4ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "54e01364d31cf3ee36a3dbc91f39f172f01b728b93d9ee8455a31dc3ea331f3f",
+                                "uncompressed-sha256": "4f64dc11685c6368a4dedb7febd33ba6a57872ea899bbc650a2d90df995519a2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "45b539ee3752916681e21607981b58fd671596a298ffd1a43a0e7a6ddc23a4d4",
-                                "uncompressed-sha256": "317708af6781634dd3494982f3cc2b132b58b2751f8780e5c5466e1f513b208c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "4d36a3b606700d2c0719c0cb0b617e03bfc95149ecc0d8ed7fa3c565e7f03c60",
+                                "uncompressed-sha256": "06ff518805b48e10351df01ff96876110bfae7d7e8a762e96da5b7995ba5474e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7aab07abea6864c487eb67ef99e868ab6147442e03771d91bec34a1af2c193a7",
-                                "uncompressed-sha256": "68bd6da1bf02b9daae8731f3470ebba1fac73febfb96b2777f88b52cdd421bba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e2f8e91576bb330683675d04ad8f78cd59390af71007e031a739c651921dc86e",
+                                "uncompressed-sha256": "ae208e6bd855c816abb77f008e64dd104622f8770dce5fd170f29c3960f4906c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live.aarch64.iso.sig",
-                                "sha256": "b1cf53c3cd5219a483eee1925be17f8efe9d841703f8c0633c1d7957821b86dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live.aarch64.iso.sig",
+                                "sha256": "fd6bd08ae302c78fba612928a6efa6d6033840d7cd85138ed214fbc1c4ec44d0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live-kernel-aarch64.sig",
-                                "sha256": "5a8d3f044f8ab56cada5820da8400321bb44ec9797a9848edbacb8c45d5ed298"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-kernel-aarch64.sig",
+                                "sha256": "121d52884cacf3d791947adccfd70ad477c360510a56eff25978f631c5ce6060"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "c4098e8377a1fe7b311ca977aa77f903f14c72a5e5655a879a4b1936abdabdb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1c1c444454a2f3b5ae590ce81458564ee31092d17a3ba75b2a6d3824181f933a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "987f94e529678b2cb7d597b33ca5d2d440208bf09dc8ad8366e433e0c6b2c0b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0f60aa05f3d684c160ccdb37fe191933116987b71947b39af5a4a457079662c0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "cdc9aa4f5bece082c6d8c12c724ce025b45b77ea15e1086ceea27a6fb6914075",
-                                "uncompressed-sha256": "ee30a07d72fc614e0e9ed575dcc3d6bdfc2a8ee813617569daf42bb7250028d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3fd28dbb2952290ae38e5f353636979fa908250f53671a663b68e5b5873e361e",
+                                "uncompressed-sha256": "2f3a1b103cdb14390089a785938cd0f92fe072b5c250b3a7a69f7c5c52f735f3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "459899172562fdab0be14274ebddd23da9e61e96d0cbaa54b27bde5bd6f6641a",
-                                "uncompressed-sha256": "3bdc5774868b87194c740309a272b7295be93e444e29e856e5be2aeb0a432b11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "062d02fd6aa1867c1adbb16773a6e46c0f7de80f5149da6b24800ac46c5582c1",
+                                "uncompressed-sha256": "c3fc91de6aa9abaf465a29705675a84ab20c63805f05e6b08250b1b42c679d57"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/aarch64/fedora-coreos-38.20231002.2.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c9f2ae489f543326175eebd4e9ebef8f20b012a877f14bf43ae4cfc10cefb11e",
-                                "uncompressed-sha256": "e9d785b090bc40444159688a0960bbd5053a94c55d456d4870b9274cb6b0e14a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "13c27d2dddb23c0a7cd4cda2025729eb5e0b96c2daa513f21aa7e1e77229059b",
+                                "uncompressed-sha256": "ae0144596787464c2fccd25e213684e86faee0f6008b072894c54da889713fcf"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-03f4620f2735ae4ba"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-084a957218c571653"
                         },
                         "ap-east-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0ca6c456da8d762d6"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0019d5ada3bcd9952"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-09c8090211cf76041"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0347c80045abbb775"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0d75236d8eae63526"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-08d463d8f95d7b6d2"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0370ae6ab57734301"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0b16ab65feedc9abe"
                         },
                         "ap-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-077398c2ea50b1142"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0be21d0906746aa23"
                         },
                         "ap-south-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-00f715d019cf5ba92"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0196e3ce11e1c99bb"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-069cca80cd588d41c"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-09bb6277cc0f79b84"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-039606e36bfd17a4c"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-01ff199a05b1c3235"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0d1325b3ddf1d6fea"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-05ff4d32d0262d273"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0cdd33e69b12da824"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0a2a1eedb3da562a1"
                         },
                         "ca-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-066fc698da4bf72c0"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-03013585639364bed"
                         },
                         "eu-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-004bc83cac9d11daa"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-070d7b11ac181793a"
                         },
                         "eu-central-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-08969235ff8ede405"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-03f65cc0065e95204"
                         },
                         "eu-north-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0acf04ff7f1917508"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0e50194081b1cc4b9"
                         },
                         "eu-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0a6a51cc62b833930"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-07ac2fcd5101781c1"
                         },
                         "eu-south-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-063c824ce4072a49b"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0f400e60fa7a92872"
                         },
                         "eu-west-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-03b734c578dfeb172"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-079140d96b764259b"
                         },
                         "eu-west-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-04c408c7cc3e68e7e"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0c3a68dea7b41a54e"
                         },
                         "eu-west-3": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0455b41f5045f7e75"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-084020176db527480"
                         },
                         "il-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-01d97e7c5c7c7d980"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0a057d66621aaca3e"
                         },
                         "me-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-02abd8e72b8c05929"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-078995cb50f9153ca"
                         },
                         "me-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0e54a27504da4cdf1"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-092aa567f89ff2ed0"
                         },
                         "sa-east-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-05e2d93dd23c12dc9"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0ee99ba2b9b3b20bb"
                         },
                         "us-east-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0d447393c26f316d7"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-04f1e4f4e911a3978"
                         },
                         "us-east-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0d524aab76bb34629"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-06f067bd3d3add1fd"
                         },
                         "us-west-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-05007e3c1c763aa05"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0206e3e86573b947d"
                         },
                         "us-west-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-08af252a3ff1688be"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0199bbf35b808cd73"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20231002-2-2-gcp-aarch64"
+                    "name": "fedora-coreos-38-20231014-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ed6fcf0f89497da61b16f2b74f6dc2bea783e1d84cb3eeb1a2088930159b74c4",
-                                "uncompressed-sha256": "88abc4e0fbaeb33eb475334b0ce56b5a29a279c8a53ab2af004df5b75fddd14c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8ebbf5236459723516ddbe36ab04f18675eb7a79123f57f3c42d9fb985d0f2ff",
+                                "uncompressed-sha256": "30b7b9f5815ac9c6615eeace083035fe9994896f7ab27dc9e88e1aafd34e9026"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live.ppc64le.iso.sig",
-                                "sha256": "105a9375ce654e4b2a65d89ae6ac9d1b853ef9408606c141ad856fbb6b1c5956"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live.ppc64le.iso.sig",
+                                "sha256": "56761ae57e98dfa5b06b202ccdff69cc2bb5a1eccf25f27823d28180400fcefc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live-kernel-ppc64le.sig",
-                                "sha256": "3cb685061328c9f7fe7536c67bc375978a3349f4b0d7a6145e5450dc7a824202"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "addbd3a2c24d7ce92e9280b65892336f60da236ff79169cff9624c5a241752c5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "6f5c2cb51251fca0692c610c811c7bafd6ab47ff72b2659ead4454d23000f06b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "429f097506c9cfffac41a0b79a2a77ef0de73bc682f620c16a6180264d71e8f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "5d6fb5084f7171787220718d1a148fac2107500809eb0f14f87ecc9f98bb3fdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c90b383d4dbf51f758dbeeea480f7e468cc33119a2fcb0425a2818b6abf7180a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "349074782048785b72dff9d5bdf7b60a7a8ce63cf44e5c40b9157ab7df771f94",
-                                "uncompressed-sha256": "64e258992277b0a768e1792746f341a181528e18f21c1e058af12f88d0f895c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "7e200f59d4c1fd1704a940b2799f11acd93d4472e7f0da54e97b290776350c77",
+                                "uncompressed-sha256": "113807d99b3412b56570f3806f1a6f1e19ed78c1c6c982938fdea70f9c51543c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b4cace7a39222c276c042b0473be5d967ef8ddcb51b4e4ca3674c7cfba1d8d42",
-                                "uncompressed-sha256": "36ba4552a904661014b8212f2a631c75fbf877866d050221a58b801e836a2060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0d1d2a3fb813dc1c8ba7c7e05f939379fa54056d67d5bf80c0e0bd16997cc345",
+                                "uncompressed-sha256": "47861330c6bb7984cdf1990c32abb8b79e6dad5487d4e583b339f7e8ce724c75"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f87adf90d60b0232deb8af10947e55303c86437a6ac5c6d570cdbcf97ae00e83",
-                                "uncompressed-sha256": "981329854f888ece350ef611e7289e5f38a3f0f909cb3e8cd14ec74429258a34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "78e08463cbc0031093fc374987f9a00c18b8d2c2d593cfc8451880408178184c",
+                                "uncompressed-sha256": "63b20b1f3215f75703f5d19923b55a25f2a6630355bebec0fe967104b5f3f035"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/ppc64le/fedora-coreos-38.20231002.2.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "08aa058988b3c9372f04f817588a52c4dc6b01f776651fcc858d7ba0c051e50b",
-                                "uncompressed-sha256": "b930e2b8f0133d0c70b8979f843981d25d9d87fe007c4fca67ba69f0b7e900a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "74d011dd09c08c7ce4df5fae6128805a77c6ecc467b36c684a715958677243d1",
+                                "uncompressed-sha256": "5ada343f31d9f67887eb8867ed492411bd4a567ae8c66560ef592174a85c674e"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "77edb0dae5e085201f66b2d525f6a76db66e4123b0158c6535734dc39708629e",
-                                "uncompressed-sha256": "2e18975c1858c78d4be6fa97bbc01e0c530d9270d14a80bdcc016eb85e54072b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d9d74bc092a9e8b5345c431af68fa50322e73e14a24174ff8ac1d11eb2218e7d",
+                                "uncompressed-sha256": "13b90d7fba36c4ba34a0c58489a762117f931dcfb73dfdc8d6d7adec219d295a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3696ccca17b7bd6f9f55938ad9fa8ef5a41ddc05c4456db76f668c46543d0ca8",
-                                "uncompressed-sha256": "090f804c9ffd98a24eabdc32635329ce5263c17e7a7d7e21a1bd904cdbac90f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "34737374f1c276149f5e07fd440def6f49ea247d292114aae683c5fadb731f91",
+                                "uncompressed-sha256": "b70ca9c67dcb3ef59dcd7a6b18c9573a99bd25cb2cc7c94dcf00b81fb0affb84"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live.s390x.iso.sig",
-                                "sha256": "51e8de553411186aec99524fb1d60eebef5dc7b03f746fce95b0d31b362d6a7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live.s390x.iso.sig",
+                                "sha256": "d12e7948602e86fafcbf525bc08e1ce319252d6ef1310382e8dd039fe3db52da"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live-kernel-s390x.sig",
-                                "sha256": "29d81e2de06f9158ff9a10dde5030e39d6754629ded5d52b68d7f2b7b6154796"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-kernel-s390x.sig",
+                                "sha256": "0a0058bd2959e2b77e1ff6f62d5111a130343a7bb045d51f43cf714133e69cfb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live-initramfs.s390x.img.sig",
-                                "sha256": "dd68930be45e342083807b6eb4766fa7eb9e05fddd908f0b7546b4af6a312310"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8e917e24cdb4b0fe79190f89eec5ea692884505177e7673df4e75594f5a847f9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-live-rootfs.s390x.img.sig",
-                                "sha256": "c0ec84475e932cb1fc41e5d6b9d03656741f942b35fe0e0da9c3b09f8b5c6f6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "990bcf5ed0731dce5f2b50fbadfbaadbc416d33eff28b22e651ed67f76b2d084"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-metal.s390x.raw.xz.sig",
-                                "sha256": "7054aaee3b37f9a3c179254b87a6e0d378e96ac11e133684f2edd947216f7e9e",
-                                "uncompressed-sha256": "aadd079d32f2c1efc4a98a9d2d4951cc384040ae9615b1210be32f3ef185c7ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6252f3c3af4f43b57f568ff4c7c463c945b60f39ec3807bccc1938cf999d9ec6",
+                                "uncompressed-sha256": "ea6651770ad364a85cdc36f09bcf77918f2f5849ed55c2555a876ed56e636d5b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "16abd5b2920a7fa04a5ed53f86603ed2193294f8d707613f09d29007090a6740",
-                                "uncompressed-sha256": "dd3cf28a79adaa19a35ebc2d1e62c7d9a6bf2306f13bf902ee4f70b083a3f054"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f56aa83edf59469607d6f44b6628b1a3832a812d13ab8ca4fd40e7fc90bb88be",
+                                "uncompressed-sha256": "e4314d1428c9512141a6c5758178be5888b8a74b5bf521dfb2527834055e4d95"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/s390x/fedora-coreos-38.20231002.2.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "02846030155ed33e6514c9647ba839fb029ba37659f9d1296b605c29f02126b8",
-                                "uncompressed-sha256": "92ca26bbaf8b51d7605368dbededb8b44909f72e1226a142991e1ec79f05b0a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3a301ab8b1549a940ffd4a5b4128478f6049f0e56f13e748423eea80ae74a524",
+                                "uncompressed-sha256": "cb8d616281fb5c68028d1ef8c09ad638c33656b09f4b273bff6ae5d28a8be051"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a17baad07a382f8af1c4994bcfb9e03937238c054d278c3fd9321dd92a56e0d6",
-                                "uncompressed-sha256": "8d589d37e58cf9a79c2042b0d02a8018c3db356c6f006a072df68b4e2993b11b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9104e2e6329417a760933eb8d2ff41fc31956066340a1727fec11b77e4522025",
+                                "uncompressed-sha256": "5e84cd9b80d50ea50874df7feedb4bf203d27bb9ffde2f456db538612741327d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "21160b2361aa5d8a8a44d6332f4441a88ca0e83a4fb902a97052c4aeacc27144",
-                                "uncompressed-sha256": "8d9951f7b5e9098b1f0eabfb84be52fa852835eee7e7553acb1e0ff79df896c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "125471826a9618d2e051f90bb2b119546012268f4684ed5ae3f0e7fa4ed30748",
+                                "uncompressed-sha256": "0c623e64f3e2c75879e25c4ff1fb5fd0b3b9a622e22a262d7b4959596681f5b7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a80da37417f642f9f69b7dd839e54c6e8dad4355fa072085f9dd53fb8ffd92a6",
-                                "uncompressed-sha256": "07655f7879b7036ae15c990f7ddc8c1db29ab6fbc4a37be68187ebfe4ecb0f2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "612debd09b9b5aa2743b41f61fcc261d5582afa4d54ae359ebed05bbc1f6536f",
+                                "uncompressed-sha256": "7bfe50302acb46d082e3b8c4b01bbf58ac5891cf235ab7ede922f0b37092757d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ac126dad2307dd6a05c5fce593304794ba50a3e9284bb320fe454ff911c324d2",
-                                "uncompressed-sha256": "99a8e69ce7afb216c8f4e040c1514629824f8fbb5d1702cc8b15abb6177da107"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "13be423bf28fb0a3841b0a4839ddefe5f1382a409d9ea1dc0f365beea8478ef3",
+                                "uncompressed-sha256": "66fc228fac7f7b4c857a76e2c5e96bff7e2ef86ad33bea1432ddfc60d239a9ef"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "593f4651b72e9754da204fecce47a43d90314e247f3f91e30a5599e8163687c5",
-                                "uncompressed-sha256": "3e75bebfb26118d2e554556d15268220e45bec97a1382566dd8d53b3717c1e38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "285d21d17d276dce3c7c63c9ebc1947d66bafc58aeee413abcbe69d00be4df6f",
+                                "uncompressed-sha256": "ae0f917deb6c64c22f0eb0a30121baedb1e1ff9e16b0cd76fa9e0f1580b450f0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "55047456775ef91ad35d1c491a4b44677d2a3ad4aede8256721c5678869d8cb7",
-                                "uncompressed-sha256": "ea847b7378ba7a3332199331b37efecfed78eee04907135d0751f8b78173fa7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "9fb8981d436db9bb51af3f099f7da3844ea3c1a291a80c0c4d38f2b7e09235f0",
+                                "uncompressed-sha256": "d85ad1f0b69f89a473020abe06ce7620844368199fac854667cc63b51ccd2d0c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f4103eca1066bc0dba1b596fc239d69a593641c91eae31dc3abf594f4638fa34",
-                                "uncompressed-sha256": "3636a53e45ca24d01c89939dbc4ea0256c5f171f4465d84ff7e56b7a0bb3dc3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1cfd4c77ae8a2a7e687c3122b9216a8d9ddf9114141e493d21fb63c4f406ee27",
+                                "uncompressed-sha256": "636180973f47aef98f1c93c983037865426c0b16f1ce83493c37093ae77a4a82"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ec714e1a7c7e001ba7721566f722ee789ba92e71e6c2dd7d5452aafcbd733a21",
-                                "uncompressed-sha256": "02faa765f9cfdc08b1f75a004b04d783978b52cc851da1974ce22b28b97e442b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e00304c7a32053cfa16150daf9655edbbd2fd93e967aa957f6f7835fdcd72921",
+                                "uncompressed-sha256": "247892955d3227f13dd6352f0f18457f32025deaab3092ca343e0656ef7984c2"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ff7354035ff11bb427bfe392c7d216bc178af5eb2b405252ea98f1527cf6eafb",
-                                "uncompressed-sha256": "25cd006509c02ea9b0241bcb56e0376810705df542a4df3de136152149cbe0ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "33b5468730399363e6fe506ea10a5a9a84811e51c1ccdce9f116aae554012728",
+                                "uncompressed-sha256": "7869c37af313faa0691cb93dbbe153d8b395e08acd6b354afc6dc87aa5f92563"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7e6eef74358d1bd20e0ac4f980d3f407848f8f699f49e106b275ed05ced16f73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "4e2bfaedc5de78ba4840b769c06fdda4fef556f63585fd826149601286dde1a9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6ec080de55a220ca27306f9da68777784953be0679d731419fe6cc76ec9996fe",
-                                "uncompressed-sha256": "f74f7cef40ac7620e9a0130f9c6f775e22fd7b00e64b12a5bce203dd03aefe07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3b8d9c9212b6d12b7d6c2ac64b74e9b6f72c1eaee6cd8a2707c68f5355e8520c",
+                                "uncompressed-sha256": "48e8c686bcc4ba11751f9ea4b2a9a29e548a989a0bb55c2c42a509dc88b7b701"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live.x86_64.iso.sig",
-                                "sha256": "3754ea04a6fcb99a7e2197ac8220ed27ff5eea6abea0af5599efa406b23d47ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live.x86_64.iso.sig",
+                                "sha256": "3cf2c7beb1d9ef12699cc26341d19a3490b99862cea77c2acda43b84f306f5bb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live-kernel-x86_64.sig",
-                                "sha256": "af72f61a3571dca6515182320b37afedf881d5c51e1c2b07be39f227849d8bd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-kernel-x86_64.sig",
+                                "sha256": "744447077ed037699690b820fb333ee71e5bea796133923765039339a3cfa7b3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "250734d8cea86606025cdef389ee45cfabf2ff7fe5d2542fe004779437a52f2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "99208bf78535e69b728f29c487cddb30799aeaeeeb68d31fa7f00b0d38d92f6e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "6c01c57b5cdaa02ed520ec256f3316008ab96e01f02f39db776320dca6f22533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6e401e17a46ba1f6e204c06b1ba131a977fea0479f59d958c052d2dd2961dd30"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "8719f8faab0b014bf9900437f682f2d7d6935070a909afc99a4ec804de269cf3",
-                                "uncompressed-sha256": "341801345b6de62d33a72d8027c28dd056c9bc4f9e297d0d79137361bd486f9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e829cf711b44c8b5632e5a7da4d3e9f3292a3417833ee3b44cd99fdb3e00331a",
+                                "uncompressed-sha256": "982622773105ae9f7a353382f4788d6d3582f6e657a8d1b55ef75ea84742469f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "5e0ea10679c9822f11315b1e2f1bf4bbe74925c1c61eb93cbd40bead8ca98569"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b9a9b2e320db7be7c2fffd649a8f36bf605804f9eeaa0cb5e7d510fbac2547ea"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d5b0ede616ccfae0ba6d6e0140eb45c63af73eba24e348d7f992ed5e0a754e6d",
-                                "uncompressed-sha256": "fdb5505904c3436fdf8428379c5cfa2135cf3989d417d44406ee12fb81e09b3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ae49d05eb406ebe51346915a6494b4dd4fe1352d796873ea9f3540898b136b66",
+                                "uncompressed-sha256": "4279488d7d266932f12ce57872b670cb38bab807aaca8cb34e2518141545d59e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d603972146d6e86478e327bf4d6965f9d7a3cd0d2dc5acbc488195ed7d4bbbdd",
-                                "uncompressed-sha256": "94cc23ae2816681636464f249afdaadaa082810699c02ffb420cfcc29ed97830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "07fc4965d3001c85262ce452c0a410d4751de84c554a6115a8e1db82f46ecc03",
+                                "uncompressed-sha256": "97479c38b469daf08eb0a059ff1d4d10971ea7650899d5c9263084f18619f5b2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "e7507221722bb0b134963466d2c707428373c65af0ad25b33e73d483384d807c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "09433176b06506941fdefe2f78010cc85447f2deac4ec4efd0f970344db7a8a5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-vmware.x86_64.ova.sig",
-                                "sha256": "5e61b1a1c5b021813938a84b92d5477f082cb4ef247b355a139bea3ba9bdb6f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "7578262978340ef138fcbcb1d00c41416c74c5cc00073c05c212efe8f6c37c4c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231002.2.2/x86_64/fedora-coreos-38.20231002.2.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b9ec98b32495911aae3bb08552f41c53275a4d46cdc72104d08fa02d48e570cf",
-                                "uncompressed-sha256": "dd0306ee4369ba0d55faa3be8c50b8b002f4cb6b5e8491da2d693cbe85beb106"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "05edd613867ff84f72c0b17326e8466726142f51263340cef1bd92fd383d6e2c",
+                                "uncompressed-sha256": "ab3b1d08a0b76260736862bff739cbc6cd6ea45f14baf8663b938727df6d0232"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-07e075d2892e2d95d"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0545d4d73d2adc853"
                         },
                         "ap-east-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-08c4cc730b3db6486"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0d6feb9d2d84f8a0b"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-05726828e873502f4"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-09cc26d241f9aa792"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0fca91e66c8a8b1be"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0ee9aca9a99c02ab6"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0ab73ffbfee733bf5"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0c9f879467e64bc74"
                         },
                         "ap-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-084387bf589bc95a3"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0707fdcdcb4dce23c"
                         },
                         "ap-south-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0ea3056164b4cb6f2"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-09fce1e5d43a3d848"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0928a070131af2ba6"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-04bc5020a8a8d6a76"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-05cdb4106e8087676"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-060a4554257ff212b"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-05b83b496e80464aa"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0dd5ef86fe2239f85"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0b237a90b3dc0ccf4"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0de9cc0d1d06c3563"
                         },
                         "ca-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0b1480cb16c7ddb5e"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-06b5d28675091e6a4"
                         },
                         "eu-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-03e3f709bd9816c0c"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0c684de6b7b6044fa"
                         },
                         "eu-central-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0be9858f4c1d1f7d0"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-082ee5b9133a90ddd"
                         },
                         "eu-north-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0872cb88b7da7c557"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0d40db124c2eaaa91"
                         },
                         "eu-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0be40361b45b050a3"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-099d20aa7e347b4fd"
                         },
                         "eu-south-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0287c06d9df0b5f4d"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0b062d782d40da20d"
                         },
                         "eu-west-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0ee962996555d5985"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-087b089d05cbd7992"
                         },
                         "eu-west-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-021d4056a1eeef969"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-04ec57cf62ae8d199"
                         },
                         "eu-west-3": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-032117f75e348e3f2"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0578f3ccea934bdad"
                         },
                         "il-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-00bbaca81fdf09851"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-05632e978a299ffd5"
                         },
                         "me-central-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-06c573dff2ad8e2c8"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0f5ad5f88c8dbbabd"
                         },
                         "me-south-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-019d9ccd8d2e3e9df"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-08c1bc05302bc0cbc"
                         },
                         "sa-east-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0623c09cfa9712b6a"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-06033a9b326470208"
                         },
                         "us-east-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0e47818459cdfce79"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0834ab212f72ecf93"
                         },
                         "us-east-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0786a7f95ddfd29cc"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-08468ab540b4c7dd8"
                         },
                         "us-west-1": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0c3b58b3984199fde"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-08754c17cd1e3c0b9"
                         },
                         "us-west-2": {
-                            "release": "38.20231002.2.2",
-                            "image": "ami-0570552acf5074e63"
+                            "release": "38.20231014.2.0",
+                            "image": "ami-0f45a1193d698bb67"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20231002-2-2-gcp-x86-64"
+                    "name": "fedora-coreos-38-20231014-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20231002.2.2",
+                    "release": "38.20231014.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8e14b168017eaedd5aad2b92452213c6b5eff5f6fd9ff44c9289dc5e1a5fa8bf"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6922e8bf54c1903ea0d90e71dab65acbe4b1191407942e38f98317fcf5c49b75"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-10-10T14:00:10Z"
+    "last-modified": "2023-10-18T14:27:02Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20231002.1.1",
+      "version": "39.20231006.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231006.1.0",
+      "version": "39.20231016.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1696951800,
+          "start_epoch": 1697643000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-10-10T14:00:09Z"
+    "last-modified": "2023-10-18T14:26:59Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230918.3.0",
+      "version": "38.20230918.3.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20230918.3.2",
+      "version": "38.20231002.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1696951800,
+          "start_epoch": 1697643000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-10-05T04:07:55Z"
+    "last-modified": "2023-10-18T14:27:00Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20230918.2.0",
+      "version": "38.20231002.2.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20231002.2.2",
+      "version": "38.20231014.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1696514400,
+          "duration_minutes": 2880,
+          "start_epoch": 1697643000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).