### PR TITLE
Roll out stable 39.20231101.3.0, testing 39.20231119.2.0, next 39.20231119.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,118 +1,131 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-11-10T16:43:22Z",
+        "last-modified": "2023-11-20T23:53:10Z",
         "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1c49b6c12c1005e7b64e934700d118ca6909b9fde9bee794c27801f1c807cbe6",
-                                "uncompressed-sha256": "d133e232f1ba75f2c41acb89d79ca77ba4d6979968a28b64d60a58d8216172a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b6344787d21f62b19e16f00da270d42e9ca0f5d8d908420b970bd85432009779",
+                                "uncompressed-sha256": "6f84ad8b38495377004babc00511f7e81bb6903d13ea464f476e39b69cc434ca"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "be785616333305d049e5f0c008d0aaa9b0bef3c6fad7a1dc51eee728d76c2199",
-                                "uncompressed-sha256": "234d97f9079bdf5a94143bf07565f4ff868b8ae6d4d2750cc85c44091d7dd28e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7273ae1c82338a1d82e51070ad15edeb1570a90885d08f3cec593e6b53d7a8ce",
+                                "uncompressed-sha256": "e8424cae647db77fb7dce1158e60a7c713bb7434567fd2eee4be084551a879fb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "069c0336eacca085a9c3b5d0ffa7b2c0919476e0950c171d271caf3bd8f88373",
-                                "uncompressed-sha256": "4c63918e0778506753cb67e55b2ab43f65227aa36de2255b3d384edd5007f5b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "04585758268089cd37680c5ba412854436eb8687634c26152923a35abf309f8b",
+                                "uncompressed-sha256": "64fc962dc7940cecc4aa53b890a34c6816b9b87ca5cb3825a542185d11a1769f"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "39.20231119.1.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "07ca9e22d6384b8ab19f9d8aff9cd5c9a7eac3331f435d8f23f4311f481aeb91",
+                                "uncompressed-sha256": "30dc3ccc6b5c128b463259db51b81b346164c7f98dc46131b9168cfdebeffd8b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4e7dfc400355116252c7dd63d01d3e5f046ca2e7887ce1690ca9f3f7b9cb5226",
-                                "uncompressed-sha256": "87885e40b2d80c834377ec1c7d7648dca110c47633b61692c6a834872f6648e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d7827ac88c349e14a7283b972415a18e05e0635f27d51ed5400626b14039c50d",
+                                "uncompressed-sha256": "f07b24d97ea6280e573abeaff3b275227b46406ec3c22914a0bab608479347a3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live.aarch64.iso.sig",
-                                "sha256": "5a299744bc728d33bc0bcd85d9d2203ee26f4def63244cdbadf893a8352642bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live.aarch64.iso.sig",
+                                "sha256": "257f3de9da72158285a9adee031ad54c90e1681ed5023b0d3228575a4f3dbc11"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live-kernel-aarch64.sig",
-                                "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-kernel-aarch64.sig",
+                                "sha256": "aaa5b752507227e97b7d1ce3e63d71fb0697b1b54ad1417db80c2977fd9952f6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "8dae43d67b0ead74b6d1a566e2fef4299f683fccd5829abdc7404f1837cadf0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0a6e3bc06e66c900563f0cafb11af3e16d13860dc993d5fa585cfdd66767dc73"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "0b079dd3afd12c9c2c1b5733854186197d6e069f7d18680c7441fbfebdbd9174"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "853166149b630c8681f5b16a698826ba28993379528946680bb6276a2615124a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "99e35620ca326fc6be352dcf9ccace38327b7ee2f0f0cb441b85bcdccae387a6",
-                                "uncompressed-sha256": "422e23fdc94a0bff6c485356e537ef03050d0f210efe7f2eee619bc1926073bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c68fa5b6edf62f3d5e04d9d59e64a2f66f494209b34bf97797f3bee90568adcb",
+                                "uncompressed-sha256": "0509e8a32385f3d4d86486e00c54d619b7c5bc975f9062681d2e4e0481683db1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bf20196340db65e716b9391827a473875da6c3b2746a334cfae35faa585f3e7d",
-                                "uncompressed-sha256": "565a4102d8a617bdb93b3f5ed05177c6b8cefba124e057dbf9f7256188d0e845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "cb4bbc3bb8c513992ccd99c943f268b61fd525702c5b5e24c3d8e977b396b48c",
+                                "uncompressed-sha256": "5e5b48586f03de0b13789b7ebb486df43a5e4c3e184282b3d40f6c2edbde48bf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/aarch64/fedora-coreos-39.20231106.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "253b4466db577e6c945268e225c7a30f3d137e086703b2fc5a73796047ca5bf8",
-                                "uncompressed-sha256": "f3de6b1ebc1a9683606b2a0d3a0c8f4d5c5059d35ff2a009e931430997e13925"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1e6d9878c8a63e41b6c4a4031698aadc82ab6df4819a20c1760d04e031bfad59",
+                                "uncompressed-sha256": "5653008fddd70fab3e7aa0192cf638c7ae0d5a476894eed98aada38abfc5a03b"
                             }
                         }
                     }
@@ -122,209 +135,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0d5f06005c53bbdc6"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0cf80869c41dd0e07"
                         },
                         "ap-east-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-033a813440f21805d"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-064bac687eb15f9d8"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0c9c4079cff3ac341"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0a36d2f7ef3491958"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0022d4deb9715c1a8"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0799237ce3381ce41"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-069d0658c89ece52e"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-08761c8ebccb73724"
                         },
                         "ap-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0968730632a394ea6"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0fb430b6d0423fa0f"
                         },
                         "ap-south-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0ba6e2e23a88c2929"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0951163a735dd2013"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0fb31a92d2539e603"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-02b1fd0a557ba92b4"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0575c736170941211"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-02dd86fb0d78d67a8"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-01ac2eee22abfba6f"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0477db62ac3816dc3"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0972a3caccf9675a8"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-07f3a28ea9ec76df8"
                         },
                         "ca-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-06e187d331b0173f5"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0de101f1457a9a6ab"
                         },
                         "eu-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0f2ae8a3c066e0953"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0992c2fb0739a44f8"
                         },
                         "eu-central-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-076eab4476fe0372a"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-07e8448eb7f95d914"
                         },
                         "eu-north-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-03501fe0e6b98d942"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0a6c46282743a01d7"
                         },
                         "eu-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0afe270c20e0f786e"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-050d53528591dc66d"
                         },
                         "eu-south-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0d493b62c5de212e1"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-01f1992ee7dd2a4a3"
                         },
                         "eu-west-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0b55962642841de63"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0f5927f60fb1368c9"
                         },
                         "eu-west-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-06db2bfe35abd04db"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-006d3e256cdc8bcc8"
                         },
                         "eu-west-3": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-014085e47bc060a84"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0c65398ae99f78e8d"
                         },
                         "il-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0678fa3e368a6d366"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0aeb152a324eea188"
                         },
                         "me-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0484d60185efcc05d"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0415e947b0ed3a97e"
                         },
                         "me-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0e17907d900584e7c"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0ae3aea10ce9c8616"
                         },
                         "sa-east-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-09d22a4c42361f191"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0b8810b88266db677"
                         },
                         "us-east-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-08516c0cbf37e5bae"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0a0b0955646097a59"
                         },
                         "us-east-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-00b3abe4ea34c3183"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0d3f046eef947f8b2"
                         },
                         "us-west-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-06d58734643c498c0"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-094c4a54db2d18778"
                         },
                         "us-west-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-091c20a3b3a9f6ee7"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0e27d1d643a36f2e8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231106-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231119-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "051003b668c2534f4de7eaa651cbf36fdbe9ff440ab3b30e7df4d27b4d70b1ab",
-                                "uncompressed-sha256": "358f65d1bd9a7fbfeb0cffb741bef18f949a8fd048b82e470338d57e835ff101"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "984ac43c31c1bf37ff95e19d1fd9c520154dab65ce1c46079131df845688916b",
+                                "uncompressed-sha256": "fff34ebf493e68e4c47d396ccd897b5cbdc030b55b66febc5ee990c74ccc2f4c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live.ppc64le.iso.sig",
-                                "sha256": "c00455c0aaefe725231a3db4850fcd11aaa666c38dae10f949c6400d7081db53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live.ppc64le.iso.sig",
+                                "sha256": "19e9bcff5f6ab8461af26bd1313cef1779f14dbd52c3d0a9c7f1efb304220a49"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "2111e9fa36b583c02ab90f05b80b6f3378cae24089cd4afa76fd603291138d60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "d7355fdc0adb530caa052b58fbdcf5add59a6cc5ffb4afc8517e5caf298e9ba5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "108cc08244363d6ceb7689430e005752107f74c95ed72559fbcd1b84a979830b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "95ae35433d7c4135ca8882b6e7929b37c2c93a63fbc112231b8c2046ee1518d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "04c3e7d965bcd42fc148553a4e6bac9c8a311de8f2eef89a5d1d20de329c6df5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "4f835daa5e4d53b0b86ddef6294598987277b6df4d3440f2a53a8fc784e34017",
-                                "uncompressed-sha256": "59d6efa10896ba5d6f3586c430f1b658397daf549f831abf8ec0dcd45603478e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "ad132e8f43ac04fb5cf88a68f5dc3a25fbf787d9f97eed2606d5d3583ce1d743",
+                                "uncompressed-sha256": "33e529e89ac4dc0ee2369a4164f77d23cb5996c8942738ec1112c04dd7fbcce7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "649d87e31d1b8deb96c0a749ff69e839b7bc285a3db4105ebdddabc6aad4f4c7",
-                                "uncompressed-sha256": "4519b7982cd93255f277618da96bde43f07998df5613508a5b5f486e58f56693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "987ec82523b3f094afe94aa5fc8078367886711a3e5647196cba6e797306165b",
+                                "uncompressed-sha256": "3ba46557dd7fb6432bacb7cda18f41b23f2c2bcbb757cec395f28402282e0af3"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4559a272c8ee7ddd739508d262d4df544682d0fa414ae0666aac3e7d36fa9ee1",
-                                "uncompressed-sha256": "bfbec29401aeaa8913822156af237a53b7d35b578ac6eeb6a4cfacd338244026"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "27010b31e2ca510601410271740f0fb0a1ec825e7fcffb8f5e2acc288acfd687",
+                                "uncompressed-sha256": "98eeeef2e6ca635335a39e43cbf58a2939d4c60ad7e9c72e3f90f3e8a9c57173"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/ppc64le/fedora-coreos-39.20231106.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "55afdea96a4d50c1fdde0431967c21d1e49f80d98aff926167045c9f42fd1c83",
-                                "uncompressed-sha256": "446731fa80504d22c3049c6eab74880b6407352fc22b9a6500deb47b1c15e54e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4afc9df58a249e97c7381ad3524a57e4956cc971a0703284f2d030816011509e",
+                                "uncompressed-sha256": "49b48b35c9cae105a610d3dba1988c596e10181be59f2d651e206c55321016b9"
                             }
                         }
                     }
