### PR TITLE
Roll out stable 38.20231027.3.1, testing 39.20231101.2.0, next 39.20231106.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,118 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-11-03T03:36:29Z",
+        "last-modified": "2023-11-07T17:09:46Z",
         "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5a52d931ee8005ba9b51a045a19ef7002d413a2c61c8466c536ee6d40d8227e0",
-                                "uncompressed-sha256": "e43f6223ec92e87081e558846285095bdcbfdc91a8ee697053082b0c4d66b945"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "03dc5da3c40e1405e56e1c9e5a979ac550f681aec9cf842be65f1323634f08ed",
+                                "uncompressed-sha256": "d2f957d86cd169d9f11eb4913dd1720bb88a61003a10158135542f836e56b0d5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "eff8af3a916bb032b2b60170945fadd8f4919065755a0d787ebecd422687360d",
-                                "uncompressed-sha256": "896c921b74ec616e8e40f542f383d5f1eeed1f340d8e1b3f30c2ae1f564f0814"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1065f87045439cda327a4284eb8e64dcfa5a31e7594b8823f893f1893dad1ecb",
+                                "uncompressed-sha256": "1f94348a4483cc0005d103e969e48657e515690b1968db604104adc773ab0d48"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "431879fc1aa8f99990e130872501805566f3f286bd468c7f81b216bdb2052de9",
-                                "uncompressed-sha256": "78d77115f9788da8102b97fc1b8d44964d6807f6e4bb4e3ef58f6fa8a4155ae4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "eba6984d30e63c6484d71f15b6749a8061909c4d88b285aef50f65c2f9225f63",
+                                "uncompressed-sha256": "40d39fa8b73f224f13fac8944e2f2d53f88952fdc19e3d01a6bf566cacc3585e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "57e06c50e33e7c41f87f28000575bc400ce4fc2fb34ef9fcd1475ae5c7fa4a0c",
-                                "uncompressed-sha256": "7db419a80732bce1c73ab24075e40b834abbded9b7931571927ee7721d3da442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d45f7b1f0b93d3f0e03aba2b579b5de3ec1d577e6f898d6da70b0c9fb78f73bd",
+                                "uncompressed-sha256": "101dda2a6a9e93b670190d0d4001d832a0822153511baf2231763162c9df7432"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live.aarch64.iso.sig",
-                                "sha256": "6624f7baecbff7b75cf375e88508434fa888be7b7268e649ae8b8ea2655b55a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live.aarch64.iso.sig",
+                                "sha256": "ecc95db6ccb46173d0e814c5ccad5a1f98c289f665dbdc979fbcb38e98b0ece1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live-kernel-aarch64.sig",
                                 "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "52e8eaa1ead4728af53059e7532542344aa56d070895738bd37cf4981f5ffd66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3f12faa6735f1bfd353564762f0601c03da2227dfd08ef6f874a5c5694c0dbd4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "727695de11e43e9e66ef7e427f0668e0a5844956c4b54adaad3528020a72e679"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9c1ead592ff5b420d184410a58776b389a428b84896e0dff9dbb75789fb3f20f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0e2c6eead55c21990e86a2104b0eb77937f886b738813ace5cc85e5d3deedafb",
-                                "uncompressed-sha256": "7410445379aae5014dc5f7857e4fe83d3e1390bcf98ea7709de229d640625c4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cfdd20a3718051959aec86c20f380a1b995959cebf35bf68680af15702189a68",
+                                "uncompressed-sha256": "b332ef0bf3f1560c769e9d8fb3ca324678686ebdc61944e24b44496a75675b9a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a4260cf4a4c57006ad5a30754e05aba0a80ab26dc246c4b7631694da369718ec",
-                                "uncompressed-sha256": "4d85285927f75d7f6463747ff88db11dd899056728413acf6bbc27fb0403cd9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "cf3a1627f4ee61eec3fc568b96bdc212dd4adfa6cfe64a2c82d6e214e08d6711",
+                                "uncompressed-sha256": "17d543efaebd055832bd0fd7516b4c8edf4512ee8311184cbb5fc65228eeb3b9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/aarch64/fedora-coreos-39.20231101.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "59fb83d068941b170a2cfbe055b57c3658881939d62b730fb01720837c123adc",
-                                "uncompressed-sha256": "7607bb10c20d2e81bd082a63f55a42721b4a935aa45f28bf48399ace978e0fdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/aarch64/fedora-coreos-39.20231106.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "316729f98d593bb126354dcc406cf9b80488f4b92bdf4e11b35c879661afe3a2",
+                                "uncompressed-sha256": "2986b0d1c2912f3ec34b957c1042cb42f43779c7d7f0b609c32fb1728b88f22f"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0f15ad6f0d5afa921"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0f803a4bb482bb07b"
                         },
                         "ap-east-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-009eb4a2f2dbab51c"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0c7ba972e98b9efd4"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-07e2113939e060d2d"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0a4c688127bdd5b9e"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-06e7d264b7f486b9a"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0a0ced3fabcf25954"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0e49a29112268560d"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0ac974917e19722c0"
                         },
                         "ap-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0bbe3d35e1e85e7e6"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-040304e71849105fd"
                         },
                         "ap-south-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0befe0ef3063b2a02"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0adb6d6a6b5bf1fa1"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0ccc8bd28d9216978"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0e349eea7914ffec8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0d5a3367ab77e34c8"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0acf47e5dd5f78342"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0c6ee2dddc3875158"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0b9172739df9b92da"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-090b89314ab46feb4"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0d9e62bd3109a0947"
                         },
                         "ca-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-05ca29b479b04d950"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-06b84efe1a0a0d176"
                         },
                         "eu-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-030c428bdfe891d9e"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0be4d712374534eda"
                         },
                         "eu-central-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-03c3ad57a2a4eea28"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-00cee532c19d3c92a"
                         },
                         "eu-north-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-057b7e725e7c94e4c"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0ea818f819933f380"
                         },
                         "eu-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0661bbd305198851f"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0b5760af749bf9182"
                         },
                         "eu-south-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-00aab559c86bdac0b"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-07e8b3175ed05a303"
                         },
                         "eu-west-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-097765306fb71444b"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0956b25851f2dceca"
                         },
                         "eu-west-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-08b4b51cd7e2f0d97"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0e82c594a46838d93"
                         },
                         "eu-west-3": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-099bd0b145fd48fb2"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-08191d8829a43a906"
                         },
                         "il-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-08273ba0da82ae9f2"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-00030a2c97803cc54"
                         },
                         "me-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-093a0fd95b35c9775"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-07f1a0537ab35d8be"
                         },
                         "me-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0c5462c23d5ffa55a"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-03a6f5af2c05cb414"
                         },
                         "sa-east-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0b9f1f11be82df53e"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0ed94fd553ecda0df"
                         },
                         "us-east-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-012f4d949380056e1"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-04be6e8139d745141"
                         },
                         "us-east-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0227762f27a883036"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-038e032ae0f95ed46"
                         },
                         "us-west-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-02121852fb9c849ef"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-067cdef383c112bf6"
                         },
                         "us-west-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0e472bcd1f6313392"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0aedb0303f4bcbd86"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231101-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231106-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3308d73599b09610cee5350f6c3eb84665462a5ddaf2c4ddc8bc01d5f94a4710",
-                                "uncompressed-sha256": "b7ca9e6b0092733fcfb330973e8e7da1494053e61455be4de471e67047e19d70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "7c82f19038fd4aec32e0478c6c4119653c59af3f46d157456ea3df5c5cadb419",
+                                "uncompressed-sha256": "43fa7e0c6941d237062f9f0de4d9a030b92377ab666ea4664bc65da2ff419bf0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live.ppc64le.iso.sig",
-                                "sha256": "10661a65537c3c3044ba0269eac7ff264366db53ddcd49e1c770322139c1cd4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live.ppc64le.iso.sig",
+                                "sha256": "967f572705a5004ad307014d74184c2478bc6df59a5845a58bfd9ef7534360b9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live-kernel-ppc64le.sig",
                                 "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b9ede5b1b312908710dba00c832714531ebbfcd9c1d94f41f2da8a9f18474d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8e30ac360ccd2b9e36f4330231744922c9aca2bb70715c050585a18ebaa436fa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "79d2d6e8cced608858f2b044d9a7e926639ec5b970c1e7d52ae3c485d02ec4da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1cb77a70b2f9457d5b99619baf56e519b117aca971f1bec0c06027a947ea7ce5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1bf12a6f07bcc9ce067964bc245cffc4361133b184fa64db82b70f0c865b7bc9",
