### PR TITLE
Roll out stable 39.20231119.3.0, testing 39.20231204.2.1, next 39.20231204.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,131 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-11-20T23:53:10Z",
-        "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
+        "last-modified": "2023-12-05T23:35:38Z",
+        "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
+                "applehv": {
+                    "release": "39.20231204.1.0",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ebf563f60eed2e7864997912f16228b840aa76961ae176fc5bf4aaf872552977",
+                                "uncompressed-sha256": "9c35012685872411cd572e2ddbda610456ee76cea7a1b6fdebbc928b52946fcd"
+                            }
+                        }
+                    }
+                },
                 "aws": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b6344787d21f62b19e16f00da270d42e9ca0f5d8d908420b970bd85432009779",
-                                "uncompressed-sha256": "6f84ad8b38495377004babc00511f7e81bb6903d13ea464f476e39b69cc434ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a7d2bc276ce8a9546d16bbbbf1b312ba673864d7fefb0ed9d42a31c20a49f8e3",
+                                "uncompressed-sha256": "bb990959dd362a5ab660b4ce1b1f1b5c44dde03e162efd519817c5b75a33b258"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7273ae1c82338a1d82e51070ad15edeb1570a90885d08f3cec593e6b53d7a8ce",
-                                "uncompressed-sha256": "e8424cae647db77fb7dce1158e60a7c713bb7434567fd2eee4be084551a879fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1c3d28e86b1d290c3e0d3a0baebc3f818ca837a4d178788a3fe895d6469b0af2",
+                                "uncompressed-sha256": "83653e5dec8b83f8bb236960aed2f2aa1430419198682e4726a63f2576d40128"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "04585758268089cd37680c5ba412854436eb8687634c26152923a35abf309f8b",
-                                "uncompressed-sha256": "64fc962dc7940cecc4aa53b890a34c6816b9b87ca5cb3825a542185d11a1769f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a2e81d9666d974d35558a0a6a3655deec478b3c2ef821fca5f6289d6a98ea9d5",
+                                "uncompressed-sha256": "d516e6acd862544532042d4aeaa3be8c550f6c9f9f5658ce9815b23e84c8a33c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "07ca9e22d6384b8ab19f9d8aff9cd5c9a7eac3331f435d8f23f4311f481aeb91",
-                                "uncompressed-sha256": "30dc3ccc6b5c128b463259db51b81b346164c7f98dc46131b9168cfdebeffd8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "62284a472acbf139a3fc5f91f839e6e11944d823d7e6f26cfab7b6b5b295e33d",
+                                "uncompressed-sha256": "90e69896ec5162b23a7da608f81a346e741c28af92a566309b6c63f428faebef"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d7827ac88c349e14a7283b972415a18e05e0635f27d51ed5400626b14039c50d",
-                                "uncompressed-sha256": "f07b24d97ea6280e573abeaff3b275227b46406ec3c22914a0bab608479347a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f2b8472b70bd11f380bdd0a4327fef91d196f941b138b01fb9a7cb23012cf698",
+                                "uncompressed-sha256": "54e513149285957a757bccdb65f75c5184eec19154e32745cec14a3615533b4b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live.aarch64.iso.sig",
-                                "sha256": "257f3de9da72158285a9adee031ad54c90e1681ed5023b0d3228575a4f3dbc11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live.aarch64.iso.sig",
+                                "sha256": "cdc189ab54bdfcbcc41fb74c098bba0a556f9df7bb44b7d11d1ef7c2adf5a81d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-kernel-aarch64.sig",
-                                "sha256": "aaa5b752507227e97b7d1ce3e63d71fb0697b1b54ad1417db80c2977fd9952f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-kernel-aarch64.sig",
+                                "sha256": "7b8d0485c7b70cdd881b4b728d7d87a88a49847a17901292030ed9bbdfc217e9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0a6e3bc06e66c900563f0cafb11af3e16d13860dc993d5fa585cfdd66767dc73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ef3ab6845993815370cc42edc79784deb7fad226208efaf0b34ee50c1cc68c19"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "853166149b630c8681f5b16a698826ba28993379528946680bb6276a2615124a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7c7a014ae106ba0dca9d5347c43d3a493f37b06c8c6cdebbacbc6f7ea6eddf27"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c68fa5b6edf62f3d5e04d9d59e64a2f66f494209b34bf97797f3bee90568adcb",
-                                "uncompressed-sha256": "0509e8a32385f3d4d86486e00c54d619b7c5bc975f9062681d2e4e0481683db1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "629fd980451f1e9d6851eb4a888c533cd226a541652ba47a0af17525ec55bf7b",
+                                "uncompressed-sha256": "c72b60c4cfc9da57f94b2e2588fcc4de874d06c728b272d1b4979c49fd2b4cd8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "cb4bbc3bb8c513992ccd99c943f268b61fd525702c5b5e24c3d8e977b396b48c",
-                                "uncompressed-sha256": "5e5b48586f03de0b13789b7ebb486df43a5e4c3e184282b3d40f6c2edbde48bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "fe727a00b6fde38a51bdbcf210a2b4d08375c0d76006423fc18e9dc2167c3134",
+                                "uncompressed-sha256": "b11a00c87eeddf02a225ceb8a1956200aebeef1e8b1129605cda53e8cd798466"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/aarch64/fedora-coreos-39.20231119.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1e6d9878c8a63e41b6c4a4031698aadc82ab6df4819a20c1760d04e031bfad59",
-                                "uncompressed-sha256": "5653008fddd70fab3e7aa0192cf638c7ae0d5a476894eed98aada38abfc5a03b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8a7d89e0c97d90de01315af17f2b84625fe4e09a007715a26309b7d8da4f026b",
+                                "uncompressed-sha256": "737bfc63034c8c883e10220dbf4d32e6010c84d8ef8bda301f71278cf8c6fb34"
                             }
                         }
                     }
@@ -135,209 +148,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0cf80869c41dd0e07"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-07b725cde5d86fe3f"
                         },
                         "ap-east-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-064bac687eb15f9d8"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-08a7a8fbb1b27460c"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0a36d2f7ef3491958"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0a7c384e436b4c239"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0799237ce3381ce41"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0f2b9fa3482dee91b"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-08761c8ebccb73724"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-066ac8852bfafcdb8"
                         },
                         "ap-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0fb430b6d0423fa0f"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0ad5e737b94fcfd03"
                         },
                         "ap-south-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0951163a735dd2013"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0eaf1e372795a418e"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-02b1fd0a557ba92b4"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-009570614d9cdfbb8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-02dd86fb0d78d67a8"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-04963731b22171628"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0477db62ac3816dc3"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-00fbaa3aac0e9e28b"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-07f3a28ea9ec76df8"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-06efcdd8a4e7c4f75"
                         },
                         "ca-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0de101f1457a9a6ab"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0130e132e259bc397"
                         },
                         "eu-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0992c2fb0739a44f8"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-021a0b71d057ccea2"
                         },
                         "eu-central-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-07e8448eb7f95d914"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0207c56274a7e1337"
                         },
                         "eu-north-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0a6c46282743a01d7"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0ce2bd8abde1648fb"
                         },
                         "eu-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-050d53528591dc66d"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-04c147637102eac2e"
                         },
                         "eu-south-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-01f1992ee7dd2a4a3"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-02f7d7e4566e51ab5"
                         },
                         "eu-west-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0f5927f60fb1368c9"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-07d77b9d97f94eabe"
                         },
                         "eu-west-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-006d3e256cdc8bcc8"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-071e0112603903bb9"
                         },
                         "eu-west-3": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0c65398ae99f78e8d"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-02ec7bbcc42f68ba4"
                         },
                         "il-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0aeb152a324eea188"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0f9822a3dbb2895b0"
                         },
                         "me-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0415e947b0ed3a97e"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-025bb6993f3d50df0"
                         },
                         "me-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0ae3aea10ce9c8616"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0715476369ec3a3bc"
                         },
                         "sa-east-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0b8810b88266db677"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-06564a016f822847b"
                         },
                         "us-east-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0a0b0955646097a59"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-013c61ef6314fb3e9"
                         },
                         "us-east-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0d3f046eef947f8b2"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0afff3d5a4c4aa42b"
                         },
                         "us-west-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-094c4a54db2d18778"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-05919c596363a317e"
                         },
                         "us-west-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0e27d1d643a36f2e8"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-09a9d0150083e72bb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231119-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231204-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "984ac43c31c1bf37ff95e19d1fd9c520154dab65ce1c46079131df845688916b",
-                                "uncompressed-sha256": "fff34ebf493e68e4c47d396ccd897b5cbdc030b55b66febc5ee990c74ccc2f4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "650d12a820ef930ff1162edffa947c031b8108935996095d1206f47a408e6bf8",
+                                "uncompressed-sha256": "8655045cccee7452f3700ea31ae4c9fcad58472f3e7599984d2a923b83a4dadf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live.ppc64le.iso.sig",
-                                "sha256": "19e9bcff5f6ab8461af26bd1313cef1779f14dbd52c3d0a9c7f1efb304220a49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live.ppc64le.iso.sig",
+                                "sha256": "f561b845ca872bc71514abd058206a2ffc22191f8424c3e72422cd76b951d906"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "2111e9fa36b583c02ab90f05b80b6f3378cae24089cd4afa76fd603291138d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "e2cdb0e0c84489ca5d1853a52b7cd17e3b65ae4f40a7ae975cc626b111723ecd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "108cc08244363d6ceb7689430e005752107f74c95ed72559fbcd1b84a979830b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1775c09ecbaa890f61ae35647ebf5e2eed259681d4bd9b171bc823221c7ff1e5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "04c3e7d965bcd42fc148553a4e6bac9c8a311de8f2eef89a5d1d20de329c6df5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "ce2b6657a32279d9667fead8a83651e40818207065b323e55cb5aa1d4a489fd4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ad132e8f43ac04fb5cf88a68f5dc3a25fbf787d9f97eed2606d5d3583ce1d743",
-                                "uncompressed-sha256": "33e529e89ac4dc0ee2369a4164f77d23cb5996c8942738ec1112c04dd7fbcce7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "fba76ecfcbb647ad13c08629e15f2baaffd9b9f1a02d3c9e7033ec35b513439c",
+                                "uncompressed-sha256": "ba13a93f0973ebf06e2d346453fca630819d8cab77036bc3619c19891609344c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "987ec82523b3f094afe94aa5fc8078367886711a3e5647196cba6e797306165b",
-                                "uncompressed-sha256": "3ba46557dd7fb6432bacb7cda18f41b23f2c2bcbb757cec395f28402282e0af3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ec8fc4c97699bf577454b6f20df1a3f92fe9ba89d34a773f81b9677a93b9551e",
+                                "uncompressed-sha256": "2ae08b6c775d00f657e2dce77800ec5899a4300c0a754cb938f578a82b680241"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "27010b31e2ca510601410271740f0fb0a1ec825e7fcffb8f5e2acc288acfd687",
-                                "uncompressed-sha256": "98eeeef2e6ca635335a39e43cbf58a2939d4c60ad7e9c72e3f90f3e8a9c57173"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2714516ca090665eefefa91521527ec4f6256e09dae9ec77795ccad40a20006d",
+                                "uncompressed-sha256": "356ac96ab9db55bebf23d607e0aec68d65b114ab6177112a0700ffa96c4e6515"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/ppc64le/fedora-coreos-39.20231119.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4afc9df58a249e97c7381ad3524a57e4956cc971a0703284f2d030816011509e",
-                                "uncompressed-sha256": "49b48b35c9cae105a610d3dba1988c596e10181be59f2d651e206c55321016b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4f2dc9b196b2aecc566792f221279bd1187aab7f50044b9eaacb1c94fdb4ddb5",
+                                "uncompressed-sha256": "5729abb52cf33d7c7e9acd76aaa47d77abdffeea7b6c91257f74af75ced5898a"
                             }
                         }
                     }