@@ -335,85 +348,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7f6e3c2984dc44f3ef7a74e3119c1e172a833794c2e275771423b530b91cfbd6",
-                                "uncompressed-sha256": "0ace97aaa69df1d6fd9c04f8784f220aef635195379a26928426dbf0686e945b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4c56ddea8d37ad95053aa6551ed94a6e74c04ed65a036ef4a5a325bb687323b7",
+                                "uncompressed-sha256": "275cc573e1987ac42839cfa91d225b2c02cde7d4375ef16794cc4e7fd96acb2d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1a9703d08b252c02456aae0839127f9a94f3264395be9efcd152a322d7cfc847",
-                                "uncompressed-sha256": "7c9d4db4cb990d0a29d5e2d24c22c31dc07fb6d83f64cabb92a95f6fe54f8ec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "0a6a57ad99a49ca84c6b7ea5ee3cf7fe530ce52ddd88cc1c87b909d7ffb5c200",
+                                "uncompressed-sha256": "6e6c282c42a03fd5d995d0d9ce87f613062c33300763a34d384a16a6568259d0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live.s390x.iso.sig",
-                                "sha256": "ccc75d131b8aba9fd93c5a6b05eff40d3feb9829388ac76018d84335534d48bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live.s390x.iso.sig",
+                                "sha256": "d1d3a805e0ab0934bb3ab459eb4b22e2236764af2ff1f15c0465051ae2e93fd1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live-kernel-s390x.sig",
-                                "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-kernel-s390x.sig",
+                                "sha256": "57fa889d4480a8e8e902be74df44d2a52b281019696890122d22e7ede1e5ca0f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "dde5feccc021e478b3a94bda3d5e9956b7b47a0f4d71f74e4c1e504ec70a8efe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f5360eb4a6d6a9008669ecd08030225bc406990e0f4bd39a4e5aa73eba0e24f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "737a1aee659fba98983aae436beac0dffa4bc4d0b6c0cd5fc0b4c7235a756fcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "dd9e0f9f9d5715e3a4969bb8a569bee8dff83f2daf83c475e86fdba79788f5a3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "140775a4e595f269619017a6426bec664c70f2061ad5f32fc30a63968968a978",
-                                "uncompressed-sha256": "6cd9a820f84ffb41d4d5e213d2a73bd8022114f2ab473deaa611304af098e0dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "88cd8f8d048e5df19ccd43777c25cadd1dc108d5714dada1b303352c9bdee026",
+                                "uncompressed-sha256": "b0ee432ae087bed2626476cedd53acae8b41b81c87c3a9666498009fa94d74c2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ab06265cb180b5dc38b1131effac74e31169fd2f5e0b7a65f7870ca77c2de673",
-                                "uncompressed-sha256": "ea888efe5f87d6db940b52fc627199b3e6c18bfbfc6ff98f186ceb4643856325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "67048f2b849723928a5343a798066a15b6555b41be0e7c58e83150976844f296",
+                                "uncompressed-sha256": "5abace10039671e267a0f09a4d17162ba9d3ca50fdae17866adb60477ff87216"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/s390x/fedora-coreos-39.20231106.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ee0d3cf275095cd70e9a591dd57d61275b9c4c51d4f3a4683c31d5f2925cf1a9",
-                                "uncompressed-sha256": "23c186f1ae46e3984e20c8288c42b23ed89c122deb9997ef6ec76ab464653eeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e0e76eec6a9a18dae7808cdb18c80c797762274ef01f166c93aef30e353ccd78",
+                                "uncompressed-sha256": "ea5957b84d3c2020636b40e926fddf081e343dddade8b269dc34220829ccd9e0"
                             }
                         }
                     }
@@ -424,250 +437,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "30ca8c249fd164a4194a9affc075e87038391a98f28fd76b78e7e2be4fc05c1f",
-                                "uncompressed-sha256": "7a1d0ba89bbeaba43b20bf06db3ddee0b5a670b2cf07ed3ea33d478b67015c72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "38a52da4932515fd04791541ae9e13cb437db50db293c2d281ec05134605c308",
+                                "uncompressed-sha256": "ff23fe66cb9b0f40c50bcd7d8863bffbc3fe79701652ed6532906699506a0c30"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3f460e5cf74d994b7964c5f10ab2e2bd456772231263a1a9a586ef8b5a5cedee",
-                                "uncompressed-sha256": "85efb919d8166495f3dde1e61970f4efda54382c818b112b2ae385a727edb4a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6c471477f202b7bd1c580bf0c82ec11509ec3aa768d6b0286eadd1192c0296a9",
+                                "uncompressed-sha256": "6364293efa4d6dd404584bd7db863ad4161357e3d051e12623e23135aa352033"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3c91817568d3a0070105d58de57baab5bf8e8a6990690f9b156f83e1eca953a9",
-                                "uncompressed-sha256": "e9548257f16bc80134a8ac64ba1801b267fac6892e5294733de5744fe1920faf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "fb028ccd8a2644b58a7cfa26bdd58c0b564741dd6c798496531e97bb5b13b29b",
+                                "uncompressed-sha256": "14066e3f0e60dd2935e5ff301e44d460d19e2143e5293470e91dfdadcf0bf82e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "786b741aa052ca9e89c21b99dee986175dbbb6bc34583a7064170f9a80527e27",
-                                "uncompressed-sha256": "09b79384d54025d58ff31557cb72529bcbdf3319a907171c6aa6295070433600"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4496f3e4418d6a9b06d9b7c00b90da69a155f792801b9b9eb3e17c1e00fea878",
+                                "uncompressed-sha256": "2c55cc7a2ac06567e77e9bb2ede7855fd1408ec16b48457cd819560ea465c6ef"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8f58b9f49142bf6b09bd562034617b5b355b6b5274c3354e31f07d3ce2dd6d27",
-                                "uncompressed-sha256": "ffecb58ed5c4f3423393c3e75ca73f1f29ddb64551543bebdd587d536bfb1e72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d3d88110125c1e454b6bb47e479e6a7017b8575199368703255ba42327855c7b",
+                                "uncompressed-sha256": "a02aded320438cd4e5fbf9d1520bb9dd29de6b1229f60f8b1628a5f5ea200843"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6b11ae698c6e93fc662c3aaf948daf27466d2eadda536c91264b9e054ef72c72",
-                                "uncompressed-sha256": "be2215581427a921ffe35f0fca7377eac70414bcfb0510a13a1ff0aec1b9ff76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "216f146475f1ea5b3eab11e4f82d69052c2880ada582187b2fd9aa0d96a212a4",
+                                "uncompressed-sha256": "688497a9176082e32700cc6420e3c820f3c59e7981543591313516269d20c7fd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "98ffce5ebdefcaee1d161ff2995280c8db1d45956a36dc12130d88312509f2a0",
-                                "uncompressed-sha256": "4c91cb9b03d91bafb15933affbd554aa56ca54d9c9fb4f16c6909eb3b26cb75f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2bb3c7fb7ff4c31113609804aa71fdbc76a8e7a77572fe4c8c6e0d59cf4f539c",
+                                "uncompressed-sha256": "c143de3694d43ba73acc2bf5c0f6807e1244b19753fc81c35261b9fbbf73cbd6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "1845305bd203784bb62476acd1910cfa8f0172a1fb13c39e8e19d48019c2a1af",
-                                "uncompressed-sha256": "c675c7a5da52c00262bf0cadde9604bb12b24d7c982708ede1398a830320a670"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4678c1f4e19e199ce892746afcf7e8707102027d6dfd21f22c50f20eb2e62fa6",
+                                "uncompressed-sha256": "8d3b3ce06d8a6e79e8f8d62324aa184b84388f41170011a1de8457de5bae5962"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2a6162a60b64f34215c986021ffac4aced5ad74f06018b5829abc61b1dfbef0f",
-                                "uncompressed-sha256": "38902373b4feea98a3c284dad0687e33f3522d6f930acf6c37092a7d28125c2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f0161913d68fca940cf54f6baa856bbbe095481be6ff41018fcba5affa975f21",
+                                "uncompressed-sha256": "bee085dd7d93e16125716439c1d35c36ebe4987ce95df52ed1d47944e9462148"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6940981c8cc2815af5c6246ac9bf5cfe09b602ed4b58000ab1a643658cc71374"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e03c59d5950a67b0862bd1a0cb00005ac0cb34a6f22723b64a564e2d3cc5956d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bd1d9fabcf1f1874df3bdeb798517a3eabfcf8bd54a53df5054fa32e92c9ce36",
-                                "uncompressed-sha256": "c7537a7140304e3e283885ede3b9e6276412347a5d9d199496f71f799fa446c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a4c144dcd794136556e476739f0b988488225a56301155005faaee89910b5865",
+                                "uncompressed-sha256": "6ce6bfb95339c8149319424ef805c9fcc1b52dff721c76459d85187c3961ca2f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live.x86_64.iso.sig",
-                                "sha256": "d7881fd5e4d5dc85bcbba8a542c9ac87514508e9c9831bd03cb889acf073c3ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live.x86_64.iso.sig",
+                                "sha256": "df96d6f8d3e736a64481e903dce7dce57c6f082bf82bc5f8f64ec208d63060d3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live-kernel-x86_64.sig",
-                                "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-kernel-x86_64.sig",
+                                "sha256": "3efd416a625571345cbb330b434272b99813a1146cc9b4eaf7bfc8e29317c986"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "05c6f3e16f04ec91f3fa6527d9344c9c847a76e8444263fc3bb90e28bff16fff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d181f85508657cc8c7643bd3da4934134b202b50a0ed7a6a7c78caddccf2e43d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "5260f5fd9e5a14a12e82ffeb1557b85ebd0caec4921000de443bb8427d28919d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b89222c98093b4505d0ebf75bf5435b89886689c774995b5cb95071fa544c213"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d1061fed6ed8f171b86ad86fc5d568fde3b8c51b70f309916289ec491eb7b9df",
-                                "uncompressed-sha256": "f3faf5b21da0da8ee9fe4a878c3423b736c1ed72bd58e6036bcfff35d5f7dfd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3f2b5af224080acfa178efe65cfc961177f45f0393a1d5b61e1f9a189d4520ab",
+                                "uncompressed-sha256": "3f26ed240db2cf2c65846f7b560409337de7e2244b0f0d392039cf60dde55342"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b698bbaec1ec523e95775f18c146ccb2b9d596fd90083f304a75e16e45c4579f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f726bfaa7930b04d1409ec1d0928ed1eff3191c7706c735ddc616b82c73df428"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e1efc43e0d450205f03ca97408c163d354c66b1cb0a8e63d94fbc94e82772291",
-                                "uncompressed-sha256": "71f0abe77db8980be9f17aa9f0e391381ad60b9e18d169bff330160c1ecf671c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b74b81b512d3823cf2d833e0fb4a90529e0c9fb3376e66010b78f579ee3fdf58",
+                                "uncompressed-sha256": "c4ef115f7171c384a3d45c9ddfabc95c7f760f38903deecacf2629600aafa1d6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c37b26f3358603fe18740e789845a4769fb2afe61b509ae0962a3dc01d2d9f8b",
-                                "uncompressed-sha256": "2d7f2b1df6bffe9a1fd06978e1bbf0b9798eeae2cd823d7ef998c5aabcacf877"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f6924f8655e847d71c7b1eb381ed6c8131095f3b81e2531bd8bde9baba0fa4e2",
+                                "uncompressed-sha256": "b343cefad1274a53b76b5420c39817089205e40001ec11d52b001b56c31581c7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "b580ff0154b253a53746e7f9f426d42b8afd28699e257e0b016574116b963353"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "cc659e5b91ffd7d2cacff4cbab51b9efac3373172e0f30fd8e26247569eec841"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "68d0e11b22c0d4ae6de7548f1504e1a7a9b4926addddf1a4587f278b0f512386"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "7600eec0292af33ac86b1fe088220a3565664cf7ed0d0106aa296f37179d2088"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231106.1.1/x86_64/fedora-coreos-39.20231106.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "aaf65a6132a88b43f29c543d69ad3f5d04f05d74a78773e346f26912f73624fe",
-                                "uncompressed-sha256": "f86dc51e080854e610a3ffc321f52ed3cb622a94d1f959705978bb70e1dbf2e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8dca79961dce55b6e7f7430af3109f4a18dd327d20fdae3da87b7696044c85aa",
+                                "uncompressed-sha256": "d7f0d337df477182116f30fcb45758ba22732502b35ac02f4814037d8311cbc8"
                             }
                         }
                     }