-                                "uncompressed-sha256": "2dbc93145084f02633702393f493250da8e649465ed2d8d8961695d5486f2c0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "85c780c0e0d835f2f0282ee16fc6e1ab63c57eed4851ab2edc536744160e75a1",
+                                "uncompressed-sha256": "e659657e3d9ce1c398a0b2b1ac8ee8d6b6f78c5d4fb8dd4981c1719d6085fec3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "24c4c6cb8c60374b34cc1bf1827b8029a6e7a51ffb482e78c1e2cbcddfcb0c77",
-                                "uncompressed-sha256": "f9cd2e6289aee14392e05997f72c5620df2fb6c3ae1d493a29cf4085dc979498"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "024458435d3586b64ef8216ed6271de9f68e64b08bcd49af32ce546f64f9ce42",
+                                "uncompressed-sha256": "d68f861fb01dbdda045f9440dc02a03fc8434605f09e957637ad35ffd95206e4"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "14946e3f406beafb484c75dab48d66ecf51168b74fe1aeb7e1947d03924c9abb",
-                                "uncompressed-sha256": "2ea223ffa1a431f7c0c7bd24c16601c38982d66c75326bdcb1479f0d59562df7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ae82c053b27a7cdb4dd6c9d9f512238a7ddd93342e803c9d9c666206827794f4",
+                                "uncompressed-sha256": "13a8947510d53408c297c5026fc88d3eec2ea1d3c3fe1c186353a572eee0ec22"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/ppc64le/fedora-coreos-39.20231101.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f2535d662951d5bab851034e5797d4b1925a91be64bd5076950d5bfcd0f3f873",
-                                "uncompressed-sha256": "c8bc09749ff5e22b680bfa93f9b4224f808e2bf28c3c17d23a90fe851260871d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/ppc64le/fedora-coreos-39.20231106.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7b322d92b307b4ab747a8a11bd4c9508acf02a178c52700b4f64b5e1382ff275",
+                                "uncompressed-sha256": "85a3593ee7263da1bb7dacfe60be8c4b6da878746d63ff7f88b54fdf2f378e7c"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e62366d0d6faa137415ac2196966d77774a1b7a70a535b94641dbe48f40e4eb4",
-                                "uncompressed-sha256": "290065085e03e3bd825e0e664a719bf18ee2cb5866120d974e782f06943766d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0ff0c9c8827b9688a07005a86739b534e5c6e4f98e1265f3012b5697532af3ae",
+                                "uncompressed-sha256": "b82be33a07624b8c91f12fe79601cb4e2a7c59ce05509082b174b9ffb86ed3f1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "593f6025f3e81a5122ee5c61335d9617008eaf637c792a95cfb7accafb381752",
-                                "uncompressed-sha256": "47a44aff4f73ca3b569e338f7a68d2ef97ad7840cb1b85b51837300202b13109"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "48b0b93d0c904776ab4d3ddd3f57f5ba8c211214e47d02d63deb9e95f02e1539",
+                                "uncompressed-sha256": "4a3ab6964d5031b9524c61e1c226cdaede13608b397fde43f69a8c5cc357782e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live.s390x.iso.sig",
-                                "sha256": "cb856adebad660296d2a029cd177259149d0a0cc806bc943fd10f7b2a225079a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live.s390x.iso.sig",
+                                "sha256": "7477f4c29329b4375ab97c7a1242cc83ca4a28f25d24ee829fd855908532b44f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live-kernel-s390x.sig",
                                 "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fdbcb067c2215b0007f83f9a05fc0bc81076552c9e1bf2e78b3913ea70838d34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "9ad2cce17369248db6f75660d210381fc46263d7de5bd0ac618e57bfe5f563a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d404f2aea8708652e5d87ba13e1a54d2eca3360b577b5e3b6712cd78a4e31420"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a369a76db51d27784afa23a4f750315744d6417d65d0ae7def03b2425323a0a3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "ad240802fa1ba064e268dd48f63aa21160cf3f155f6464e9767ad069254a4a8b",
-                                "uncompressed-sha256": "06cdb62140330a1b2463812e815b73cdbcc7c9d287f9e4e465a950a8b6ce3783"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1af6ca14de5a1a7d3605117cd2ff71de29801f6c8302a086c6f02eee519ecfd9",
+                                "uncompressed-sha256": "98092bf1d23f4c339887ff92a2b071aeaa84635ac1c46b988c665a0d02e2e5de"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c5a8e1c55a53515fed87144aa179d265cab3403baf401e8bd338b19677166473",
-                                "uncompressed-sha256": "2ddb55ad45d498068ac59206ac8a2046af7aa9c47aed8c316069bbba7bae50a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "af5b440f6ad0cb5dc220c2b01e97cdfd437450ad42ad5efa1e82c6177fb373cc",
+                                "uncompressed-sha256": "4e4a31ef4ce063ef5c5ebe79c6f8a0e483ac9576202bb3f77d23770701d8ba7f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/s390x/fedora-coreos-39.20231101.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "021b0f8899eee79b6cc13eb7f3073d4ff45e3870e86850f120d951e14600ff82",
-                                "uncompressed-sha256": "5e749eb517180f0eadc84a7f640d24de3709f059373749ff61db3efed0d6fcb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/s390x/fedora-coreos-39.20231106.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f5d16ec7194d76c933b5bc72b2e17ce7429a2589a1e2e4cd73489ef84ac86c0b",
+                                "uncompressed-sha256": "09992a4552ff39e6415ecde1316609beaa850f35716bd2c7fdbb7c6c7fe39eae"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7de421943231fbbc71e26c17324b7ae30c99f76b7e48dae6edf7d4e09a608e81",
-                                "uncompressed-sha256": "40cc3c3fde0b37fa7481d9178825f5565623d6587acf0106c0a4cd22ec4a83a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8adc56fff5b9aec59efe86277cd60e0adf160f64cd7407f4c9081cdb86b15053",
+                                "uncompressed-sha256": "5e4f8d087d8c4d67012411a1f9767a1a7e8bde975fb8a668549412e3468895f8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "11877ee3da826cc146d5dd3bf8ab8f46d3520f8d07d725cee55baa64d32215b5",
-                                "uncompressed-sha256": "a27713c40347de927212e489d06d3304b783cd31f8dcc8a4b4017128a138659d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "59e11996272c20dda8fb0bf38dfd4788b58015394fdaedd364437a62c51f7325",
+                                "uncompressed-sha256": "626e3ee43baa611a78389daf5212cd101235d5cabe8795a50c441d6dfebd65de"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "67df8d58ec39b4fcea1a3fab4696ade62d271c2d42547ae9e4541bc51142480a",
-                                "uncompressed-sha256": "832181a1df07d173d7495d76110a5746981cdb1e58029f0097ed7bc87412ac3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "22e3a28bd37ea91d29d86775abdeba8c91ece3c7b7595d83f0532b911d44317b",
+                                "uncompressed-sha256": "2518c552889ed5883d8f2845199a9bd6553c8d2bd8cb766c06ad14ca51f8ddec"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1708d020670aa1d405a10d0ae55025bbffcabc028921e40782fb81fe6bbd98c5",
-                                "uncompressed-sha256": "0d579f7054e7b7a298f389cbcddebe7766405f9bcc5cd95d0d05fe592ec0719f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5595ca1619a1aa59157d67653b9266a74b88e174c3ce6793a1bcd7be52401591",
+                                "uncompressed-sha256": "f5225da6eb6c384ab3cdd993c8562ca08426e0202fd41b71cdd5e7021d09c953"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "87908937f36983634d729d581bd74f08aa064bb11153424f8e9908071bcdee92",
-                                "uncompressed-sha256": "aa92f62e89a4777954d5deb2d295c8078bc1cc1b930c3d6fb1ef7531aaa6d4cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cd1097ddf145052a1ce07759acda514b7d53eb7d4cb9adae52793e174797a277",
+                                "uncompressed-sha256": "914d09233e1f182f4106525eaa9ce62cfd76fb9c4ac7103350476a1044f59e30"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "880f78317a8a81d535984c7b6fea17673629729d5ec7f9de849cc49e65011785",
-                                "uncompressed-sha256": "e13e2793a8d38772569068b6b63efb01a55000500f1a4e9771a631468093a14b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "983ea97bc4a2551e34d1bd3b139d853bcdd7729cc8c539a57de1eb0c9b4d2239",
+                                "uncompressed-sha256": "9e0d2177659cb08ee4aada9e66937f50e068f1a83edeb2787486e6519df56630"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "de8a23ea83b7f47d6a6045abc30bf87c96daf2bff4429e1b38218ef13b17b5d5",
-                                "uncompressed-sha256": "82b44c8148968c65e81e06d59369946ea5594f1b87343c86b16b91c21b97980f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6ce63a2f2ea7eb9f4b0a2339cfff4b1d83d8e0b06d8d54977a067e5dcf504ad9",
+                                "uncompressed-sha256": "d75aca06ee0521e7a0cff8088f510fdf3b7aea48e8a565be061156b72403e7ab"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "1230892d5e20cc0b82535cd6cb6b53c0b71a55b7a9f6cb0f097ff8b05cbbd7ec",
-                                "uncompressed-sha256": "e4b7ef76e2a9b343088299226c100ff1dcf10b355e596e133bfb6aeba59fd062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "027e589441a2a3fb7e007af4cf1a95e4ee0adc853b44699bb79d7cbb1609989b",
+                                "uncompressed-sha256": "b6c885199097dd8b131b4453c745dac2ae425eb9c975e92a26a675adda1aadc6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "48341403b102dd6c0685d1ddc36aa2481ed9fa424f810830ab8ac1ae6d439800",
-                                "uncompressed-sha256": "ea291270606cd5dcfb1c2d2fd04d8e5b553bc3abe3c86fd6d6e5b69d1127f825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1a1251f80d7d660b00dabdb8eb4ef440b2f93644e207c46c5c494d28e75c272d",
+                                "uncompressed-sha256": "e89bdf682228462452e42eff2dd587edd61b6fdd2d8f1ecf50a1cd62b7460e12"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7c03c238e65e2cb50eb9209e6058190a7793ec4260dc9fa31513e4b9b8212088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "441b4b006e7d2dc1cfd79041ed1abc56d8a3b2c2f3cffecd6d77f72dc38db83c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e15bd87a8031a45a10128b09314a999a413f039533a6d95165d09a4cddfffd4d",
-                                "uncompressed-sha256": "e42137d18df6a589293f00d351497d45f4279c348b756f8cfd5cb70e168e02a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "87fbe7f5ce684ef986c4778cf5383cf2fd08f602dbe525bf30c775943fd12330",
+                                "uncompressed-sha256": "5921c5b846aa625f68aceeacf2e8f98e1e6d4140159952e5f3aa6e1a2d32c23d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live.x86_64.iso.sig",
-                                "sha256": "033c8109763c2870ff55a103088de6d6afbcafd5d589de3da9886731618dab96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live.x86_64.iso.sig",
+                                "sha256": "f8252339228c5473b7e1cb2a42228f6baf0b1453e06fbd9baaa9335b9daf923e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live-kernel-x86_64.sig",
                                 "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "720ab66eb0b9a5aabe70cdd47177614ba2836255b50aef811f241772dc314ff2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "89ad7ac1eb0e3bb8c28ed0520a57a190f10a6e5e8fd85ec1dc3f873584068fdb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a6453857f8c33fa21ea5b9ec8970f1b8ad31abb3e0fa5a3cc4e3799a2aee6aea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c58ad8dc0e49c512662e2ce5ec18a39795985c8e5f1201e995bef1203bc81bb2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ead36a18ab93b244e5ad91998de345520d3006d4f6004f9580e47ea0c5d61b8a",