@@ -348,85 +361,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4c56ddea8d37ad95053aa6551ed94a6e74c04ed65a036ef4a5a325bb687323b7",
-                                "uncompressed-sha256": "275cc573e1987ac42839cfa91d225b2c02cde7d4375ef16794cc4e7fd96acb2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "31ca78ab0223a3324170fc5e0946fbccd006752297ced1fe61fdd2a4a95c00f0",
+                                "uncompressed-sha256": "ea68a3570c73180115925bb2d33225f4f1ebbaef12413ce7cef6d331064a9c99"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "0a6a57ad99a49ca84c6b7ea5ee3cf7fe530ce52ddd88cc1c87b909d7ffb5c200",
-                                "uncompressed-sha256": "6e6c282c42a03fd5d995d0d9ce87f613062c33300763a34d384a16a6568259d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c296559aecb53393f32c2a5865724e3546f252672055d4fafbc5f4e9afa7d68c",
+                                "uncompressed-sha256": "c3b8d66686435f31fe39e91f52020d9f27fb24e3f5916b69a6ff9905a915edfd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live.s390x.iso.sig",
-                                "sha256": "d1d3a805e0ab0934bb3ab459eb4b22e2236764af2ff1f15c0465051ae2e93fd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live.s390x.iso.sig",
+                                "sha256": "32e6012cbb4be479f4d8a7a8d91385c56cffe2c6a93efa06a68eedf17b2b209c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-kernel-s390x.sig",
-                                "sha256": "57fa889d4480a8e8e902be74df44d2a52b281019696890122d22e7ede1e5ca0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-kernel-s390x.sig",
+                                "sha256": "7e7f58c54b7f843a8391e7478a33826e152088422497416da0ea342301405dd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f5360eb4a6d6a9008669ecd08030225bc406990e0f4bd39a4e5aa73eba0e24f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "588af73eaf7ec17bea67bdb09259d42d731df4c8127cd0b32f193e665364817b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "dd9e0f9f9d5715e3a4969bb8a569bee8dff83f2daf83c475e86fdba79788f5a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c9a03413d096dcc24d67a22f1a6628ec0225d80cbb2aaa93e4fcb9ea794a6785"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "88cd8f8d048e5df19ccd43777c25cadd1dc108d5714dada1b303352c9bdee026",
-                                "uncompressed-sha256": "b0ee432ae087bed2626476cedd53acae8b41b81c87c3a9666498009fa94d74c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d9673f29e8a9ac49edd3305f2ee360f03120a5554e5574ee6d80783b1a6b27dc",
+                                "uncompressed-sha256": "303dd0545b3aeb8a75d36931e3f6e6bbc292b0a044302ec187e28e9fef517721"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "67048f2b849723928a5343a798066a15b6555b41be0e7c58e83150976844f296",
-                                "uncompressed-sha256": "5abace10039671e267a0f09a4d17162ba9d3ca50fdae17866adb60477ff87216"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5c95ad22a5083ec32194e8273e5a413c83d3924a6afec4c655fbc5853a2561a3",
+                                "uncompressed-sha256": "c248963628a768180d3b93791d5beffd0bf31f2e4924877149287d2d4316d0fb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/s390x/fedora-coreos-39.20231119.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e0e76eec6a9a18dae7808cdb18c80c797762274ef01f166c93aef30e353ccd78",
-                                "uncompressed-sha256": "ea5957b84d3c2020636b40e926fddf081e343dddade8b269dc34220829ccd9e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c8c5c98e0d4b7336502ecb1ac06cf78eb3b89b38bd9c57f34370cf49efa5fc78",
+                                "uncompressed-sha256": "04f5a579b2200b924c3b2674411efe744fd86c10f3b09650b1b85871567c7a72"
                             }
                         }
                     }
@@ -437,250 +450,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "38a52da4932515fd04791541ae9e13cb437db50db293c2d281ec05134605c308",
-                                "uncompressed-sha256": "ff23fe66cb9b0f40c50bcd7d8863bffbc3fe79701652ed6532906699506a0c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9904fb8739457aca5bdc425b436479862d308b16d214452ebd7444068d84d41c",
+                                "uncompressed-sha256": "07d49cd271d8b442dfdb4fc2ea21cbd8fdad58d9c7d6dc8d52f504db594990f8"
+                            }
+                        }
+                    }
+                },
+                "applehv": {
+                    "release": "39.20231204.1.0",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "74c67551219ca452e54325d6327f176fa538c3e89d4e84ff18aba0c9b2462a6e",
+                                "uncompressed-sha256": "903bdd6fa314905bf473bbab4b45b89da3bb44e4a848314630c2b509c7f9dd22"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "6c471477f202b7bd1c580bf0c82ec11509ec3aa768d6b0286eadd1192c0296a9",
-                                "uncompressed-sha256": "6364293efa4d6dd404584bd7db863ad4161357e3d051e12623e23135aa352033"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1a7a35d4d410c730d7e6ef20aa452824cdbec53f751aa5d05faead1943c7c0f8",
+                                "uncompressed-sha256": "e245d8c21aa74a44dbf2b8b093b3f8ecd8dffb0c95f6d34fc04b135b14cbf305"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fb028ccd8a2644b58a7cfa26bdd58c0b564741dd6c798496531e97bb5b13b29b",
-                                "uncompressed-sha256": "14066e3f0e60dd2935e5ff301e44d460d19e2143e5293470e91dfdadcf0bf82e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7e826525da529bb57e9c9ca31ad9aa6a94303aa0b1814094e53da87454575900",
+                                "uncompressed-sha256": "8e421b2d329868da8800cca57f8f5a6a5954e84fede22058604dd8a81eb60578"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4496f3e4418d6a9b06d9b7c00b90da69a155f792801b9b9eb3e17c1e00fea878",
-                                "uncompressed-sha256": "2c55cc7a2ac06567e77e9bb2ede7855fd1408ec16b48457cd819560ea465c6ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "aa7a8a4bb0e69ca06290b23a4772fe51e7438ee2e313f0cb6390eac88883b5ec",
+                                "uncompressed-sha256": "389e0dad43fd1894774ec11492158c29a67c480c21c5bd6cc01bf1248a07de9b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d3d88110125c1e454b6bb47e479e6a7017b8575199368703255ba42327855c7b",
-                                "uncompressed-sha256": "a02aded320438cd4e5fbf9d1520bb9dd29de6b1229f60f8b1628a5f5ea200843"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c0f71dd38cd66b5446452bf3e472c3a7bfee4893d64ec27f2acdd4df434081b4",
+                                "uncompressed-sha256": "e4ca60badeb8b6124090fd8191007aa05217709f3740e827b1dd0c289fccfc87"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "216f146475f1ea5b3eab11e4f82d69052c2880ada582187b2fd9aa0d96a212a4",
-                                "uncompressed-sha256": "688497a9176082e32700cc6420e3c820f3c59e7981543591313516269d20c7fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e50b4918b13049f5029f60187c95fbdde5a22841872b757410211dcd78815ab2",
+                                "uncompressed-sha256": "77acef4b306e53d97ac355d239a6772b0a2c2437371212b96db477d57feaeec5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2bb3c7fb7ff4c31113609804aa71fdbc76a8e7a77572fe4c8c6e0d59cf4f539c",
-                                "uncompressed-sha256": "c143de3694d43ba73acc2bf5c0f6807e1244b19753fc81c35261b9fbbf73cbd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "bebad5052d7ef893d48fd6855b171addb50114061edc60ecd38a91e5fbf96291",
+                                "uncompressed-sha256": "092d043329ec53efca7a703e57b56f7b264f0247acf83865d8c3cc5eaa80b57b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "4678c1f4e19e199ce892746afcf7e8707102027d6dfd21f22c50f20eb2e62fa6",
-                                "uncompressed-sha256": "8d3b3ce06d8a6e79e8f8d62324aa184b84388f41170011a1de8457de5bae5962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "052ee8826eb502c17b663734a19dd8bf4b2c31632fc9fda3e177ea820ddca88e",
+                                "uncompressed-sha256": "031f5f84ef73b0b4734ce345132386fa98fd82806bfc32bd83ed9add6a710c4a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f0161913d68fca940cf54f6baa856bbbe095481be6ff41018fcba5affa975f21",
-                                "uncompressed-sha256": "bee085dd7d93e16125716439c1d35c36ebe4987ce95df52ed1d47944e9462148"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "dc60336b3372171187059ae64d0486fce4fd8062def3db62223b090fbf4023f1",
+                                "uncompressed-sha256": "7473a810bd55df150842fee7c37bbdc019778da3519db2069211d96a16655538"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e03c59d5950a67b0862bd1a0cb00005ac0cb34a6f22723b64a564e2d3cc5956d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "df8672e81cfbeed60427fa59aad6b36beeb8eb45e7322b484e819f16487c3a09"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a4c144dcd794136556e476739f0b988488225a56301155005faaee89910b5865",
-                                "uncompressed-sha256": "6ce6bfb95339c8149319424ef805c9fcc1b52dff721c76459d85187c3961ca2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a46053d78cd810753b47582a651e9c18998ba70449d5fb62ca85518a1bb2ac0d",
+                                "uncompressed-sha256": "2479a50436f4693b75231e38372b5d41e51315f668329c689032f8b39d264b34"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live.x86_64.iso.sig",
-                                "sha256": "df96d6f8d3e736a64481e903dce7dce57c6f082bf82bc5f8f64ec208d63060d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live.x86_64.iso.sig",
+                                "sha256": "8f3983b122c246010a755aafddf166bf4928a1fd9d8b26fc682f958c16aa4d4b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-kernel-x86_64.sig",
-                                "sha256": "3efd416a625571345cbb330b434272b99813a1146cc9b4eaf7bfc8e29317c986"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-kernel-x86_64.sig",
+                                "sha256": "5490e2d24924f2f9a71b5cab901d6f9936ad9ad5190f3021b58adb4f2e7d1e09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d181f85508657cc8c7643bd3da4934134b202b50a0ed7a6a7c78caddccf2e43d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "21acd443337b4a0168fc78b38d8a1a1df8afe21c151c94d399b6db048c0093d9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b89222c98093b4505d0ebf75bf5435b89886689c774995b5cb95071fa544c213"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1f35a400fa33222d2ec41c6f80fd7c30702f1e14f9dbf18a2379e73574da6a87"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3f2b5af224080acfa178efe65cfc961177f45f0393a1d5b61e1f9a189d4520ab",
-                                "uncompressed-sha256": "3f26ed240db2cf2c65846f7b560409337de7e2244b0f0d392039cf60dde55342"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7d91829c156c4c43d78998dbe324ef99426baec0733bac82d0aba6e64e5441a1",
+                                "uncompressed-sha256": "38340f9c8aa3eea1084df1082b5a6266f56e5265f7f157c39af723b06b756ed2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f726bfaa7930b04d1409ec1d0928ed1eff3191c7706c735ddc616b82c73df428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8e7af58e5389b978f5d7d696f5c525ff6057a22a784caa57ee1e2ea70311abf2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b74b81b512d3823cf2d833e0fb4a90529e0c9fb3376e66010b78f579ee3fdf58",
-                                "uncompressed-sha256": "c4ef115f7171c384a3d45c9ddfabc95c7f760f38903deecacf2629600aafa1d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "80246c869853a774054e0266711030d9c6ac471743e196c352dcf844a46cf902",
+                                "uncompressed-sha256": "a18480291473dc342d6b1c7b721b35a6fc7042b704a25da134a7bfc0d20b9247"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f6924f8655e847d71c7b1eb381ed6c8131095f3b81e2531bd8bde9baba0fa4e2",
-                                "uncompressed-sha256": "b343cefad1274a53b76b5420c39817089205e40001ec11d52b001b56c31581c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a8051c4c49e662a51d43d52d57e1e52d588b1c029ec69733bfb661b65cf41491",
+                                "uncompressed-sha256": "5783108b1e703fef81aa159b0277b090841544fb09d69625cbf821e54c20eed2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "cc659e5b91ffd7d2cacff4cbab51b9efac3373172e0f30fd8e26247569eec841"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "29a7c0431e602d791e2c8b4f35163fbd97fcf10641ab5e6e87887bddc36027d2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "7600eec0292af33ac86b1fe088220a3565664cf7ed0d0106aa296f37179d2088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "eebadd2ee93e479e4ea71b6c3a36344c29b7f9d4e83053005d522eb532c0475d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231119.1.0/x86_64/fedora-coreos-39.20231119.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8dca79961dce55b6e7f7430af3109f4a18dd327d20fdae3da87b7696044c85aa",
-                                "uncompressed-sha256": "d7f0d337df477182116f30fcb45758ba22732502b35ac02f4814037d8311cbc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5e49aa09551b7b906659963db5d9d8615e30ca513b3129a2abac456e4f290a6f",
+                                "uncompressed-sha256": "5858b947cfb6d6fb4c0b812c3eb35a837857044309868d5840de41b99bf599e4"
                             }
                         }
                     }
