### PR TITLE
Change barrier for last F38 testing stream release

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -93,10 +93,10 @@
       }
     },
     {
-      "version": "38.20231027.2.0",
+      "version": "38.20231014.2.0",
       "metadata": {
         "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1810718374"
         }
       }
     },


### PR DESCRIPTION
In `38.20231027.2.0` it was the last 38 release of `testing`. It also happens to be the first release with the zincati problem [1]. To avoid this problem we'll make the 38->39 update barrier (the one that satisfies https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/ be `38.20231014.2.0` rather than `38.20231027.2.0`.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1608