@@ -677,129 +690,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-078f40e5d240f903a"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0b84569ae662c0416"
                         },
                         "ap-east-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-03aeb3b54c67486a7"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0a7e71932c9855f39"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0c0d15cd183f7541b"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0c3cf2d74df60f172"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-075d9508fa0d7c09f"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-06ad1fa23673348f0"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0845a12f28957496b"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-005c44869b24d9449"
                         },
                         "ap-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-06586254e9b812965"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-05410ef420f77a75a"
                         },
                         "ap-south-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-07acb070a1839461b"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-052f52e6b6cd6a382"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0ed4b791ee0300206"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0f4519830ab7a0223"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-068e991c07839d299"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-025c18afa1083e6e0"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0d67c7a401af038f0"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-00206412cc5e25408"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0b7028bdd31bf2fda"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-05c53bb0f413c048b"
                         },
                         "ca-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-07c3d00da6c30c4dd"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-075aee7882402c756"
                         },
                         "eu-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-01582f3ef1967ee46"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-073a73c17e0138454"
                         },
                         "eu-central-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-03db4fb47faad5c66"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-04775bb894f4d0d61"
                         },
                         "eu-north-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0cfcbff674a46802e"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0210539d5eea85246"
                         },
                         "eu-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0eae919f3c826052b"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-07c7bf579b8958548"
                         },
                         "eu-south-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0857ea6dd43918d2d"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-05cf9557c8ad093e0"
                         },
                         "eu-west-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0139a69499ad03fcc"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-03e1934bac82c55db"
                         },
                         "eu-west-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-06a31e9eb451e1c5e"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-08876500d0628d016"
                         },
                         "eu-west-3": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-032247fb3988a594a"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0e9d99c05e08c614c"
                         },
                         "il-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0ebc45880a8922c65"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-06c974f9c7b8410bf"
                         },
                         "me-central-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0e8bd2594613376fd"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0f01d093249a4542e"
                         },
                         "me-south-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0429e9ecc09a1ca47"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0a3d5d77ef07c04ee"
                         },
                         "sa-east-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-0192fcfbec15f8bdd"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0ef36fef23e496c0b"
                         },
                         "us-east-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-067045f5fec94ae30"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0accc8b12375a3bed"
                         },
                         "us-east-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-082c4e39efb1f1188"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0867e476d36fd24a6"
                         },
                         "us-west-1": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-08fa52cb24d6c68df"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0a8e90e7bd49e85e4"
                         },
                         "us-west-2": {
-                            "release": "39.20231106.1.1",
-                            "image": "ami-05e9d14bf9914f0d6"
+                            "release": "39.20231119.1.0",
+                            "image": "ami-0b57fe63fb626e7ec"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231106-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231119-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231106.1.1",
+                    "release": "39.20231119.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c1c37619d555ce347b181eb168d5e122507cc6ff159dcf4fb6e12dd18dbead39"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b5f073f1fd3357fa3673691810b3059130bd65cfe16b788ce02fd07b642704ba"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,118 +1,131 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-11-08T17:43:17Z",
+        "last-modified": "2023-11-20T23:53:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "68a2a14851e24c4b09ac242cb9d28fdca53e7907e3f8323c902633d70c9534a2",
-                                "uncompressed-sha256": "7be1ac13fa8f4cd3c6f3e3ef4af579972a19e8b201ccfa64ee64d512566fd1dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e120984458956ec552caad4e6f1e93a8402a0394f3042fda1025d5bf4030baf2",
+                                "uncompressed-sha256": "de2cf13bdac9213f39f6a62e2062c5c0f7cd0d53fa4b49ef5962c3e0b66644f1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "de9c524af560294cbf7c6562382bb76b3ea1b38c1c3d61000b0e14c05b7e293e",
-                                "uncompressed-sha256": "e240cf3f4d92ece8cb6250b5c1237419eb8878cc17150d41c61608f8dbed0115"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a68e4e92fd16e8c9e6d023af83eb3f6b9d0875d49e3f164dd42345755bdfd08b",
+                                "uncompressed-sha256": "3c1502fe8950b14206a79a83e32336ed5bcfebf0f49c05214a032e313ee415cb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "7e919ebe086a4ded8607d4cd86f049953dc607d97080a2b2883d73659ba35250",
-                                "uncompressed-sha256": "611682ca2b2344993b0b368ae980d1672ab1224506afd96af156642c96c1eacc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "521b8ac61386cb644993f85921012818eddfb8efdf42b305609b9a083d506257",
+                                "uncompressed-sha256": "98dde99e091ee2981c1f0d05fa8c7ca49b35e762ad416ec4a5f1519349301c39"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "39.20231101.3.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4b7c8f8217945dada9167d0b1825df577adeb40c330ddb869de5761eb3d305c1",
+                                "uncompressed-sha256": "6d46b18ec0637412e0892f04b359750e788624a468d4179d4430de56a2d619a1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3bbb7727c0649329414c770759aeac3b587214fa2513a25c1d574d454ae8b2e5",
-                                "uncompressed-sha256": "f360daf39afa67d512ffa3c001a5de177efff5f7a9f6af9e46fda82c785e0b22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "25e84bde4cea038df2d635eb28c4f9ed43b3d781f9e2576ef2e78fffccb7607c",
+                                "uncompressed-sha256": "4b6a62012dd9954cc83560024097b3a32af869d7facda2d3cc434a4ca051e72e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live.aarch64.iso.sig",
-                                "sha256": "da92752400d0c459d8439c5ad6eb424dfe72465e7b033e6f44a414eaed195338"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live.aarch64.iso.sig",
+                                "sha256": "feaea60cbd0b9d41f5980b9257a673dc4c81526e50323647765db5cf892e6dce"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live-kernel-aarch64.sig",
-                                "sha256": "550f68c1cb9b03142b170af25b7e0083ca0f03188c34f7134d72dbcd84f2178d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-kernel-aarch64.sig",
+                                "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "fb6d78df7d7d2b708d7af3a731e1100af24adeda2a2a886d691b12e911a7efb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "15244cf473cc5ea0d22d32dbe70f38ff50231caba079907234c9bbfb5dcaf08e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "78e776a090184f2c06a681a06d65dcf54f302be8c36fa24c8ebfea413c1bb1b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "04b9820ac47ed7377805f78b083a52b593ac29de82187d221649581fcf2562b2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "b0f8cf9f37291a1f5809e2356cecd020d9d4692b5ff5aa6f32ce06e4d6d4554a",
-                                "uncompressed-sha256": "1b00393f718718ff0586c9fb79645773c3fd839399bf79161daff830b0e3dff5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "bd3f851c39f175c0f86325502bbd60413f616aafb04e4088adc93be6600b03dc",
+                                "uncompressed-sha256": "8d1f3c7172b2890e3ccf197494a3c6e2edbfde4693c44aa41f15032b7ecc4787"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5b4998b7ea051174b13b3c27e6d16fc3c6fa00a48b5b084f91932e98fb543bd2",
-                                "uncompressed-sha256": "d2be4c092099bad1cb6709e48d947df646b55356b9fa90ca26fc6c60f305f755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a294b02887956a6218e90208cbd88b30ea986a5d1ddd9cbccffa64837da9934a",
+                                "uncompressed-sha256": "49e3f90f01704c7c37df90486f9496fa8675a7dd77424ff3d57e6244edc7e2d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/aarch64/fedora-coreos-38.20231027.3.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d5fb549eac9273d63acd077e63af840b3b579d2039a42596f532172017711ea4",
-                                "uncompressed-sha256": "c7fcfdb10913cb81d44c0ebbb0b034e63967fd8c0ba181a44580a997efd7530d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "09fa17bdab3908a5d0d368ba21723b064da9e8060b33cd1535f35bbc38b62217",
+                                "uncompressed-sha256": "07867d3b868a0cf116caab8cb73f7872106371adf9cd6395bad9c60481071e55"
                             }
                         }
                     }