-                                "uncompressed-sha256": "7d8e9544bfc6d990016ca5d77a6c9960fd078106102cc422e24581a17136d53f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ab1917a4e751a4336fdc2c4ecec2d11c9333b44f70546f208c19b6e84a5434fd",
+                                "uncompressed-sha256": "e78272b072120c37b0feb42eca8ce139d6477215377a3fa4be172162412d9d01"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3604c97da7c547ba34dd290dfef5bf9d42b723ff60c9db16e08937f5fbb1e3b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b706ae16a972e90b7230ae7fdbd7a2ea8f90e9ac4fea0315197633a203fe33b4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4dc95ef4489dd5b1c872069441bed8a2549a63c7f1815ca01baeabe25ecb243c",
-                                "uncompressed-sha256": "5938e189377dc2d19549b6f83c0a3054b955901d4e7533a3eb4fd6419603f796"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3e0a24c741c4fecb7c3a5cc0e852eb9ed83b59ab26a40dbd8584c57fe4c605dc",
+                                "uncompressed-sha256": "be5c0e2cd15be42555a58a6e33722e7b48ca7d6df4f486cdd7b7524f59283911"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f0e2e7b2ceffa1470e93db0b17bda80a1489a5faec473ed974e2d7327f2a672d",
-                                "uncompressed-sha256": "fca362989553a178f588eae568eeaed5061cdfeeebb303c8d00682ab6094ad10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4585180a7827c2779643911c829a8c75ffb5e1cffe840a09681713e3d47536ad",
+                                "uncompressed-sha256": "b88008dceda1d973c88c801c976acc47074fff2be712fe73368878d917e631d7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ed1d7a52c08a17b1e72e6b9c19b0f0006b38066f2e9b79ee76fd23fbf0a41991"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "cd625fc9024db9e729f82469e7674651e428e82cf83e787f1f9ed351a1383dcb"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "2507b77184f6b630f93515caab2802236d326eb2f168c037e6a2df6f29658ed5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f7a7cafe602243dd60b7f7b3cd539a4738f33ff9e00ccd192717ab1f70adfdfe"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231101.1.0/x86_64/fedora-coreos-39.20231101.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "18ed7b2a13f59282b0315356e71e28d2e1180829bb147803f0c27ba197fe9403",
-                                "uncompressed-sha256": "8bb2acfde8026e6afe5b48856f1d7002c1ace909248f1b3f2f68d451cb50fcae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.0/x86_64/fedora-coreos-39.20231106.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e9280c3dc59fd0b70229e9f7a22effce2101081623a3ae900015ee1ab1dc37f7",
+                                "uncompressed-sha256": "59af53f727ac4da37510b28b99d915bc9d318fa8779a59e8394a78d7a4271729"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0d20d613c97096986"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0dc8a6f541642c62d"
                         },
                         "ap-east-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0e9d78fb3502190ff"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0ec53ac62f88a0fc4"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0f678483dc0986423"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-070749281a56c96f0"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0ba7e493857a9f092"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0e0ab7d509bdf328a"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-023fabd240eb1339a"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-03aef36a3116b9261"
                         },
                         "ap-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0e62f1adedc546f4d"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0cb12bced32004fb4"
                         },
                         "ap-south-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-010a8d05e2297a530"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0c1267602f50eb0f7"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0de5b7ffe751f201b"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0d45ac83fe9b630dc"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-000afa1e5f2b37a14"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0d1b21340d9f07d70"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-07c79f92c4fd26aaa"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0f989055a653a38f3"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-057def9ce3312a0d4"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0a28957ddddd41758"
                         },
                         "ca-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0d53bc4d939762ae3"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0b6aea9389f8cc421"
                         },
                         "eu-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-01de56cbdfee27409"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-036700bb93916d9ca"
                         },
                         "eu-central-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0f6a31a78ee1c1f40"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-07443ed4c1205dd94"
                         },
                         "eu-north-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-05203cf153f24590d"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-038de5a5a59c8c01a"
                         },
                         "eu-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-07cc977943d03b1cc"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0c1a8c479f39dfeef"
                         },
                         "eu-south-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-05002d6837b8f847f"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0fbeb49d03b795900"
                         },
                         "eu-west-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-093cfb603e46b1f90"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-02b4da18534aa7947"
                         },
                         "eu-west-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-098cd98c38d421625"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-08b493e612457d0e9"
                         },
                         "eu-west-3": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0755043ee91b0ff5b"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-09096daf5c2e89733"
                         },
                         "il-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0a74cac93740078d3"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-04f1d6f2ba870275a"
                         },
                         "me-central-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-08e7f33d0388b4861"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0caef6aafc420e657"
                         },
                         "me-south-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0cb264f416971b529"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0aae6aacd3f13e592"
                         },
                         "sa-east-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-07cdbbe9b5f92c920"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0c1be8ea6f390215d"
                         },
                         "us-east-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0b9d8baf52b75e62c"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-08c925cc5757b21e3"
                         },
                         "us-east-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-06b79428726a640b0"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0a32e0b3eb39e7e2a"
                         },
                         "us-west-1": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-0b8037b9dcf49e74e"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-0db602efb5ae6f4f3"
                         },
                         "us-west-2": {
-                            "release": "39.20231101.1.0",
-                            "image": "ami-07dd62472f3028db4"
+                            "release": "39.20231106.1.0",
+                            "image": "ami-04f526e25e8cd637e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231101-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231106-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231101.1.0",
+                    "release": "39.20231106.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d14aa9fefe0e368f3642382f29b1cb621a2bc8f2efa63e6f33d5728f77ef2286"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f7c43e710055a7c2eb6084701c77c3bff5d07fb1f6f6a98facdbaa559f7b357f"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,118 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-10-31T21:20:57Z",
-        "generator": "fedora-coreos-stream-generator v0.2.14"
+        "last-modified": "2023-11-07T17:09:44Z",
+        "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fa044ea3d299ffe032e05c3ef0cd46a0f02ae1a158551396e8da706721e3ea8b",
-                                "uncompressed-sha256": "32efc6ecd53ab19a66799baa1a47b7a6deee77a80761dde48ac0d11978181a4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4bd7de8d2947588c6572570a088eba5d86b83fe02954edadbf2e0386bf136613",
+                                "uncompressed-sha256": "6489a20fc05c68fb1b7ae9a304d47bb522f7e8432ec2f6a01b73e1811c291a7a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "81bd52741538e427359468c6b00379e6e52c9fe47a5a752ea45b3a455a8468d4",
-                                "uncompressed-sha256": "5070b5c6a4dc3c421258c7608453c77e5bfe0c1f7609605c8e684d2146cdf1d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a8be848dd57902f659a1c905a34508f61d63a308a68d78ab6f5b27dffccb4b96",
+                                "uncompressed-sha256": "da312174a0bd81a91261bcf0f2a928bdfd712a5bfa20fd4e9208c89a772b7965"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "8908c8039bb61f72ce4fb7b8552be60e7c83becf58966de79edf59ca0562c4b0",
-                                "uncompressed-sha256": "f7d72ada0f33a05a237eccbb19b7b08f6fb4e77af3ed2c35f5b7afc8d09c54b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "dc8ba3e7f74b624d7a8b129ffa5d2fc84282d08991871a9e2a8bd41cc91a70e4",
+                                "uncompressed-sha256": "f4e5797eeb67e9d12d98e93605dce37a12d128014f3c158d4b82ab2661295f23"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "87ea176ec4b1fb265e445d0c88d5f630a501d6737c79e788de73412807ec3dfe",
-                                "uncompressed-sha256": "774aa919daa09f7a3eb398a5e89ac13f1537dd2e1694ee7c08a9a91082737d9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5ebbec43000429e02f76a445d52dd4875740252c06ba94dd698857814d2b2ba4",
+                                "uncompressed-sha256": "2ab3c3e16941a78912eb3d53336d8c54046cc1eb76464cb9597973a5b50cbde1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live.aarch64.iso.sig",
-                                "sha256": "e1f3857d2fe95f35de6332f02148ed9a3c9e994708d62b931a52d3b49931b177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live.aarch64.iso.sig",
+                                "sha256": "3511fb458e035ae19292f4b2639245fe732fbb4862ec15349e6e5e2de9b330e9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-kernel-aarch64.sig",
-                                "sha256": "121d52884cacf3d791947adccfd70ad477c360510a56eff25978f631c5ce6060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live-kernel-aarch64.sig",
+                                "sha256": "550f68c1cb9b03142b170af25b7e0083ca0f03188c34f7134d72dbcd84f2178d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "41dea2b705f2621d5d6db33dd8e455b58c99e65bb4cc1c6b711bb95a65dd00b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "8d23d107bc749481d3f86f6d963f805a33c2051c9c2daf742da71fcbd3a66792"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0a04e8caba4e051d667066a7d8a889f1817f035099e812790fbfb68eceec301d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "aa6843cb3bea4b70d1d60e608040f8d251870581e0bb0b9d02168b348654c36e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f22b6a4cf162cb1aae037e4862ada8c49ef5b50c90d0014c98f4d592f48c5132",
-                                "uncompressed-sha256": "44c3990b5f0ee114f1ba9a21a8b8fa77a9d374d3c99ee01b8ac10a0fe8d6df10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "39a456b06f9c8f122f55b64a6d18a208bd5978a0362e1be54484523d89184013",
+                                "uncompressed-sha256": "8f67cdf16e89a665db0042016e08d44bab0c93764e469a39a1dd4a6b5319f490"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ede124a5b897e9d0966f3acdcb1a70d23ab70e0f5fc40c14b14d8d2d66df60e3",
-                                "uncompressed-sha256": "e9114068b01ee91a178a6fdeae1bf2a2aaba6272bd8f9eaa89b83ab948a58b9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d3aac7a310efaf3ac05d2f16647d91aeead6e8e6f4f460ed1570880d6a412e22",
+                                "uncompressed-sha256": "bf9a6f218351921b75047132f7922f05e7a22628a1b9a85588d104641dbcea02"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/aarch64/fedora-coreos-38.20231014.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ec2d50130fdaac48da5b7661c2acb1ed2b79e0464bd75c6a9a04f78cd0471728",
-                                "uncompressed-sha256": "9dc507572f7ea6359809bb7fbcf01c981412611968f74393b249c7ea678228b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/aarch64/fedora-coreos-38.20231027.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "70c0313c4fdc12160fd1081a37678c5121d28ae0a729fbe7ac19fe8c482a4ca5",
+                                "uncompressed-sha256": "77bec467e15c003155b075e5bc9faf71a958e3d99419b8d100a8bff5cb14aa1c"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0793fe97a1dd3f08f"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-086db53d0f840e6ac"
                         },
                         "ap-east-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0950bfa8a8ac73a84"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-086122062d8ec3b4c"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0961a4684bf1b1f95"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-01823820813f3f96e"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0ede556e6b14ed788"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0bcc559e8d0ba68b0"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0c3bc39efb656bccb"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0bef6996d7baba858"
                         },
                         "ap-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-05f4c9d7c89c89ebe"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0657be8dc131f3d77"
                         },
                         "ap-south-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-001ff5576abc12667"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0a2dfb0300da68c3c"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-039ec73cc6c240caf"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0280e18a80ae03634"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0a8a637136d5a7cab"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-08bd25196fe5f4453"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0677049b04c852132"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-083dca90f673eb5de"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-03abbd2d5aa7736d9"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-00018b987fc2dbbe0"
                         },
                         "ca-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-05ac6be2654c85c18"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0dbd9ec51313e64f4"
                         },
                         "eu-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e6ebdbce2cb93002"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-006c2df8ca1afad60"
                         },
                         "eu-central-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0fdfd4e7f068a89b4"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0bd2001f3ca27fa63"
                         },
                         "eu-north-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0d37849de3375a861"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-071cf8cbe170f16da"
                         },
                         "eu-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e8cf36c4a204854f"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0037f52ea29612c02"
                         },
                         "eu-south-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-00914ed2706940781"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0bde3e518c0e5463d"
                         },
                         "eu-west-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-084badc53f428fce4"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-029c1ed7f7c81098c"
                         },
                         "eu-west-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0ddde4cd742920e4e"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-065bcb3d6a042be44"
                         },
                         "eu-west-3": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e894f5eb6c9f7b9b"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0bddbb6e06d8548cc"
                         },
                         "il-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-09ccb02e4a42a0f6b"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0b0ea87eca1e38e2f"
                         },
                         "me-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e453f615e411860a"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0a22e06162c481289"
                         },
                         "me-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-00595383709b27097"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0274f93bb591b9a48"
                         },
                         "sa-east-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-07abdc48108fd91e1"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0e13ce6cfc35be94b"
                         },
                         "us-east-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0ad99b192a830a2ba"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0d88b72cbdd2948b6"
                         },
                         "us-east-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-01b8b3e5d5cf89483"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0e24a94dc6a5ab82a"
                         },
                         "us-west-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e0e24f929d476760"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-035091976f8524ed4"
                         },
                         "us-west-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0f6d5c3c939ece0a6"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-09abace21e3ce692c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20231014-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-38-20231027-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "211d9439691330058bff86f80c39f256b26b9d3ff5f37eb67aee8763da927db3",
