### PR TITLE
updates/stable: pause stable rollout

### DIFF
--- a/updates/stable.json
+++ b/updates/stable.json
@@ -83,16 +83,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "38.20231027.3.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1699378200,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
It includes Zincati v0.0.26 which may be a culprit in

https://github.com/coreos/fedora-coreos-tracker/issues/1608

where updates appear to break in some situations.

Let's pause until we know more.