@@ -122,209 +135,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0be44bccca4544a3b"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-045772f1fa0d4df64"
                         },
                         "ap-east-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0ab07d53404c59705"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-01753613c3c9d6d86"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-07d5288b0a88aac85"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-05942596976488534"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0e5befd63d7650df7"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0d2e899263181c091"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-02d17ef15bfdbad66"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-03c9f1dee14c27efa"
                         },
                         "ap-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-042643ead45272c49"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0342287d152843bc8"
                         },
                         "ap-south-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-098ecdeb23a4ee007"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-00a19b4321e9709b5"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0497d1c3c5189ebb7"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-01d63db230eef29bb"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0c8682e650f21ad0b"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0607661d09e32895a"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0db89875fa26e5e7f"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-091948b5fac6328b0"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-02a45b83a8df8e642"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-03fbb1faaa68b39d2"
                         },
                         "ca-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0e0a6ce76a230146e"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0e0a21469a0c6ef84"
                         },
                         "eu-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0e989a91d85f611ba"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0808e4ba2caae3372"
                         },
                         "eu-central-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-07e5693dfd2b11568"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0be1dcdfa2f389fb9"
                         },
                         "eu-north-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0aa79d8dac3474463"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-00ebc46cc16bde64c"
                         },
                         "eu-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0c6fdff7b5312f595"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-01e825d7d129c2ce2"
                         },
                         "eu-south-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0f74855ade66b98f1"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-02f3a2489211edc94"
                         },
                         "eu-west-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-046db29ea80f49032"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0faaccea4bbe03bc1"
                         },
                         "eu-west-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0c5a5634f3846f17e"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0e19a32d7ce40282a"
                         },
                         "eu-west-3": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0096fa35500aa204f"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-09e81b79f53473ec7"
                         },
                         "il-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0941ae777f41526df"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-03d724602578d39eb"
                         },
                         "me-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0d5f7bf697904ec5c"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-06325d650391a3919"
                         },
                         "me-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-03a393240bceec8a3"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-090606dff6042991d"
                         },
                         "sa-east-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-05e3282213d0faa1c"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-052a974161b366d68"
                         },
                         "us-east-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-08bfab126d585a90e"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0255583b265f03a55"
                         },
                         "us-east-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-08ffaa81b416b8863"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-02295f483608eb92e"
                         },
                         "us-west-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-074481e84191e50ed"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-08535407836d1de27"
                         },
                         "us-west-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-006f97be630e574ac"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0d2de5c012e1c150e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-38-20231027-3-2-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231101-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "071bf429d858ca4ffb7bd72780cb76343a6a7ece9de58a2a7fdcebed4421f838",
-                                "uncompressed-sha256": "72ade3cf1cc1b6d2fe1ec40346b8dca5f08e823f4fcded6117599bf89cb91b37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "055d8d39e8d47872b845814dd588136d8928a626e7071f3aed5f98ba3c5ecd39",
+                                "uncompressed-sha256": "bf49b3e31750adf869a0ac2d9055251ca640d61b8e711cd2acdf9ec35a0f35e0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live.ppc64le.iso.sig",
-                                "sha256": "a82b96e1e1b51b9979ebcb549e341cc4449f8988393ffde8262f7e499b961cd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live.ppc64le.iso.sig",
+                                "sha256": "2cba41d00cd6516bd68463e6dc78e56c31d99ec0b23162fceab9afd0c8a5a1d7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live-kernel-ppc64le.sig",
-                                "sha256": "a8858970ff932c92271454ef7337c88396753353bcafdc0630749db3efcdbb35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "d89af7e85a9e46f3c34022fa0df7e77d7eda24caba29a6575a21b8242005f239"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "a08d34dc4c71e3021e689c9f3909091156e1300aab640d5c6b8690a0eb1b0a4a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b429d511e414ad2a48997a19b952dda5adc8b632cb953513a0d597b4eac66c67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "83645862a886cd5965d4ba5b7dcfe2526218a82f016e0b534138d2a029a53199"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "adf85a98b5ef37fdf46f713d6de26f0e9c8b3e1c999fc6b746b2045e3dbe8bef",
-                                "uncompressed-sha256": "e9d7655b65b181490b6f8421bc75d511c1c4865cb26698d365a5dd8653549fd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "ed683f90dcd709e65065fabd8fef32ccb696c693908465e711819e5b3d1ea1db",
+                                "uncompressed-sha256": "fe629bb58481e8d83f72cfe48151a0f1b1ea55d9129d0a4510eaf2ef42f2962b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "5c1421af1c09792251e028c86ca1ee9e439a0b2401d889df67b2a8e594ba3967",
-                                "uncompressed-sha256": "31556b9eb2282796ffc952bc429377bbb1ba9213d414c0ac09437e5665bf27dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "db5a1979e1e378c101c5062d36d2128633f836c1dbffec221647daab04a9dbad",
+                                "uncompressed-sha256": "eb4c3ee8aac26c90d69460629c518558f7bb2d00cb63498a10f7ecb00e1307cc"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "870bbffd4fb67e4ccfc78821ca5b45c7bd2972630f4366454bec6eab16f790fc",
-                                "uncompressed-sha256": "5548bb0e991030add4ebfd47ed84dd1d6156735caa0125e8c4a2d013e4c49bba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "db6eeed5a323702a2486d3402d3d0e80fe4c0030ec8479dd17f8c1b772883054",
+                                "uncompressed-sha256": "5e8cdb964ced883da1fe01a78788f498a19fb0faace6b00039eb4fbe7131432c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/ppc64le/fedora-coreos-38.20231027.3.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5bf24a022bb3fc01cc50f75061091846b34295b3ed5984bc8d74e3424f9cac5a",
-                                "uncompressed-sha256": "9c536611df2370cd235ce02c5095307613034246b9ddbf40128da573dd655d52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bb9a5acab44e9f5a85da4306eb2d731d00dd4e1da717342e437a179927b6a36e",
+                                "uncompressed-sha256": "2dc062c875f8c9a12985307af7801a50a7283e2e0012e13074702a9dd8fe426a"
                             }
                         }
                     }
@@ -335,85 +348,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "250170cd5f6d63a21606926bd2737f2259eef9a232d2de7d1219a79fc002de54",
-                                "uncompressed-sha256": "672afd1ad1105e0a4b782119d7d37c89da0f405db44df1a1727aaf9bbe534a75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6bd1bc9dfdb08056e56d0668a84244d3e545fe394dcc42a45e8b8bf8b9160064",
+                                "uncompressed-sha256": "ffb8b58024a5814fa366c8dba0c7a24492babe1448d9b7ed2105985ac133b776"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "26a419a3068646942fc9801c6b7c7c24e91871dee6fb3f306156b47eee37250b",
-                                "uncompressed-sha256": "eebb0cec2b3360559249f9c9e936d6c6f282f19972783b4da3341661e55ef477"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "a6c47ece6ee74e94f839277916e15271975760fb38db02f50c34848a890e7bd5",
+                                "uncompressed-sha256": "ad5a703c36326bbbfeb99311a452eed93682966f73fe21044ee45dc446cbb58d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live.s390x.iso.sig",
-                                "sha256": "368c6779213a24010b695556edc377235f4937a3f7cce779e5f2d35bcfdc075f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live.s390x.iso.sig",
+                                "sha256": "b6cf50eb99acf060586ebaa84d0cfc935a05e38af4b29512ce965b5f09152136"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live-kernel-s390x.sig",
-                                "sha256": "663940ceea45309bd5a1e0f014c5fac17d3fe21c0b6d716f2b7d2c30ee8e131e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-kernel-s390x.sig",
+                                "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live-initramfs.s390x.img.sig",
-                                "sha256": "eec90ca6f62b57a460822f16658aff5b3d7ed53e1e672e6d6167c47626bfb949"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5b496f7991a91e7af715f1d87d75f1736c24f2069a02e7b668bd7f952d896bcf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-live-rootfs.s390x.img.sig",
-                                "sha256": "c0b1b4bfe3406cf2b83e684c7e29b1e28ed6fa35be97c37bf7f64f2195d25347"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7e902dbdeca615768f9927882e0aee361a178976fb3b0cd369d069bc7275fb45"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-metal.s390x.raw.xz.sig",
-                                "sha256": "cc610f1aadf3888397c54e13d950a1fd622cd7af325b5f78f26f90e7fd3e6828",
-                                "uncompressed-sha256": "b0d0783874915933eff4e2cf1b5d5cecc5d178efb1a7fdc3006a685573a97928"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "9ba854a282a4e13947550d5914e499a080e9dd40745267ce2a8f02bdac006102",
+                                "uncompressed-sha256": "90b7c147a2cd858b2f20504a61e9df262686eb078e9b6adb69044caee03c2180"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d9cfc869ea01f5e4b3918226ee583e90bbd6d1ce64deab550d1ccf20060c3644",
-                                "uncompressed-sha256": "9ebf32a2598cbf6ade76863cae7b9242d9571bd1408a49e04055be320cc06c54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "da6774968ca8ad39f9635dc89d75b48006aa4aa370fb03ef3c8920fdf2442ee5",
+                                "uncompressed-sha256": "7e2212947c838014f8138360cddfa7b7bfec710dbc035d62c0572f6c24416e07"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/s390x/fedora-coreos-38.20231027.3.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b0bbef875000cf86b9b89c909319703c2a6960080b7ce783d0d005d2ed7249b1",
-                                "uncompressed-sha256": "84d200e437efa6bd5790af614f8d64bfdd4149122f0082cebf0d72eb65cd8a36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f15c477d1d7999879646e5738db3886b90a8f05eb5c28e83992c02cdfe297aaa",
+                                "uncompressed-sha256": "39af1a9e6845272592bac2ed7021fc24b57c0eac3277984c75c4dd0e86feba14"
                             }
                         }
                     }