-                                "uncompressed-sha256": "561dfc0569d6c214c06dae3669e4b2bdd5b8b5e576ba8ed35874f5e24066b809"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "29062f4b125ec945a743570d7cdacee5edfdf22d7a4672ba5efd31d7e1d491ca",
+                                "uncompressed-sha256": "0c71a0145f77b06185b24c149e15bc2e76635156adadbb7b243b3c9825bc19dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live.ppc64le.iso.sig",
-                                "sha256": "999c75b576b9cec6f85c3f9164bde1eac3e06ad16e0c13b7b46552ee3a0476ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live.ppc64le.iso.sig",
+                                "sha256": "6b8d41a127ea240d724f5b53809f40db0eaa68e58a0cdfd00ec39cd040448b1e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "addbd3a2c24d7ce92e9280b65892336f60da236ff79169cff9624c5a241752c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live-kernel-ppc64le.sig",
+                                "sha256": "a8858970ff932c92271454ef7337c88396753353bcafdc0630749db3efcdbb35"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "950758cdb49a7ffafc4a21b5742bc9f613ae967aa0f7e3907409e0dbfcdb3edb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "3c84ac20b3fbe48553f05cd5e5e50f05d1003720f2b048a5aa8405a187d4a919"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0170a17b9fd3afb1d22aa15a01004de174d816a5c1ea110d9b6c55f6d26520db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a9ad13d12137478762499de820b3ef778978df00bb1f93bc08fded8bb888dc5a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1f67c2648d50dffe1ad3538127043c8cee8eb24132174701d2990ad37facc9b3",
-                                "uncompressed-sha256": "40835654a351580d9abbda6d003ccd5693cb9795f167e290114a00f1c2a47583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "963c1f6e697ffd685bda08914a6982ede93234c4e77d7480d5836b0be13ebe8d",
+                                "uncompressed-sha256": "e7472afff96379380c89be6c2a503280f27d9bbfc4cbd161b08d2549f9594728"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6ddccdd2402c87aede40179fa18995ec3cbabe87ded2812b6fb4391809b9577a",
-                                "uncompressed-sha256": "da740bda3bb432a41c52ed670929a728d2614f854aace03e7127a92a5a3c446e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a61239fd7d06a84cba35b8467bfd89f4f4bb11e43fe0b19557a608e0d5d59bb5",
+                                "uncompressed-sha256": "e5f40c27cc1d22394a7b99a19699c22bcc3fe18719a27d7bb763dd34a6e38e98"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5e22e2e68a4782d76051845152871b27f39f624b4fcb2c83499ec121cc425551",
-                                "uncompressed-sha256": "d1bfdcf05619b0b517f5aa87ce5a5422bef1e65dc5c28e9ef2143180804c3202"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2c691671cca4fce39ace9d251d65cbb438073299d0335d505002c03f73d480f2",
+                                "uncompressed-sha256": "4a5ce4039407f1c5f884c9c42b57b1055d49b4df6b4f0c5cdab13094a8be15c2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/ppc64le/fedora-coreos-38.20231014.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "3d2fd06f6cae8fc89f32c64a6527510e3e41c8356d06ccc5943d007207d0b30e",
-                                "uncompressed-sha256": "26448e1992661ce576c8b435121e15fbb707237793f4743813ff25f9c2ca55b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/ppc64le/fedora-coreos-38.20231027.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "62e3652a7b40049724838e8ca0dabd9811cbf8be1375eafeb6c6047f8c09f74f",
+                                "uncompressed-sha256": "3375edb7528a54a1d06004406717bb254bf69b76ac3ab9dc93e569af6d84ff79"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "eeb3f7ab250245bdb6d3ab5e8b96ac508bad6adc6ca18dcbe293714af2f5bc15",
-                                "uncompressed-sha256": "5e2dfe7c4e09669e1dcb10219efbe4ebfe7f0a97484c5bf99051f4715c5b3ee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a5ac502d1eb5512405697839c43257280213349e5f0575b02fb4189353183a27",
+                                "uncompressed-sha256": "1d76e3c4380b8b7ed905de043c351c3d826f399eaed77942b13a984d94ba6404"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "63a5e65899b44cbeba2bc985352461685c40a4924526c77eb8b54dcea64cb838",
-                                "uncompressed-sha256": "fc91afa49e2659919b8946d94022fd4b063b6bd334388fb40bd8bc0763de4e1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "cfcee4342ad90afb18ab1e60ee0b24c8331fd5f30980c3f430877a35f91d9bc0",
+                                "uncompressed-sha256": "fa609af15cf1d3fb4fbc5c31aeb97a2e31b0dd15935226456e58ee24d48f0124"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live.s390x.iso.sig",
-                                "sha256": "a8aad118e857e85eafc0e49a38c465b6be9c8616f6a3f72fd8e9e6c3c86cb71e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live.s390x.iso.sig",
+                                "sha256": "6c7ee3b63da0e2beeb1edd2517874eaf05d78520487e6e36ce3f9c2ca31fdfbc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-kernel-s390x.sig",
-                                "sha256": "0a0058bd2959e2b77e1ff6f62d5111a130343a7bb045d51f43cf714133e69cfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live-kernel-s390x.sig",
+                                "sha256": "663940ceea45309bd5a1e0f014c5fac17d3fe21c0b6d716f2b7d2c30ee8e131e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "186d655c5aea09f169f3836b5018f71fb6bdd6eedecf089493f520195f71844b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "16c307ea7e5d0426ef80210d3dfffb4cd557e4b486aa0b67bd372bfa13b0a50c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "0277a948f5a5362d9940d7b28c1400604f84639bf1af2150435900eb8f7f22e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "8590c4728e0f5971b5004759c74b09c1952b59a11fbe4ae0b1ae580acb922f37"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "979a912234df58d9430f097832513f9b4e3088bf76223f04a7545422c7d064ab",
-                                "uncompressed-sha256": "4ec842c88c016a5eca95352608153eeb3dcf8bac6a4bca3a6496b632f5e16b60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "ffaa4299e068c01abb369373a5fc9cd7bf6f70b1db6cd20abd9b33bf0c412be0",
+                                "uncompressed-sha256": "abc92766f3b29cba45d8128f25a59a2267f49cd2850829e8a38e659cf3384477"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "262234fb9ea6aafc4b5bc33f6938dc94fadca089af3fad2d0060b08bb0219e6d",
-                                "uncompressed-sha256": "e6631af5298e32f372b9288276dd6f14fa2adfdc01bf1d5bc98da5e68fce9ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a1213ea3b7a4e5322bd7cdac5fbc8ac551a43ea6fe3f2ee3e35613f6ce01de08",
+                                "uncompressed-sha256": "4218bb99fb739f27b0c6ee49fd4b7bcf7d66e8bd85c07ef4ba077f54c3c12c09"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/s390x/fedora-coreos-38.20231014.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f56639e00e7debf4fa23bb359eb1d846a15e58c38bb36ed4d94b37b9bb4b06cc",
-                                "uncompressed-sha256": "57ea85fee46ebd5eb2480bb6cd4f44c7a19313b6f6a2a4ca56f4bea42734775a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/s390x/fedora-coreos-38.20231027.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "45ca06b9d93a03f32dae274741d3a6aca23694606d9874afdeb89ad25b7f2708",
+                                "uncompressed-sha256": "d9d0d2af709abcc9a0ea25271def5533a98848a0af62d8102d15a6c15d2eb593"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "382717850bfbd93c5f3561adfe3b38bda4b222c0545c354dfdb87265f9a269c0",
-                                "uncompressed-sha256": "dea17bc22a8efd84452f317525891dc11c7cb601f4e893c76938823c52fa1ea3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b5a70d1af913f55606bf772b496f3c0d9f08758c53c26b341962a0658dde9682",
+                                "uncompressed-sha256": "47c9c9c1608ea090de553d803f17162c77aae7cbcd994c075c5b8d08f5f0bdbc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "61c5f5e50d6600233306cc37fbb6e979957c6d4b07ad056e75b16f3fe40687a7",
-                                "uncompressed-sha256": "60e36005189b0b738c13e19ae6f293d931bc3aefa3cd6a099f0c93af625bb247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "20dc9ebb60a240877b909c26bf7f37006524db5d007428c19431ded69b43b6ee",
+                                "uncompressed-sha256": "357d347c8c3251ee8132fb16c81d4bbe0a75ab105ef357c42ee814eac93a6c8b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5ca92478e862dc238b071ba83b09d8f7bb9071ca10f2ab761794f201077559da",
-                                "uncompressed-sha256": "b73d7c0a1d94a8ce5a445a355c15239e9cef6f3989d4e593d2776f1b5977c9db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a108f4a854cbfb6a665a8633846d0f9d8c15c1fff302b26116efc6e91746bb04",
+                                "uncompressed-sha256": "2a88823bc825748b52a56a0d738f5e31bfb9849b4844dfc05875a4abe77e1565"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "36dd5e03e68ac34b77d98e71bb03a0e8b7efda4ee5119bb7830eea751c64b8e4",
-                                "uncompressed-sha256": "834f5cbeaa3887536f9a6f0c31a748798ddc307f539d90d54df03fa6e4f6f708"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d78db20a3d23b4510b51f66d884b9136dee5abcaf06df76e483885c68e36bf5f",
+                                "uncompressed-sha256": "9313d15641c7d5d49deff925cc7e7d71658e86f3e77af01046d18b0cf6e56276"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c7c7ecb0607dfc78ad4b55fa703f45d9095ea8925334e81a6e2ffec76ba1d753",
-                                "uncompressed-sha256": "e2e8f80cb490ed78e27283bad9018975a278bdab8155cf9e2294bf475aecbe13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4902f4615f6dfdf7803ff7de98b27cc244b49fc07458d34611d1506a9085f1e9",
+                                "uncompressed-sha256": "ef48db3487dc75f7239488003655643e4c7d0b9c54c24c71f39e26c1a5fd4d98"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "33a31524d4430e3832e44ab1fd57e2b49a9b131d4666cf0f3f398c0460c754fd",
-                                "uncompressed-sha256": "a700017727f44424d3450fc9434a1763e87a15d034f0e613026100de0c8ea123"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "45de2641d670341e6c4eb56acf112cc400cd89b458eaf2a3df2f2fa44a5a138e",
+                                "uncompressed-sha256": "5a19cd3f5e9078ee9ebb0d4f6d406cffa22ba5a6b3d2b1d968d29c2635fdae9a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2ce8d4baf17d9d2e2e162bddba2090e4311198445ec25575583eb79389101303",
-                                "uncompressed-sha256": "3cb7905ed069e263f61402c1ff396046d1440b76abfbb76463583521d5eee4ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3da96091e4e6dc477e49c1f7909570176696f654f9f44f10d688c80a273723a4",
+                                "uncompressed-sha256": "77ebbfee54b3347e5f90d6c41feaf15a19b7bd31ab6a8a6ba10a1e9f23eed184"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "bcb6adef555589672cee778f274a146a994d19f6660c774011515889e859af5e",
-                                "uncompressed-sha256": "d4c1c1a1632cd79c159db9786a1dd4c2870b0a52ff1f1e42720f94c0c14dfcbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0e5a12fef42df7719595c6b78d841795d92383f2ab1f67f13549a72ed8314fff",
+                                "uncompressed-sha256": "d6fea4b781f6f66c04b2c35a01d3cfeb875ac021e4336cb72a93ee44b79bd82f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4da22852c8aabc111ffafcdde22cfb607a97805e1e1fd2bc07f6b31fc360a43a",
-                                "uncompressed-sha256": "a5f4264f0e5c575fb3f63c5b51ce5264681170dd16d47cee25a90f81a3067e5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6f90bb2221ad5f73f352e64bdde4b314c94f707a1600eb65081fc8496715d98c",
+                                "uncompressed-sha256": "8eda0fe1972f07b1af2d37cc926791f459216cd724d20e5cb9c86a7c1b61f570"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d90ad93fe66bb9ed27598e1545339a275eb55b8ab8ab887f95eed081937041ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "fcfa570aba7dbfa286393533a6f0a877dcbedaffe536b34d85333c9f56135c4a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1d9f9037d59493d4a0c9a4b6f41b7c6680b487ee8646097893a5eb0205165fcb",
-                                "uncompressed-sha256": "366a2be55251a08fe98d756fe0b45c6c1cda36d80936c1c8ab64cdeb5cb73846"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "80d503806a453858d4249d92ed289d1e70bba3b1512308226992c907e1e4e8a5",
+                                "uncompressed-sha256": "5bb0f64a7de23c146f522600a0278d72f6cf739451adddacde7ad166361448a6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live.x86_64.iso.sig",
-                                "sha256": "dbc4f7443d95cbd325e50c68c57b41f7c21b945487b8298bda465cefd9680cca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live.x86_64.iso.sig",
+                                "sha256": "62b0efca68ca1ccb3d20cbf15dc64d8f1313f5ad29f3bef7ef42032975ed02d7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-kernel-x86_64.sig",
-                                "sha256": "744447077ed037699690b820fb333ee71e5bea796133923765039339a3cfa7b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live-kernel-x86_64.sig",
+                                "sha256": "ab24d2f4ee2b8f7d175ee6a814bffe5a78e0123e5f5185e2aa17d3ed74acc958"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d4219901d71d63a3f56f7b6389156f33570de0815ff12d9c3d10c5c682347458"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "bf278cce55d73dcceadc232e0850fc7d3e5f204919a7453373b579189f257ea7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "78338453bd63d888a5d1de6e90b036c8c6d5e5ab1662dadbfbcdf12223d63257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "f5cda25d58a95241eda8f341db856b5d85d8f1315ebc557c0e710d66bf899fe1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "8739d522aecf1bcdaff8e5c0df6146590642d1da7680a8dc9a644aa5835371f8",
-                                "uncompressed-sha256": "19e467b259fcabe185b115dadfb0a892ac8ce572c6ca6006bab30fcffff07d32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "572e1aac1cab04e2b03527cde6c1c87b335ddd6b5b00bdeef96c3ffcd6233235",
+                                "uncompressed-sha256": "0f58e61f5568f7bd7e29124bc9e83f039203e186fb5ca5c24935875f0148fb4e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3b7c471281da3a50bd2ec150db859873483b76323006f42045a3c19033a09364"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "62daccc1efe7b2f5752aaa250a34db69ce82d9a0626231b05da6936002f03936"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a04c2e3257405f25512ceb857b15d0d7cd492a57f070da90b1f62a2a7c4f69b9",
-                                "uncompressed-sha256": "e08a5493a59230c0af4a865485b30e58a8a38d9a7cba83585c5acf9b2b6c2aae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "afebb381432d863b68e654aeebdeb592ca3ad6555ce9ff00b73904bb1fd5b715",
+                                "uncompressed-sha256": "c8024e30369a09abadbd277b299f0ca8b14b159bf5e043e069efbbaa73798c53"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ad0c44169bc6be0a490801d097a418332bb55a9cc24a8138234c66c49d4780ed",
-                                "uncompressed-sha256": "9487e4effa6205fc02ac80a97f621af5d617ce0f14f9f19ffe7d6dc5c62a515f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2e8108dfc594314b0900f82e1775ec94defb1a6e5f499e1cc889b5e89b4eb3d5",
+                                "uncompressed-sha256": "ea817e4fa4a5590afccee219a3048ce23f7e5641601e49ba2286be7575964105"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5128250708f4a428ac4e74f2e8535bc1c6d8b0995702f6f3214285177428bcb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "83041637f021d9ce343da47a927dda6118309450aac873b25702bb70345b65b0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "7c421df88845119d5db862edcb2cb0ee90ff936afc25c350a10350cdf67f883c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "f5540d99853f9956456046e86f8205155fd7a39d4cab5d32d696ba77914677c3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231014.3.0/x86_64/fedora-coreos-38.20231014.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8544163b7ef2900564081d995e3b735304784d186a01a96833db76bab738ea72",
-                                "uncompressed-sha256": "0f27b377287dfffa22305b6629153c67d68b058b65e3764cd4353bf484b9c1fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.1/x86_64/fedora-coreos-38.20231027.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "96ad6dbfb08e6089ad4b3f37b59cb43ace86cd8bb20105fcbaa6b776bef468dc",
+                                "uncompressed-sha256": "619348c8c4cae0859960befe918b6cfc561cfede4ea304c6a9f543d6a7dfd03a"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-08a033a669a675d43"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0f8737f53ea4e070e"
                         },
                         "ap-east-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0bb05d6e21f3b4c50"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0866e913aaa9e727b"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0b1d00d19ecc79a90"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-03713d4b35e62aa7a"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-05f61c11a665639f3"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-076d9d99c6de88212"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-03c68523fca364aaa"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0098fbcec1407b8f9"
                         },
                         "ap-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0af71e363dc2a0e91"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-07726ac590cac6847"
                         },
                         "ap-south-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-017b372956f2534e2"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0e82b5b14afba8628"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0ff963bef7ade0385"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-07b64b3f08c23fa44"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-08c8eb9f509a59cd0"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-02d7c8c6bcc87cf94"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e30987ec7a182afb"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-06aeaac029d8c801e"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0f50bf40aaaa5b224"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-060a343d6bc562fbc"
                         },
                         "ca-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0d4e6b09889dccf24"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0d35614df15a6a77a"
                         },
                         "eu-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0420cce8539354888"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-097731ce0993b44df"
                         },
                         "eu-central-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-06b223306ba4da176"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-053deec373cb0c9a9"
                         },
                         "eu-north-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-07eec175f86cbb6e3"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0906f2d293131c04f"
                         },
                         "eu-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0285f9966df98ef5a"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-00278bd64e9986f3e"
                         },
                         "eu-south-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-03d35b786111f8a94"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0e5994bd1b0056600"
                         },
                         "eu-west-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0c5e0c7ae202ca1c6"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-047dae0307a1b7f6d"
                         },
                         "eu-west-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0e804fbd0f259bfc9"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-002fb994a610cd70c"
                         },
                         "eu-west-3": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0b68d56e9965e3dc5"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0f9eed18ae4442d4f"
                         },
                         "il-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0827773ccd5f90473"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0dee522a8607deab8"
                         },
                         "me-central-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-02733ab8b9593358b"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-015f6113ec4f13502"
                         },
                         "me-south-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-03e1d5422560e0955"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-02362bd7379840289"
                         },
                         "sa-east-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-065107948c4eb6dba"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-0d26c0228710a3976"
                         },
                         "us-east-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0ca9d34b3313fada1"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-085a6e49d77da3947"
                         },
                         "us-east-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0ef92c009fb16c836"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-07322f6e9cd34e00d"
                         },
                         "us-west-1": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0862564bd57a01299"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-058eec0dd1a8e0913"
                         },
                         "us-west-2": {
-                            "release": "38.20231014.3.0",
-                            "image": "ami-0129b90a765b8a43a"
+                            "release": "38.20231027.3.1",
+                            "image": "ami-07b0bbfe2e3dac613"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20231014-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-38-20231027-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20231014.3.0",
+                    "release": "38.20231027.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f6f991173027dced8a45c175a702132020120c56c13f978de3da19dc979b5c20"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2475e1e01e4b0be5557ecf8d8b6af3e29b927e7b27dd6091f210227bb468ba4a"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,118 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-10-31T21:20:59Z",
-        "generator": "fedora-coreos-stream-generator v0.2.14"
+        "last-modified": "2023-11-07T17:09:45Z",
+        "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2449242700a1acb9b30d8c36bd08fdff522bb6a420ee3dea160a6eda17c0e5c5",
-                                "uncompressed-sha256": "67bb45d26e7c6b5d34208a31e8a4936e5a75cd7184bfea200e1c93fb3b94d324"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "595081f874c9fe328a12a7025c499287c3903bac3e9130e72ad999f38af337a7",
+                                "uncompressed-sha256": "cdbcf73a7e02d00965f428634c5d0c6692724ee8bfb92b1465c5b1e53e75f843"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "81c308045ff355bc8efa1bd12c114c42498b60664f39601454d6b80765da126e",
-                                "uncompressed-sha256": "b683d43325716735fe6a3fb3c7da8e1e6bf3b0897b0154fec981ccd319d75035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "15c6b8f767353c55cf517514efd6e59afbdd9c7e521ddc16aed6bd59cb5a995c",
+                                "uncompressed-sha256": "85979d167b0683d0241156b7302f50d20dd364a89f5fe14ee1c5fc360427b68f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "fcf6544a1fb4d13a6536c100caf356ad12c89654249660d273a267c768b0dc62",
-                                "uncompressed-sha256": "22e9debdeb3384440a251170449048c1869d202eb3b9c97fb49cbd80169282a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3c0eb39eef39b808cd4cc0d28a788f67c24cdfda909e2ca2bdf4d67af6e1dfb8",
+                                "uncompressed-sha256": "c68827a7e56dd3c524bb23049adb83ad9bc103f2a1c78b4819f57a71cd305c5f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "cfcf1ba3886038074d21a16a144442cd073d8f72e84b09a858693692680a44bb",
-                                "uncompressed-sha256": "faf92d97c215cf71f1443aa3598a45519f186ce88455c5f9817a23f305ff0266"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a9d96b7a82de75b2f604d25b1d5f9b9ba67f76540f9d2a09537536b0994ee769",
+                                "uncompressed-sha256": "295a5020a6ef0415a09a6620a1ae92cc562ec1db9d5ab23e70f6f016dc2dc25a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live.aarch64.iso.sig",
-                                "sha256": "cf0ed337b3730ac92c49c4b757174e6ffa909365557a10b3eb71a46f3f5cd07b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live.aarch64.iso.sig",
+                                "sha256": "fdbcf593885982aa5bac1b8d4db0a4fed8d4af02dbc13eaca0e0aed239e2eab9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-kernel-aarch64.sig",
-                                "sha256": "550f68c1cb9b03142b170af25b7e0083ca0f03188c34f7134d72dbcd84f2178d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live-kernel-aarch64.sig",
+                                "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "759df482f5922dcb076ce3ead81cb5b04bb146374447339550689a9f742f909c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0def1d416f033e26eec9b14ee683e3809ee91fc28eb9e5f98f4dd2cd0b10fb1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1a31ea80355ff5f58587e3e02beb9cd25e8c296176273932336eb4aea78481ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "96da18e720037e8285ce4f2d87f0ce5e0a1dc88db8015f84c08f64e66b7dd1a8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2a815bf7c4b55c878478f5f449f7846bbde70c18e528ea5463d070b010fc5ae0",
-                                "uncompressed-sha256": "291f07b1d7b7002e573d42ddb699ffc9214c5d13be83a8e90904bfe3e035303e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c921b74e0b8e75c80a521378a278ac6a2b3edec4d42b55746dd187b2d26d5dc3",
+                                "uncompressed-sha256": "5c345be71652b8a996b4ea7672d4c125141148a4b59a3a169a74412ae576838e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2f2028cd116a6e5b68542c201304ad5a4fd6f03a52a66f2e3271ca0b75ffc2ed",
-                                "uncompressed-sha256": "2ac358b5cd86c1a520e493d72ee8a3b5c78318ee372d0f43edc863a4933e9153"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "170682d379ed5bd6787bb659a454ffcc25a7c4f63e20840ab5e5c5e81f9f9d8c",
+                                "uncompressed-sha256": "d0facaffdc98603430d106640fa5f94db7afe592dbec513339c5fea723f581f2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/aarch64/fedora-coreos-38.20231027.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6810cb6d51371a1a8487f13a5117d6dd65330fece592b32c932a70c1c0b7770f",
-                                "uncompressed-sha256": "947d30e22d98ad4f3c32e019c684a501f6082e2481ace174e66c40de8d767ab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/aarch64/fedora-coreos-39.20231101.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0b6cbb5ebaa6615d0563f37e7856ff794516d2ba2e7844f8f93ca0d585b1e15e",
+                                "uncompressed-sha256": "2bc4b390cdfae61fd4877fbdf2c136a83f439d8555afe50fe90792f571fff2d6"
                             }
                         }
                     }
