### PR TITLE
Roll out stable 38.20231014.3.0, testing 38.20231027.2.0, next 39.20231027.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-10-24T14:22:25Z",
+        "last-modified": "2023-10-31T21:21:00Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5822b0740a2839f7ffd076bee4996879af0006b318955638aea506eac90e99d2",
-                                "uncompressed-sha256": "19fcb40707e0f337f2d8b0e0fa2dd47c8bd85004e4ea3d80eb8febf977d51bba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "00016166c87722339a61b05ab3eeb0e9c20fc08f51c71c7966037cb461ded361",
+                                "uncompressed-sha256": "bc3105552a08c0070c40ac2e7803e300bc8a38078cbffe668f4bceb77c15b151"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b8a16d10c30cf9851201a44fb3561b5e5053c4976bf845d8a883130f735ad8ea",
-                                "uncompressed-sha256": "c6c2641c958ca0afbd9e908bdbab1e24c0c64b0c3b3f3eff963b4ebe119e3376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ca5747e9fb81568d907d422d710e39e2057a82681183c9f02e67727b2cd91fe6",
+                                "uncompressed-sha256": "11111cfe6946943f48a08c50c107aed9e0f7c9377a1e4fd51a9a703e59d219c0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a462449e28b3cd41c2c56c36a9e33cf2a1268e1740437ae911f207182d326eb4",
-                                "uncompressed-sha256": "5f2d00f9be46bb3b775faab49e82644dbdb324e4a50f1cba44d4765f9a94857f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f0f9f8cf8ff937dd20006589a5ad562a3e9d2277dc097e9829d9cf70bccd8796",
+                                "uncompressed-sha256": "4c7484dc92576ace86f3d1fcb7f2073eedae00aaf503861bea94517dc183c6bb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "267045a29781d24e4efa2edec9d2b90a5b0093b9989e6bc23d04a9e83c41d308",
-                                "uncompressed-sha256": "2aa3b3dab177e3a577951d28b5e806f72b7471daaab46a48e5b9a7da239a82ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5a0c266f0ac3fa98ad23fe9639146de72df6cdd985699b17440a991b683070d8",
+                                "uncompressed-sha256": "4bdc2f6a2d9b322083175e0ac3ad708e62b3d3ee381a65c42cc19040c696e3db"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live.aarch64.iso.sig",
-                                "sha256": "e3aff4d9c3ad1f526795bd08fe58a3ebf8c9888fa8560c4e523cc03ff9228a3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live.aarch64.iso.sig",
+                                "sha256": "055dbecc6f5736874c863abed119f3422e1ca28476e48b4c2452f2cba48b250d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live-kernel-aarch64.sig",
-                                "sha256": "a36bb36a491e2adb4a6ab0734ede9859ad4320c4f5325fe7411d753fdbae8539"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live-kernel-aarch64.sig",
+                                "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0294ee214247a2dd3cb30fb7251e83272e1d59ab531d1b76c5f5625de724d7d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1edf1938aef0e33be14a7d9dcc536234ff264a98ed00eaf926c8e07d5669fe1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "067ac505a26ef3312568b048a594a3f510c5359192e9d8bd0c5f1e4b5549a0a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "14b1c1b3c99e78c97c228bfec6fa71f0de8fa90b4693b63477f2a84984fc793b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5bedef9e7b37723bd7b5a1f7277c4d916798fab5b20fa0990c006bc0934892da",
-                                "uncompressed-sha256": "2ef1b8ff374f82334158abfe5606f8ee4b811fb25a9141c840faff7b6823c5db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "48a99b7ac0ca0d5e750ec02b2f0e1556dce7969bfffc6d1796b6e645315d3ed1",
+                                "uncompressed-sha256": "e613fd67808edf2745baf27393e5c35a9f57aafffec5e895e5c50d95056c0417"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "164c4ca031f0902509402d15370c4845666aca4def68ce29309f0b01da5ba9f6",
-                                "uncompressed-sha256": "d92682506aaea82705f23eb8ef90ba0173efbfe9a8ee7c77477693e99c7b7ce5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "13459fa97c4631c8f58eeed4274af1d6607bf3e35348c691eda79d9ea8c39443",
+                                "uncompressed-sha256": "f0445bc96b461c72d71cb62a514d3a1aa82679ba995310200128ec14994b83ab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/aarch64/fedora-coreos-39.20231022.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0c952f62b981001c58fd35ce5534baaafa347887e362dce36ffaa80993f28aba",
-                                "uncompressed-sha256": "f3a9b7db643302f438c98113dbc841963b55a074dfe0c4d17079812b20b4fbd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/aarch64/fedora-coreos-39.20231027.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f1c04c4256727687532b1cc3cffd99f112a23b70071f2273d66b4bb082f8ce17",
+                                "uncompressed-sha256": "812bea18b2df74abe7d718f68f65a2a6c891a63fa5b8045ed07ca0890a6a7b06"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-08d26cd22395d2cc5"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-09b6c046967825ee9"
                         },
                         "ap-east-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-02d2f6724f623f6b0"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-00c07268931813638"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0183540b1062ee976"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-062e9eb253e3430fb"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-062f8d0b6de6f985f"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0e9b105300dc04f23"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0af9de52a049b3271"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-02ef9eead9df266bb"
                         },
                         "ap-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-07921fbc392d1965a"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0c2558106b0036d8a"
                         },
                         "ap-south-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0b026e36120d202a8"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0ab69bb403da368b3"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0a2ccfb39f3c3c9a4"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0f502ecf4df8dd8b2"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-05525b0fa21389239"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0416250ad3c9f0093"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0e8b7e33dcb832fc0"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0a886159f9d2831fa"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-02211909c9554e640"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0b3e81c298033baa9"
                         },
                         "ca-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0a6be96738104f634"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0e3d82af5bdb27ac2"
                         },
                         "eu-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-07613370092abd5ae"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-03e92d235de9ca0cf"
                         },
                         "eu-central-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0bf3deea5a3da0ac9"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0c4354f2447e22815"
                         },
                         "eu-north-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-08d5b101003fe872f"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-01cd5d63568aabc61"
                         },
                         "eu-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0d818e8e86795893e"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-034ea62352839af3a"
                         },
                         "eu-south-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0e750d70d30cb0a91"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-08a5282cce26a621a"
                         },
                         "eu-west-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-01b7624cefe2ac14a"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0c71b0bd2b3fce0cc"
                         },
                         "eu-west-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-02a8b108793791fdf"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-07e6b1a43fb1cdb5c"
                         },
                         "eu-west-3": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-04799027d947ceff4"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-01d02fa432e5a4de5"
                         },
                         "il-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0f98067c72649eb15"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-08447fba9bc71d8f1"
                         },
                         "me-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0e12774af16d68d36"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-05b81623318d844e3"
                         },
                         "me-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-08c9cc0627960eb9f"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-062c9a55164b72517"
                         },
                         "sa-east-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-01b40cb8bfe875ab8"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0ba268c9850867181"
                         },
                         "us-east-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-054e5d8f46291ca1b"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0cb60a06e385f0ee8"
                         },
                         "us-east-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0c8de5df8cecf06d7"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0c5ba8d736a72674a"
                         },
                         "us-west-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0a763cea8b4792015"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-02fff1ca100e3bfcf"
                         },
                         "us-west-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0596a259d3f190eef"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0193b7791ab370546"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231022-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231027-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "057e3e0d2d408ce33d74791b8bdadddd4ec5a0823a9900c755ebd57338d31af2",
