### PR TITLE
Add barrier for last F38 testing stream release

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,6 @@
 releases:
+  39.20231101.1.0:
+    issues: []
   39.20231027.1.0:
     issues:
       - text: "'Protocol not supported' on mounting NFS v4.1 mounts"

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -103,6 +103,9 @@
     {
       "version": "38.20231027.2.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1698847200,


### PR DESCRIPTION
Also add release notes for `39.20231101.1.0`. 