@@ -122,209 +122,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-04a219db08afca905"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0c5c677468c25f098"
                         },
                         "ap-east-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-09eaa3684d1d2d906"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-07ee8b4c1c005b04c"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-08ae175683550daff"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0a3da25644e7895e2"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-026e7f87e30bca7f5"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-05a52cc02997f1c37"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-087d0484a52e2bcee"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0eceeec3760310a51"
                         },
                         "ap-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-099cc79f2f237fd8e"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-04e87df5f08fbd194"
                         },
                         "ap-south-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0d42d9fe9383aa691"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0ebfbf4a87f139026"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-07bcc1e0cb8ace4ae"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-00431e067726be24d"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0e6a0a1f9d0b6aad6"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0f650c3830a0b9773"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-058c223f60f117ec6"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-05711c6520da2ce7e"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-01f93993e687fbb93"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-096eff73e5b7916fd"
                         },
                         "ca-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-04cd2e3d3f3903f3c"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-021da4cf8fa3a381c"
                         },
                         "eu-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0256e555c7080f9ac"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0ac396894f0e10c8a"
                         },
                         "eu-central-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-08997f96912599115"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-050a500c35ef27b1a"
                         },
                         "eu-north-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0f349e6857f78797a"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0f91fc0c41b4c9002"
                         },
                         "eu-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0752e848290985f42"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0146e9fda419c84f0"
                         },
                         "eu-south-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0d1f80bfecdad234f"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-060b8eda4a602ec3b"
                         },
                         "eu-west-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-04ee8e5ffcd203053"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0377ef3c6beab64c2"
                         },
                         "eu-west-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-05c0ca0d121e28a70"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-02894fd39ed1d3a61"
                         },
                         "eu-west-3": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0502c7b06f4d8c22a"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-071f3987f68035e3c"
                         },
                         "il-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-00e3d0b46df02d260"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0b8d251030a778235"
                         },
                         "me-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-070241e22c5e3acd7"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-088bb526f39165aea"
                         },
                         "me-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0f885d11be1a4bef0"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-05dfcf3c5b4f6e562"
                         },
                         "sa-east-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0d05cbbc9d4b4f8f1"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0628b3056fcd72b1b"
                         },
                         "us-east-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-071251e4544f6cda4"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0a8247cac3ceea1ad"
                         },
                         "us-east-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0e4e7bc8d28835e29"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-00ceff34a09a7d844"
                         },
                         "us-west-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0c58434c6db96b8cd"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0087e60328e6fed6d"
                         },
                         "us-west-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0a715613c33cace8d"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0e4630f94e77ec20f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-38-20231027-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231101-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5eb47f00d896bf5376b091c52eb30d1e1bc8f8ca9e192628b3dc612d7c8c020e",