-                                "uncompressed-sha256": "93857b14f20206f709f8f8f7a12466c4187cae7df63dd20ab4682fe5f35b5239"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "baeda7ac571d6c74b9f84364b4cc6cca11330f6960fdaa737f24efeb431ee32c",
+                                "uncompressed-sha256": "2ed8edcdc425d6f97910cbf59c2c86be591e386bc6e25df0ddaeb658c56d47c6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live.ppc64le.iso.sig",
-                                "sha256": "60e52e01d2fa1fb3e253970714a9fff96664ec443f94813fac5942215ea6a939"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live.ppc64le.iso.sig",
+                                "sha256": "8fd43bfd76e45710c0f40f60c4a2f13dc9254fe91a478c9a6e945b27a47907cc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "9ee110f29b46a73a3db8ebc9378ee245491dd9560b6977db68c655a971b5363d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5c6d3e926de3db2cb7e02d1b27121b4b678652ab8cd7a650876b57e5fc424418"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "fde760d9ce34a4fc034104573242a7f684a27bfbf7161fbbbdb8521862d890be"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "fab45a848d0d1e793642f8585a8d1aa331cee5430db3636855a2e60f880f7e2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1a14561dab8bd6b4b39aefb997766a5d36741f31de249b6d1e26f864d56b6807"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "853e63cc467605bf0658001432e9142af9c3a337b296de0265c4f611ab19b47f",
-                                "uncompressed-sha256": "d370d0a2cb3bdd4c02c7150faffc18f314c3519dc88045b9c9ec9a8a6bd515c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "d2d3d59b2eb2ae2794091453ee997d0eab4981fee608d4a6e8a4a20c8eae590e",
+                                "uncompressed-sha256": "c2cb0c1cedb9b23606f0476a2c8315e1baea476fc0bf29ec377130f1a61a18bb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d03d1d68b7fd90af392a2c87232dbc0a97b74f3199152054f975fabb16b24128",
-                                "uncompressed-sha256": "bbfe65095e8fac62637145086b996423f0c3d83e59671d5680789fa60cbc13fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "444ea1d924653d463201e48f9cc3e8374771b5b3cbd22e88b26998aa35ce5215",
+                                "uncompressed-sha256": "4533533bea87cb4f9eff919678fc912aab5f72d42e06ecfc374a60aa21cf8132"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "dec5f4aea4d44ebec332b43cfccef91785d692609c2dc6c21319056927648057",
-                                "uncompressed-sha256": "fe65869ec0fd3c7c3624edea2e6ba7d0e891ac3e36af7f73ddb55306ab54c676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c3ae4c62e9c86f50be13b49388a2e526f3b828b844cfb720c5657ee4542089c5",
+                                "uncompressed-sha256": "40698c47970328c0b73f748a8063f40931e745b3073d83be48664360e387446d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/ppc64le/fedora-coreos-39.20231022.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "611a5dc79589b1f409427e21786b4f804b114fefe09afecdd4cc917bd0c81f24",
-                                "uncompressed-sha256": "de5c6a3a610272b1b3fa46c5eb9e9b2f993865a5795b5d1c97ad69f7e6e0c294"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/ppc64le/fedora-coreos-39.20231027.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e16d16e4f7d7b6b277ee711bed038f24b5036d83fe748ec6b5505b1f00e940b4",
+                                "uncompressed-sha256": "bda101a51a37f0f1d1c2fdb816858ccd106ceea42c6c30ee0f621de2ba35d8b5"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6949577cfe76cb2c5d5bd61abf9b239dbf643e00fb86f5bf7d078f8aa23a95ea",
-                                "uncompressed-sha256": "7e59ad0a5539fb1db779034ded40cbd213936171013b45963e11312998997cd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b4f78c00c7cd133abb8c0c623931300a87c42a266bd486b735706ad82bc7f61f",
+                                "uncompressed-sha256": "a0feb8e91de86e9f814b5896e1eab03073ed1d7f83d195c158f7d227dd4b2e9b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "60c8ad18585323fce7e16eae17329898e2dbd28dbb7383377ade1296b305048e",
-                                "uncompressed-sha256": "30bbd4a9668a6779d25120dc9d5ee0454a49a46a3a67144b2833066550ed51ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fbc739a7513c86300f0f4078dbe9fa8e2acdcf41ba80b8683ceef4b82d8b665e",
+                                "uncompressed-sha256": "3d924481625b4f3c06a7b0abca085f4e5745294e1365930de84b4333e53b70bb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live.s390x.iso.sig",
-                                "sha256": "239b4d9f73667ff0361f141914d29e97db8546cfba7bb67ca41a1484c300be91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live.s390x.iso.sig",
+                                "sha256": "958fa360eece9246d83f18d24c9268ee935f2d46d5e0ddca9e29fda1ff825806"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live-kernel-s390x.sig",
-                                "sha256": "21f9a5831500c2ebefb91e8a8e40590312d801f2f134311f525c1a30e9576729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live-kernel-s390x.sig",
+                                "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3db0342e42153ba7b1646c6a8c3adab45bebed0e8600a28e8593efd99543be4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "e22abcdd7416d36e28bfd977e4ec83386e1f600ad93abd835e10f1afb148dc8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "897ad15e961b2801eb1e91451ef766b2375b14e0d62001de97fac7bb05fd7477"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "18030ff6e177f5131b567e38c5d49a416239d63db2257b056e8fba5089e7eee8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "97983168bb68fedb058cccd3724843b677467b60ab6d3f5a5e7ae72a757529a7",
-                                "uncompressed-sha256": "f7a415c019c39685e621670e6b7845f4b6a28f8a4cffbbecc37c5a5b68c67492"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7db04907cc4e96a59fbb005c8eab312d3cabb5a79e916e99770bbaff317cc8d9",
+                                "uncompressed-sha256": "88bca45bd27c4c3fc9eb536ac50bf5468f7659de2294751b0cbee08463855710"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8d087573fbe09c2b3506323d61df53839e382ff7fbc04cfd90b815c585e6b67c",
-                                "uncompressed-sha256": "f4263661d190bbf9bd096914a141ccca6d23e12215dcccf89e260aa780994ce2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2bb6ef5daacdee2f4f2a6870c59ff08209af1440545a95b5872c9262bf445ccf",
+                                "uncompressed-sha256": "28ff4dae2c596321aea092a4b79ff8f14c1135db2203668c6f9660cdb9537914"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/s390x/fedora-coreos-39.20231022.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5722201fc85221cb6501e793fa3b595794bf10b338107b52b9ddf21469e6f964",
-                                "uncompressed-sha256": "c7530c11a2638ddf62d9b6a284a0917afa02f2bfc49cd4e25af8a3e7dde00823"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/s390x/fedora-coreos-39.20231027.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "83e9a01ab5f49516b9da0a7ce65652d463bbd1d0537ae533b9062d7fbc2a1171",
+                                "uncompressed-sha256": "79183e4d189dde54d41b804ac7cc81dad4ebe2d9cb9f88db080849c7aa3edfe1"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0b9ed336699ef737ad38afadb5f0b9cd528ba076ca8e7a7bf71f3d7de11213cc",
-                                "uncompressed-sha256": "e14afc2066f3e9bfafd2c65c95647e59af3e88cfb66f521fb9fedec21640ab3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d32042939349d3a548d52de8be7c1326c32cb03f3d6d4bc5c61c71d45f0d7743",
+                                "uncompressed-sha256": "64a18eed02748b5d463606352e5011fbda323522b3d362fe52d6533e4027148b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f0a7a0504a0730132d5ab080d60a1da9134ff5aadc46bbbcdb877e590dfb8d4b",
-                                "uncompressed-sha256": "bc38bf7f8d184f5185da4a9cee46e12194424fa9970c6f10e16bc2f4c5ff6c58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f1a35b23a78528b2febe0ddbe7772d808aaccf475b98071d2297610d9c82e3a5",
+                                "uncompressed-sha256": "2065a37e1b9f3a4fa08616da5bc771c52337fb658f8b3be24f895df6b808b65c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "cd5f610fb46ef1222b60ba21f8c5eb04756609357a00ef73db4ce3fc54e42663",
-                                "uncompressed-sha256": "289c5c767fa16e4e21f89565cf6e1c0043cd3e21c7492d72b54be51db75a87d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "258154c5b4141e43ebfc411a1ae442a5e2bdaa194f5d45d1e939fb666b58ceb7",
+                                "uncompressed-sha256": "5d9e024e398c62072f4897df738e4e8951cf74d7f39c99f5adb08af834a437e6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "178f2f4fcac3620fa607914c1206ef66b2216e5dd7e13c514a7c2f4fdc1a7a19",
-                                "uncompressed-sha256": "5c077793470b95ba65dd0e20561056b9700bfa69258c9464f2ce277e15c2404e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e845e5fe0c2f82627f55e15abbb2fe46da5d8d701854330a28ebfc114a364070",
+                                "uncompressed-sha256": "487513977546031562c04b809a80a250880d23311b82a2888839affdbb14e8da"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b14fe09f6f78cd7bf7672d5a44a6d569fa0c9b8f09df3a7bc04022f343988210",
-                                "uncompressed-sha256": "0bf1f493c238ed6ac4a95e8aff1fba62a7f548bbbf7ff007b1c0b1a0d9638c94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9791542a1b41f59746feac9435398c7bb258d2432a6179744b04eee96ef9ade5",
+                                "uncompressed-sha256": "a5cc3dca740fd487375c2d1911bbb6293fda36ab70654bfbdd216c1e4fba8e26"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9bb16e3ccf05a4e5fdfb67f2699aeabadd7936302316e179abe7ab715caf20ba",
-                                "uncompressed-sha256": "a228ddd6c6d9b864d12b8b41126ad9438f9c6db30709918bc965b53500b8ac9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "910c7dc29124e0f921cc6cd7c4ce5f70b71459cd0b6df437dc4edbb43f76468f",
+                                "uncompressed-sha256": "5c125f22338c6d055e369dcd9cceb4e5fea221293b34a64700fd87f3168fd9d9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "24b092c2e080b0cd0b6cf576f86bf7d74afb898ef131593fbc13c6531ccf487d",
-                                "uncompressed-sha256": "54b3c571aa6bbdd6a9edbcb8716a14a300e7dc51c5e17c20b6397841127f140b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c81366e95a64968dade3996aa87a2ace457d6a90cad478d9f0d59af5f83acfee",
+                                "uncompressed-sha256": "2bd06e3a8c5f9fd076ab0b0aa3ac84d1cf76da0f1ce39d684adeeb201126e75d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "5a205432d18ac216b9086c3ade9a2928fde01f917f28cf6157a9dbdab788d2e4",
-                                "uncompressed-sha256": "ccad74aed884eefd542990b3dba44672f2f97d768c07e4c02cd920cad7d972cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "3c05894ef99f70dd1af2a01abcce32effdf6d32dce9c769a393a3dc6f8066942",
+                                "uncompressed-sha256": "c4f8c30dfb0040d19370de51801d654b2bc3c656d0a747fe8933bd856f4f0867"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0fa7b46f7d233bf8559490b0a457d36ac4da5084266b862f28b0aa9c0535d1f8",
-                                "uncompressed-sha256": "b09766140d75a62ed34d8f0465d3202c011f147311ec3d4007823b6a00c53639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9d6287b326b6d1708df5194d5e4009087837ac40bea08119f2615544a2aa3415",
+                                "uncompressed-sha256": "e76dea0480c2eed1c94445c1682d18729d6f523a9e0e8b09c709a8391d8ecb15"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a88818577532b0e09e330f8c04e18dd7cfbfddc8aedb94b8ac011e9e79dfc93c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "53d4befc1ceac05d95b0de076b45654c0e983779b8bf6b00214281ef594dae6e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6f1beab112096e9016774072d3ccb17ce3ebe220b580ec78afe770ed09400043",
-                                "uncompressed-sha256": "270931899e91d6305c9cf0f62091d5e183ad6ed7849380637ea7a753733b3c70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7b0a6b7163e86bcf4a0a3044383536f3f109e23d7bae2725580bead1034f7872",
+                                "uncompressed-sha256": "4bcc1ed387a94dc2c7c09c5165f05cbcdf419bc3173d44a2d1e328d2cec8edb3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live.x86_64.iso.sig",
-                                "sha256": "4421fef9d04bba2f7ff79a0c1eaa94b3931e387c2e236956c452dbb0b9611868"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live.x86_64.iso.sig",
+                                "sha256": "a196f2adaf115fd0149fa32ead84b4354443cb25607c82dedd5f25dba04bb4e5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live-kernel-x86_64.sig",
-                                "sha256": "c77c30cad3502c06d11c030d2f4471b53f559fd6553088f682de868ace4889d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live-kernel-x86_64.sig",
+                                "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4e051470b231a25cba0f2b062e5dcd67ddfb102a02245525507b8fcbe2bac52c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6c5d18c6b80339a129fcabd3bf2f901ef1362bde923b3d65ed01db320e7d9db5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "32d146f51be1f44d8cd069bfa166cd9f7ea916c07bd2e21b0def6f5e3e8e5581"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8b07f7768aaffedce6c1d13ae9daa532c06667bd845a13877528e2995a20a772"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1d2ffb47732d11a6cab0a797e4553ef203dbe25776e9c9bbf6bc557dcaa06911",
-                                "uncompressed-sha256": "233cef5a3935773e55c6c3efd60cf9cfca793bbd55201a306bd9723b129ef4bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6fec974c68c233e7364eb41037316068cb877581ccd004606bc790851002e427",
+                                "uncompressed-sha256": "073a1d2c99f67ce510347361d12655e9ddbfbe909c97d55579088087f5a56c26"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "35760eee3b15f3f0a6dd425f1f8ea279a3c131c87fefa848816f7659ce64869d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e9ee04efc22cf9dc4f3a119a84cd9678f7725897982e5c66a2e7b0ef44c07554"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d7be8c9d61e98cbf1651e0f18fb337e18c6dcdf469ea84a1918db0e6fa83580b",
-                                "uncompressed-sha256": "f77f46e2701d4a0cbb51259d65b7684905a30b6bf808e7cba076bbb7516d6bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e34565e0d98762d65fb778a41fbef8c7c3d327b5dca6547cba2e125017dbdd42",
+                                "uncompressed-sha256": "6e0b30eaffb2819da30ea706a2b7d1d9d1f69a94ab4e2919e40590f59655017f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e2ffd61a2791adf97fe9dd963adaf38139eeafc08eceb39f2c8d125336cf917f",
-                                "uncompressed-sha256": "c12acfce2b861853aac1256340c7fea137ef18f2ab96997461f19ae2b36803da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c2ecc9c4d829aff5d73d65607838aa33b62891dc6ca772d73191dee691e70274",
+                                "uncompressed-sha256": "51c7986f60e6d9e70d9d58571688984ae2c8208932cf3dbffa5f48907cdf5f18"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "18b3b3302a48a232a3ea45fd42620fe25668a70c0f623f4f42c23be395e4a4b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "63fe0dd6c3a36bc1a5986a6174df04ba0dea694c22a793f54edce20f213d8054"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "32378ad011ea6cec8ebe5fb455a087d2ae6acdd1b83ae1ff2fce17e6cff18652"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "c6586cfc679540f773425d27d82bd7b9ed7bac9729d7d4ca39dd87f560a38897"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231022.1.0/x86_64/fedora-coreos-39.20231022.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "95ac1f29b5bcb489af82f372b3933485a1544ebdac274a1b27b35332aeddb118",
-                                "uncompressed-sha256": "50eacbea64aeccbe3f0f1c34f4dec6f6aab1c6d537afb8454ca85da8ac36bf42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231027.1.0/x86_64/fedora-coreos-39.20231027.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "226390c8bb74b9fc5f5622c4e739b0e7a5aaf0ba56cc4ba73aa37a92e2383cd3",
+                                "uncompressed-sha256": "5d775d811ad4fa6b5973f5728aa264d7ec4adbd5e19fb1fe4ca3c944cde654cd"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0d2a3216f1e021afb"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0131a99245a118a43"
                         },
                         "ap-east-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-081411a9cdd4ef559"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-00d8c37a9eb49f8cb"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-01203957cf871b7fe"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-05f0e15a79a77c4b4"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-08e8a6467f4c3e618"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-063e4bd5eae204ef4"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-06854810215e85942"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-08c78706da0a65d08"
                         },
                         "ap-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0d7edb073f81ff510"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0104114087cb3a742"
                         },
                         "ap-south-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0f5987f1dde90f7d0"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-041dd2d555a2a3741"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0a6cea285d22e39fe"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0ac90e4bbf6610f7b"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-077f6ac99f366d231"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0afcbdce761f53f72"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0ce94320480d1d8e0"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-04482ac5a85338e1a"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-095b41ed03ea8a429"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0fbb4978ba77df04a"
                         },
                         "ca-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0d3f6a42139d90ceb"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-07dd9e491cd3585da"
                         },
                         "eu-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0ec7099d92cbb8307"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0db84e2c52b7f6940"
                         },
                         "eu-central-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-09b108ddd8a7efd79"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-00767eae03af198ba"
                         },
                         "eu-north-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0257b016def17911b"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-03cae46f7e0b83aec"
                         },
                         "eu-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-021fa585d56a9235d"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0d14de607f3502bb9"
                         },
                         "eu-south-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0361bb442ed769ad9"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0eff50194bcaeca96"
                         },
                         "eu-west-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0a93907f14ca81e49"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-00d297464ff221de6"
                         },
                         "eu-west-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0a2ed456164e32495"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0958e81472704ccd1"
                         },
                         "eu-west-3": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-084aed9efb842fa64"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-070be6bed27b4c926"
                         },
                         "il-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-097385eab3fdc0006"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0d71e1a7946246e25"
                         },
                         "me-central-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-027d1699419a13330"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0e2acdf8c76b402c8"
                         },
                         "me-south-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0441d44f628a829cf"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0037232e69c80c0bd"
                         },
                         "sa-east-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0c6397e989afd29ec"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-079b5538873b4366a"
                         },
                         "us-east-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0e10ee580d3e692d1"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0e0bbfca39afc988f"
                         },
                         "us-east-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-05ceedd0634e26184"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-09d025fa60a70b180"
                         },
                         "us-west-1": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0698d474ae14c0ff5"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-060cb98c46c3eb1fe"
                         },
                         "us-west-2": {
-                            "release": "39.20231022.1.0",
-                            "image": "ami-0400b1312b24a2c77"
+                            "release": "39.20231027.1.0",
+                            "image": "ami-0c6f9f16758259e62"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231022-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231027-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231022.1.0",
+                    "release": "39.20231027.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4629cbdcd5a701423b03dfdf8a9826fb072fb64c33bb730ef57365f919b47c6e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:18ff3d0a979863142efc2fb0bcf29e8fc228ff258534cdb69a5b9e06cca27daa"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-10-18T14:26:57Z",
+        "last-modified": "2023-10-31T21:20:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c7b72d2be0f3be32f6265e58fccfbdd8663982c72cc6c5049cdc8a3a7e2e12c1",
-                                "uncompressed-sha256": "b9aeea96f55cfa6e3de37b66cd6e38594731be1f8d7f3bf0b3798433c672e55b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fa044ea3d299ffe032e05c3ef0cd46a0f02ae1a158551396e8da706721e3ea8b",
+                                "uncompressed-sha256": "32efc6ecd53ab19a66799baa1a47b7a6deee77a80761dde48ac0d11978181a4a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ef9db358e8506bd1c7af16557a3a9dea6d9f197483f6a1bf2aa0da29b84512aa",
-                                "uncompressed-sha256": "6c409464132ac8eb84609174c7cde04fd5de4c12b28442b2a7b1c126fa38aac7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "81bd52741538e427359468c6b00379e6e52c9fe47a5a752ea45b3a455a8468d4",
+                                "uncompressed-sha256": "5070b5c6a4dc3c421258c7608453c77e5bfe0c1f7609605c8e684d2146cdf1d9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3814fdc10230febcacf483616cf424664c7bb0350d2c2570b7ecda464def0319",
-                                "uncompressed-sha256": "e90a293b9b42539d54e7a68e2915c3b4df14edd02f1a14c31425543ae37b35d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "8908c8039bb61f72ce4fb7b8552be60e7c83becf58966de79edf59ca0562c4b0",
+                                "uncompressed-sha256": "f7d72ada0f33a05a237eccbb19b7b08f6fb4e77af3ed2c35f5b7afc8d09c54b6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "9030b580d43d0a0df5725c5e591ce9532091c52143d00c439229bf6ef55e7fd5",
-                                "uncompressed-sha256": "521207203ac9571eb09766cd8454546e22fad4e7f4716cb74acbdf90f2415095"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "87ea176ec4b1fb265e445d0c88d5f630a501d6737c79e788de73412807ec3dfe",
+                                "uncompressed-sha256": "774aa919daa09f7a3eb398a5e89ac13f1537dd2e1694ee7c08a9a91082737d9b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live.aarch64.iso.sig",
-                                "sha256": "56d308e67638a430784e4fde39d375c60058a4bad401a1110b6a4669ecce0983"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live.aarch64.iso.sig",
+                                "sha256": "e1f3857d2fe95f35de6332f02148ed9a3c9e994708d62b931a52d3b49931b177"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-kernel-aarch64.sig",
-                                "sha256": "5a8d3f044f8ab56cada5820da8400321bb44ec9797a9848edbacb8c45d5ed298"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-kernel-aarch64.sig",
+                                "sha256": "121d52884cacf3d791947adccfd70ad477c360510a56eff25978f631c5ce6060"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "c9296ce3958fa69df8e03d1e430882eadfedd4e8ce2ec03ba21e088b603e90b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "41dea2b705f2621d5d6db33dd8e455b58c99e65bb4cc1c6b711bb95a65dd00b6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "6f5e7aedba658dd0cdf60d0bb6cf153be0838eb60f8dfa74429bc5d981c07dc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0a04e8caba4e051d667066a7d8a889f1817f035099e812790fbfb68eceec301d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "58a855d7f5ec0c13c56abe73b4518604cd99c2ea97b9301e08ccc1071e4ef880",
-                                "uncompressed-sha256": "a870acedfe8e8543fa3a44fe0446f10823359e79d94dd4fb515af1188ce6da54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f22b6a4cf162cb1aae037e4862ada8c49ef5b50c90d0014c98f4d592f48c5132",
+                                "uncompressed-sha256": "44c3990b5f0ee114f1ba9a21a8b8fa77a9d374d3c99ee01b8ac10a0fe8d6df10"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "84f3b2a4d9da03e0c7484ebb2d103bdcf9bcdd5d05ed6c42cd124657289aab91",
-                                "uncompressed-sha256": "455a3f7d5e15f79ed8a6042b7af0d19a3a8bb3ede5908cefb2a47605b676f14b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ede124a5b897e9d0966f3acdcb1a70d23ab70e0f5fc40c14b14d8d2d66df60e3",
+                                "uncompressed-sha256": "e9114068b01ee91a178a6fdeae1bf2a2aaba6272bd8f9eaa89b83ab948a58b9f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/aarch64/fedora-coreos-38.20231002.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6051c5c2332d7a51f014a77b7804a9d01e0ef8792dc68c130484976107481e11",
-                                "uncompressed-sha256": "5beba76aef4e87044c32d7170bb61ab6b559d74bb99a510677cb38ce48144d7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ec2d50130fdaac48da5b7661c2acb1ed2b79e0464bd75c6a9a04f78cd0471728",
+                                "uncompressed-sha256": "9dc507572f7ea6359809bb7fbcf01c981412611968f74393b249c7ea678228b0"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-044c5837e0c79897e"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0793fe97a1dd3f08f"
                         },
                         "ap-east-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-033db5509657620dc"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0950bfa8a8ac73a84"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0d1ffd32c25a27693"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0961a4684bf1b1f95"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-059b90cd95aff1a2f"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0ede556e6b14ed788"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0b94bdb4ec2eae6d7"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0c3bc39efb656bccb"
                         },
                         "ap-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-008efbdbcc40d8726"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-05f4c9d7c89c89ebe"
                         },
                         "ap-south-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0bc0c41ab3613df9d"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-001ff5576abc12667"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0504691c505bca141"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-039ec73cc6c240caf"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e718a58e26d23b95"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0a8a637136d5a7cab"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-05a9b5634f8e96d2e"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0677049b04c852132"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-00404bb428d3c8f47"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-03abbd2d5aa7736d9"
                         },
                         "ca-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0bccc2b3385ac435e"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-05ac6be2654c85c18"
                         },
                         "eu-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-09b6088a67bc9d35a"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e6ebdbce2cb93002"
                         },
                         "eu-central-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e428d3c5724a4c28"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0fdfd4e7f068a89b4"
                         },
                         "eu-north-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0c280a723564a60d5"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0d37849de3375a861"
                         },
                         "eu-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-039b0f6caf897e252"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e8cf36c4a204854f"
                         },
                         "eu-south-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-050f1f0316b655c7f"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-00914ed2706940781"
                         },
                         "eu-west-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-03f64e7fa748c3186"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-084badc53f428fce4"
                         },
                         "eu-west-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0b4d30328483d3253"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0ddde4cd742920e4e"
                         },
                         "eu-west-3": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0a932a3e22c7fe286"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e894f5eb6c9f7b9b"
                         },
                         "il-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e7cc2df48976d0fb"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-09ccb02e4a42a0f6b"
                         },
                         "me-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0ad2f6ec8b909c21d"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e453f615e411860a"
                         },
                         "me-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-01a8c060067c75f4a"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-00595383709b27097"
                         },
                         "sa-east-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-07fe2ff62a61cf7b7"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-07abdc48108fd91e1"
                         },
                         "us-east-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-027c7dc302e55c11e"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0ad99b192a830a2ba"
                         },
                         "us-east-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0cd4265eb62f71834"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-01b8b3e5d5cf89483"
                         },
                         "us-west-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0b56c24530e694a1f"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e0e24f929d476760"
                         },
                         "us-west-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-06b667f6f9c774e36"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0f6d5c3c939ece0a6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20231002-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-38-20231014-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "15edb2ea3fe1aa7a41ea6573307219821f0d4fabff639f690dfd5c3328a8680b",