@@ -690,129 +716,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0b84569ae662c0416"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-064627e21afeb2f12"
                         },
                         "ap-east-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0a7e71932c9855f39"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-049528c32b0ae3e4a"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0c3cf2d74df60f172"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-092fd453bc3c91004"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-06ad1fa23673348f0"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-073d9002f61e2fc5d"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-005c44869b24d9449"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-00f312b2878b68a03"
                         },
                         "ap-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-05410ef420f77a75a"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-04387a79a1694ba27"
                         },
                         "ap-south-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-052f52e6b6cd6a382"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-08bce188fdc14b1da"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0f4519830ab7a0223"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0827169dd948e8f39"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-025c18afa1083e6e0"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0e7145dd7598b2695"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-00206412cc5e25408"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-09e39bc098c8ba55c"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-05c53bb0f413c048b"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-05fe1223a0b558a1d"
                         },
                         "ca-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-075aee7882402c756"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-093edcd4a2040cbf3"
                         },
                         "eu-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-073a73c17e0138454"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0d4577217ac047128"
                         },
                         "eu-central-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-04775bb894f4d0d61"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0030d403b19a3ae93"
                         },
                         "eu-north-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0210539d5eea85246"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-059750fc435650a27"
                         },
                         "eu-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-07c7bf579b8958548"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-079e9e01d25939055"
                         },
                         "eu-south-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-05cf9557c8ad093e0"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0ed2459d2cffc3653"
                         },
                         "eu-west-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-03e1934bac82c55db"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0a615535ce2629ec7"
                         },
                         "eu-west-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-08876500d0628d016"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-044e71f99f1959e33"
                         },
                         "eu-west-3": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0e9d99c05e08c614c"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0f9a6e2efe65a1b78"
                         },
                         "il-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-06c974f9c7b8410bf"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0b07ddc0b9f81a9bf"
                         },
                         "me-central-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0f01d093249a4542e"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0990f407b71be2e59"
                         },
                         "me-south-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0a3d5d77ef07c04ee"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-02866e07ddab396c7"
                         },
                         "sa-east-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0ef36fef23e496c0b"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0943ad62408138bb7"
                         },
                         "us-east-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0accc8b12375a3bed"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-000752936b4d0cf4c"
                         },
                         "us-east-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0867e476d36fd24a6"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-00d29c638027685ad"
                         },
                         "us-west-1": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0a8e90e7bd49e85e4"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0e8da5fe34b4b394f"
                         },
                         "us-west-2": {
-                            "release": "39.20231119.1.0",
-                            "image": "ami-0b57fe63fb626e7ec"
+                            "release": "39.20231204.1.0",
+                            "image": "ami-0b9f1aa2768ecb0b0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231119-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231204-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231119.1.0",
+                    "release": "39.20231204.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b5f073f1fd3357fa3673691810b3059130bd65cfe16b788ce02fd07b642704ba"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:18e3a5cc2a613245be2bf22de6aa020d0c13b1e4b4d64267ca68055b1fff4b66"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,131 +1,131 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-11-20T23:53:07Z",
-        "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
+        "last-modified": "2023-12-05T23:35:34Z",
+        "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "aws": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e120984458956ec552caad4e6f1e93a8402a0394f3042fda1025d5bf4030baf2",
-                                "uncompressed-sha256": "de2cf13bdac9213f39f6a62e2062c5c0f7cd0d53fa4b49ef5962c3e0b66644f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "794271047286a631c456e4e5368d443bac68adab459b8a40f82f6acd3c9810dd",
+                                "uncompressed-sha256": "41ac13849786a7ff7814db44ea7da71cacbef504c8c6a2fd7fdb0d975d3bb274"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a68e4e92fd16e8c9e6d023af83eb3f6b9d0875d49e3f164dd42345755bdfd08b",
-                                "uncompressed-sha256": "3c1502fe8950b14206a79a83e32336ed5bcfebf0f49c05214a032e313ee415cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "85a557bfc803a2c3ecbafc65c59f8464df6262dcb7bbb2af448408542301b6c4",
+                                "uncompressed-sha256": "c7b552f950498251bd61acaac896f235db52579c607f2a6c8e58bf860d217ede"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "521b8ac61386cb644993f85921012818eddfb8efdf42b305609b9a083d506257",
-                                "uncompressed-sha256": "98dde99e091ee2981c1f0d05fa8c7ca49b35e762ad416ec4a5f1519349301c39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e57d9d1016e65b218353928348d628478b43981507096da753998e64cb3b2b39",
+                                "uncompressed-sha256": "780a2125d26ed1dd6ff2b11d668616ca13de2e999875edb00e60efff261e517e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "4b7c8f8217945dada9167d0b1825df577adeb40c330ddb869de5761eb3d305c1",
-                                "uncompressed-sha256": "6d46b18ec0637412e0892f04b359750e788624a468d4179d4430de56a2d619a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6be3a258be8fb0318606645dac5c85001099b90b1817da9727cd03cf52c7b746",
+                                "uncompressed-sha256": "cd314316febd6ba5c03dda17ae0e56736fbcf88201c5a0bd69ff23cf0ac93a13"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "25e84bde4cea038df2d635eb28c4f9ed43b3d781f9e2576ef2e78fffccb7607c",
-                                "uncompressed-sha256": "4b6a62012dd9954cc83560024097b3a32af869d7facda2d3cc434a4ca051e72e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2bbde5fced749da06030336e41edaefb0609a532fac71ead5eea241b5346bd8d",
+                                "uncompressed-sha256": "bcdc7d20eebc6fc212d6300fa6625fb5331406bb1300e12bd3000b791bfebd25"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live.aarch64.iso.sig",
-                                "sha256": "feaea60cbd0b9d41f5980b9257a673dc4c81526e50323647765db5cf892e6dce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live.aarch64.iso.sig",
+                                "sha256": "c3e90c40fdae52a7dd43231fb0694750e9149963d516cae03bfd51524e2d1943"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-kernel-aarch64.sig",
-                                "sha256": "20b774bf887c145886c0d71cc654b4eec91c0988345e97529056b1ea70bb1afa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-kernel-aarch64.sig",
+                                "sha256": "aaa5b752507227e97b7d1ce3e63d71fb0697b1b54ad1417db80c2977fd9952f6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "15244cf473cc5ea0d22d32dbe70f38ff50231caba079907234c9bbfb5dcaf08e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "cc00387e8de66b5dedd160d4ade766d34026a17f7c30b6aad40a4095523cefbc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "04b9820ac47ed7377805f78b083a52b593ac29de82187d221649581fcf2562b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "e8bd8d960d500911257b52b832cbcbc0d98935da6d2a56b2c40eac99be2de4f5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "bd3f851c39f175c0f86325502bbd60413f616aafb04e4088adc93be6600b03dc",
-                                "uncompressed-sha256": "8d1f3c7172b2890e3ccf197494a3c6e2edbfde4693c44aa41f15032b7ecc4787"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "53f77322b23ba48e045085c3ff47b0196888783c2e700437f5c389f0aace5baf",
+                                "uncompressed-sha256": "abc4444d468addd96777664cd27aab63dbf28acc74d1bb1c1147eddbd696d832"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a294b02887956a6218e90208cbd88b30ea986a5d1ddd9cbccffa64837da9934a",
-                                "uncompressed-sha256": "49e3f90f01704c7c37df90486f9496fa8675a7dd77424ff3d57e6244edc7e2d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b3fda5eec6287b30f632e2addb7d343dafb3c89a34946a428c02c4d9ab798310",
+                                "uncompressed-sha256": "7b49785bffe3672065b9645c7b177ae227fbfa905bcfe7f8c62fcaa613ac1d40"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/aarch64/fedora-coreos-39.20231101.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "09fa17bdab3908a5d0d368ba21723b064da9e8060b33cd1535f35bbc38b62217",
-                                "uncompressed-sha256": "07867d3b868a0cf116caab8cb73f7872106371adf9cd6395bad9c60481071e55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4d9a72f5d50ee9d9c136c431aac946845df6950583e17a10938c5b0c08587c7c",
+                                "uncompressed-sha256": "65f287f802f83052eca183049e6cb963937398275fa71220db9bcae6004fe501"
                             }
                         }
                     }