-                                "uncompressed-sha256": "5a63ef1d0c1d6097feae8e9f8dcec2376cf6422d16f6ddf9bc8b1ae00bfa858f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b37ae5184e974740d0085718cf3267f57db469f22858619df5909db0908edf63",
+                                "uncompressed-sha256": "dc018b0a63b18a1b43d23a5c12ca99203b3fcaa07f3b8f82fc5457e386fb04a0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live.ppc64le.iso.sig",
-                                "sha256": "ed90e991f16e569d0041015673b6b85c189e3aa66bc94024e4736de7178161e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live.ppc64le.iso.sig",
+                                "sha256": "74a2209dfd5663d5a78088cac2fa4972d7e8320b12823f5b49816a869fa72cf5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "a8858970ff932c92271454ef7337c88396753353bcafdc0630749db3efcdbb35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "469534fc866090a408b3792f8b8f2964e13794965ba9df1c9ee7d008928e8b8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7984263612716ca2079f4a0321441a5854f155eef292ac4abfad43100d716d20"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "041a6c17f2e5fb07c7d5ac731e2f062eea0b04b6c460b2bbfbfb155f64892fa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f611f23a75f1eff4be2da40d953d0f48f511e837d9c6ec69a635f88a8318fcf1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "323a5b06ba2ab0c6a34ad5716044dba0022b2b1fd370a3939a4ba4d02862f30d",
-                                "uncompressed-sha256": "d7b3d7f7054518f5b85e862a63085bf97444a9c2379bd21d7726790f3885f281"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0012e1feddc78d9300f171942686e9e42fbcb13c2d8a7a113777c7a04e595a21",
+                                "uncompressed-sha256": "65eff6ce64b2496ed6145e8b63f4bf2b376cee294fea263d96523612b0eba78a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "61fd9c21666f75ade9d8345e6c795af11fec33d38e5b292926870c2125f956de",
-                                "uncompressed-sha256": "5b3c359e0c624a4f0c21767a8c175023019342aebc41cb8e891d449dd046ba54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e75ba82de6c1097a3d4a2af32fbb69629b7787fe7b0f009c0504ed8fdfb4756a",
+                                "uncompressed-sha256": "fbf0d40866f8eddb532a7b044033ca32dbd5a5c61b8f26311a955d6d1e99a500"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2da8732059596204b6f4397571746eba92cfdaba9abd00697463a00a72db9d8f",
-                                "uncompressed-sha256": "48f9b87669945d133c642a5e8d23909cb34a7a83f85270226ad82f4e0423f6ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "89ab185fba32b2c8f9122cbc2bf09007b46eae74423f20bc322552fbadffaa5a",
+                                "uncompressed-sha256": "1971555814957f4c399dd6206720558608e1d92ded0ce1ac3badf7500638a866"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/ppc64le/fedora-coreos-38.20231027.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d23f850de768ae0dd3e7c6e51c3f3a25f83fc92549839c319754ccf574b34965",
-                                "uncompressed-sha256": "6484b403160aa7c498d8730c0eba64126705ec777e76767b15d43a9b9bab336d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/ppc64le/fedora-coreos-39.20231101.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "0f4fa571a4a36f3014dece8759edfce856ce981b4e58886d3d16cd59a8ab93b6",
+                                "uncompressed-sha256": "7cc9f58d66fa35090b3f9f80ad8d12204df4226c55ae63eb1915bede12285ab3"
                             }
                         }
                     }