-                                "uncompressed-sha256": "4f3a8054764f136232cc38ccd30f646d9013bac51bd1df36b014f2fb0f7e5b0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "211d9439691330058bff86f80c39f256b26b9d3ff5f37eb67aee8763da927db3",
+                                "uncompressed-sha256": "561dfc0569d6c214c06dae3669e4b2bdd5b8b5e576ba8ed35874f5e24066b809"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live.ppc64le.iso.sig",
-                                "sha256": "6dceb4cc320288ff6dba6b030797afdd55ec818b9590879da9f488e41e622167"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live.ppc64le.iso.sig",
+                                "sha256": "999c75b576b9cec6f85c3f9164bde1eac3e06ad16e0c13b7b46552ee3a0476ae"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-kernel-ppc64le.sig",
-                                "sha256": "3cb685061328c9f7fe7536c67bc375978a3349f4b0d7a6145e5450dc7a824202"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "addbd3a2c24d7ce92e9280b65892336f60da236ff79169cff9624c5a241752c5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "9264aba911efeca5b76e5c3764ed8365a4d4ddc671cd1ff2cfca3eacc33509fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "950758cdb49a7ffafc4a21b5742bc9f613ae967aa0f7e3907409e0dbfcdb3edb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "aea85c746569a2490f07ff85ca1f0b14e3f525c375841095b70b34e140cd94bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0170a17b9fd3afb1d22aa15a01004de174d816a5c1ea110d9b6c55f6d26520db"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "263bc65796c2b80973aeb376b79876b2869449c3b10e0f78f0a66a205c535b85",
-                                "uncompressed-sha256": "413054a6c23d7ce3a1e761c7a055882fe5651468b0fa23b132b31608580eb859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1f67c2648d50dffe1ad3538127043c8cee8eb24132174701d2990ad37facc9b3",
+                                "uncompressed-sha256": "40835654a351580d9abbda6d003ccd5693cb9795f167e290114a00f1c2a47583"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "dddc2384f5b5fdd31d9b2c792057906acd7fc7ca19a57797dbad2bda24501d50",
-                                "uncompressed-sha256": "823746727d4cb8b0a69d6620e8b47ed7a725d0bdb1c0afd5133302c13e40ec28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6ddccdd2402c87aede40179fa18995ec3cbabe87ded2812b6fb4391809b9577a",
+                                "uncompressed-sha256": "da740bda3bb432a41c52ed670929a728d2614f854aace03e7127a92a5a3c446e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "fef07fe4fea252b10cdf782d0383c1a3e4ebbe2d6bc33ef562d059aee1a1d3bd",
-                                "uncompressed-sha256": "a65f620434c301b2708222e3b0006fabc40335a8285e6d96270ed48e37728bec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5e22e2e68a4782d76051845152871b27f39f624b4fcb2c83499ec121cc425551",
+                                "uncompressed-sha256": "d1bfdcf05619b0b517f5aa87ce5a5422bef1e65dc5c28e9ef2143180804c3202"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/ppc64le/fedora-coreos-38.20231002.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9f656189441f26d791b1f39f0be03cf25d694ad1da1b9ebf876d2e418d4b84e2",
-                                "uncompressed-sha256": "0f256d2775dbfc010c8dbc16aa2f57b1d9bf6f976a0352198f4810e8892d56c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "3d2fd06f6cae8fc89f32c64a6527510e3e41c8356d06ccc5943d007207d0b30e",
+                                "uncompressed-sha256": "26448e1992661ce576c8b435121e15fbb707237793f4743813ff25f9c2ca55b6"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "f17f0e2611dfd6ae44e05922f0c4f76b787981040eba9a54fc302cc12b27cd3a",
-                                "uncompressed-sha256": "25f9d370ac19d7cb5184f8f09b73ae6b000a4884648bd91b5d051a7005b1b1b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "eeb3f7ab250245bdb6d3ab5e8b96ac508bad6adc6ca18dcbe293714af2f5bc15",
+                                "uncompressed-sha256": "5e2dfe7c4e09669e1dcb10219efbe4ebfe7f0a97484c5bf99051f4715c5b3ee4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "487ea5455c691d4f1c020abfc498d5a1b89acd384e07d4b2a0cbb4c972aaf00c",
-                                "uncompressed-sha256": "19ccf84f2d772ff27bcffe964c99adabbe799b8beddd59bb62df187900747874"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "63a5e65899b44cbeba2bc985352461685c40a4924526c77eb8b54dcea64cb838",
+                                "uncompressed-sha256": "fc91afa49e2659919b8946d94022fd4b063b6bd334388fb40bd8bc0763de4e1e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live.s390x.iso.sig",
-                                "sha256": "b81ab4453d43b1b0fc8387c942a211515e0d868f8e30b7a384e3997438d61ac7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live.s390x.iso.sig",
+                                "sha256": "a8aad118e857e85eafc0e49a38c465b6be9c8616f6a3f72fd8e9e6c3c86cb71e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-kernel-s390x.sig",
-                                "sha256": "29d81e2de06f9158ff9a10dde5030e39d6754629ded5d52b68d7f2b7b6154796"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-kernel-s390x.sig",
+                                "sha256": "0a0058bd2959e2b77e1ff6f62d5111a130343a7bb045d51f43cf714133e69cfb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "a9eaca40448343d0156701d3dde8c8d9c02f11b8b7a32b648ac14eaf229824fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "186d655c5aea09f169f3836b5018f71fb6bdd6eedecf089493f520195f71844b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "858f6762c4c037cf7ef05b20f6f237f82c685c22d39e3d01454926347f4d9bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "0277a948f5a5362d9940d7b28c1400604f84639bf1af2150435900eb8f7f22e5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "0cd5c3338b47d5c5cc96b244f38e5ab7e15f9edc6af189da393c4346ccafcc60",
-                                "uncompressed-sha256": "e8a01387fa4608c9fcd15d992e6249c40fa9b1fc3eca9916584132659797e7f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "979a912234df58d9430f097832513f9b4e3088bf76223f04a7545422c7d064ab",
+                                "uncompressed-sha256": "4ec842c88c016a5eca95352608153eeb3dcf8bac6a4bca3a6496b632f5e16b60"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1ba4adfce696e1b1a43a121c1a3e5001577881fc5eb9971410a8d4fd48e72393",
-                                "uncompressed-sha256": "53ae1daa3e8b024ce0f74377d416424a8a659bfe9a485416e4eb39261eb1bd7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "262234fb9ea6aafc4b5bc33f6938dc94fadca089af3fad2d0060b08bb0219e6d",
+                                "uncompressed-sha256": "e6631af5298e32f372b9288276dd6f14fa2adfdc01bf1d5bc98da5e68fce9ef6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/s390x/fedora-coreos-38.20231002.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "94fad78df24d3b775361f61b7b877dd52a79ee77c40e2a5a1da3facd76b2cac9",
-                                "uncompressed-sha256": "ce5139e1dfe6f83eb037b2a9673de42305c6cac02bac5fa93b8fb07c92dfe48d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f56639e00e7debf4fa23bb359eb1d846a15e58c38bb36ed4d94b37b9bb4b06cc",
+                                "uncompressed-sha256": "57ea85fee46ebd5eb2480bb6cd4f44c7a19313b6f6a2a4ca56f4bea42734775a"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0c09668a71258ce86daf4732da94e4eea4a6fe40d489c7f24a57c808c10d813e",
-                                "uncompressed-sha256": "f3635087bff2be70f74a9dabd5d5d3b16d9f7439a3ddd061410f07a622166f22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "382717850bfbd93c5f3561adfe3b38bda4b222c0545c354dfdb87265f9a269c0",
+                                "uncompressed-sha256": "dea17bc22a8efd84452f317525891dc11c7cb601f4e893c76938823c52fa1ea3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a3f424a058c1603fe9d6d93e8b4150d2e9351dbfb19cdc40c051e42471e1d977",
-                                "uncompressed-sha256": "1552db0c4ab8180ab24937feb8d9788b8d7b40a2b2c3dd1d6e625ff5953677cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "61c5f5e50d6600233306cc37fbb6e979957c6d4b07ad056e75b16f3fe40687a7",
+                                "uncompressed-sha256": "60e36005189b0b738c13e19ae6f293d931bc3aefa3cd6a099f0c93af625bb247"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a29b2eadb552015387c48ec63af352234fd5077b58b1e3ae993f1946544050c9",
-                                "uncompressed-sha256": "5e45f955ba5b528b92f68a4381b7c1772c6607a905a9a0568a8abd2853ecfd1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5ca92478e862dc238b071ba83b09d8f7bb9071ca10f2ab761794f201077559da",
+                                "uncompressed-sha256": "b73d7c0a1d94a8ce5a445a355c15239e9cef6f3989d4e593d2776f1b5977c9db"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1c0f3df14928884efd46c377ad18f1dfb1190a1a274a35688055dc36a7f08f18",
-                                "uncompressed-sha256": "110d45deed79dfcbaf9f95362a913f19f6fea03df10b35a977b04e90751dfce4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "36dd5e03e68ac34b77d98e71bb03a0e8b7efda4ee5119bb7830eea751c64b8e4",
+                                "uncompressed-sha256": "834f5cbeaa3887536f9a6f0c31a748798ddc307f539d90d54df03fa6e4f6f708"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "038b06f4153f7e441629741ba06782b166d2893b1f7f0c73d41cbce7e196fdd7",
-                                "uncompressed-sha256": "5b11abcd177989e082ad2e1b1c5e618cdbcbd084901834f464ca233d0f2eb30a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c7c7ecb0607dfc78ad4b55fa703f45d9095ea8925334e81a6e2ffec76ba1d753",
+                                "uncompressed-sha256": "e2e8f80cb490ed78e27283bad9018975a278bdab8155cf9e2294bf475aecbe13"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "52303a7de83b6ef9307c48b38282c2579b490a5ba1c43cc0f4df3df00cfd16a0",
-                                "uncompressed-sha256": "d6e3936475105ca331b4adc2078701579ce132c3de1df04316e67bd3546f2ecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "33a31524d4430e3832e44ab1fd57e2b49a9b131d4666cf0f3f398c0460c754fd",
+                                "uncompressed-sha256": "a700017727f44424d3450fc9434a1763e87a15d034f0e613026100de0c8ea123"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "811b4f7fe01626ffd7a6646601920f0b5b899b7733d6b400440efb5fa338c0f1",
-                                "uncompressed-sha256": "986ff3a601079cb3d57abd662b83498975e9271c5313cf8127e45c39832a40e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2ce8d4baf17d9d2e2e162bddba2090e4311198445ec25575583eb79389101303",
+                                "uncompressed-sha256": "3cb7905ed069e263f61402c1ff396046d1440b76abfbb76463583521d5eee4ba"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "36ad86fcea2355f691431809d41737a008c1f55385a25247ae4032887a18ac76",
-                                "uncompressed-sha256": "cad811971867eb7ebd650f80faa83e75520469a454559f435451af82203b835a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "bcb6adef555589672cee778f274a146a994d19f6660c774011515889e859af5e",
+                                "uncompressed-sha256": "d4c1c1a1632cd79c159db9786a1dd4c2870b0a52ff1f1e42720f94c0c14dfcbd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b083a39904a57b9a8423ab1444706f5db0999d9d35e75544381213def6529a2b",
-                                "uncompressed-sha256": "6827ae1b52f17252971d328e6a2e5881603007c5e1b0e41c6f14a05038b9bb8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4da22852c8aabc111ffafcdde22cfb607a97805e1e1fd2bc07f6b31fc360a43a",
+                                "uncompressed-sha256": "a5f4264f0e5c575fb3f63c5b51ce5264681170dd16d47cee25a90f81a3067e5d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f4b6bd50140581c2479b1838c3ce76012aca05b880b2f26a70668820b72d5d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d90ad93fe66bb9ed27598e1545339a275eb55b8ab8ab887f95eed081937041ce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5d1250fbadefc9b787e45201a464825b62f2817b544be82adeddbc0b43c29339",
-                                "uncompressed-sha256": "6597a3b7e9ae53d3a0af6b603f933e60a055af3abe90f93ec6679ebdc063c023"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1d9f9037d59493d4a0c9a4b6f41b7c6680b487ee8646097893a5eb0205165fcb",
+                                "uncompressed-sha256": "366a2be55251a08fe98d756fe0b45c6c1cda36d80936c1c8ab64cdeb5cb73846"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live.x86_64.iso.sig",
-                                "sha256": "d7839771d1810176f71e8b998d23d60eb580c941914264b5f5dec35798ac7503"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live.x86_64.iso.sig",
+                                "sha256": "dbc4f7443d95cbd325e50c68c57b41f7c21b945487b8298bda465cefd9680cca"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-kernel-x86_64.sig",
-                                "sha256": "af72f61a3571dca6515182320b37afedf881d5c51e1c2b07be39f227849d8bd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-kernel-x86_64.sig",
+                                "sha256": "744447077ed037699690b820fb333ee71e5bea796133923765039339a3cfa7b3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "e602806b53e09a898079eaf5e216cc610dde19e8a3f8fb6598aae02286203cd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d4219901d71d63a3f56f7b6389156f33570de0815ff12d9c3d10c5c682347458"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b80c63e56bdf19a42d0a6aa8062577ac5dd6cad7cff7e47aa2cc5d1d589589ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "78338453bd63d888a5d1de6e90b036c8c6d5e5ab1662dadbfbcdf12223d63257"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "8517c69cd578406d93a0b8d36ccba1b330acf2c2fdef8654ed374eaa8ddc114e",
-                                "uncompressed-sha256": "79720f5c6bf72a683828ccf4acfa7c7e98bda3634faf0400a66953bc4cc2bb7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8739d522aecf1bcdaff8e5c0df6146590642d1da7680a8dc9a644aa5835371f8",
+                                "uncompressed-sha256": "19e467b259fcabe185b115dadfb0a892ac8ce572c6ca6006bab30fcffff07d32"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "23778bf59e0e25a5a62b7450a6f71e633e3ead92303defeb13e4fc97592d1a14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3b7c471281da3a50bd2ec150db859873483b76323006f42045a3c19033a09364"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9f1ee492b27c5b0c3f00b2373849eed2af2ccc5c7b5a6c934ebe351684634be2",
-                                "uncompressed-sha256": "e6e00dfd8b3a626fdc2f3ef68880cf66d040e48e8d9184c364bf1897e8594738"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a04c2e3257405f25512ceb857b15d0d7cd492a57f070da90b1f62a2a7c4f69b9",
+                                "uncompressed-sha256": "e08a5493a59230c0af4a865485b30e58a8a38d9a7cba83585c5acf9b2b6c2aae"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "bd34a9becc532bdc5d80e2a03378c24334302cd0e6626ca98a771a00695770bb",
-                                "uncompressed-sha256": "a508cdaf6045bcdbe7b1b34c74ca40e13d21bdffb42e69b3d5dcdb19015ea82a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ad0c44169bc6be0a490801d097a418332bb55a9cc24a8138234c66c49d4780ed",
+                                "uncompressed-sha256": "9487e4effa6205fc02ac80a97f621af5d617ce0f14f9f19ffe7d6dc5c62a515f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "89f3ebc9a35af4d01572d6658c913fe720e8f3315974ca5f16cebd38b453e04f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5128250708f4a428ac4e74f2e8535bc1c6d8b0995702f6f3214285177428bcb6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "cded1c7030c0edeb5c660946e50b57e5f901c3060684669710f38b3e98d79f82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "7c421df88845119d5db862edcb2cb0ee90ff936afc25c350a10350cdf67f883c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231002.3.1/x86_64/fedora-coreos-38.20231002.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "83c51f20915451e31ea4043f6b2fa734a2f2b487f2b9eed4fb4a3d544cd9ec4d",
-                                "uncompressed-sha256": "5a04e78fbfab83254adc051fc7dcd8ddfedd4d0860b76a871ef1db26829ad2fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8544163b7ef2900564081d995e3b735304784d186a01a96833db76bab738ea72",
+                                "uncompressed-sha256": "0f27b377287dfffa22305b6629153c67d68b058b65e3764cd4353bf484b9c1fc"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0720932b5c7d84c57"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-08a033a669a675d43"
                         },
                         "ap-east-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0bed057fd762ff5e0"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0bb05d6e21f3b4c50"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-08b791df633d18b93"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0b1d00d19ecc79a90"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0fbe831e7fdb92b01"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-05f61c11a665639f3"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e45bac6bf3944629"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-03c68523fca364aaa"
                         },
                         "ap-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-07d883513706ce7d2"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0af71e363dc2a0e91"
                         },
                         "ap-south-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e0dd1012510e851d"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-017b372956f2534e2"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e90b354807b9b5d1"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0ff963bef7ade0385"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-073d341030dcfbb20"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-08c8eb9f509a59cd0"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-012a496f6190d9b65"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e30987ec7a182afb"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-09381b0f94c557578"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0f50bf40aaaa5b224"
                         },
                         "ca-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0564962451c797744"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0d4e6b09889dccf24"
                         },
                         "eu-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-05a372c9a4cb6f6d8"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0420cce8539354888"
                         },
                         "eu-central-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-022019216c02770d4"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-06b223306ba4da176"
                         },
                         "eu-north-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0710a7e0dffb99463"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-07eec175f86cbb6e3"
                         },
                         "eu-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0da8f818327f6d64d"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0285f9966df98ef5a"
                         },
                         "eu-south-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-03bfb04a97f30d793"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-03d35b786111f8a94"
                         },
                         "eu-west-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0c08f78ede249af29"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0c5e0c7ae202ca1c6"
                         },
                         "eu-west-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0dc5ab23fbf367aa2"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0e804fbd0f259bfc9"
                         },
                         "eu-west-3": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-08b3a0285907eb922"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0b68d56e9965e3dc5"
                         },
                         "il-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0d3154d9b03966180"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0827773ccd5f90473"
                         },
                         "me-central-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-006060f80fea0ca2a"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-02733ab8b9593358b"
                         },
                         "me-south-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0e807582954151545"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-03e1d5422560e0955"
                         },
                         "sa-east-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0f29554a793778d5e"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-065107948c4eb6dba"
                         },
                         "us-east-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-089899354cd079d56"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0ca9d34b3313fada1"
                         },
                         "us-east-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-03f92dea0f13a7a05"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0ef92c009fb16c836"
                         },
                         "us-west-1": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0a410f6b124de378f"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0862564bd57a01299"
                         },
                         "us-west-2": {
-                            "release": "38.20231002.3.1",
-                            "image": "ami-0910d8aeb8134f493"
+                            "release": "38.20231014.3.0",
+                            "image": "ami-0129b90a765b8a43a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20231002-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-38-20231014-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20231002.3.1",
+                    "release": "38.20231014.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7ba3408b6008e1b182af167d439fac93c04ff5a8d2d72782bb45fd8562ac3e6d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f6f991173027dced8a45c175a702132020120c56c13f978de3da19dc979b5c20"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-10-18T14:26:59Z",
+        "last-modified": "2023-10-31T21:20:59Z",
         "generator": "fedora-coreos-stream-generator v0.2.14"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d977f7990be3e3641c49050d37ffd3d7c46af2e7497f54d64a864a414c699407",
-                                "uncompressed-sha256": "162785d5f1bea038380e28182ca8e24e94d0db4d37b21972197b63c101a0ecc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2449242700a1acb9b30d8c36bd08fdff522bb6a420ee3dea160a6eda17c0e5c5",
+                                "uncompressed-sha256": "67bb45d26e7c6b5d34208a31e8a4936e5a75cd7184bfea200e1c93fb3b94d324"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "54e01364d31cf3ee36a3dbc91f39f172f01b728b93d9ee8455a31dc3ea331f3f",
-                                "uncompressed-sha256": "4f64dc11685c6368a4dedb7febd33ba6a57872ea899bbc650a2d90df995519a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "81c308045ff355bc8efa1bd12c114c42498b60664f39601454d6b80765da126e",
+                                "uncompressed-sha256": "b683d43325716735fe6a3fb3c7da8e1e6bf3b0897b0154fec981ccd319d75035"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "4d36a3b606700d2c0719c0cb0b617e03bfc95149ecc0d8ed7fa3c565e7f03c60",
-                                "uncompressed-sha256": "06ff518805b48e10351df01ff96876110bfae7d7e8a762e96da5b7995ba5474e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "fcf6544a1fb4d13a6536c100caf356ad12c89654249660d273a267c768b0dc62",
+                                "uncompressed-sha256": "22e9debdeb3384440a251170449048c1869d202eb3b9c97fb49cbd80169282a8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e2f8e91576bb330683675d04ad8f78cd59390af71007e031a739c651921dc86e",
-                                "uncompressed-sha256": "ae208e6bd855c816abb77f008e64dd104622f8770dce5fd170f29c3960f4906c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "cfcf1ba3886038074d21a16a144442cd073d8f72e84b09a858693692680a44bb",
+                                "uncompressed-sha256": "faf92d97c215cf71f1443aa3598a45519f186ce88455c5f9817a23f305ff0266"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live.aarch64.iso.sig",
-                                "sha256": "fd6bd08ae302c78fba612928a6efa6d6033840d7cd85138ed214fbc1c4ec44d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live.aarch64.iso.sig",
+                                "sha256": "cf0ed337b3730ac92c49c4b757174e6ffa909365557a10b3eb71a46f3f5cd07b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-kernel-aarch64.sig",
-                                "sha256": "121d52884cacf3d791947adccfd70ad477c360510a56eff25978f631c5ce6060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-kernel-aarch64.sig",
+                                "sha256": "550f68c1cb9b03142b170af25b7e0083ca0f03188c34f7134d72dbcd84f2178d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1c1c444454a2f3b5ae590ce81458564ee31092d17a3ba75b2a6d3824181f933a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "759df482f5922dcb076ce3ead81cb5b04bb146374447339550689a9f742f909c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0f60aa05f3d684c160ccdb37fe191933116987b71947b39af5a4a457079662c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1a31ea80355ff5f58587e3e02beb9cd25e8c296176273932336eb4aea78481ed"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3fd28dbb2952290ae38e5f353636979fa908250f53671a663b68e5b5873e361e",
-                                "uncompressed-sha256": "2f3a1b103cdb14390089a785938cd0f92fe072b5c250b3a7a69f7c5c52f735f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2a815bf7c4b55c878478f5f449f7846bbde70c18e528ea5463d070b010fc5ae0",
+                                "uncompressed-sha256": "291f07b1d7b7002e573d42ddb699ffc9214c5d13be83a8e90904bfe3e035303e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "062d02fd6aa1867c1adbb16773a6e46c0f7de80f5149da6b24800ac46c5582c1",
-                                "uncompressed-sha256": "c3fc91de6aa9abaf465a29705675a84ab20c63805f05e6b08250b1b42c679d57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2f2028cd116a6e5b68542c201304ad5a4fd6f03a52a66f2e3271ca0b75ffc2ed",
+                                "uncompressed-sha256": "2ac358b5cd86c1a520e493d72ee8a3b5c78318ee372d0f43edc863a4933e9153"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/aarch64/fedora-coreos-38.20231014.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "13c27d2dddb23c0a7cd4cda2025729eb5e0b96c2daa513f21aa7e1e77229059b",
-                                "uncompressed-sha256": "ae0144596787464c2fccd25e213684e86faee0f6008b072894c54da889713fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6810cb6d51371a1a8487f13a5117d6dd65330fece592b32c932a70c1c0b7770f",
+                                "uncompressed-sha256": "947d30e22d98ad4f3c32e019c684a501f6082e2481ace174e66c40de8d767ab2"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-084a957218c571653"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-04a219db08afca905"
                         },
                         "ap-east-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0019d5ada3bcd9952"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-09eaa3684d1d2d906"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0347c80045abbb775"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-08ae175683550daff"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-08d463d8f95d7b6d2"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-026e7f87e30bca7f5"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0b16ab65feedc9abe"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-087d0484a52e2bcee"
                         },
                         "ap-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0be21d0906746aa23"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-099cc79f2f237fd8e"
                         },
                         "ap-south-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0196e3ce11e1c99bb"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0d42d9fe9383aa691"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-09bb6277cc0f79b84"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-07bcc1e0cb8ace4ae"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-01ff199a05b1c3235"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0e6a0a1f9d0b6aad6"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-05ff4d32d0262d273"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-058c223f60f117ec6"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0a2a1eedb3da562a1"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-01f93993e687fbb93"
                         },
                         "ca-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-03013585639364bed"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-04cd2e3d3f3903f3c"
                         },
                         "eu-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-070d7b11ac181793a"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0256e555c7080f9ac"
                         },
                         "eu-central-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-03f65cc0065e95204"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-08997f96912599115"
                         },
                         "eu-north-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0e50194081b1cc4b9"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0f349e6857f78797a"
                         },
                         "eu-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-07ac2fcd5101781c1"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0752e848290985f42"
                         },
                         "eu-south-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0f400e60fa7a92872"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0d1f80bfecdad234f"
                         },
                         "eu-west-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-079140d96b764259b"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-04ee8e5ffcd203053"
                         },
                         "eu-west-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0c3a68dea7b41a54e"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-05c0ca0d121e28a70"
                         },
                         "eu-west-3": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-084020176db527480"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0502c7b06f4d8c22a"
                         },
                         "il-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0a057d66621aaca3e"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-00e3d0b46df02d260"
                         },
                         "me-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-078995cb50f9153ca"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-070241e22c5e3acd7"
                         },
                         "me-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-092aa567f89ff2ed0"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0f885d11be1a4bef0"
                         },
                         "sa-east-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0ee99ba2b9b3b20bb"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0d05cbbc9d4b4f8f1"
                         },
                         "us-east-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-04f1e4f4e911a3978"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-071251e4544f6cda4"
                         },
                         "us-east-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-06f067bd3d3add1fd"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0e4e7bc8d28835e29"
                         },
                         "us-west-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0206e3e86573b947d"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0c58434c6db96b8cd"
                         },
                         "us-west-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0199bbf35b808cd73"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0a715613c33cace8d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20231014-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20231027-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "8ebbf5236459723516ddbe36ab04f18675eb7a79123f57f3c42d9fb985d0f2ff",