@@ -135,209 +135,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-045772f1fa0d4df64"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-08884bb1e75ec0b1a"
                         },
                         "ap-east-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-01753613c3c9d6d86"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-02cb60c1e0b3445c0"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-05942596976488534"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-047dc07807222209d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0d2e899263181c091"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0e9f6ae173538f4c7"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-03c9f1dee14c27efa"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-096218078b7aad299"
                         },
                         "ap-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0342287d152843bc8"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0cbd7be129df40865"
                         },
                         "ap-south-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-00a19b4321e9709b5"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0e7a5b7e4619b5535"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-01d63db230eef29bb"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0085305ab1ce3f690"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0607661d09e32895a"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0fcc12ee4a1916db4"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-091948b5fac6328b0"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0eaddf91b7c2c5608"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-03fbb1faaa68b39d2"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-07271b92e05646edf"
                         },
                         "ca-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0e0a21469a0c6ef84"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-00607d57f59bddfac"
                         },
                         "eu-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0808e4ba2caae3372"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-04b08e15261dfdf2c"
                         },
                         "eu-central-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0be1dcdfa2f389fb9"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-07fb979019b3a594b"
                         },
                         "eu-north-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-00ebc46cc16bde64c"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0c7ba25a75ca323f0"
                         },
                         "eu-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-01e825d7d129c2ce2"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0cd04d6ddae9090fa"
                         },
                         "eu-south-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-02f3a2489211edc94"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0f2c8cbd336e9812d"
                         },
                         "eu-west-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0faaccea4bbe03bc1"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-02b00285794a341d4"
                         },
                         "eu-west-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0e19a32d7ce40282a"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-089c38e60799dbc12"
                         },
                         "eu-west-3": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-09e81b79f53473ec7"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0f756fafeba8bd1aa"
                         },
                         "il-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-03d724602578d39eb"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-04f888342905bce2a"
                         },
                         "me-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-06325d650391a3919"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-04bb39ca5a01420e5"
                         },
                         "me-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-090606dff6042991d"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-07eff12ef0b7b4ec8"
                         },
                         "sa-east-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-052a974161b366d68"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0391bbd98bb461646"
                         },
                         "us-east-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0255583b265f03a55"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-071f0bc129ecca4b0"
                         },
                         "us-east-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-02295f483608eb92e"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0067320da00fbff17"
                         },
                         "us-west-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-08535407836d1de27"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-05ec93939e264ce56"
                         },
                         "us-west-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0d2de5c012e1c150e"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0ae563ba9813b5b55"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20231101-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231119-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "055d8d39e8d47872b845814dd588136d8928a626e7071f3aed5f98ba3c5ecd39",
-                                "uncompressed-sha256": "bf49b3e31750adf869a0ac2d9055251ca640d61b8e711cd2acdf9ec35a0f35e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "abcd449f357d50d9e9ff9d1f2fcdd3ff814c9bab8a599e223d28eda68f6a685c",
+                                "uncompressed-sha256": "c3fc42c99df9664935a56d30c237420fff82830b49921a4ab40144c0a9a2f8db"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live.ppc64le.iso.sig",
-                                "sha256": "2cba41d00cd6516bd68463e6dc78e56c31d99ec0b23162fceab9afd0c8a5a1d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live.ppc64le.iso.sig",
+                                "sha256": "7969533e2ecfbad0f9975b38fe4574a865911b35fdf947c287426469815c2ba8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "5dac3a5d65e5b411f4fef6848232a8faf8fcca3f32021e28b56faa92f4707bd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "2111e9fa36b583c02ab90f05b80b6f3378cae24089cd4afa76fd603291138d60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "a08d34dc4c71e3021e689c9f3909091156e1300aab640d5c6b8690a0eb1b0a4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7b67c08282e8d07b380b96aeb24c25e7df7e1f3f58e9100952c8dff656d46ec2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "83645862a886cd5965d4ba5b7dcfe2526218a82f016e0b534138d2a029a53199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "96e98c8afd8e59121bc4f9f2beee18be5d60dda90b4dcd02a4be39c4803f0f4a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ed683f90dcd709e65065fabd8fef32ccb696c693908465e711819e5b3d1ea1db",
-                                "uncompressed-sha256": "fe629bb58481e8d83f72cfe48151a0f1b1ea55d9129d0a4510eaf2ef42f2962b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e5ea892ef3501d47aab6aed8d7137cd1ff16b0c4adaf644bc7fd22afc276214f",
+                                "uncompressed-sha256": "5d43db4baa6e9b427c3752a22382ac8951603df24632fbe0681ea9a70b592000"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "db5a1979e1e378c101c5062d36d2128633f836c1dbffec221647daab04a9dbad",
-                                "uncompressed-sha256": "eb4c3ee8aac26c90d69460629c518558f7bb2d00cb63498a10f7ecb00e1307cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "272ad9114ba01afd11f7aeef864abd3835504192d359afffdc03bd96f8102af9",
+                                "uncompressed-sha256": "11395c641f49b93c2a35a3d1809ea400933717a13b6bd8dc1b654a6546b1d54a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "db6eeed5a323702a2486d3402d3d0e80fe4c0030ec8479dd17f8c1b772883054",
-                                "uncompressed-sha256": "5e8cdb964ced883da1fe01a78788f498a19fb0faace6b00039eb4fbe7131432c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1e05d71f78337cb323857bb50ea644786ea88cbde0f1b6264f53dbcf63a019c0",
+                                "uncompressed-sha256": "052e14f041199b5c79500850bd447476b42925946e8d7d87dd6b130a7183af8c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/ppc64le/fedora-coreos-39.20231101.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bb9a5acab44e9f5a85da4306eb2d731d00dd4e1da717342e437a179927b6a36e",
-                                "uncompressed-sha256": "2dc062c875f8c9a12985307af7801a50a7283e2e0012e13074702a9dd8fe426a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "6ed938ef7b26ca1de461fee125a117130537a8cafef73b6f56b0b2d1e583d9ed",
+                                "uncompressed-sha256": "a9783a4b214e292c22c8fffdb7b869506d536739b4bd20a7789f2150d5cd1fe4"
                             }
                         }
                     }
@@ -348,85 +348,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6bd1bc9dfdb08056e56d0668a84244d3e545fe394dcc42a45e8b8bf8b9160064",
-                                "uncompressed-sha256": "ffb8b58024a5814fa366c8dba0c7a24492babe1448d9b7ed2105985ac133b776"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ee51b8d06186e50b41d563da98e17fac9920dede92d104150bd8feadcc1f873a",
+                                "uncompressed-sha256": "e5a56e16d94fcc12a1691b49d878bc9c3692b69f3b3dcc25f7a5e496862e263e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "a6c47ece6ee74e94f839277916e15271975760fb38db02f50c34848a890e7bd5",
-                                "uncompressed-sha256": "ad5a703c36326bbbfeb99311a452eed93682966f73fe21044ee45dc446cbb58d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "961e6f4e5fa404b0cf3f26a60b1ebef8d08a0c7b309ee4d9b775cde192a78de7",
+                                "uncompressed-sha256": "663c02af0d052983f58a6f1dbe82a665e2b0ef9c049662bc34aaefbdb263b3ae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live.s390x.iso.sig",
-                                "sha256": "b6cf50eb99acf060586ebaa84d0cfc935a05e38af4b29512ce965b5f09152136"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live.s390x.iso.sig",
+                                "sha256": "412fb1ff3f625ed3726d6af9b7fbe1d505a93df92d7ee4a300ba96438751a765"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-kernel-s390x.sig",
-                                "sha256": "0878d7993a034ec80caefec6fb8204181c298ebe000eee4b25b4be8021696b9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-kernel-s390x.sig",
+                                "sha256": "57fa889d4480a8e8e902be74df44d2a52b281019696890122d22e7ede1e5ca0f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "5b496f7991a91e7af715f1d87d75f1736c24f2069a02e7b668bd7f952d896bcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "71f228513e0635fb53d2c9f893f6a56106bfe78f6689373bbc3814bd8b92c7cf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "7e902dbdeca615768f9927882e0aee361a178976fb3b0cd369d069bc7275fb45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "436af260c83a38866c0aa1bd4f8671a3b869a496e49292bdd8cbf4cb37d039e1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "9ba854a282a4e13947550d5914e499a080e9dd40745267ce2a8f02bdac006102",
-                                "uncompressed-sha256": "90b7c147a2cd858b2f20504a61e9df262686eb078e9b6adb69044caee03c2180"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "084fbd3003734db4effef91d46659375d4e48df8b0ce6e3efece06d5d36386d4",
+                                "uncompressed-sha256": "3c314d94edd188ce93290cf6387241281a09072e56d1374d24651c2da7072dec"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "da6774968ca8ad39f9635dc89d75b48006aa4aa370fb03ef3c8920fdf2442ee5",
-                                "uncompressed-sha256": "7e2212947c838014f8138360cddfa7b7bfec710dbc035d62c0572f6c24416e07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "227d87943f1434c0bc842f03ca1501596a0e10e616ab72e22a178b171d78d9c9",
+                                "uncompressed-sha256": "8528c9c3b1385404624c0a0cbc592c2388284f528d7a456a29ccfe899f0a969f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/s390x/fedora-coreos-39.20231101.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f15c477d1d7999879646e5738db3886b90a8f05eb5c28e83992c02cdfe297aaa",
-                                "uncompressed-sha256": "39af1a9e6845272592bac2ed7021fc24b57c0eac3277984c75c4dd0e86feba14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "34924160d4a7f416d0be83987d3eeb7667c7cf5c01879ea1957b45ef3b46604d",
+                                "uncompressed-sha256": "91b33f1d3344dc53f888b234e9c359b10d97024da18904074d69ba8172f00b73"
                             }
                         }
                     }