@@ -335,85 +335,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e6b2803fcdd6e8f9d329a5381a4d4a5b488fdb7847b18f8b402703a0bfa8c18d",
-                                "uncompressed-sha256": "5e39bf3f6dd6ba59269be7165176f405df343f736eb562aa27d2446a82db33ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8f339f2e11610261e4f854f5bbd23e8c6b98494f35659524a83cf5178147e2fa",
+                                "uncompressed-sha256": "3d0b8d0ecd7cad8f4b16ecc76dbeb3e7f03c266ac2b23b4fd5a7ba95f6cf71a6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "0ef0376dfb59cc6bfff86ed7f6fb8866c0b0d44de8c1903c04cac5304821fb33",
-                                "uncompressed-sha256": "06ae7b6e43805ec8ab99c97e6b27c6a9aa3f112cd2beb54c18ad960716845cdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ee8ada4714e97646a15dbda6d7b57709799336369d7a59541d72c32d10163c6c",
+                                "uncompressed-sha256": "f2297b4d7c9967d934dcee8d552eabb42b9b23b163a28428c6019641123de049"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live.s390x.iso.sig",
-                                "sha256": "3597985182d1a77bb8dd4b6a9ee299c5c532c9ba7e1c910a8ad764f291a90fdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live.s390x.iso.sig",
+                                "sha256": "edd5dfdf4c3ca50e465639f49e01dfd879fa965b2def50062a203849606d8678"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-kernel-s390x.sig",
-                                "sha256": "663940ceea45309bd5a1e0f014c5fac17d3fe21c0b6d716f2b7d2c30ee8e131e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live-kernel-s390x.sig",
+                                "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b341da9e9b27edd66210538dd1002d7c2f1c69f884cf107d05e301fa628ce890"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5c24a60fb5a45ec066c718e1d1d346ca36d68022234ee65f73ac7cd0c5fead8b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "8cce3c7586b1e2eed81ebd66162f07d6d4dcc0bbe43e7db5cb85b9c189bf3c7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "99a3e2120d8e0c3f67a57db06198b3ba842ce51ff844fcbcea4711b7d1686071"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "3b845f03657522bb38d8ef57c92fd9a1c8d574b583d9743e10894ccc52546ab2",
-                                "uncompressed-sha256": "df19c82777fed8ca8ac8e77fb21c59d7ba612f0931fb8f009bad2e7df2ce2a2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "dc3f66a6ae8c9051a85c3e2523469bdc3042e2cf2fb83fff7046cc3543e8d42e",
+                                "uncompressed-sha256": "c9aa08f97a5ef726b7e5167700cb673973b08814ed356dbb88c919237d0584e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1b7660767aa023cb985ed26b8b69606887000b9a951a311d10acc6a6fb63985f",
-                                "uncompressed-sha256": "c005c45feb34b51499fbf05cb896371af61e6c5cbc66c674607c2fe6e02cfa5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "494afb81a8f2a1ccdd31f5c48817dd117359e26b360f61e380aa3164a38cd4cb",
+                                "uncompressed-sha256": "f4cfc6276ee7b44f7f7813d68b3c49c2e6049123c2fea53bedf600b5629436cd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/s390x/fedora-coreos-38.20231027.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "fb2ec4fbf45224fc8701eafc3cafc3a4a1823d74b1adb07966cb1b34a9a0fcaa",
-                                "uncompressed-sha256": "eec4b3b9870699307f09ca942c76a871a2d3880935e728299d7ac5bb55a9c93f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/s390x/fedora-coreos-39.20231101.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6f1ff86d4824bf11d745bdbc5ffc4929b63f3a0e10ccd6e952ebbe9f190234da",
+                                "uncompressed-sha256": "d75fda1494db3e0b91ea7edadec6b130c7bd030f859fe8dbc7192ed06be579c2"
                             }
                         }
                     }