-                                "uncompressed-sha256": "30b7b9f5815ac9c6615eeace083035fe9994896f7ab27dc9e88e1aafd34e9026"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "5eb47f00d896bf5376b091c52eb30d1e1bc8f8ca9e192628b3dc612d7c8c020e",
+                                "uncompressed-sha256": "5a63ef1d0c1d6097feae8e9f8dcec2376cf6422d16f6ddf9bc8b1ae00bfa858f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live.ppc64le.iso.sig",
-                                "sha256": "56761ae57e98dfa5b06b202ccdff69cc2bb5a1eccf25f27823d28180400fcefc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live.ppc64le.iso.sig",
+                                "sha256": "ed90e991f16e569d0041015673b6b85c189e3aa66bc94024e4736de7178161e6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "addbd3a2c24d7ce92e9280b65892336f60da236ff79169cff9624c5a241752c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "a8858970ff932c92271454ef7337c88396753353bcafdc0630749db3efcdbb35"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "429f097506c9cfffac41a0b79a2a77ef0de73bc682f620c16a6180264d71e8f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "469534fc866090a408b3792f8b8f2964e13794965ba9df1c9ee7d008928e8b8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c90b383d4dbf51f758dbeeea480f7e468cc33119a2fcb0425a2818b6abf7180a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "041a6c17f2e5fb07c7d5ac731e2f062eea0b04b6c460b2bbfbfb155f64892fa3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "7e200f59d4c1fd1704a940b2799f11acd93d4472e7f0da54e97b290776350c77",
-                                "uncompressed-sha256": "113807d99b3412b56570f3806f1a6f1e19ed78c1c6c982938fdea70f9c51543c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "323a5b06ba2ab0c6a34ad5716044dba0022b2b1fd370a3939a4ba4d02862f30d",
+                                "uncompressed-sha256": "d7b3d7f7054518f5b85e862a63085bf97444a9c2379bd21d7726790f3885f281"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0d1d2a3fb813dc1c8ba7c7e05f939379fa54056d67d5bf80c0e0bd16997cc345",
-                                "uncompressed-sha256": "47861330c6bb7984cdf1990c32abb8b79e6dad5487d4e583b339f7e8ce724c75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "61fd9c21666f75ade9d8345e6c795af11fec33d38e5b292926870c2125f956de",
+                                "uncompressed-sha256": "5b3c359e0c624a4f0c21767a8c175023019342aebc41cb8e891d449dd046ba54"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "78e08463cbc0031093fc374987f9a00c18b8d2c2d593cfc8451880408178184c",
-                                "uncompressed-sha256": "63b20b1f3215f75703f5d19923b55a25f2a6630355bebec0fe967104b5f3f035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2da8732059596204b6f4397571746eba92cfdaba9abd00697463a00a72db9d8f",
+                                "uncompressed-sha256": "48f9b87669945d133c642a5e8d23909cb34a7a83f85270226ad82f4e0423f6ad"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/ppc64le/fedora-coreos-38.20231014.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "74d011dd09c08c7ce4df5fae6128805a77c6ecc467b36c684a715958677243d1",
-                                "uncompressed-sha256": "5ada343f31d9f67887eb8867ed492411bd4a567ae8c66560ef592174a85c674e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d23f850de768ae0dd3e7c6e51c3f3a25f83fc92549839c319754ccf574b34965",
+                                "uncompressed-sha256": "6484b403160aa7c498d8730c0eba64126705ec777e76767b15d43a9b9bab336d"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d9d74bc092a9e8b5345c431af68fa50322e73e14a24174ff8ac1d11eb2218e7d",
-                                "uncompressed-sha256": "13b90d7fba36c4ba34a0c58489a762117f931dcfb73dfdc8d6d7adec219d295a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e6b2803fcdd6e8f9d329a5381a4d4a5b488fdb7847b18f8b402703a0bfa8c18d",
+                                "uncompressed-sha256": "5e39bf3f6dd6ba59269be7165176f405df343f736eb562aa27d2446a82db33ce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "34737374f1c276149f5e07fd440def6f49ea247d292114aae683c5fadb731f91",
-                                "uncompressed-sha256": "b70ca9c67dcb3ef59dcd7a6b18c9573a99bd25cb2cc7c94dcf00b81fb0affb84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "0ef0376dfb59cc6bfff86ed7f6fb8866c0b0d44de8c1903c04cac5304821fb33",
+                                "uncompressed-sha256": "06ae7b6e43805ec8ab99c97e6b27c6a9aa3f112cd2beb54c18ad960716845cdb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live.s390x.iso.sig",
-                                "sha256": "d12e7948602e86fafcbf525bc08e1ce319252d6ef1310382e8dd039fe3db52da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live.s390x.iso.sig",
+                                "sha256": "3597985182d1a77bb8dd4b6a9ee299c5c532c9ba7e1c910a8ad764f291a90fdd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-kernel-s390x.sig",
-                                "sha256": "0a0058bd2959e2b77e1ff6f62d5111a130343a7bb045d51f43cf714133e69cfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-kernel-s390x.sig",
+                                "sha256": "663940ceea45309bd5a1e0f014c5fac17d3fe21c0b6d716f2b7d2c30ee8e131e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "8e917e24cdb4b0fe79190f89eec5ea692884505177e7673df4e75594f5a847f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b341da9e9b27edd66210538dd1002d7c2f1c69f884cf107d05e301fa628ce890"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "990bcf5ed0731dce5f2b50fbadfbaadbc416d33eff28b22e651ed67f76b2d084"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "8cce3c7586b1e2eed81ebd66162f07d6d4dcc0bbe43e7db5cb85b9c189bf3c7d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6252f3c3af4f43b57f568ff4c7c463c945b60f39ec3807bccc1938cf999d9ec6",
-                                "uncompressed-sha256": "ea6651770ad364a85cdc36f09bcf77918f2f5849ed55c2555a876ed56e636d5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "3b845f03657522bb38d8ef57c92fd9a1c8d574b583d9743e10894ccc52546ab2",
+                                "uncompressed-sha256": "df19c82777fed8ca8ac8e77fb21c59d7ba612f0931fb8f009bad2e7df2ce2a2a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f56aa83edf59469607d6f44b6628b1a3832a812d13ab8ca4fd40e7fc90bb88be",
-                                "uncompressed-sha256": "e4314d1428c9512141a6c5758178be5888b8a74b5bf521dfb2527834055e4d95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1b7660767aa023cb985ed26b8b69606887000b9a951a311d10acc6a6fb63985f",
+                                "uncompressed-sha256": "c005c45feb34b51499fbf05cb896371af61e6c5cbc66c674607c2fe6e02cfa5e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/s390x/fedora-coreos-38.20231014.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3a301ab8b1549a940ffd4a5b4128478f6049f0e56f13e748423eea80ae74a524",
-                                "uncompressed-sha256": "cb8d616281fb5c68028d1ef8c09ad638c33656b09f4b273bff6ae5d28a8be051"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "fb2ec4fbf45224fc8701eafc3cafc3a4a1823d74b1adb07966cb1b34a9a0fcaa",
+                                "uncompressed-sha256": "eec4b3b9870699307f09ca942c76a871a2d3880935e728299d7ac5bb55a9c93f"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9104e2e6329417a760933eb8d2ff41fc31956066340a1727fec11b77e4522025",
-                                "uncompressed-sha256": "5e84cd9b80d50ea50874df7feedb4bf203d27bb9ffde2f456db538612741327d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "05cf4ae921b3ccba90be8800c5a15fdffd4b3eca75626ebd5a911b2c4451a2f1",
+                                "uncompressed-sha256": "0c54eff4a069ffb1e5c7c5a44b55d3988156524412cb224d0e3e04f9949fd14c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "125471826a9618d2e051f90bb2b119546012268f4684ed5ae3f0e7fa4ed30748",
-                                "uncompressed-sha256": "0c623e64f3e2c75879e25c4ff1fb5fd0b3b9a622e22a262d7b4959596681f5b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b87bf05fdfea896b85b5e6d390726bf64f0a087a8727c3ab96a60a67c004914a",
+                                "uncompressed-sha256": "4a242f1bdf62d73ac4520b6ba75e8acb8e9c084f7d07d603fb5c0526c21a474b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "612debd09b9b5aa2743b41f61fcc261d5582afa4d54ae359ebed05bbc1f6536f",
-                                "uncompressed-sha256": "7bfe50302acb46d082e3b8c4b01bbf58ac5891cf235ab7ede922f0b37092757d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "347968a2cfc9cd240efeccb3ec30e7d4c9d9d587219bc73b5c4a103d0619c355",
+                                "uncompressed-sha256": "c9dc11975b1411293e1b55debbe4ee4125962ef500d7ab157eb6c31c55372b90"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "13be423bf28fb0a3841b0a4839ddefe5f1382a409d9ea1dc0f365beea8478ef3",
-                                "uncompressed-sha256": "66fc228fac7f7b4c857a76e2c5e96bff7e2ef86ad33bea1432ddfc60d239a9ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d46a8a49f2c4d50d007913add105e167f457e5bb9994e2567c59687a0dbeb977",
+                                "uncompressed-sha256": "a4ec7b73d78fc505e312bc7e2ff07331c90782875c9b5c568bb1245e428eb712"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "285d21d17d276dce3c7c63c9ebc1947d66bafc58aeee413abcbe69d00be4df6f",
-                                "uncompressed-sha256": "ae0f917deb6c64c22f0eb0a30121baedb1e1ff9e16b0cd76fa9e0f1580b450f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "36ac901203512d27cf35f323ef465afd3e98238e0244379dab210a809b2ceea7",
+                                "uncompressed-sha256": "c28dc6df5ab00e9e270f6e91e521567c7ae9b6f434828c65d3548962341d9da0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9fb8981d436db9bb51af3f099f7da3844ea3c1a291a80c0c4d38f2b7e09235f0",
-                                "uncompressed-sha256": "d85ad1f0b69f89a473020abe06ce7620844368199fac854667cc63b51ccd2d0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c096b038a73af6d43bf0c975d0b4fbc85125182009297193e03773176bf1ee9f",
+                                "uncompressed-sha256": "3a138f48538605fc68456e26175a1a9fb29a96642bbea82ea293b70a93778688"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1cfd4c77ae8a2a7e687c3122b9216a8d9ddf9114141e493d21fb63c4f406ee27",
-                                "uncompressed-sha256": "636180973f47aef98f1c93c983037865426c0b16f1ce83493c37093ae77a4a82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8638f88d5370e5680567557022d6d38e32cb1150b6ef9d5d3606f27d744bc590",
+                                "uncompressed-sha256": "22dd9c15f46ae2cb6252d0d8dde7cfdfb2f5dcdeeaa74a75e5bece1e35a13da1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e00304c7a32053cfa16150daf9655edbbd2fd93e967aa957f6f7835fdcd72921",
-                                "uncompressed-sha256": "247892955d3227f13dd6352f0f18457f32025deaab3092ca343e0656ef7984c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2499fab9c0e0c4c54962b43712b7d8370dfedd619ed8ca20bbc46e4b4dc34e18",
+                                "uncompressed-sha256": "f0c8fc90e724636c2defcd7276a3f9abd79c7dcb67a7c61fbc76597a2ffd58f2"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "33b5468730399363e6fe506ea10a5a9a84811e51c1ccdce9f116aae554012728",
-                                "uncompressed-sha256": "7869c37af313faa0691cb93dbbe153d8b395e08acd6b354afc6dc87aa5f92563"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a479c87ef6a40b5f3983d87002d520edc4af8054524fb78fbfa05dd674a0bfe1",
+                                "uncompressed-sha256": "5005cc9776e26576b70c1949a733c9cd1fdb6cf05b202f4cfeed8e1d1c991314"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "4e2bfaedc5de78ba4840b769c06fdda4fef556f63585fd826149601286dde1a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "832d6c9f64d858c70f77bbb8175d562d52fbd70e9c283a2bc9888e50d87a377d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3b8d9c9212b6d12b7d6c2ac64b74e9b6f72c1eaee6cd8a2707c68f5355e8520c",
-                                "uncompressed-sha256": "48e8c686bcc4ba11751f9ea4b2a9a29e548a989a0bb55c2c42a509dc88b7b701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b21db372143ade70838ce071016aa7967e2ff0eb0bcf49dc990be5402f2d3a63",
+                                "uncompressed-sha256": "38931893bfeca74bd637fd23a69169b0fbbe3cf1218ad48b3f1f1a059f2d83d5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live.x86_64.iso.sig",
-                                "sha256": "3cf2c7beb1d9ef12699cc26341d19a3490b99862cea77c2acda43b84f306f5bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live.x86_64.iso.sig",
+                                "sha256": "88d0b0c6230e6f83471a784b24d7692d43c96da64e4ffe7d5409a4cef107fd44"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-kernel-x86_64.sig",
-                                "sha256": "744447077ed037699690b820fb333ee71e5bea796133923765039339a3cfa7b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ab24d2f4ee2b8f7d175ee6a814bffe5a78e0123e5f5185e2aa17d3ed74acc958"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "99208bf78535e69b728f29c487cddb30799aeaeeeb68d31fa7f00b0d38d92f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "65990f2493651a5a6dbc7ede0a633f61e789250ef4a974e645978adc22c2926c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6e401e17a46ba1f6e204c06b1ba131a977fea0479f59d958c052d2dd2961dd30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "9863bb2ab56397277c08e7da8a895e66769eefa6f8af1942593a98865c0aa7be"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e829cf711b44c8b5632e5a7da4d3e9f3292a3417833ee3b44cd99fdb3e00331a",
-                                "uncompressed-sha256": "982622773105ae9f7a353382f4788d6d3582f6e657a8d1b55ef75ea84742469f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6b72323f48f9af4b3194d15a0e19def700c835ee467d5568f5d3318ad404ad1c",
+                                "uncompressed-sha256": "6ad076cd3c712f0ae6c010d3cbbb3911e7888cbfbc6784cb3a6bd74f15202071"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b9a9b2e320db7be7c2fffd649a8f36bf605804f9eeaa0cb5e7d510fbac2547ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "23995a16ed635a7b57ab0cea11dd5fe632c97ac3bd8120c386a1a268a70ac05a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ae49d05eb406ebe51346915a6494b4dd4fe1352d796873ea9f3540898b136b66",
-                                "uncompressed-sha256": "4279488d7d266932f12ce57872b670cb38bab807aaca8cb34e2518141545d59e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e2b51c616782f740f569b736baca12445a93c98ba6d0d64d446f03b2cb79f211",
+                                "uncompressed-sha256": "8eed33c8e78062038a1721b683f8810c1e3cc0f293f08d68ff6c04292b3888f4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "07fc4965d3001c85262ce452c0a410d4751de84c554a6115a8e1db82f46ecc03",
-                                "uncompressed-sha256": "97479c38b469daf08eb0a059ff1d4d10971ea7650899d5c9263084f18619f5b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "90577b99b03028d603abf199b9f6dadf8bbe5e0bd181eceeb0e7cabe1b1be939",
+                                "uncompressed-sha256": "d4193564ac7f155a709dcd1576841280cc36f223845268cb9c00bde91b9b5111"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "09433176b06506941fdefe2f78010cc85447f2deac4ec4efd0f970344db7a8a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a3b0c7cadf35382318e4883f6731ff91b00ca04e92b1b3ccc2d11335b3fe92fd"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7578262978340ef138fcbcb1d00c41416c74c5cc00073c05c212efe8f6c37c4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "768ca6efa294b25e2fd4034e787e3caef571a2b8ecfd65329b89e47c0e67f66f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231014.2.0/x86_64/fedora-coreos-38.20231014.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "05edd613867ff84f72c0b17326e8466726142f51263340cef1bd92fd383d6e2c",
-                                "uncompressed-sha256": "ab3b1d08a0b76260736862bff739cbc6cd6ea45f14baf8663b938727df6d0232"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4523877d47d70703ff4701da93551652dfb46ebe87d230b35f754559f1bbab87",
+                                "uncompressed-sha256": "823f044b30a078668017a11941866fc895986d252feee6d047dea709a064a77e"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0545d4d73d2adc853"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-02ddc786e583ebe6f"
                         },
                         "ap-east-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0d6feb9d2d84f8a0b"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0b9af5ae1ffb8a6a6"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-09cc26d241f9aa792"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0a1e71dcbfe15dea7"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0ee9aca9a99c02ab6"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-03ffe63c4852d11c8"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0c9f879467e64bc74"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-08683bfef45caa7e3"
                         },
                         "ap-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0707fdcdcb4dce23c"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0238ed3e40b5b3e4e"
                         },
                         "ap-south-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-09fce1e5d43a3d848"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0e1ea140a38678488"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-04bc5020a8a8d6a76"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-00346cdf612ed3f82"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-060a4554257ff212b"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0193670fe3f81f878"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0dd5ef86fe2239f85"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0b235fead239b2ed3"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0de9cc0d1d06c3563"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0bea5ae91c43841bf"
                         },
                         "ca-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-06b5d28675091e6a4"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0711e300bf65f323b"
                         },
                         "eu-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0c684de6b7b6044fa"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0440663ac07594ea0"
                         },
                         "eu-central-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-082ee5b9133a90ddd"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-041601399ea6aa1e8"
                         },
                         "eu-north-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0d40db124c2eaaa91"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-028bfcb7dd51f7a54"
                         },
                         "eu-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-099d20aa7e347b4fd"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0743741c38ae2bf5d"
                         },
                         "eu-south-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0b062d782d40da20d"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0f17087dbdfc98306"
                         },
                         "eu-west-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-087b089d05cbd7992"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-02f0bd8690cc3cc2e"
                         },
                         "eu-west-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-04ec57cf62ae8d199"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0fc7b652460f5502c"
                         },
                         "eu-west-3": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0578f3ccea934bdad"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-003aa9de8eb138cbb"
                         },
                         "il-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-05632e978a299ffd5"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0ca3c96fc6b57deee"
                         },
                         "me-central-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0f5ad5f88c8dbbabd"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0aeda2cadeaf8622a"
                         },
                         "me-south-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-08c1bc05302bc0cbc"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0325776aa7d0cf8c5"
                         },
                         "sa-east-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-06033a9b326470208"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-02d5df1b594f83aa4"
                         },
                         "us-east-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0834ab212f72ecf93"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-02e0e14ba3dc3dea4"
                         },
                         "us-east-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-08468ab540b4c7dd8"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-042adb82d8db22cc6"
                         },
                         "us-west-1": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-08754c17cd1e3c0b9"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-0aebe94c776aabb8e"
                         },
                         "us-west-2": {
-                            "release": "38.20231014.2.0",
-                            "image": "ami-0f45a1193d698bb67"
+                            "release": "38.20231027.2.0",
+                            "image": "ami-09e246b10cfff6b8b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20231014-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20231027-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20231014.2.0",
+                    "release": "38.20231027.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6922e8bf54c1903ea0d90e71dab65acbe4b1191407942e38f98317fcf5c49b75"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:981744d57998fd21c3b2c0807222ccd1801c968b4f300e4196178281a8d2ff6f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-10-24T14:22:26Z"
+    "last-modified": "2023-10-31T21:21:01Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20231016.1.0",
+      "version": "39.20231022.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231022.1.0",
+      "version": "39.20231027.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1698170400,
+          "start_epoch": 1698847200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-10-18T14:26:59Z"
+    "last-modified": "2023-10-31T21:20:59Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20230918.3.2",
+      "version": "38.20231002.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20231002.3.1",
+      "version": "38.20231014.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1697643000,
+          "start_epoch": 1698847200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-10-18T14:27:00Z"
+    "last-modified": "2023-10-31T21:21:00Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "38.20231002.2.2",
+      "version": "38.20231014.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "38.20231014.2.0",
+      "version": "38.20231027.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1697643000,
+          "start_epoch": 1698847200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).