@@ -437,250 +437,250 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2fd4ebb5b726400258393626df11ccc33a74214339b3c613b1fb5f004e19e63a",
-                                "uncompressed-sha256": "3e2914c57179806213aff1d776ab70c31368768740275ff0318643909e84899c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b9ef12680e47d2e89ec42fc17972d7e5889613c8b1e78c30a0feaf81d6a22b1f",
+                                "uncompressed-sha256": "0409001d49da931105ef8c04d6beea77960a3e4f5d4714c0ae8d72cfba5b8ab5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ba56658b56ac23b4b1dd092cee4994ed53996c8e63e40410e19e31b99ecb2eca",
-                                "uncompressed-sha256": "5b9b89847a23ecf72409cff1d3631d0054ff25f2af814e38194c8f62852019a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c21624d61b4d660cd1c303a88e1a8da90502cbb21edb293c1e9ed89b196d4cf8",
+                                "uncompressed-sha256": "c6d3fa2433c3d11fba851f1fae42b2e178308fba15b3f4eaabc8c3f965799053"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6cf549dfc880a3a6a7b25a6ee274c120d6fba0e0c983050f1bd1baec299a35da",
-                                "uncompressed-sha256": "ad413cdf6f19db657910f66714f5b06314676fc7e1c8d3ba8431d51c875d14c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "350f8f8d9fbf985ffcc8bae8ef996127210daeae5617ff490ef65ab0b376fe8a",
+                                "uncompressed-sha256": "7fbc1c5ba2f713ac423485731f47a91d73f3d15447453de2557b261025da7ce4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6d0b854648b02ed1fcda4ba1eda2192ed9d5f44ed728daeba8999d59cd81fea3",
-                                "uncompressed-sha256": "b98ede6130c5ecf4f3c3c473832804bb3f2583ad4bbb81e69442a160ebc437e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "af538f4ad5266e0afed6ab8be7ebc7e15af77cc3cc7b89bc85ec4cc0f039aa4f",
+                                "uncompressed-sha256": "7b86712e01dbf247fdb5c7ac201836400598566cb2f870873bbef0e0cd726c5d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "fb07ccf5d1f34a0368fb621370a5512fa4f6cfdd682b049c5c7d9d6c664957db",
-                                "uncompressed-sha256": "a09b30a4efd8246676594d082882d2b87866c176f9614b8537d7b40ae7401bb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ee4278cd8c9ca04e20d6ab1e71635021b4329983518d5ae286f582c08d6ab585",
+                                "uncompressed-sha256": "1a326302016cc0b002d3291817b372afcce4df2acede827980bbfbe29e1b552a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ae579db54b095ca8481cc32b01ccde4d25e5d66a0bab2161cda14c26b00a3ba7",
-                                "uncompressed-sha256": "08abdf5f0fe073d652f486c768f4865fb0b69a056b6a25ec365f412428356755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3af77a922247190552a07af251ebca55d06736c5c8fc21124d90656f6a7e74af",
+                                "uncompressed-sha256": "573f0386f1f577767732c4485404533cd9fabdd03989643f78616b75fcf638b7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2529209b72af7126f6c2860697f96b2626ef5db4faf0bee6509dce0c295e9b93",
-                                "uncompressed-sha256": "d685e558322d5984e19e34d41b7009a705c7b27cabf0a9276f9ecbe987df50e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cdaa5635abdbf519748672e043e67699fa47f8cca96cb63cc58e0427ee01d0e2",
+                                "uncompressed-sha256": "9701afe91ca9fbdc5e86fa86e7c30a596797b5697bdbd68c390b5dbad629a99a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "6aec1fafb185386ee650121c9fae47b9a1f2fbc7e689f7e89d4e9a1ce26a54cc",
-                                "uncompressed-sha256": "31ee4f582496bb211b742546a8c674138afda3425d3106b6dd45d16ec67751fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "fd41576b0caac96fd62cdbed58ed15597758ced778e878cddb74f5007c573c70",
+                                "uncompressed-sha256": "38b95dfa97f6ae2af9a23224476e55e8276c743c58203e58bcddfc93a47b5220"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "606d2f2ec3067b10d6aa5f3b6cea4d0dd7b1951d973923de5fa51dee6c6bb0e2",
-                                "uncompressed-sha256": "a2654abde46f6f6dee602776efc67beb0c646b9a90ef334b44be2140d7280a1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f60f8bd3da9b3f747be02dad690a0e0fe51cf3d50a7f9c5d54effc430571ae90",
+                                "uncompressed-sha256": "e5bb19148a7b0a3734bc6f70724d4cd4618cd363ab79fa3e597f198421403626"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d076cab8f6b74454e522655f444a2e08cc0649b1874e9bbd769900dda7de8282"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d968a8f1f3ee6c71d897e61864199586db4ecd9114875c27f923096f8a2ecff4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b289537c83f56354c278f93ab9a9fb3b8a5912d688966d5b75c1fe9982274cd1",
-                                "uncompressed-sha256": "dba43eb0578fcb35aa23ba641d6c78d09727bf41339dab09aaf0373ade465368"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "31036a3fec74fb68f1c190f876104690c52b53b5416b0e4a9684b9c8126735b7",
+                                "uncompressed-sha256": "fe3de2289ee47a4e841bdfdf208af8addc0d5c69cbe87c18f83c8b20c6e70749"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live.x86_64.iso.sig",
-                                "sha256": "0b09997ca0170a2d8634b5942c9437a18b6d354b020c7e24aa9fe41f1458f33e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live.x86_64.iso.sig",
+                                "sha256": "39d1170345ea1404549d39383885310a460d62068cfa77d60d2f8484ffacc889"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-kernel-x86_64.sig",
-                                "sha256": "341f068fb4ad4c6ce1b9a822edab58123c533c73f3bafc8951e4463c3c6f27cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-kernel-x86_64.sig",
+                                "sha256": "3efd416a625571345cbb330b434272b99813a1146cc9b4eaf7bfc8e29317c986"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9563bc05a8d078640a587ebb6f13b97ba4d40286ec420f41721158867512e257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e50a45a3da2face2a808cfccc3318f7d0a9ad8d04c3845f798dc19646bcf4138"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0c0fd3c27db3768a6dc28ef7f8c4b96242ddc4c76f19462b0ab1b09989b0b6d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "a7bbd175100d567cd7e27130834990a837b49bf3181d41106b9dd967d1c1058d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "319b68705149bebe6a4af16c08a91675383c4222980e204541b3834b40dcc0ed",
-                                "uncompressed-sha256": "8f34363844df85465bbb0f89441cc0db0d89a80a17b12df0195e0923c1acb89c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c72d19faba67ed1a72424daec7303513b9f6dfc97d454537fef675f0c52ddbdb",
+                                "uncompressed-sha256": "11cbdcac328985d1fa8556f93c36c6b20b6e9700978355c29d54e06c35d2608f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "93c4c904944d23eb1688230fe5ce6e692ff5f2ece1055566f7a131212fd57dbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d84fb06d56d212dcf44dff3dd607685504ff8198c5cfcab58937a1100f3f9745"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9abbd308c9571604d231660510a5512a7bf1cdf457914c68e53bf4484d670308",
-                                "uncompressed-sha256": "0d988863e9b8561e6bc647abe93e5db6276dde8b10c59662603832ed7700049f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5d494ca321d36a17c028446f5333053a769eb5538bce37fe4e944fe0c279ed0d",
+                                "uncompressed-sha256": "6eb19db3a49d10e5acdb2b2d35673e901086d771d13b0925c3eb39107a22f39d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f3b209efb6ea9fe9b8bbfe1c1d4cafc0046ae7aa62bf6b63189494ee90155b81",
-                                "uncompressed-sha256": "924811866346c35fa32ee8012be4d6c73b2428ac09a43dbcbba4b4dcd660f914"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "937a6137cf42afb09c6c25a9bee4bdbf596953d0e5c46c41afb5907846791f03",
+                                "uncompressed-sha256": "b4a561edf73c8860dfca73a058a29ac9f442436117c1a83f3e4ddc9fb31706ee"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "57b2acdfe0666a63f7b7222ec46d8302117f4d964fe78714b5abb430b5d32408"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "8d8c9a15412cf051f2d5dba3084a76ed207b4e5f72db02fdcf952f6af1fa7964"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "e7637603e78f1569ff4f1461c6e209e8d2b6ed063c08f222f662e9afb2bc4742"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "642fec61dec1ccde53903916b7546ade8b7b04ac87c714a6369396f1c3f92e5e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231101.3.0/x86_64/fedora-coreos-39.20231101.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "64725113b9c2c613d62b7af8676647cb989ecf62c6ba5a06378f196a397d4b18",
-                                "uncompressed-sha256": "97329f1c485a7cf293d3803efdf7653cf48e08a54e844d40e573e960a48a8599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6c9074b9236f811cdc26d8e5bc694bfced8a2f2249c710083d91ffac2272d6c8",
+                                "uncompressed-sha256": "5c26f85e7ef9a7a39b2fa3c910921a3ac809147024c96d993e3630db25583c3c"
                             }
                         }
                     }