@@ -424,250 +437,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "99afeddcb48f104fe4e2c190eea6fa40e48e7fc602b4202db19b3b0debce06f9",
-                                "uncompressed-sha256": "e78329bda8e37d10ff664364daee26a71065cc1b0bdf3e63563dffe3756f11d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2fd4ebb5b726400258393626df11ccc33a74214339b3c613b1fb5f004e19e63a",
+                                "uncompressed-sha256": "3e2914c57179806213aff1d776ab70c31368768740275ff0318643909e84899c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1ae7c62949fe5f29430633c35ad8f3df2bd547aef1f076bcff3fd5f31bf52570",
-                                "uncompressed-sha256": "86bd47528c7b83a587a5627b44f1c39828b20a8eb09906bae503715135d05d20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ba56658b56ac23b4b1dd092cee4994ed53996c8e63e40410e19e31b99ecb2eca",
+                                "uncompressed-sha256": "5b9b89847a23ecf72409cff1d3631d0054ff25f2af814e38194c8f62852019a4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4b2ffc93b69e0e691a99ceb13b2092a407a12a2283f06783e35678f741a33602",
-                                "uncompressed-sha256": "579d65b271a23bc005d4f864e7754f84abc0504ef1a4ae515ec161a67cd8efd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6cf549dfc880a3a6a7b25a6ee274c120d6fba0e0c983050f1bd1baec299a35da",
+                                "uncompressed-sha256": "ad413cdf6f19db657910f66714f5b06314676fc7e1c8d3ba8431d51c875d14c9"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0fc260647d4cbc270fc9b34149b2657a1849b1aec74fdf0be66c6665bc3759c9",
-                                "uncompressed-sha256": "abed4f394f455bc083f21954f639e396ff9ee8429e9622c5f10d987b98e185d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6d0b854648b02ed1fcda4ba1eda2192ed9d5f44ed728daeba8999d59cd81fea3",
+                                "uncompressed-sha256": "b98ede6130c5ecf4f3c3c473832804bb3f2583ad4bbb81e69442a160ebc437e9"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f98cac21a70fad444f2289ccbef27ee9930d241d1cbe21e9061733cdf0717d16",
-                                "uncompressed-sha256": "45d3b6c129f3d3bab00ece5ebee08babdd63bfbbeff8d317a1c6ad061f907405"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "fb07ccf5d1f34a0368fb621370a5512fa4f6cfdd682b049c5c7d9d6c664957db",
+                                "uncompressed-sha256": "a09b30a4efd8246676594d082882d2b87866c176f9614b8537d7b40ae7401bb4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b4099a040ada3799fbaab48af01b86a44a22d77471ac19c86b64ec3373d06d62",
-                                "uncompressed-sha256": "04d0b0b9370426a9d889b6c0973f77a3cd898f0d9a959a4d93caf020f14953ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ae579db54b095ca8481cc32b01ccde4d25e5d66a0bab2161cda14c26b00a3ba7",
+                                "uncompressed-sha256": "08abdf5f0fe073d652f486c768f4865fb0b69a056b6a25ec365f412428356755"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4c201ab7351e7316281f9125535fea780b4c741ae1992bb88fc3c45683af790c",
-                                "uncompressed-sha256": "31f78979ddd0121e9d8d582fbfbdf73c684c0f4fd02e5460e57689106a9020c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2529209b72af7126f6c2860697f96b2626ef5db4faf0bee6509dce0c295e9b93",
+                                "uncompressed-sha256": "d685e558322d5984e19e34d41b7009a705c7b27cabf0a9276f9ecbe987df50e2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "152c76086d33d38a6f0f6e003f076ea777e0327064f09347c82b1e643febe523",
-                                "uncompressed-sha256": "2982a47330a32f09b0f863ff431b424d657779d985df0b3f6260ccaa47420b6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6aec1fafb185386ee650121c9fae47b9a1f2fbc7e689f7e89d4e9a1ce26a54cc",
+                                "uncompressed-sha256": "31ee4f582496bb211b742546a8c674138afda3425d3106b6dd45d16ec67751fd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8e8cfeb70595de4e09e4645043213505404f3a2620a9124f7b45cf22843c72e3",
-                                "uncompressed-sha256": "900d7bb3c0308dfe374add7754791b680cb8139a106553304d18b3fcc5152b1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "606d2f2ec3067b10d6aa5f3b6cea4d0dd7b1951d973923de5fa51dee6c6bb0e2",
+                                "uncompressed-sha256": "a2654abde46f6f6dee602776efc67beb0c646b9a90ef334b44be2140d7280a1c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a5f5883fb39cd304a36623e828a37c62f81b1d6b6ede82b7f6f5ebeb6d81dc32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d076cab8f6b74454e522655f444a2e08cc0649b1874e9bbd769900dda7de8282"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "faaf16c4f5fe76a38cf34c8fa9a5a9ad5a5274132306ca5e7492ef99f8de3442",
-                                "uncompressed-sha256": "5bc2faa2ce57bf503564b6af8d56c8203a95ac24958df97c4942db4e792598b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b289537c83f56354c278f93ab9a9fb3b8a5912d688966d5b75c1fe9982274cd1",
+                                "uncompressed-sha256": "dba43eb0578fcb35aa23ba641d6c78d09727bf41339dab09aaf0373ade465368"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live.x86_64.iso.sig",
-                                "sha256": "ce5ef998148f51f6d26152339547ef12144127a01e8a2bee71c4572f2b46489f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live.x86_64.iso.sig",
+                                "sha256": "0b09997ca0170a2d8634b5942c9437a18b6d354b020c7e24aa9fe41f1458f33e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live-kernel-x86_64.sig",
-                                "sha256": "ab24d2f4ee2b8f7d175ee6a814bffe5a78e0123e5f5185e2aa17d3ed74acc958"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-kernel-x86_64.sig",
+                                "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "5431590f53fb6266b8807739160a08603450f7bbdc986a561c3cc73a057839b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9563bc05a8d078640a587ebb6f13b97ba4d40286ec420f41721158867512e257"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "b8826873a32d7bda4d42ca2a7c9514cc2977464d3cb08e8b5fe64e2b5449c60b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0c0fd3c27db3768a6dc28ef7f8c4b96242ddc4c76f19462b0ab1b09989b0b6d3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "2b59a5a4725679431220c734d1ee3eaf47caf9c314877dcb1f804b49c2d699f8",
-                                "uncompressed-sha256": "249781c147b26a24a0d62fbf2791f4afdcdefbd8c2f647ad6d0c007b4e87c22a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "319b68705149bebe6a4af16c08a91675383c4222980e204541b3834b40dcc0ed",
+                                "uncompressed-sha256": "8f34363844df85465bbb0f89441cc0db0d89a80a17b12df0195e0923c1acb89c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c867e257cbce7c569ec3b0dff5248ea69b604cee0c579efc5e374d4b1c8ffdf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "93c4c904944d23eb1688230fe5ce6e692ff5f2ece1055566f7a131212fd57dbb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "eda4d38bcd248faba98e85a78066522dcf2bf1e618fa7f9dc400a1368f38dd51",
-                                "uncompressed-sha256": "7d82a94748b8b6792f627f41c30ee850191a57db9f84d7308eaa0c4b9f39b378"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9abbd308c9571604d231660510a5512a7bf1cdf457914c68e53bf4484d670308",
+                                "uncompressed-sha256": "0d988863e9b8561e6bc647abe93e5db6276dde8b10c59662603832ed7700049f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "31b79e85198f880ea3e7cfffd84d1aa24f366b9dd0ea025ce7ca144435cf7038",
-                                "uncompressed-sha256": "21ba55f39006fa20fbc436c3dceaa94feedd5ce4d41b48fbda99e2285cf4f435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f3b209efb6ea9fe9b8bbfe1c1d4cafc0046ae7aa62bf6b63189494ee90155b81",
+                                "uncompressed-sha256": "924811866346c35fa32ee8012be4d6c73b2428ac09a43dbcbba4b4dcd660f914"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "558410c564e1dad98213e9b1fdc024fe097bd964c340fe83fff87582d279446f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "57b2acdfe0666a63f7b7222ec46d8302117f4d964fe78714b5abb430b5d32408"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "400b48f912e06dc20a1fa68606619f4be4b68a1fbbd5efd95d25f4ec47af3452"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "e7637603e78f1569ff4f1461c6e209e8d2b6ed063c08f222f662e9afb2bc4742"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6e4261d1343bbc14e80c6614b8d551ea9b7c090063812053152e8663fe6f8965",
-                                "uncompressed-sha256": "0383a3a0c3b0566ff0ea5b6279ba2b17c2e49889a311d2c66c0a0f01e98e9813"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "64725113b9c2c613d62b7af8676647cb989ecf62c6ba5a06378f196a397d4b18",
+                                "uncompressed-sha256": "97329f1c485a7cf293d3803efdf7653cf48e08a54e844d40e573e960a48a8599"
                             }
                         }
                     }