@@ -424,250 +424,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "05cf4ae921b3ccba90be8800c5a15fdffd4b3eca75626ebd5a911b2c4451a2f1",
-                                "uncompressed-sha256": "0c54eff4a069ffb1e5c7c5a44b55d3988156524412cb224d0e3e04f9949fd14c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "113bb6f27cf0072ffc2e0968ce8ab282db00ebe0c9784a3719f9caf68e66f740",
+                                "uncompressed-sha256": "8fec67becbb5115fb498e96bdef7b68b31dcb389c712750740b9572df42fd5bb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b87bf05fdfea896b85b5e6d390726bf64f0a087a8727c3ab96a60a67c004914a",
-                                "uncompressed-sha256": "4a242f1bdf62d73ac4520b6ba75e8acb8e9c084f7d07d603fb5c0526c21a474b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ff19e6f31d5b7ec837e339cc380f290a0db80edd69db3909cb0a0ceb40e76040",
+                                "uncompressed-sha256": "2bf03daa6a04e765a4a9d2cde8402f70baec59664b8f81b6af16d6d56dbd0aa0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "347968a2cfc9cd240efeccb3ec30e7d4c9d9d587219bc73b5c4a103d0619c355",
-                                "uncompressed-sha256": "c9dc11975b1411293e1b55debbe4ee4125962ef500d7ab157eb6c31c55372b90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "30320b21d9c6e513126d654e566c03c1d7d23f02b582caad7739f963f73b9dd3",
+                                "uncompressed-sha256": "5f0d60807838fb3a32b855551845a1db21d2819cbd0163684175ec8446bf524a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d46a8a49f2c4d50d007913add105e167f457e5bb9994e2567c59687a0dbeb977",
-                                "uncompressed-sha256": "a4ec7b73d78fc505e312bc7e2ff07331c90782875c9b5c568bb1245e428eb712"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cbca016bb53abbfc3fc9672b176e56558e008ed1205864bf43d096cb1877c7fd",
+                                "uncompressed-sha256": "457a616337e0f8b840bf710634ae22a3fd957d78500ec79a398699418dc264e1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "36ac901203512d27cf35f323ef465afd3e98238e0244379dab210a809b2ceea7",
-                                "uncompressed-sha256": "c28dc6df5ab00e9e270f6e91e521567c7ae9b6f434828c65d3548962341d9da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a0e03b3ec1d0c5021d8f6b97cca71e4311a167c019eeafd8630f60a34a8f2b77",
+                                "uncompressed-sha256": "90c6baf054fb4b6bc202ead599ec3f5200b933829de03eeb4146057e41d1f7c7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c096b038a73af6d43bf0c975d0b4fbc85125182009297193e03773176bf1ee9f",
-                                "uncompressed-sha256": "3a138f48538605fc68456e26175a1a9fb29a96642bbea82ea293b70a93778688"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b74c05a8fb1b46aa6189962774d5f0d1f8002664004cbae8b5455a724dfff426",
+                                "uncompressed-sha256": "12f74c5b32f6e83419aa0f2b5e8bb731fdb3b2c7646f70efcfccb6d291aef6f3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "8638f88d5370e5680567557022d6d38e32cb1150b6ef9d5d3606f27d744bc590",
-                                "uncompressed-sha256": "22dd9c15f46ae2cb6252d0d8dde7cfdfb2f5dcdeeaa74a75e5bece1e35a13da1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4d245bc6a2ba889897a86619271505bea8c647428d8083fd60bdb8c2026a13d5",
+                                "uncompressed-sha256": "9ff4d323bf77e4bf528910723a29c756ee9a39c87516a57b5beeafbb699dd8ca"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2499fab9c0e0c4c54962b43712b7d8370dfedd619ed8ca20bbc46e4b4dc34e18",
-                                "uncompressed-sha256": "f0c8fc90e724636c2defcd7276a3f9abd79c7dcb67a7c61fbc76597a2ffd58f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "73f1923d5fc9ee24ad15eb433a31235cdd669fddf09b270f36da585a1202101a",
+                                "uncompressed-sha256": "ead61a853c9cc7e3e82893be993ba55fb2bfb5f86dbf75e167119b06bc6f4884"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a479c87ef6a40b5f3983d87002d520edc4af8054524fb78fbfa05dd674a0bfe1",
-                                "uncompressed-sha256": "5005cc9776e26576b70c1949a733c9cd1fdb6cf05b202f4cfeed8e1d1c991314"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "355dc08a515742dd2fa0f5d4e668b9ebbf490ecb52eade5ac6a0ae563c47dc4b",
+                                "uncompressed-sha256": "ce450b2900b57e10c5bd0aca3419cd851632f70a34fd593b411f398d4a3e6480"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "832d6c9f64d858c70f77bbb8175d562d52fbd70e9c283a2bc9888e50d87a377d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "320ba3d9c9aedb24fe798ef0d50d934b348f7b741c3874e039f01524fefdc6c4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b21db372143ade70838ce071016aa7967e2ff0eb0bcf49dc990be5402f2d3a63",
-                                "uncompressed-sha256": "38931893bfeca74bd637fd23a69169b0fbbe3cf1218ad48b3f1f1a059f2d83d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a2e01b8b6d309f7d1c4da744c98be3c60742bfd84e7b37ba11e51b993a492d8a",
+                                "uncompressed-sha256": "7a23ded8757511aad689fd336f9a5d55556cf7672305009baa3510b8faf352ae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live.x86_64.iso.sig",
-                                "sha256": "88d0b0c6230e6f83471a784b24d7692d43c96da64e4ffe7d5409a4cef107fd44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live.x86_64.iso.sig",
+                                "sha256": "4f150c0d6ed60773188ac51b99778c5aa83448bedc93dc7c325e726fd10550b3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-kernel-x86_64.sig",
-                                "sha256": "ab24d2f4ee2b8f7d175ee6a814bffe5a78e0123e5f5185e2aa17d3ed74acc958"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live-kernel-x86_64.sig",
+                                "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "65990f2493651a5a6dbc7ede0a633f61e789250ef4a974e645978adc22c2926c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "947429d2013ac7b9dd2cf7149eb1337a9076857eb873ff481fdb5a4eb87490c0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "9863bb2ab56397277c08e7da8a895e66769eefa6f8af1942593a98865c0aa7be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "119a5d573bad92c766a4fdb445043781488aee8974489403c6a0f367284b97f5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6b72323f48f9af4b3194d15a0e19def700c835ee467d5568f5d3318ad404ad1c",
-                                "uncompressed-sha256": "6ad076cd3c712f0ae6c010d3cbbb3911e7888cbfbc6784cb3a6bd74f15202071"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "bd8503f1bbd0aac6696de2c5f265e75fa237b9ad6e659d5995b7f263d2c18ba9",
+                                "uncompressed-sha256": "5e9b8fbdf9b312421931973b33c8ce12f50a442ab02eb8340de26e6146795f1d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "23995a16ed635a7b57ab0cea11dd5fe632c97ac3bd8120c386a1a268a70ac05a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "bbd5f1ad198f98c3f94a8bb17708279d22c0ccb81b556fffd89f5b5275a68163"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e2b51c616782f740f569b736baca12445a93c98ba6d0d64d446f03b2cb79f211",
-                                "uncompressed-sha256": "8eed33c8e78062038a1721b683f8810c1e3cc0f293f08d68ff6c04292b3888f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cb35dd6fbba9d4ec2cb025ab3a055c723af6c27ca7004fa5724fbc7a095b2d0c",
+                                "uncompressed-sha256": "81c44b0fa11369002f060aeebe68efc176bafdf9891751b19a053a67cfdf2793"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "90577b99b03028d603abf199b9f6dadf8bbe5e0bd181eceeb0e7cabe1b1be939",
-                                "uncompressed-sha256": "d4193564ac7f155a709dcd1576841280cc36f223845268cb9c00bde91b9b5111"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5249325cab45737e535de1d73f5cc6da52ee19f80f0e0c776efa96eb836da139",
+                                "uncompressed-sha256": "2581b7d2da354eeecf047a30471861490781e772a9e6c0fbbd3653b54a67779f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a3b0c7cadf35382318e4883f6731ff91b00ca04e92b1b3ccc2d11335b3fe92fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "103092ae7385a46c5c0b9d2bafa75d8ecad441d9e1085e606e6b9fa12dc3f148"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "768ca6efa294b25e2fd4034e787e3caef571a2b8ecfd65329b89e47c0e67f66f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "a5632a248ecc1538dab6b8faa876b5c445487648e397d1c2052584241cb0a52b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/38.20231027.2.0/x86_64/fedora-coreos-38.20231027.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4523877d47d70703ff4701da93551652dfb46ebe87d230b35f754559f1bbab87",
-                                "uncompressed-sha256": "823f044b30a078668017a11941866fc895986d252feee6d047dea709a064a77e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.0/x86_64/fedora-coreos-39.20231101.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "f21c2a15edd490662cf04ace73276ef9519961ba6c9f8a27e881e49581d66d1b",
+                                "uncompressed-sha256": "f5b94b6dbb7a790bc6e9ac6296d02a20842edc07e4f116ae8efe4cca3a0b6acc"
                             }
                         }
                     }
@@ -677,129 +677,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-02ddc786e583ebe6f"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-072fdbc92b7e6a7b0"
                         },
                         "ap-east-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0b9af5ae1ffb8a6a6"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-016ae97691acae146"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0a1e71dcbfe15dea7"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-09245765c05165dbb"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-03ffe63c4852d11c8"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-04a43441732b7f692"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-08683bfef45caa7e3"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-090eec763770c48a1"
                         },
                         "ap-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0238ed3e40b5b3e4e"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0b3a511586b29fec9"
                         },
                         "ap-south-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0e1ea140a38678488"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0011bcafe925e9df5"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-00346cdf612ed3f82"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0a9920e8d3460fd39"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0193670fe3f81f878"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-03beffdd6166c5436"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0b235fead239b2ed3"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-05bcde91a073a2c9c"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0bea5ae91c43841bf"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0fb7e4f071a2ee347"
                         },
                         "ca-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0711e300bf65f323b"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0c56a344ea34c4d33"
                         },
                         "eu-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0440663ac07594ea0"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-005f294e593543b45"
                         },
                         "eu-central-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-041601399ea6aa1e8"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-037f1a804a7a53134"
                         },
                         "eu-north-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-028bfcb7dd51f7a54"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0c1b9f75888ba72c7"
                         },
                         "eu-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0743741c38ae2bf5d"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0ab895c5cea6605c4"
                         },
                         "eu-south-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0f17087dbdfc98306"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0164f45a42d86e435"
                         },
                         "eu-west-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-02f0bd8690cc3cc2e"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-068cda32da6228cfb"
                         },
                         "eu-west-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0fc7b652460f5502c"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0477e5756246da36f"
                         },
                         "eu-west-3": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-003aa9de8eb138cbb"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0afc73d128743f10b"
                         },
                         "il-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0ca3c96fc6b57deee"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-03e1b4298782906f3"
                         },
                         "me-central-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0aeda2cadeaf8622a"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-07b10090988aa875a"
                         },
                         "me-south-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0325776aa7d0cf8c5"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0162c0779cec7de74"
                         },
                         "sa-east-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-02d5df1b594f83aa4"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0eb801cf455594de4"
                         },
                         "us-east-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-02e0e14ba3dc3dea4"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-07554d39f09591eba"
                         },
                         "us-east-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-042adb82d8db22cc6"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0734eb7e42583e6d0"
                         },
                         "us-west-1": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-0aebe94c776aabb8e"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-01f3fffb4d5bbc0f6"
                         },
                         "us-west-2": {
-                            "release": "38.20231027.2.0",
-                            "image": "ami-09e246b10cfff6b8b"
+                            "release": "39.20231101.2.0",
+                            "image": "ami-0b9971f96cc6a4c92"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-38-20231027-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231101-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20231027.2.0",
+                    "release": "39.20231101.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:981744d57998fd21c3b2c0807222ccd1801c968b4f300e4196178281a8d2ff6f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c000961d30c8306f4775f16832583aee9290bfb21a62b3668a2bb6cb7db5ae0f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-11-03T03:36:31Z"
+    "last-modified": "2023-11-07T17:09:47Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20231027.1.0",
+      "version": "39.20231101.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231101.1.0",
+      "version": "39.20231106.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 480,
-          "start_epoch": 1699016400,
+          "duration_minutes": 2880,
+          "start_epoch": 1699378200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-10-31T21:20:59Z"
+    "last-modified": "2023-11-07T17:09:45Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20231002.3.1",
+      "version": "38.20231014.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20231014.3.0",
+      "version": "38.20231027.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1698847200,
+          "start_epoch": 1699378200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-10-31T21:21:00Z"
+    "last-modified": "2023-11-07T17:09:46Z"
   },
   "releases": [
     {
@@ -93,22 +93,22 @@
       }
     },
     {
-      "version": "38.20231014.2.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "38.20231027.2.0",
       "metadata": {
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "39.20231101.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1698847200,
+          "start_epoch": 1699378200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).