@@ -690,129 +690,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0d6a194196909601b"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0768b58f913b4c2c0"
                         },
                         "ap-east-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0b4b027c5422b421a"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-00d83a0b4987c1033"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-035653912ad9f4827"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0e14474b99609c859"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0e0a64c8b5d1bcd09"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-05b22100093a294ae"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0c89124f095cfc624"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0c73c9ad1feb0b315"
                         },
                         "ap-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0e8204659c7ae181e"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0a4b2c9b747304948"
                         },
                         "ap-south-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0f778b0f04e6cd8ca"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0b45351ede2b59e4c"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0b65d55ae62e97d1b"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-05b663bfb8d56143b"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0643a4f5ce30b3077"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-050054e04a23a6ef5"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-04fcf971286201341"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-04c371ef6ec2fbebd"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-05528ffc195388509"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-037504e5da15d757d"
                         },
                         "ca-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-085f7cebe9630888e"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0f49cad9e7c9a344f"
                         },
                         "eu-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-05d5863b17761d25f"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0578516e98cb4f7fe"
                         },
                         "eu-central-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-055be21ed167fe4b0"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0891b31ee25090dae"
                         },
                         "eu-north-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0ef1f4f99198436f5"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-01ed2f6fb774d75b1"
                         },
                         "eu-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-039247f2ef73521aa"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-03eb4f80881bef3b1"
                         },
                         "eu-south-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-00149bf7330207b2d"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-04123fc310639a5bb"
                         },
                         "eu-west-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0f43255f3f471957f"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0e800597d85495bd0"
                         },
                         "eu-west-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-06f099d4671234f93"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-01f6d1c1277fc9e24"
                         },
                         "eu-west-3": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-06edd11c7c3573601"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-016d58eb81c1701a2"
                         },
                         "il-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0d1e697f147485e05"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0e6d2faf414024000"
                         },
                         "me-central-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-027abbf0e37753e7c"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-03407bb67d1305951"
                         },
                         "me-south-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0889f54acc52f4458"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0d31ad54675825066"
                         },
                         "sa-east-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0bf368f7c80e4701d"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-000b678dcf4d6f701"
                         },
                         "us-east-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-064a1e6e200a99d7a"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0bba7c37b9de21f04"
                         },
                         "us-east-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0c1c2ef7c2e336126"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-07c4eee4a7d09aae7"
                         },
                         "us-west-1": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0c0e39d4137de7774"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0abfc28120e7288b5"
                         },
                         "us-west-2": {
-                            "release": "39.20231101.3.0",
-                            "image": "ami-0f2d4c6c0cb3d9f12"
+                            "release": "39.20231119.3.0",
+                            "image": "ami-0343bbc579715e364"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20231101-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231119-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231101.3.0",
+                    "release": "39.20231119.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b4ca0883a794870a033c03c64982383e06482948248f6e36f753998e3b165027"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:44c540296ab2a7ba0e31dda531ca341f03942a8f67c7d1c99e80a32b3c5c042e"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,131 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-11-20T23:53:08Z",
-        "generator": "fedora-coreos-stream-generator v0.2.14-1-g8ef5cb1"
+        "last-modified": "2023-12-05T23:35:36Z",
+        "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
+                "applehv": {
+                    "release": "39.20231204.2.1",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "6e2b333812da86d71c845c3e691fd9197144b7d5759f7d3e39d025bfccb24e6b",
+                                "uncompressed-sha256": "0d7a45f66bc0442853b513ffaf225952d0868e41d6594e69016dcb5a2f089541"
+                            }
+                        }
+                    }
+                },
                 "aws": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "856f74782b1d70c67855ab72a321b63c5181d5b492eb4dea3f80cd6fa49fa8eb",
-                                "uncompressed-sha256": "857cc73d87cf9303a3fe52b6f05f8d40c80ee212df622f62af041517a5ddfa59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "cd1ea550b5b44c6485c8a7756fe7754c038cf741c06b6757facece3d770e0eb5",
+                                "uncompressed-sha256": "b477c749c727ef6e4c620398722a050c583aefc54363be6f41fc933476a11a03"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "4eb1444197d72f72d0734e198c8e0cea5e6ac3663cab6dab733b2abf74688ad3",
-                                "uncompressed-sha256": "553af66bce5307b82b7f7676f60cfd5a8891981d0d6c33b286a85c049e43fa20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "fca2b5334282dffd4a391a2bd16ffa446a5eaa2524f6f972186783f985bb30b7",
+                                "uncompressed-sha256": "11ad8810622d1b7a8243efa94f475d952b363eed7170b1b5f83cc53fb6d7eabf"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "69fb7e5c66821485fa8db9c7daccd699ff4b6962ec8eae029b777df7e3594486",
-                                "uncompressed-sha256": "fb3fc0f24b82c25e8a59c7a6753e19f903cc0df19e3332ef13719ed080fd7e61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e686189446abb4f9186c899986ef344ed0ef243d509c4d0fcba9db83fa5e1178",
+                                "uncompressed-sha256": "f581a7864d0d31b2e8b05da11ca843afb066a6e147d900a6f4ac006b77a934f9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "72008b8bd3b78a7e047fdc64a51029be377ccc98fe94a57eae41dacf2d1e88db",
-                                "uncompressed-sha256": "594102529973dfe428ca4b8637b0021b949e2281aba18c7c93be53ef323fb491"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ae6e0c780fe1d2ca81d29b0ec136172d2cfa559d338284f085f6716add400cd4",
+                                "uncompressed-sha256": "21d546c857538083153cd4ca22d50e683e83ce783f5667aee6044c0496327b37"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0e1fd2c27674ba13f4914e84dbfb1152c64115ca22cc622ee17717160766e914",
-                                "uncompressed-sha256": "83240e0d4b1f6633f69e525c50121719c468a3afca240209c43bf88ff7f80907"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "03d961376fa7a90ad1cd8ca50e0d861a6d0af31d6eaa0c92098943acc6293af8",
+                                "uncompressed-sha256": "060404684f23d7ec177b45b9e752bb7074ff6bed1c13d66c128b9ea2d133e81d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live.aarch64.iso.sig",
-                                "sha256": "f776a8f2bd5b91c3d7b77478281de4b1cda91c9bbe6c152d026bc8e7980dfc67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live.aarch64.iso.sig",
+                                "sha256": "2b888f694104509a95c9dbd23a7d2dd38b41d5e6882797812191eb900960be9e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-kernel-aarch64.sig",
-                                "sha256": "aaa5b752507227e97b7d1ce3e63d71fb0697b1b54ad1417db80c2977fd9952f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-kernel-aarch64.sig",
+                                "sha256": "7b8d0485c7b70cdd881b4b728d7d87a88a49847a17901292030ed9bbdfc217e9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2e6b877b46ded227705a79dc5eb5594e545e0df7747de63d58a4e18c2b943e0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "de83b840351e68b544231f6660b23112859eb463aaaad99aa55863ed6c071e1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "96bf11202b4c4187c98b739854633aad342f127fc8ca4c1db98a27eae4716cc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "dc7ed865d99a5257852280f63e0d0f993a0e96b90346ebb7d6e732224cd58b97"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "01b48f980d4b6577ec15b237f8cebc988cb6eacd3d6fa5dd71db6db7c37b44a5",
-                                "uncompressed-sha256": "6f5c7fe71555e743aa62455a83f91f4c535d0b18fa0f5ef9b8a5427fc5f66428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "583b4cc9c325a4fdca11f586d3e7aca7cb69ec417e5e924297ddd448371f0c9d",
+                                "uncompressed-sha256": "55c2fc9e022de87275f76978986a966cb3708fbb28985de17cfdbe461e6781b3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "134227d777331b8b2a53eaec394c86ddfb326e8d3386a34df0bdf14bf6b15f7c",
-                                "uncompressed-sha256": "2648e08dd153e501fd4d505fc5039f15fbcf18b7c18f34746990dc8a9e66784d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8a52330a6031c59708490a2e9e457a486190db8255a5d79d9a08e1462f46056c",
+                                "uncompressed-sha256": "1cb91d57d955e4550710ae864f1abc225b75a8c68b61085df25e603a92b6901a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/aarch64/fedora-coreos-39.20231119.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f93cb3b5544b7ea62fe07476bfa5908ff3e0ba6f0d150a084824159174f0c349",
-                                "uncompressed-sha256": "ee050d77e6bd8cf8ac0007005a915f31388cfe6fa2ca07d8f6878aaae3cf59ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "aebb1fad68948394755b3f8da16c54021c362c5984dad4beb270825fc738066e",
+                                "uncompressed-sha256": "d6c897bc0b0de4b0311833e1e1be3d13981b480e5ff8b1974450c7fd34a25e5a"
                             }
                         }
                     }
@@ -135,209 +148,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-056ae18573bcbc94b"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0cd17d18b77ff3797"
                         },
                         "ap-east-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0cc13a1d54461a82c"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-032e89bffe9d55162"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0582bd4a04f1335a7"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0c1ad8e3289e54cec"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0f0630c7c04279227"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0ecb61a47ed261b42"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-06d4574a51d652853"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-055fdca31e57b0ab0"
                         },
                         "ap-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0a496edfe19171b11"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0e5470c5a9b7f1124"
                         },
                         "ap-south-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-06bde75e4c439082e"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-03e95a42473ace11c"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0c1173010700f337c"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-04cc33952ce700eaf"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-04eab8db2c03f99ab"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-08cd6aa8f550cf054"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0c9d805e2a70ece59"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0f52700d78bf7a284"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-00f5e41bcbaf4839c"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0c7c53607c835b832"
                         },
                         "ca-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-05b7479d1c6b8ae4c"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0a78d6253c7e1bc5d"
                         },
                         "eu-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0d57792016882d9a9"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-06d2cf06b04a8bf41"
                         },
                         "eu-central-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0597567b8a3f1a056"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-004e099ce07bfa6cb"
                         },
                         "eu-north-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0ad873eda6064c619"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0a8121d3354a4d3de"
                         },
                         "eu-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0498bf7c60013caca"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-03dacd68236bdfcaa"
                         },
                         "eu-south-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-07812edc7e9374749"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-001dbd28c8929cd92"
                         },
                         "eu-west-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0fa2f4c29b2a77504"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-074e67cd22c1c71bf"
                         },
                         "eu-west-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0a671cd641a35d1fb"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-092ffb2a95655df08"
                         },
                         "eu-west-3": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-03e95a35997cd2185"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0f91da153990f8bad"
                         },
                         "il-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-07ce35d25dad065eb"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-09e3d26d87a71dc8a"
                         },
                         "me-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-06e29c0ac70ecd02c"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0a5f5bed98c6bd7dc"
                         },
                         "me-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0634435f4c85c9b2b"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0f25c7756619384ca"
                         },
                         "sa-east-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0bb14fd93fb43f841"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-09e73d6981e6e0c7e"
                         },
                         "us-east-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-06b4a8d473c3c68bb"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0a1a5cb4d80b8df26"
                         },
                         "us-east-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0efebe1433bba134f"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-08338cc6eb80e100c"
                         },
                         "us-west-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0d7a07f0e18a17b35"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0a5dc39cbba9f731b"
                         },
                         "us-west-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-040444ebfd505843e"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0b53a97600d8c8953"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20231119-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231204-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ed7e474db5af0b69418628fc9e0137d04d11b187f530f6d597fe9b4eeaf0972e",