@@ -677,129 +690,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0845b6b326f8b94bb"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0d6a194196909601b"
                         },
                         "ap-east-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-054eb6bf6c2d00dab"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0b4b027c5422b421a"
                         },
                         "ap-northeast-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0296f9e43ff2a8986"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-035653912ad9f4827"
                         },
                         "ap-northeast-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0434b69b65a4f78bc"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0e0a64c8b5d1bcd09"
                         },
                         "ap-northeast-3": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0ff35e1909ae4581f"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0c89124f095cfc624"
                         },
                         "ap-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0dd90340840c49fa4"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0e8204659c7ae181e"
                         },
                         "ap-south-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-016f54189aa8cea42"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0f778b0f04e6cd8ca"
                         },
                         "ap-southeast-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0beb082c45ab9ddb2"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0b65d55ae62e97d1b"
                         },
                         "ap-southeast-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-07995013bce0bddaa"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0643a4f5ce30b3077"
                         },
                         "ap-southeast-3": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-025172a9ffba4f798"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-04fcf971286201341"
                         },
                         "ap-southeast-4": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0a4f09a3aecc1bdf5"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-05528ffc195388509"
                         },
                         "ca-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0684c6ce7f912a142"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-085f7cebe9630888e"
                         },
                         "eu-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0f109fb7b495a434a"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-05d5863b17761d25f"
                         },
                         "eu-central-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0846724729d4f6dff"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-055be21ed167fe4b0"
                         },
                         "eu-north-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0a04b447d49632628"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0ef1f4f99198436f5"
                         },
                         "eu-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0c13a2a97fdf05323"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-039247f2ef73521aa"
                         },
                         "eu-south-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-06abf893a091b7c36"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-00149bf7330207b2d"
                         },
                         "eu-west-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-015d8e78855b3eb79"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0f43255f3f471957f"
                         },
                         "eu-west-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0347fb21b74dce1c7"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-06f099d4671234f93"
                         },
                         "eu-west-3": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-07f6e2651eab4f762"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-06edd11c7c3573601"
                         },
                         "il-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-034d70e00ba9e220c"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0d1e697f147485e05"
                         },
                         "me-central-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-04085ab138be0fa7f"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-027abbf0e37753e7c"
                         },
                         "me-south-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0be26f5f891a76563"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0889f54acc52f4458"
                         },
                         "sa-east-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-05a7eab644ce4826e"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0bf368f7c80e4701d"
                         },
                         "us-east-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0be39e8378dd66858"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-064a1e6e200a99d7a"
                         },
                         "us-east-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-0b91f40934bb8dd37"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0c1c2ef7c2e336126"
                         },
                         "us-west-1": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-05e98e5dda6aff0b5"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0c0e39d4137de7774"
                         },
                         "us-west-2": {
-                            "release": "38.20231027.3.2",
-                            "image": "ami-04319b7b23cbb77b1"
+                            "release": "39.20231101.3.0",
+                            "image": "ami-0f2d4c6c0cb3d9f12"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-38-20231027-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231101-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "38.20231027.3.2",
+                    "release": "39.20231101.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dd2344d58b6a116893f48304e44e0960a71993756742f983ebb4a6ab0609472d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b4ca0883a794870a033c03c64982383e06482948248f6e36f753998e3b165027"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,118 +1,131 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-11-10T16:43:20Z",
+        "last-modified": "2023-11-20T23:53:08Z",
         "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7ef75e49221346e03b0b204aad6b454bc5aa5044f7fd3ae8bad0e9a428891cd0",
-                                "uncompressed-sha256": "f6d5712be8e02226e0b54704b7cfad4e57ec19cfe550a647ee1166cbeec9f612"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "856f74782b1d70c67855ab72a321b63c5181d5b492eb4dea3f80cd6fa49fa8eb",
+                                "uncompressed-sha256": "857cc73d87cf9303a3fe52b6f05f8d40c80ee212df622f62af041517a5ddfa59"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a44ae427ec831207d2d6c5fb14ab9692feede709a6215a577a038b3c59a7a72f",
-                                "uncompressed-sha256": "596777dc74d2306ba7dcd98d4655aa40062fc2bb813f9bb0de11108e98759a9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "4eb1444197d72f72d0734e198c8e0cea5e6ac3663cab6dab733b2abf74688ad3",
+                                "uncompressed-sha256": "553af66bce5307b82b7f7676f60cfd5a8891981d0d6c33b286a85c049e43fa20"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "4e282f0ec740522651f7806edc319cda639f1112cb32c174dd7e5fc0496cd9ba",
-                                "uncompressed-sha256": "da1a03eba1321a3381969d7318883711f1b778b5a4a1f7b99d406aec64d7bf98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "69fb7e5c66821485fa8db9c7daccd699ff4b6962ec8eae029b777df7e3594486",
+                                "uncompressed-sha256": "fb3fc0f24b82c25e8a59c7a6753e19f903cc0df19e3332ef13719ed080fd7e61"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "39.20231119.2.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "72008b8bd3b78a7e047fdc64a51029be377ccc98fe94a57eae41dacf2d1e88db",
+                                "uncompressed-sha256": "594102529973dfe428ca4b8637b0021b949e2281aba18c7c93be53ef323fb491"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "829ee781ac11dec3f4026726f9ad0f29126dfffc3c21e15c8c7a7e70a2677fb2",
-                                "uncompressed-sha256": "57d094a235f7c1801376c1038eec68f173ade92dbf674a45c20a781e00128689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0e1fd2c27674ba13f4914e84dbfb1152c64115ca22cc622ee17717160766e914",
+                                "uncompressed-sha256": "83240e0d4b1f6633f69e525c50121719c468a3afca240209c43bf88ff7f80907"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live.aarch64.iso.sig",
-                                "sha256": "0e0aeca1a3aee98d94eec9a66e8d0461aafa04de0939e1055e02812bad5474ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live.aarch64.iso.sig",
+                                "sha256": "f776a8f2bd5b91c3d7b77478281de4b1cda91c9bbe6c152d026bc8e7980dfc67"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live-kernel-aarch64.sig",
-                                "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-kernel-aarch64.sig",
+                                "sha256": "aaa5b752507227e97b7d1ce3e63d71fb0697b1b54ad1417db80c2977fd9952f6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "ffdb13dd3de93eed8dd15f5de9a783e6f812f83d53a61b973fec8290ee033df1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2e6b877b46ded227705a79dc5eb5594e545e0df7747de63d58a4e18c2b943e0c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "8b90f151cd7e0d940ed219bdaff68eb7aa5102e983176320e4ab8786eb217061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "96bf11202b4c4187c98b739854633aad342f127fc8ca4c1db98a27eae4716cc8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "d770f33cee9315f708dac40bfd836ad38d28fac0177c41dd2b14df0124e0a8d9",
-                                "uncompressed-sha256": "c350655598f1c1c573c378ceea1b460b5df113241e63fb1323c1086d4fad0d0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "01b48f980d4b6577ec15b237f8cebc988cb6eacd3d6fa5dd71db6db7c37b44a5",
+                                "uncompressed-sha256": "6f5c7fe71555e743aa62455a83f91f4c535d0b18fa0f5ef9b8a5427fc5f66428"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "702c78281c8264ad155283e966ad991d1253530519906bad2e2c98b0bb02ca41",
-                                "uncompressed-sha256": "a8197b658b40672b72500be3f756f92f6b5a8e78e39dfbae61adf287e1988bc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "134227d777331b8b2a53eaec394c86ddfb326e8d3386a34df0bdf14bf6b15f7c",
+                                "uncompressed-sha256": "2648e08dd153e501fd4d505fc5039f15fbcf18b7c18f34746990dc8a9e66784d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/aarch64/fedora-coreos-39.20231101.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "087b6326a5277b0d14d43c2c1b20866f0ab1b008101780fd71db95b56c2d0941",
-                                "uncompressed-sha256": "793081e1ee03cad3247ec5e2368dd2ef87fbba03bfb1dd2977511c6c263e8806"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f93cb3b5544b7ea62fe07476bfa5908ff3e0ba6f0d150a084824159174f0c349",
+                                "uncompressed-sha256": "ee050d77e6bd8cf8ac0007005a915f31388cfe6fa2ca07d8f6878aaae3cf59ff"
                             }
                         }
                     }
@@ -122,209 +135,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0c4871529fd917b47"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-056ae18573bcbc94b"
                         },
                         "ap-east-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0cecc1c6a86846ee5"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0cc13a1d54461a82c"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-03727be7e66d68352"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0582bd4a04f1335a7"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0f2918c4c383e8eee"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0f0630c7c04279227"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-082d2b6a410b797a0"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-06d4574a51d652853"
                         },
                         "ap-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-098a76146ae9eb7bc"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0a496edfe19171b11"
                         },
                         "ap-south-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0f88f8de6640181b9"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-06bde75e4c439082e"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0628c7e6fed7203fd"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0c1173010700f337c"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0be919a2666b017c7"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-04eab8db2c03f99ab"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-06d61ff62619fb9b4"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0c9d805e2a70ece59"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0f28f8907aa8a7ec7"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-00f5e41bcbaf4839c"
                         },
                         "ca-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-07fce4ed8a4eda6bb"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-05b7479d1c6b8ae4c"
                         },
                         "eu-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0cd00b58b04df0f6f"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0d57792016882d9a9"
                         },
                         "eu-central-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0554cc5c43d383d0b"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0597567b8a3f1a056"
                         },
                         "eu-north-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0bfb89635c59af214"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0ad873eda6064c619"
                         },
                         "eu-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-09ae32a5dc72f685c"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0498bf7c60013caca"
                         },
                         "eu-south-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0f89c02c091946087"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-07812edc7e9374749"
                         },
                         "eu-west-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0d162ba8541d05a99"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0fa2f4c29b2a77504"
                         },
                         "eu-west-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0a15a947115b4759e"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0a671cd641a35d1fb"
                         },
                         "eu-west-3": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0eb27698da4dee2c9"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-03e95a35997cd2185"
                         },
                         "il-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-077644f5f29d5d7f9"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-07ce35d25dad065eb"
                         },
                         "me-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-06e2842017d313a8e"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-06e29c0ac70ecd02c"
                         },
                         "me-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-06c2a1f4f084e9933"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0634435f4c85c9b2b"
                         },
                         "sa-east-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0de7c6678d7f4722a"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0bb14fd93fb43f841"
                         },
                         "us-east-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-031bd39e6889d0233"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-06b4a8d473c3c68bb"
                         },
                         "us-east-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-05dddb1ca51387bdf"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0efebe1433bba134f"
                         },
                         "us-west-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0ff40a56c86670fbd"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0d7a07f0e18a17b35"
                         },
                         "us-west-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0dce9bca3ca73f173"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-040444ebfd505843e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20231101-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231119-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c50fbad6f81b9349a74cd2badc0b7f55a33ea8f0ed9c25e613f53e4843e8b857",