-                                "uncompressed-sha256": "4062f75c9af32ea2fc7d8a64ab098e363787ea82fe4c29123189de68b2fc17b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "55973e4de8a07aee9a16e3bbb8c152bcc732b61f2ae63fb9c2b76281d34071a0",
+                                "uncompressed-sha256": "5b633baa7b0776a79c910d87ba93ae3946119ac3977abd5e0629bd063cd721e5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live.ppc64le.iso.sig",
-                                "sha256": "bbb79aff45a9d1159228b327bb3abff935e2efbc5fa094c520657e0b4022ec1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live.ppc64le.iso.sig",
+                                "sha256": "7726ea129dba606c18c0b2263c5c664f29c699e0a2a1881ed53d432a786fdb39"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "2111e9fa36b583c02ab90f05b80b6f3378cae24089cd4afa76fd603291138d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-kernel-ppc64le.sig",
+                                "sha256": "e2cdb0e0c84489ca5d1853a52b7cd17e3b65ae4f40a7ae975cc626b111723ecd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f9f843b8ee4df0eef4c3e607ce3845f21761fca43e87688ef90b37764910efb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f6e548df68de5619a6d59354cd95c52bc6fb0f7860a96a6b282684fb20cda572"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "74dc4c872f071cbc7242d37b5425cb595f1b780d5750899fd89fd81f894aecc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "791dc0c931f6471cf8c4c1f0f31461cec463db799eb5552f549629267cec6ed4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "d4a40bd6deded605a99a6f719f4967a1c967d9ae649794dcc93daae5a060b881",
-                                "uncompressed-sha256": "dbe523ab857888cb7ce9727879d7e7e5104a514338abadd8edabae137d07c2a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "cceab66ca498f850c917217484864b722afe1b8fd6e41cc1c8e0dcbc6da78a3b",
+                                "uncompressed-sha256": "6b736081208bab9edf16b13cda7d3900dfad624ac325e223521d0432f24030da"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1d004ead9c94ba004f7dd740e5826ac5cd6f0601bc18786d0f8a5eb2c221d70a",
-                                "uncompressed-sha256": "954af4c6a5c7aa376b24bec369a3f629381579c4621b78524355530832f1ba9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "64145a625ab5fb2f4a7d79c0d10ccf9fc4d54daf5fd1d82ba8af7d1664b86e90",
+                                "uncompressed-sha256": "b0f8cfe6eb3aada2ec1620bba9b6bff89ddbb14e03c664096ec93b440497a56a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "9f8b4cace5ce7a8915914e10f0f8da279d9b9aca855f5855b9e9e4d8c3088a6d",
-                                "uncompressed-sha256": "e34dd6ee0d8a2f1358a683f6f1c523a622f2af8a921df14a40fbb88490774acf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c567792cdb429e364cfe63ba9fba0ca4c9c2a2e1bb45c7230be899c1dd85f470",
+                                "uncompressed-sha256": "13fa32cf0344db263dc618532dd0b6ba3efd98b931a40e462ccebe655f1a7f6a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/ppc64le/fedora-coreos-39.20231119.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c656afde607a0ec28e3b7eb2b8dd214c8c8bf4f5e4fa92ce25b0669f9ed3d481",
-                                "uncompressed-sha256": "b0b372655c798c005d65b7e1acdc1f1ae6b96c60c0bd95a13ef2a7de8aa49adb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5cb2c0637f6a3ca60df1ac35f9983a65e79ce8c0c0fcf83f262c7a8ddb8596a4",
+                                "uncompressed-sha256": "fae0f7cdea02d1bfe5129a7b2e3cfabf85eb4505b8aa0ce43cab6705d80f2db5"
                             }
                         }
                     }
@@ -348,85 +361,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "93f5731045869f8bee29622f3a6c7969b4e1c332661d1bb8a3da3d4bcb000c08",
-                                "uncompressed-sha256": "d93cc27948a82515d30772f5e93a89346cc71003331a6ac474425582bfd583bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "81880e7fa9b4a2a6e73e1064dafa96c010bbdbbbf941c6528242599bc68fc6ab",
+                                "uncompressed-sha256": "cbb96e6651363e85a1a1be9a8e7edeef19e5c2b2496b177788b7f36f1d0c8091"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "455d0aaeb5d7fab9cd931ab7a08f7b46cf8cdea8ca6892148d55a7ac5c4fbbd2",
-                                "uncompressed-sha256": "77a47c28bb990bc55d810d5fb1176ee74f2de5c15f9f3de983c4e753ad5729bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2d31a1460699420fa6909e34d3ac71c705ef9c75fba35657e06417b951330e77",
+                                "uncompressed-sha256": "68a00f760691bd60dc527d43aa917a6b006d42c9ad239b5cefb872cd759c8583"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live.s390x.iso.sig",
-                                "sha256": "ac7da2c60ffb43a6e9eba150d061bac95eb7eb6c187b7bd344c17ceba1b4c884"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live.s390x.iso.sig",
+                                "sha256": "92199680d52e40a5570c894b9daf6ed80cd9242d5761e5663d4a55c4c2074a8c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-kernel-s390x.sig",
-                                "sha256": "57fa889d4480a8e8e902be74df44d2a52b281019696890122d22e7ede1e5ca0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-kernel-s390x.sig",
+                                "sha256": "7e7f58c54b7f843a8391e7478a33826e152088422497416da0ea342301405dd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3dbb84c6906ffb5d31440e80ce4e3888b06242c82a0e7e7a82f5d1b0db1e9671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f9eb333c7f62df9808bf54f123c7da09cd38a1a6ee18b681ae72ccb3a6aa602c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6bbdc4d605499941e2964e87361850f1cc8c8a55c1fc1505d81453de2b801b70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "a6467ece416da50004116fdb030a6df051c5b1787c3740bd05a30155f1ad427e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "51b06622027718152baf56c8de32ea82012c3950741d111ab03f092b6160e7a0",
-                                "uncompressed-sha256": "3a1a46b2ceeae271033a87b9ed3fb085649f1825b2390f723a7dca850d5f1b64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "4754c466ce4023009e3367c4d149b5a64ee718bafe4716447f8ca3a74715cf85",
+                                "uncompressed-sha256": "ac1747f7e0bffcbf4245b42a9263129306cfe35dd963ed46db4722b648b53684"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "913d53f9ccac6053a56dc10d16d284c5cdcce131d4752147354d87c8b4639404",
-                                "uncompressed-sha256": "2253cd02f978fe04f63194d7197e6883ae9ef5654efa785d03d9f0913399c5e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6b3f33ecab1eb1d0839de2e80efc547c665215d5c434da69d776faa7550a7370",
+                                "uncompressed-sha256": "fae3558c733d8446aeef38f4906b8014800db68d5c9e15b758597cbb313cddac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/s390x/fedora-coreos-39.20231119.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "63ae6b59d1982e033a6db7aabba991c54a82b3cde1fe82832f92e5f8d9f095c8",
-                                "uncompressed-sha256": "2b69ab3083c0e64858c14afbe55fa2814dbe83745ed79eebc6ccca7b3172a336"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d935f6119b735cbbab4ef1061b9b565f2516f07b9c51169b918061404cff3720",
+                                "uncompressed-sha256": "3a112dd5f209072263fddda2118d6cb99a122d20e4630623fc3fd49ca6b891be"
                             }
                         }
                     }
@@ -437,250 +450,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "945b328c14e7679d40d20a41a9ab67a0aa52831d5ada2567d5ee5462e616f09f",
-                                "uncompressed-sha256": "a1aa22babc22ec38ff4f3b044fdca417ac3c0434da88fb29e94a48de81ff6367"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "97ca72820605f1da2e8f833cc697e1b6160a199c5450feabf3b661b9ac8448c7",
+                                "uncompressed-sha256": "7ee63bbbf687e20da0e0708c704f8ba72a30142d6ed3bd42c17fd2191212e089"
+                            }
+                        }
+                    }
+                },
+                "applehv": {
+                    "release": "39.20231204.2.1",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "e280aee1bb34174fa8a5d56a493b33a0621941ca9a2c81e2cd713980bba2de87",
+                                "uncompressed-sha256": "f393ea85a360dd7ac264c31dfab5023488d2479b2ba322d26fb6538eed2677da"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2a480b7c13fb8cf9167f9c6c3298ef348b1cbee101377eebd63d08ecd2e23063",
-                                "uncompressed-sha256": "cd805372b84becff205799be98d3f82d4c3c718e901e7273822d2d9bfe0717d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4b75f034b7329b0aa13bca7d3eb66b398382e2010fe072943b36cc4631659ba1",
+                                "uncompressed-sha256": "ae2b6a268c34d9de4af0305db3f9116e4daf5780cb9512d3db777c558c6e8ca3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0a5e777aab97ad2829c2657b7c96b635115faa57eb6868555d0987715a448c88",
-                                "uncompressed-sha256": "78bca6cdab908abc26c69c1216b2fc8a90a29116f0f25ef473c5822f2281ed9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ca27ab913449d7abce0481fe23db2c00c9f898e1b8d749f5db17c434601d168b",
+                                "uncompressed-sha256": "bccb81754b2daec82be27b69745dcc9450d29ddd52c8826143fb41345b1b1cf5"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0efd052d23ec3c8523a41981c7818acbe191bb77c649260cc037897446c2a4df",
-                                "uncompressed-sha256": "3aa729c412a7afede36fb59e31251ad269e0c24fe82b1591847747274d460b52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "786fb1c2b8b101f78f425727370af9131125e97207ff92f06a29f8b500b0e7e0",
+                                "uncompressed-sha256": "83e28f62d2d6bb72200dc99e84be5f045628747ba01f3537766b93fa13686bf7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bb722ae0874464822d9676866285700d2f492179a35c91712643fd4e572283ce",
-                                "uncompressed-sha256": "be46ccc3fc1a21a9b77e3df5298c469df4bb2f960c7128184ba249d4f24a9f14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "751ee7576d440a6233490daf0a1d50ec37d2665c8f890b7686160d4fcab688ee",
+                                "uncompressed-sha256": "282e9ca30105f047a7b6ddade41c0605b0cf65f20f1661eb181dfc7da8c16ac9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "aca52f3b6679bf15576ba0fcdb726aae2851f3068e4526f9db2d1e0b00ab36af",
-                                "uncompressed-sha256": "7f1f8f8a14223a4e5c9533471f0635c1c20fbff41d0ed81efb7e3019ff059bb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "bab4611d6485c79bfcfbb1852aea01ba09fd54b3aa7dcac31039b0ad3c431458",
+                                "uncompressed-sha256": "d29c11b7bbded1e2a6987e82ad4f0498745a7d395d6c496de5c72b20678006a2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e2306cc3abc3f75d14ca6fe1000267890ba34d2dbf109959d90ec9155b79f44d",
-                                "uncompressed-sha256": "384bfe560421c53bc1cd44d2ad3c28252eb936da88f3f1e9f3eaf899b56c55eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "85977ae256184ae7a86a4a169e1a052e410b0be8912e3280f67aad4584f64955",
+                                "uncompressed-sha256": "c1f83ede47ac210523cce4fb70b38573eec6df212cca09661e760d9b7d25b515"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "4bd0af33172834766cf883529aa9f7ba5e8710c4db0b802d532ebce41d814898",
-                                "uncompressed-sha256": "4c4c8bd78602aaa960a356f7765f0a9acc016705a0d788dca7066011556d01ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2ad7ceab61d33044ab0c35924049806bcdcf4f1a64d580fb703ef8ed608353f3",
+                                "uncompressed-sha256": "c566917ba528c83b75216087f08682299e0501c9d3b6b4e3b159916066fc9c61"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "46368e2dce7bfd1f5aac886a0de25c390f96a4fd3434333d512a42b1f9acef53",
-                                "uncompressed-sha256": "da1ff779ef308533906362b1e58dbfe519d7fa10b031dac77d07b930f67dae68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "fd8dc78473019ecad098386065371eba87c316703101b9108d8bfae59d3af3cc",
+                                "uncompressed-sha256": "b3cac37f53b1442d3d8da5fcd49c1ae710f0ba41dde3f31dec05c89ab4b90b5f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a95221b015fdac861fd8528ef5383952401f9cbc359332fe91bcf722cbdd675c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "af404846cdc0f13e0c0254d5d0c7fc9aab6f4c5d57c11b39c0878193c66009e1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a2528c2a3160d1a6f389278b7c7665531b8deef95e6fba3a6484d6de654e11f3",
-                                "uncompressed-sha256": "046256bc1a7f9e76b7565a11545182fd536550f5e3555d65a12874777e36ade9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a325df83cf0c72338519918f7c473650454d4a70591700da10444e480a494dc6",
+                                "uncompressed-sha256": "3bb2adc63d7c4806ddde55d83afb8c6afa13eee9403ea3ae9c815d69578189cc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live.x86_64.iso.sig",
-                                "sha256": "4601e4d48f453918787efd27a2acdc290469c30aa0eeaafd37a48a7069844447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live.x86_64.iso.sig",
+                                "sha256": "001274f9279f75162730dccf51aad39dae45d4cdfb18cdef2f2d19d558ee4748"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-kernel-x86_64.sig",
-                                "sha256": "3efd416a625571345cbb330b434272b99813a1146cc9b4eaf7bfc8e29317c986"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-kernel-x86_64.sig",
+                                "sha256": "5490e2d24924f2f9a71b5cab901d6f9936ad9ad5190f3021b58adb4f2e7d1e09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8c9e411b8d5d19d28abb842f519115a28f47efc4317d9f22819791de0469c00f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "df5eacb37a385285f2ed1154c2d9d01775381fe1e97f7e5c6dbafc48667d6d01"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ac62d710a31b9532603f42a86d7fb484fad7eb001d3fb861b63b0bd9ad017410"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "420060172a43908e4599c2fa88bf2c5e3872cf8835cf16b434582db471145446"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "568ecb6a7655850d67dbe82c747a8e17e62e4a1257a9cbd9992a4c07a542317a",
-                                "uncompressed-sha256": "adb5a7fb754b411c0c7e7648c392fb0b822816bc00ec11bebcb3187c49d4a1ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "bb92203eef2651043e6d75a5f77a30c095ee5aaace4be3364201c1a6a51e5eea",
+                                "uncompressed-sha256": "687128779e1dcbcaf0aeff8a53faf4fed60440e09ebd4019f4810709f29c52ad"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "186a056b6a17d3d0c23663ef08aa3c1c3b95a2ddf31f4da392dd3e4294afd8f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "98ef36abf6d4c9a86abd57a773cc9e38930e1f6344603e0467bc42727f2bab0f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1f0c225b8aa99b63506328134d3d70788dbfabf3f5c585eb969017ba98c84edc",
-                                "uncompressed-sha256": "0c7f701b90ee0463877e61705489a98a4cbda7afb00cccdfec91181b8eaa1c55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "04c040ea9c39a5236538d5e0adbabafe01a59e24b16953979ef21dbbee7f6f15",
+                                "uncompressed-sha256": "e760a1a8734881fa5aee5173072cc1251b5084f6e4cfbb7632e7f15395e7e83d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7960e84f9f69484cd0b14bd359726bf6821e39ca5acb2f3a0f362e8d7039fbb0",
-                                "uncompressed-sha256": "872c4fd04fd70d8e3198ec69e3ed745f57467a942033ff9020a364c27324ecb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c7f3422df0486509361a0f9325f6498e170e91c81a3912f41f37b54658493bc0",
+                                "uncompressed-sha256": "cf4e87241a1984087f5e4a892f3753d6adef635cd220757694f8e54353647cb8"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "aa74543466b023217c69a03a226378f1024e7f49ecff775a13739ec56e51325f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "ac2098e2ca3dc5f7fd6e82092e4a580f6158ce58dadfff5e005e12602a30b7c9"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6bce34185b1f8cff0706cfdb8db5f515b5565f0e5dd7325d0f1a94e20ade79b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "c1c4730aa87143bc7ba9d5341ceb7afc91dace57ec2aad7814b58fa200801e51"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231119.2.0/x86_64/fedora-coreos-39.20231119.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "69421423c14ff4dd3c6efb11f2d535576fbedbfc546aba9bba369861e6d67ec5",
-                                "uncompressed-sha256": "7080605d56ca6509c017458c5d59b5e63beaa0b753d3a15fc3534e4a4cb3112d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "790572e9dc5ea580ab691c456b68b482487bc650fb332538a1f468abab942d5b",
+                                "uncompressed-sha256": "e3f78c3731d71cd284629fccf3b02dc2e4fdf615f0936cc7a16f0b707492e4bc"
                             }
                         }
                     }
@@ -690,129 +716,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0bd970d1c07f1c19b"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0129170683ff22ade"
                         },
                         "ap-east-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-041e953f413974f93"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-00a14625ad5d38aef"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0ef9bd0464788349d"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-03ae8f12a0ed0a749"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0c297b85b666a36ca"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0b598118d1eb19eec"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0305c2844cd1b99d4"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0e7fa9f0eb15b94f2"
                         },
                         "ap-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-02e172f422f062920"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-090fd217cf424049c"
                         },
                         "ap-south-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-02ca45d35744b8b31"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-09862db0c06c70ed9"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0e7d8d8ecd8b32b21"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0da4c9442cf9bb15b"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-075b324ab6f2f006b"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-027d2a8bb50b124f6"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-052e8fa59650c9b68"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-05c000eaf7ca17517"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-02945db1631ea4dda"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0dc557abcc40de1a6"
                         },
                         "ca-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-08178ba2dc4a450b4"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-056ff545c81b621bb"
                         },
                         "eu-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0dfc3692f7ccb7fbc"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0e380e8138c901c4e"
                         },
                         "eu-central-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-02d5e472a97912a99"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0d3d3f6f254c87627"
                         },
                         "eu-north-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-06d73ede574ae1deb"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0ba1b1ba5c35a16a1"
                         },
                         "eu-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0ff8d329f30e96ed5"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-07c63a7b92e72c490"
                         },
                         "eu-south-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0420d8993d09f109d"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-012ec7825c29c679f"
                         },
                         "eu-west-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0eeca3c878fb2b10b"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-01f8df741ffda961f"
                         },
                         "eu-west-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0ee76d95b67bcb2c0"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0cf53b5ad66663516"
                         },
                         "eu-west-3": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-052e3b8e2753907d9"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0d86af3970dab2176"
                         },
                         "il-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0221f66e960a6cca6"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0a99e8dc21cb4e3c9"
                         },
                         "me-central-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0ecafc07beadd8116"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0f0cf952f96b63b36"
                         },
                         "me-south-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-07dd259b23658a6be"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0ac644d774de33fa3"
                         },
                         "sa-east-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0b4c1b13512396ace"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0d5147d6ba09d1981"
                         },
                         "us-east-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0bbb05ddd93050cdc"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-09298a245efd33b5c"
                         },
                         "us-east-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-07be41df8595b0a44"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0545201ecf06f624d"
                         },
                         "us-west-1": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0e2eb39d20db54537"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-0395bce1767eb2bb3"
                         },
                         "us-west-2": {
-                            "release": "39.20231119.2.0",
-                            "image": "ami-0c4ade8ec7a49ed51"
+                            "release": "39.20231204.2.1",
+                            "image": "ami-088072110605fbab5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20231119-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231204-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231119.2.0",
+                    "release": "39.20231204.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4f7c959ea62b33083f42e0473700b4f2928ce064b7832f41cfaf24d2e95e4eba"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:28ef54f083056c0318dd204bb1109c4c4c608f39dce6a4150cc920fa7adfecb8"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-11-20T23:53:11Z"
+    "last-modified": "2023-12-05T23:35:39Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20231106.1.1",
+      "version": "39.20231119.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231119.1.0",
+      "version": "39.20231204.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1700528400,
+          "start_epoch": 1701856800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-11-20T23:53:08Z"
+    "last-modified": "2023-12-05T23:35:35Z"
   },
   "releases": [
     {
@@ -81,9 +81,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -91,8 +88,16 @@
       "version": "39.20231101.3.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "39.20231119.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1700528400,
+          "start_epoch": 1701856800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-11-20T23:53:09Z"
+    "last-modified": "2023-12-05T23:35:37Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20231101.2.1",
+      "version": "39.20231119.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20231119.2.0",
+      "version": "39.20231204.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1700528400,
+          "start_epoch": 1701856800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).