-                                "uncompressed-sha256": "3f327383c7d8d5319c1a72cf2a9d2a83804698f1d3416465e73cd9bb4bdf2f32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "ed7e474db5af0b69418628fc9e0137d04d11b187f530f6d597fe9b4eeaf0972e",
+                                "uncompressed-sha256": "4062f75c9af32ea2fc7d8a64ab098e363787ea82fe4c29123189de68b2fc17b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live.ppc64le.iso.sig",
-                                "sha256": "43016bd9de3d7caffc46102e89d43c9d0e15e8d41d6ca20b116dc4a03174bca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live.ppc64le.iso.sig",
+                                "sha256": "bbb79aff45a9d1159228b327bb3abff935e2efbc5fa094c520657e0b4022ec1f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live-kernel-ppc64le.sig",
-                                "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "2111e9fa36b583c02ab90f05b80b6f3378cae24089cd4afa76fd603291138d60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "d947f1db9d544bd395f2a3605691f7a585863cca0182c382329c18a0c82f2f84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f9f843b8ee4df0eef4c3e607ce3845f21761fca43e87688ef90b37764910efb3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "736164914f770825e3dce79641d32a45260131cf9c6bb9b8b55aa2568199211b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "74dc4c872f071cbc7242d37b5425cb595f1b780d5750899fd89fd81f894aecc3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "302e8a25b7c070e46da9bb2fec70f9a034f2f19692e30c4bba7a9897f0500dca",
-                                "uncompressed-sha256": "4355d7ac0d12ad75d9bbc73e64f3a47d30cc84387b1ba4684140eb0eea241148"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "d4a40bd6deded605a99a6f719f4967a1c967d9ae649794dcc93daae5a060b881",
+                                "uncompressed-sha256": "dbe523ab857888cb7ce9727879d7e7e5104a514338abadd8edabae137d07c2a0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "3dbf0b2ab447ebb5e3a155b90bd57215f4accaa6e2a1274bc5d89ab85cc3ef63",
-                                "uncompressed-sha256": "9e0533d4cb03c604a88bd61a420a3186f036752fbd20a9f66f60eaf9deed2329"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1d004ead9c94ba004f7dd740e5826ac5cd6f0601bc18786d0f8a5eb2c221d70a",
+                                "uncompressed-sha256": "954af4c6a5c7aa376b24bec369a3f629381579c4621b78524355530832f1ba9a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "652eadeeafaa5a541c5a8b96b1402fc595144e4c1758249f6e4c4fb106cf68f5",
-                                "uncompressed-sha256": "4d2747d2503d20e91b851046f7dce849d57d2b438c5e866d7a88d82ffeaa2db0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9f8b4cace5ce7a8915914e10f0f8da279d9b9aca855f5855b9e9e4d8c3088a6d",
+                                "uncompressed-sha256": "e34dd6ee0d8a2f1358a683f6f1c523a622f2af8a921df14a40fbb88490774acf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/ppc64le/fedora-coreos-39.20231101.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "792ec1f243bcae32b8cca08aa72a4699e04caef3ba7fd02fa709fde1bc8a45c0",
-                                "uncompressed-sha256": "7c386ddf2f6a6bdb9b11ddb542ee21b88e790f6f6311cab436c70a1389ac683c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c656afde607a0ec28e3b7eb2b8dd214c8c8bf4f5e4fa92ce25b0669f9ed3d481",
+                                "uncompressed-sha256": "b0b372655c798c005d65b7e1acdc1f1ae6b96c60c0bd95a13ef2a7de8aa49adb"
                             }
                         }
                     }
@@ -335,85 +348,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3031db5d57f1af887f50eb14313b9df1da318ca010dc096adab47d2c19651255",
-                                "uncompressed-sha256": "3fc5e7e7cba555e72676df50ec876d5227a768e3ffd9bcb349e1c981d4297b07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "93f5731045869f8bee29622f3a6c7969b4e1c332661d1bb8a3da3d4bcb000c08",
+                                "uncompressed-sha256": "d93cc27948a82515d30772f5e93a89346cc71003331a6ac474425582bfd583bf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2ef700107dd749b1f698cf2898600e6b936d7dbea5146ef770accf732b9bd421",
-                                "uncompressed-sha256": "9d81b12460a678458a8e8b2e28573b19135e418b2eb3f47d0a6329040ee3038c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "455d0aaeb5d7fab9cd931ab7a08f7b46cf8cdea8ca6892148d55a7ac5c4fbbd2",
+                                "uncompressed-sha256": "77a47c28bb990bc55d810d5fb1176ee74f2de5c15f9f3de983c4e753ad5729bc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live.s390x.iso.sig",
-                                "sha256": "00f9c63caca55f92b7c2b1b4dd07f484d0c732bd8c6214488a9d22f8b00895e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live.s390x.iso.sig",
+                                "sha256": "ac7da2c60ffb43a6e9eba150d061bac95eb7eb6c187b7bd344c17ceba1b4c884"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live-kernel-s390x.sig",
-                                "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-kernel-s390x.sig",
+                                "sha256": "57fa889d4480a8e8e902be74df44d2a52b281019696890122d22e7ede1e5ca0f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "c5f691d78576556723bb94ccff91608ce593761f10115037c8b63d102a6cde65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3dbb84c6906ffb5d31440e80ce4e3888b06242c82a0e7e7a82f5d1b0db1e9671"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "6fb818077cb0bcaf34b7e241cd66af8ec7830093d0186fad5befb1972b43f028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6bbdc4d605499941e2964e87361850f1cc8c8a55c1fc1505d81453de2b801b70"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "f50c1b7ad830460ac14f9085e0f5999f2d3d2fd7358892a221f70dae2d953375",
-                                "uncompressed-sha256": "a01922d0f45637fee22d9da45816d13417960a081195ffb062fb189c5ba3e5d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "51b06622027718152baf56c8de32ea82012c3950741d111ab03f092b6160e7a0",
+                                "uncompressed-sha256": "3a1a46b2ceeae271033a87b9ed3fb085649f1825b2390f723a7dca850d5f1b64"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1b021b4c0425f3bdbdc8d60c54594b06549b0085e533fbfb19ae34117b1d527a",
-                                "uncompressed-sha256": "3259d7d9869cc4c5eacc0dce9736176a23ebb972679b8c4eeb271c3ea0085a32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "913d53f9ccac6053a56dc10d16d284c5cdcce131d4752147354d87c8b4639404",
+                                "uncompressed-sha256": "2253cd02f978fe04f63194d7197e6883ae9ef5654efa785d03d9f0913399c5e7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/s390x/fedora-coreos-39.20231101.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ac60bc997bc45ba458bf2160ee4e903fc435e71bf29ad86da967751693dce4ce",
-                                "uncompressed-sha256": "017d78f1f2f3a2eff36a94696073a962c3115ac318b658240f85a86c6b3d6d63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "63ae6b59d1982e033a6db7aabba991c54a82b3cde1fe82832f92e5f8d9f095c8",
+                                "uncompressed-sha256": "2b69ab3083c0e64858c14afbe55fa2814dbe83745ed79eebc6ccca7b3172a336"
                             }
                         }
                     }
@@ -424,250 +437,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7aee2274dff8eb937d11385c2e2d1720e0483d58d71c3c9146c3abe41703bab4",
-                                "uncompressed-sha256": "497a52592ceb3811652a8973ee94413e27507808be0c0fad51bb5a17cdeaa404"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "945b328c14e7679d40d20a41a9ab67a0aa52831d5ada2567d5ee5462e616f09f",
+                                "uncompressed-sha256": "a1aa22babc22ec38ff4f3b044fdca417ac3c0434da88fb29e94a48de81ff6367"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0a2fe5c115b6c963f4e360b25d0ab96c0930e5864b0530453ec7792cb9d65a95",
-                                "uncompressed-sha256": "4170713450e7092f646172dd1739fbc1be28151ec3dd98b6bf06feea52884814"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2a480b7c13fb8cf9167f9c6c3298ef348b1cbee101377eebd63d08ecd2e23063",
+                                "uncompressed-sha256": "cd805372b84becff205799be98d3f82d4c3c718e901e7273822d2d9bfe0717d4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ec152b631ad727f33aef5caba8abd7d9dc6899332030caaa8493901e65dcdc6c",
-                                "uncompressed-sha256": "88427ebe3ca122a9da065193cb96aa77cb5fc15169f3198d2fa41a0b8726b859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0a5e777aab97ad2829c2657b7c96b635115faa57eb6868555d0987715a448c88",
+                                "uncompressed-sha256": "78bca6cdab908abc26c69c1216b2fc8a90a29116f0f25ef473c5822f2281ed9c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f49ca20e74be4b8f1d31fe064ab1ea267868c2097eff8a3c50305116ae1d5823",
-                                "uncompressed-sha256": "0ed223adc2f2080b362d8c96bbcc1c7a80b900f74413331e29ae9314577ec5d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0efd052d23ec3c8523a41981c7818acbe191bb77c649260cc037897446c2a4df",
+                                "uncompressed-sha256": "3aa729c412a7afede36fb59e31251ad269e0c24fe82b1591847747274d460b52"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "896f29e486e71eeb54d1c6f1a3b7204ff016d872c1345e03b8efe711eb1ced61",
-                                "uncompressed-sha256": "775576cfcaf8b1bb3679a18946d023a8b8af53711bbe2d1bbf06e8ef945d238b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bb722ae0874464822d9676866285700d2f492179a35c91712643fd4e572283ce",
+                                "uncompressed-sha256": "be46ccc3fc1a21a9b77e3df5298c469df4bb2f960c7128184ba249d4f24a9f14"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "803afd5bed596a4e50077b8b28492d93331033cbb5eb60211a14e01b65474ba0",
-                                "uncompressed-sha256": "64ade57cd119e3440705e6c15bca659e3ab295d406ff0524b268bd93a3c08825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "aca52f3b6679bf15576ba0fcdb726aae2851f3068e4526f9db2d1e0b00ab36af",
+                                "uncompressed-sha256": "7f1f8f8a14223a4e5c9533471f0635c1c20fbff41d0ed81efb7e3019ff059bb8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "151712180553c30aa4d8f7b111aaed54a8a303175cec88acb8ab8e2f517a05b7",
-                                "uncompressed-sha256": "d3dc9f201609062a49a340cc0865e676180bc4ff72680a0e046ca4c4770a3542"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e2306cc3abc3f75d14ca6fe1000267890ba34d2dbf109959d90ec9155b79f44d",
+                                "uncompressed-sha256": "384bfe560421c53bc1cd44d2ad3c28252eb936da88f3f1e9f3eaf899b56c55eb"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "a06add1eb9ef92725c451ef2abab6e1524f952adf74f9c068a02452a6956cd44",
-                                "uncompressed-sha256": "fced73e5c4a2ffb7f9f023eb93d02113f0de1d5eb51574bc60dd8f8a49063012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4bd0af33172834766cf883529aa9f7ba5e8710c4db0b802d532ebce41d814898",
+                                "uncompressed-sha256": "4c4c8bd78602aaa960a356f7765f0a9acc016705a0d788dca7066011556d01ba"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1461c7b09f3c223fce587289fc0f40d7b66b9dbf50011ea29011e8d94d940965",
-                                "uncompressed-sha256": "332d3b3a4758ec12f49288930aa4700ae289834cf1bac49d14e248050470329c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "46368e2dce7bfd1f5aac886a0de25c390f96a4fd3434333d512a42b1f9acef53",
+                                "uncompressed-sha256": "da1ff779ef308533906362b1e58dbfe519d7fa10b031dac77d07b930f67dae68"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f49b90e5ce34a1cea4a5af0a2d21c2625df3cdfbbf3f889b3f8faf5a5e173781"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a95221b015fdac861fd8528ef5383952401f9cbc359332fe91bcf722cbdd675c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0816ab831cad461637e7d26e7db87cc2250cd637242955ae625d87ff2869a35f",
-                                "uncompressed-sha256": "63b9c1e1a06b6700f145864736f83e3e243726584f349927de5534e7b74bb9ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a2528c2a3160d1a6f389278b7c7665531b8deef95e6fba3a6484d6de654e11f3",
+                                "uncompressed-sha256": "046256bc1a7f9e76b7565a11545182fd536550f5e3555d65a12874777e36ade9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live.x86_64.iso.sig",
-                                "sha256": "6aa02eb9a2232aec00a770647a1d27259ddaa24732e378e12c9c806b33561168"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live.x86_64.iso.sig",
+                                "sha256": "4601e4d48f453918787efd27a2acdc290469c30aa0eeaafd37a48a7069844447"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live-kernel-x86_64.sig",
-                                "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-kernel-x86_64.sig",
+                                "sha256": "3efd416a625571345cbb330b434272b99813a1146cc9b4eaf7bfc8e29317c986"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "4a2abfa7de5ecc60639b2248169e2b490e4344d1d8205f90ec64d83cc796d5e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8c9e411b8d5d19d28abb842f519115a28f47efc4317d9f22819791de0469c00f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "5cce58132d4a23049fb9f5ca01e0d45879a22ae775f23f4ac9d0bd018222247d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ac62d710a31b9532603f42a86d7fb484fad7eb001d3fb861b63b0bd9ad017410"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "62be97ed70b250fa3e4fff0653ee8ef907fb689c6b68b0ed85603e1b9e17148c",
-                                "uncompressed-sha256": "3a0726d0edf893c90ad9faab55f735c52f46000a3ac82daa7facda06f8c75621"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "568ecb6a7655850d67dbe82c747a8e17e62e4a1257a9cbd9992a4c07a542317a",
+                                "uncompressed-sha256": "adb5a7fb754b411c0c7e7648c392fb0b822816bc00ec11bebcb3187c49d4a1ac"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "cc4f5ba6c5ffcbe0274e42a5c25a6fe52821037e1f5caa438ad9818e9e56a2e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "186a056b6a17d3d0c23663ef08aa3c1c3b95a2ddf31f4da392dd3e4294afd8f9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7cd4357f7270367a3532f05cd0947045f4181b0f1739130921e9213c6cfeea7e",
-                                "uncompressed-sha256": "b6c41f1916ba0cf7dbfbf2f4fe7e5206e77bb8839caa5240e000ba167b6ddafd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1f0c225b8aa99b63506328134d3d70788dbfabf3f5c585eb969017ba98c84edc",
+                                "uncompressed-sha256": "0c7f701b90ee0463877e61705489a98a4cbda7afb00cccdfec91181b8eaa1c55"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a6859fa1e2f8ff8f3a63269684e7a106b53eee796968440b8767dfc6447d01e9",
-                                "uncompressed-sha256": "25f5de13ba49e4b69b805f476d9ffd97ff97b9618c4d2471da7ca86bb512dfa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7960e84f9f69484cd0b14bd359726bf6821e39ca5acb2f3a0f362e8d7039fbb0",
+                                "uncompressed-sha256": "872c4fd04fd70d8e3198ec69e3ed745f57467a942033ff9020a364c27324ecb1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "b2bd7b9ea36cec7453333ddc45ce958212dbf9ae51d0466ee5a034265a231f7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "aa74543466b023217c69a03a226378f1024e7f49ecff775a13739ec56e51325f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "e15592f87622e73611ef58b3c2690ada9125c94ce9ec55728c3f3251b4302019"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "6bce34185b1f8cff0706cfdb8db5f515b5565f0e5dd7325d0f1a94e20ade79b4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231101.2.1/x86_64/fedora-coreos-39.20231101.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "db130c1ccc1c6ca13414d6cea5514eec9d949603ffe04c186d96d23a4325960e",
-                                "uncompressed-sha256": "a1a9de00eb3ea9271a53bf1902bf46fefe4c2e1c0f8a6c81c27dba45d37602de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "69421423c14ff4dd3c6efb11f2d535576fbedbfc546aba9bba369861e6d67ec5",
+                                "uncompressed-sha256": "7080605d56ca6509c017458c5d59b5e63beaa0b753d3a15fc3534e4a4cb3112d"
                             }
                         }
                     }
@@ -677,129 +690,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0732312407ef260cc"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0bd970d1c07f1c19b"
                         },
                         "ap-east-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-08bd35d015f96c1ee"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-041e953f413974f93"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0f19941c4f4a9124e"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0ef9bd0464788349d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-03aca206090882da9"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0c297b85b666a36ca"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-05ee09fac0c9302aa"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0305c2844cd1b99d4"
                         },
                         "ap-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-09f6bfe3db2753aa0"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-02e172f422f062920"
                         },
                         "ap-south-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0c2a1c6b774d530b7"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-02ca45d35744b8b31"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-022132fc593fd6dc3"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0e7d8d8ecd8b32b21"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0712c3408c0cec7c0"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-075b324ab6f2f006b"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-04a0299056037fdf4"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-052e8fa59650c9b68"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-069133a1927a2ab0d"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-02945db1631ea4dda"
                         },
                         "ca-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0b042c37fd0bdcb6a"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-08178ba2dc4a450b4"
                         },
                         "eu-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0d004be10e6e9d9e6"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0dfc3692f7ccb7fbc"
                         },
                         "eu-central-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0ebd99347209a3c8b"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-02d5e472a97912a99"
                         },
                         "eu-north-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-046e175ec5bf96ee3"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-06d73ede574ae1deb"
                         },
                         "eu-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0be539fb2b1ac8ffe"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0ff8d329f30e96ed5"
                         },
                         "eu-south-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0338c5a772020f05f"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0420d8993d09f109d"
                         },
                         "eu-west-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0cd96044186298d38"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0eeca3c878fb2b10b"
                         },
                         "eu-west-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0cce6d9012c6b8944"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0ee76d95b67bcb2c0"
                         },
                         "eu-west-3": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-069c1682e79bc9a9d"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-052e3b8e2753907d9"
                         },
                         "il-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0b54bae367d2ba9cc"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0221f66e960a6cca6"
                         },
                         "me-central-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-06807a196aa7aa9c9"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0ecafc07beadd8116"
                         },
                         "me-south-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-06fae6870ed593a2f"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-07dd259b23658a6be"
                         },
                         "sa-east-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-044aae436c38fb298"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0b4c1b13512396ace"
                         },
                         "us-east-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0a76a5cc0e110bdb6"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0bbb05ddd93050cdc"
                         },
                         "us-east-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0b506ca881358f4e1"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-07be41df8595b0a44"
                         },
                         "us-west-1": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0cc0cd544ce348e98"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0e2eb39d20db54537"
                         },
                         "us-west-2": {
-                            "release": "39.20231101.2.1",
-                            "image": "ami-0c215551200feb316"
+                            "release": "39.20231119.2.0",
+                            "image": "ami-0c4ade8ec7a49ed51"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20231101-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231119-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231101.2.1",
+                    "release": "39.20231119.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:52b2e05bc9ad518d8fb03131837a2b1756a4674e56173a936f6fb8aee5368973"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4f7c959ea62b33083f42e0473700b4f2928ce064b7832f41cfaf24d2e95e4eba"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-11-10T16:43:23Z"
+    "last-modified": "2023-11-20T23:53:11Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20231106.1.0",
+      "version": "39.20231106.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231106.1.1",
+      "version": "39.20231119.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1699884000,
+          "duration_minutes": 2880,
+          "start_epoch": 1700528400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-11-08T17:43:18Z"
+    "last-modified": "2023-11-20T23:53:08Z"
   },
   "releases": [
     {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "version": "38.20231014.3.0",
+      "version": "38.20231027.3.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -85,11 +85,11 @@
       }
     },
     {
-      "version": "38.20231027.3.2",
+      "version": "39.20231101.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1080,
-          "start_epoch": 1699466400,
+          "duration_minutes": 2880,
+          "start_epoch": 1700528400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -79,6 +79,9 @@
     {
       "version": "38.20231027.3.2",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "start_percentage": 1.0
         }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-11-10T16:43:22Z"
+    "last-modified": "2023-11-20T23:53:09Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20231101.2.0",
+      "version": "39.20231101.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20231101.2.1",
+      "version": "39.20231119.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1699884000,
+          "duration_minutes": 2880,
+          "start_epoch": 1700528400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).