### PR TITLE
Roll out stable 39.20231204.3.3, testing 39.20240104.2.0, next 39.20240104.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2023-12-05T23:35:38Z",
+        "last-modified": "2024-01-08T04:03:17Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ebf563f60eed2e7864997912f16228b840aa76961ae176fc5bf4aaf872552977",
-                                "uncompressed-sha256": "9c35012685872411cd572e2ddbda610456ee76cea7a1b6fdebbc928b52946fcd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d8e18fa2c6b87e9b0e53813ac84a776669446a13ddeece4adc5ca42d24539960",
+                                "uncompressed-sha256": "126946581a90d4e4429c7ff074d27d26fa38d6be13787ab762993274b86c7699"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a7d2bc276ce8a9546d16bbbbf1b312ba673864d7fefb0ed9d42a31c20a49f8e3",
-                                "uncompressed-sha256": "bb990959dd362a5ab660b4ce1b1f1b5c44dde03e162efd519817c5b75a33b258"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "27d0deeb2893be95e29f700fcd3d51b58ced8b6610be55e676f8dbff56ccc8a2",
+                                "uncompressed-sha256": "206ef0a9a41cfb107ad3de549b941dde6dab00bbba64bd42d75c8571754287f3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1c3d28e86b1d290c3e0d3a0baebc3f818ca837a4d178788a3fe895d6469b0af2",
-                                "uncompressed-sha256": "83653e5dec8b83f8bb236960aed2f2aa1430419198682e4726a63f2576d40128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "cc3836a55688ae0ce8dd2d50d022acd4c8a758752b7fe6588fb5955d31c63344",
+                                "uncompressed-sha256": "0da1652185399ea1106091a68ce31f957bbf03fab9a6901faa0c4ac083506958"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a2e81d9666d974d35558a0a6a3655deec478b3c2ef821fca5f6289d6a98ea9d5",
-                                "uncompressed-sha256": "d516e6acd862544532042d4aeaa3be8c550f6c9f9f5658ce9815b23e84c8a33c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0c28602551cf4fe1a3c40bc2b3f607180a5b396d709e9df7c0798e6f2fcbb8c8",
+                                "uncompressed-sha256": "bab77c615904fbe6a6ddf325989a6bb0cbb7a254c5796b08e1262cbc70f400f3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "62284a472acbf139a3fc5f91f839e6e11944d823d7e6f26cfab7b6b5b295e33d",
-                                "uncompressed-sha256": "90e69896ec5162b23a7da608f81a346e741c28af92a566309b6c63f428faebef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "8a7b00b74cc47fa7350cdfcb0b82b228ee4aa63014b5aba0360ad20a6ceecc7e",
+                                "uncompressed-sha256": "ed202ee1ef3d62a50382fe53763019cd47d953539a05aa3e944ed49d33e5e50d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f2b8472b70bd11f380bdd0a4327fef91d196f941b138b01fb9a7cb23012cf698",
-                                "uncompressed-sha256": "54e513149285957a757bccdb65f75c5184eec19154e32745cec14a3615533b4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a286c3eafc47e90572ec82831ccaeeb51b635bc9d9c6ef457549a9fb8f03f3a7",
+                                "uncompressed-sha256": "2c01cadd0d16c2fcaa85f13455c8acf54ee7c73dbf6f010c0497d25c85e3fd85"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live.aarch64.iso.sig",
-                                "sha256": "cdc189ab54bdfcbcc41fb74c098bba0a556f9df7bb44b7d11d1ef7c2adf5a81d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live.aarch64.iso.sig",
+                                "sha256": "ba4584bd7fdf358a877aa1e2af9522122d19853d7ed67923c7cddcccbacb6c60"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-kernel-aarch64.sig",
-                                "sha256": "7b8d0485c7b70cdd881b4b728d7d87a88a49847a17901292030ed9bbdfc217e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-kernel-aarch64.sig",
+                                "sha256": "79fc1bc34a8a726f61f33a96baa01c90cd5930b3da2ce2042ce1bafcf2b4f1f6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ef3ab6845993815370cc42edc79784deb7fad226208efaf0b34ee50c1cc68c19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d3759e8a8c555fca54c89a2860575b04bbd36c0dd9dca13c853e34da21f7f463"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7c7a014ae106ba0dca9d5347c43d3a493f37b06c8c6cdebbacbc6f7ea6eddf27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "89267dbb4e7cb5071cf85c6f625955a31f382b360d975ed77e046670ec62832b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "629fd980451f1e9d6851eb4a888c533cd226a541652ba47a0af17525ec55bf7b",
-                                "uncompressed-sha256": "c72b60c4cfc9da57f94b2e2588fcc4de874d06c728b272d1b4979c49fd2b4cd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "54ecd1792a3420d3b32ff2b0dc869532a7ac7f0a981acf1072bad0a9a3a6cc90",
+                                "uncompressed-sha256": "4aca18a2a8ac40abe208b9e4219ba2d194bed342facb86f0188aa5d091805636"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fe727a00b6fde38a51bdbcf210a2b4d08375c0d76006423fc18e9dc2167c3134",
-                                "uncompressed-sha256": "b11a00c87eeddf02a225ceb8a1956200aebeef1e8b1129605cda53e8cd798466"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e995974c06862e34d71430fdbf0614df4de0ccb8760bb8f34e89ff2e003eff7c",
+                                "uncompressed-sha256": "2dda7b0fb73492b6d73b353e105a6d733044b40b5d5206fd063ca34459c080ef"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/aarch64/fedora-coreos-39.20231204.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8a7d89e0c97d90de01315af17f2b84625fe4e09a007715a26309b7d8da4f026b",
-                                "uncompressed-sha256": "737bfc63034c8c883e10220dbf4d32e6010c84d8ef8bda301f71278cf8c6fb34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e1cae1f7fccadf1bcb86d126703ff5a3b0e9f7ba572c2b50ca41a340fbb46a96",
+                                "uncompressed-sha256": "957e53724fc7a11797cc966738cfe474548afb2c85e969ab7846f5bd8969b800"
                             }
                         }
                     }
@@ -148,209 +148,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-07b725cde5d86fe3f"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0c65df9649818fcb2"
                         },
                         "ap-east-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-08a7a8fbb1b27460c"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0a054c31b3d209226"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0a7c384e436b4c239"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-02488a177959f009f"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0f2b9fa3482dee91b"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-006db12007a3fcf19"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-066ac8852bfafcdb8"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-026a9d65016b04937"
                         },
                         "ap-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0ad5e737b94fcfd03"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-01b040f084643dbc0"
                         },
                         "ap-south-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0eaf1e372795a418e"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-08d8b4f135e670726"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-009570614d9cdfbb8"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0eb7c131426c170d3"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-04963731b22171628"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0677caed3e3c8f541"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-00fbaa3aac0e9e28b"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-063f161accdeb2e56"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-06efcdd8a4e7c4f75"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-04dacd014316d5ac1"
                         },
                         "ca-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0130e132e259bc397"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0da29289f23d5eb3f"
                         },
                         "eu-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-021a0b71d057ccea2"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0bbb40b6ae89e6a93"
                         },
                         "eu-central-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0207c56274a7e1337"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-017baba1031d243af"
                         },
                         "eu-north-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0ce2bd8abde1648fb"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-026a2867784ea3a3b"
                         },
                         "eu-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-04c147637102eac2e"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0da74418940d2f35f"
                         },
                         "eu-south-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-02f7d7e4566e51ab5"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-08684ab1e7955520e"
                         },
                         "eu-west-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-07d77b9d97f94eabe"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0196dcbeefd699a4c"
                         },
                         "eu-west-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-071e0112603903bb9"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0863e70c9ada24059"
                         },
                         "eu-west-3": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-02ec7bbcc42f68ba4"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0259dc7532a7f2d3a"
                         },
                         "il-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0f9822a3dbb2895b0"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-07a4b5acf43be7077"
                         },
                         "me-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-025bb6993f3d50df0"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0697fc13e65037092"
                         },
                         "me-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0715476369ec3a3bc"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0cefb23c19abe70c9"
                         },
                         "sa-east-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-06564a016f822847b"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-052847f081d5bd80e"
                         },
                         "us-east-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-013c61ef6314fb3e9"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0876e400aec4bb6d0"
                         },
                         "us-east-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0afff3d5a4c4aa42b"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0e31a9f900abd56e6"
                         },
                         "us-west-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-05919c596363a317e"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0fc43e08a97716757"
                         },
                         "us-west-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-09a9d0150083e72bb"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-059a5c304da17b334"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20231204-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240104-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "650d12a820ef930ff1162edffa947c031b8108935996095d1206f47a408e6bf8",
-                                "uncompressed-sha256": "8655045cccee7452f3700ea31ae4c9fcad58472f3e7599984d2a923b83a4dadf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "cc31c93d046045537fe293ec43dd1d2bec2c89eac195ba1d9ca05ecb30c5fa78",
+                                "uncompressed-sha256": "3e2e7b77da3e62e7b79f4f2feb5a98643901d9170e5e2268b61f7ea5e2d25775"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live.ppc64le.iso.sig",
-                                "sha256": "f561b845ca872bc71514abd058206a2ffc22191f8424c3e72422cd76b951d906"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live.ppc64le.iso.sig",
+                                "sha256": "27cfc76b03d42a3f936ebc338593fb640d3aad35488b742683746cb81b141c53"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "e2cdb0e0c84489ca5d1853a52b7cd17e3b65ae4f40a7ae975cc626b111723ecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "90132d5e3cefda2f7dc246d4ef579de4fa3e2e1d864170788e5e676034412a13"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "1775c09ecbaa890f61ae35647ebf5e2eed259681d4bd9b171bc823221c7ff1e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "352d2db6fa1cdcab7902f4158d8937826311fc60ec5681cb658d392693b12855"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "ce2b6657a32279d9667fead8a83651e40818207065b323e55cb5aa1d4a489fd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d6aac9a43c8ebe77a7e450f0b34de222c6346bee775738c15070ed1a6a7c2c96"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "fba76ecfcbb647ad13c08629e15f2baaffd9b9f1a02d3c9e7033ec35b513439c",
-                                "uncompressed-sha256": "ba13a93f0973ebf06e2d346453fca630819d8cab77036bc3619c19891609344c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "133795ad5628c816ada4559f1ee6470658a88eb0b2ee721cbec411c43f52c3a9",
+                                "uncompressed-sha256": "5edd7300816bcc50e197b015f58569eda55b4e4e0cf0e10b99fb29b613ca8b09"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "ec8fc4c97699bf577454b6f20df1a3f92fe9ba89d34a773f81b9677a93b9551e",
-                                "uncompressed-sha256": "2ae08b6c775d00f657e2dce77800ec5899a4300c0a754cb938f578a82b680241"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "168bb8a8a2210aca9bbc020a0fe645f9f4d2c4f71fb2bb533ca3570c05ea6ed5",
+                                "uncompressed-sha256": "fe01c6d2670708dc0d10c11214e0833fbec54aeb3ddfd83401c23a52cc133610"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2714516ca090665eefefa91521527ec4f6256e09dae9ec77795ccad40a20006d",
-                                "uncompressed-sha256": "356ac96ab9db55bebf23d607e0aec68d65b114ab6177112a0700ffa96c4e6515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "89d486a4d50ba8b220b2c54b7f6b57757e5f47aabe91d5189375164421920a6d",
+                                "uncompressed-sha256": "53b997cc9e9dfb261925559a952c968f7a07a0bae8bac69d29d30ab7581a4a97"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/ppc64le/fedora-coreos-39.20231204.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4f2dc9b196b2aecc566792f221279bd1187aab7f50044b9eaacb1c94fdb4ddb5",
-                                "uncompressed-sha256": "5729abb52cf33d7c7e9acd76aaa47d77abdffeea7b6c91257f74af75ced5898a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5a4fe741077c243b920d5261aee2136090712fcc782e41fcba730ad4119ed6a9",
+                                "uncompressed-sha256": "068b9ebfd58f34a06aa79e18acd7feee8c7abcc4297b87d3a4df436ee69118e6"
                             }
                         }
                     }
@@ -361,85 +361,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "31ca78ab0223a3324170fc5e0946fbccd006752297ced1fe61fdd2a4a95c00f0",
-                                "uncompressed-sha256": "ea68a3570c73180115925bb2d33225f4f1ebbaef12413ce7cef6d331064a9c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ce65a50312aaa5167dbf010d043505827df0a51109b0a8981d35e8537c184d11",
+                                "uncompressed-sha256": "7406cb368be985673a1de308b058ec2ce7672ecfd7fab7335902d60a733eff1d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c296559aecb53393f32c2a5865724e3546f252672055d4fafbc5f4e9afa7d68c",
-                                "uncompressed-sha256": "c3b8d66686435f31fe39e91f52020d9f27fb24e3f5916b69a6ff9905a915edfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c28952318cfd2eb64e4cf4ab16515b5c0fe08cb748bc79360e137f006fbeeaee",
+                                "uncompressed-sha256": "7572acf9e56afe43fd16a91e4887405da189aac5b6b5984204e7682cdc64d54b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live.s390x.iso.sig",
-                                "sha256": "32e6012cbb4be479f4d8a7a8d91385c56cffe2c6a93efa06a68eedf17b2b209c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live.s390x.iso.sig",
+                                "sha256": "b2eb5eae51764393030a0c3978a945c2f3657cc932b8ca657b2618de0e64b6ec"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-kernel-s390x.sig",
-                                "sha256": "7e7f58c54b7f843a8391e7478a33826e152088422497416da0ea342301405dd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-kernel-s390x.sig",
+                                "sha256": "ee6a693814399eb97e9451034248cdafdd65b9a6ec245a25565f50e44318a5be"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "588af73eaf7ec17bea67bdb09259d42d731df4c8127cd0b32f193e665364817b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "e1fc76b4c797bdbd3be6388242a46acf16e36ba4a31d7fe0799ecb78a8c06c42"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c9a03413d096dcc24d67a22f1a6628ec0225d80cbb2aaa93e4fcb9ea794a6785"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "502d78ad0f5ebd199c7a63ea4aa28bfb8db713d0a5fa5146198e7ee2909505a4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d9673f29e8a9ac49edd3305f2ee360f03120a5554e5574ee6d80783b1a6b27dc",
-                                "uncompressed-sha256": "303dd0545b3aeb8a75d36931e3f6e6bbc292b0a044302ec187e28e9fef517721"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e3186b1740d9d21c668ca0ea86a33ceff2ca6de98d062dbc3b1a4dbbaa41c8bd",
+                                "uncompressed-sha256": "192ef8aa6a25aa4c126ec82eddcdd0b04af13ff558be803187f776f59af578ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5c95ad22a5083ec32194e8273e5a413c83d3924a6afec4c655fbc5853a2561a3",
-                                "uncompressed-sha256": "c248963628a768180d3b93791d5beffd0bf31f2e4924877149287d2d4316d0fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "75edeb5bc53df2655659e22f77cff33e3ec2ea4469b818438fb96170cbb59c07",
+                                "uncompressed-sha256": "07e1b276d6422a74fa5e9604e9c756a7a2870663cb0b2982e51154645ee3f648"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/s390x/fedora-coreos-39.20231204.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c8c5c98e0d4b7336502ecb1ac06cf78eb3b89b38bd9c57f34370cf49efa5fc78",
-                                "uncompressed-sha256": "04f5a579b2200b924c3b2674411efe744fd86c10f3b09650b1b85871567c7a72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e9d4096d2345164f43b05fbabce218a08944fb9effd4b9a17d3ce0d09b24d4e8",
+                                "uncompressed-sha256": "2907e9b27894b5ccb1caa62649d57129c1e6329b733fbcf6c56a312a6b7bfdac"
                             }
                         }
                     }
@@ -450,263 +450,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9904fb8739457aca5bdc425b436479862d308b16d214452ebd7444068d84d41c",
-                                "uncompressed-sha256": "07d49cd271d8b442dfdb4fc2ea21cbd8fdad58d9c7d6dc8d52f504db594990f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a13126f97eb49385ef055f9e545d18f404b854b6b399f488c68529c393c52ceb",
+                                "uncompressed-sha256": "29274d2ceaed598166d0f8691b6fe8d05863d9d261a974de071225da89b2b896"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "74c67551219ca452e54325d6327f176fa538c3e89d4e84ff18aba0c9b2462a6e",
-                                "uncompressed-sha256": "903bdd6fa314905bf473bbab4b45b89da3bb44e4a848314630c2b509c7f9dd22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "223e70e2becb278a4bf92737830599205d1f6ff031cbfec81c962dc721a1b2dd",
+                                "uncompressed-sha256": "28ce9bb7b52a9e00ef4a2d6c9a2daad91b840f5d4aa23242fe577bee712cfcf9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1a7a35d4d410c730d7e6ef20aa452824cdbec53f751aa5d05faead1943c7c0f8",
-                                "uncompressed-sha256": "e245d8c21aa74a44dbf2b8b093b3f8ecd8dffb0c95f6d34fc04b135b14cbf305"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cf9e5adab94c7ccf35d535a9785ec7182f02772a509d9316f16109c7a9f7e968",
+                                "uncompressed-sha256": "5bb168af389c23a27aec07d3574f2ffad5946dec17a20dac1984f38c8372a6e5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7e826525da529bb57e9c9ca31ad9aa6a94303aa0b1814094e53da87454575900",
-                                "uncompressed-sha256": "8e421b2d329868da8800cca57f8f5a6a5954e84fede22058604dd8a81eb60578"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8ccfdccd2b94a0f20b8faa4564a8ecac178f3a0b5f6688cbccdc701eb8859a2c",
+                                "uncompressed-sha256": "09bfb1942d023ea238926b7be08a88d3ab2d99266da3d7248c6406f47b15e18e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "aa7a8a4bb0e69ca06290b23a4772fe51e7438ee2e313f0cb6390eac88883b5ec",
-                                "uncompressed-sha256": "389e0dad43fd1894774ec11492158c29a67c480c21c5bd6cc01bf1248a07de9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7134fde15e88420682d61e67f083702b33e406e485c45529dcaaf917a5a8fd83",
+                                "uncompressed-sha256": "83d4c9ba67dabc0816f009cdf72f4e1174f52b01ce0b1fdaadaa9719a36a551f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c0f71dd38cd66b5446452bf3e472c3a7bfee4893d64ec27f2acdd4df434081b4",
-                                "uncompressed-sha256": "e4ca60badeb8b6124090fd8191007aa05217709f3740e827b1dd0c289fccfc87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "367e953a2b22f0b85cb37dffe540e3aa8602f644fe201128d8f052fe4835f8b1",
+                                "uncompressed-sha256": "3dfe65beec9430983222a9942a8587948df55cdbb5d34435e164e8ef48efa900"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e50b4918b13049f5029f60187c95fbdde5a22841872b757410211dcd78815ab2",
-                                "uncompressed-sha256": "77acef4b306e53d97ac355d239a6772b0a2c2437371212b96db477d57feaeec5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "73bddc4a444c6a76385561fe79e3bcf32a9c0e711afb2a3cb7c241aad0a4dc14",
+                                "uncompressed-sha256": "79adbca86c0a9a75c35abd3ed449e4d6c26383793b586dee019e5851fcdff820"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "bebad5052d7ef893d48fd6855b171addb50114061edc60ecd38a91e5fbf96291",
-                                "uncompressed-sha256": "092d043329ec53efca7a703e57b56f7b264f0247acf83865d8c3cc5eaa80b57b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d3298e3e9505efedad11b91be5de5499a9607a8480263e62da5b565544272b47",
+                                "uncompressed-sha256": "2952d8b797fcdc08bfb1c8555c9ba66083e3c7533108de1df037a6ea7cfc1039"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "052ee8826eb502c17b663734a19dd8bf4b2c31632fc9fda3e177ea820ddca88e",
-                                "uncompressed-sha256": "031f5f84ef73b0b4734ce345132386fa98fd82806bfc32bd83ed9add6a710c4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "29a8008f673bcf3e13ef98cd6f42b1eff49b33b5b52ff90515e69ff335fb5f40",
+                                "uncompressed-sha256": "289317ecb5271da1aa8ba489b6fedff92441f8f7e7175b15e49912d190595efb"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "dc60336b3372171187059ae64d0486fce4fd8062def3db62223b090fbf4023f1",
-                                "uncompressed-sha256": "7473a810bd55df150842fee7c37bbdc019778da3519db2069211d96a16655538"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ff22acc11a320a51bc2bf99b2c30880bd657551a0fd0437932ef56c01cb42a39",
+                                "uncompressed-sha256": "0435ed4f7b28e29bfffb19f6b33a48ccdf9c6be27650d12bae45ea416c0671eb"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "df8672e81cfbeed60427fa59aad6b36beeb8eb45e7322b484e819f16487c3a09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6ac4abfce322630afc3bb2282efc488338cea3da3e624c2377984598333b3f0e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a46053d78cd810753b47582a651e9c18998ba70449d5fb62ca85518a1bb2ac0d",
-                                "uncompressed-sha256": "2479a50436f4693b75231e38372b5d41e51315f668329c689032f8b39d264b34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3f1ab2a854e6e1f6a9835c1ac02caef256c39506e9a4e6b2ce1bd7eefb37a03f",
+                                "uncompressed-sha256": "55e35c53e16ee3578dc8e960f03cc9cf8615c30f03a30e637428dac0681abb17"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live.x86_64.iso.sig",
-                                "sha256": "8f3983b122c246010a755aafddf166bf4928a1fd9d8b26fc682f958c16aa4d4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live.x86_64.iso.sig",
+                                "sha256": "330489d3272e10e5b20e086a5c4ae6639966cf8eb4b27cf415eed5bb3a092f6f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-kernel-x86_64.sig",
-                                "sha256": "5490e2d24924f2f9a71b5cab901d6f9936ad9ad5190f3021b58adb4f2e7d1e09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-kernel-x86_64.sig",
+                                "sha256": "6e82b0768a36a8ac0ab9cd5c31f2e53b4da91c773696cc5847a1db5db1953efb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "21acd443337b4a0168fc78b38d8a1a1df8afe21c151c94d399b6db048c0093d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "840ae194690e1256cbe57f7b433a201bd0aee55b04a57e0293a943019c1e3074"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1f35a400fa33222d2ec41c6f80fd7c30702f1e14f9dbf18a2379e73574da6a87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "59357847b38c3992d4c93fd2059064bff2e942f1487c483c1c3bcffe1ce5df45"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7d91829c156c4c43d78998dbe324ef99426baec0733bac82d0aba6e64e5441a1",
-                                "uncompressed-sha256": "38340f9c8aa3eea1084df1082b5a6266f56e5265f7f157c39af723b06b756ed2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "2952c02c869d5fcc235248a984180e17968b49672674a2dcb3c227ddefa93d18",
+                                "uncompressed-sha256": "07d1aa246c4ce6902bc29f080462a4c49fbccdf6e35860e31f189e8a03fdfc05"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8e7af58e5389b978f5d7d696f5c525ff6057a22a784caa57ee1e2ea70311abf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8d0d973454eee4a2ddc0a80515020d89f518ff0d84df2220592650170d1d519e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "80246c869853a774054e0266711030d9c6ac471743e196c352dcf844a46cf902",
-                                "uncompressed-sha256": "a18480291473dc342d6b1c7b721b35a6fc7042b704a25da134a7bfc0d20b9247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ac36fc0d7ee973de8626d2a8386a9950cebd15847367bc81b6f4447f078de007",
+                                "uncompressed-sha256": "8f3f8765a19ba334f327161d9075bb7a68d296eb365083ac527318bc34d85c19"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a8051c4c49e662a51d43d52d57e1e52d588b1c029ec69733bfb661b65cf41491",
-                                "uncompressed-sha256": "5783108b1e703fef81aa159b0277b090841544fb09d69625cbf821e54c20eed2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e99983755d6aa9aa63e6dd38cdba5d83837b6f25cf259f9157c169ee43009d79",
+                                "uncompressed-sha256": "f4fde928ba3a86f24c56284ba13df210cc4a9cd1c10dbc9ea00099cf3b695a9f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "29a7c0431e602d791e2c8b4f35163fbd97fcf10641ab5e6e87887bddc36027d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "9f2b3fefe442c5b18f73156a1baa0f8a3e6dd6bf222b0c3c49d1a12d60aafe33"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "eebadd2ee93e479e4ea71b6c3a36344c29b7f9d4e83053005d522eb532c0475d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "a4528eb9848b7dd3b00ca165669f5e2626f4f17afcfe164e8a7d2915c77fb69e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20231204.1.0/x86_64/fedora-coreos-39.20231204.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5e49aa09551b7b906659963db5d9d8615e30ca513b3129a2abac456e4f290a6f",
-                                "uncompressed-sha256": "5858b947cfb6d6fb4c0b812c3eb35a837857044309868d5840de41b99bf599e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4d0166738e7a6c115ee71abed640fa0308c12a13d4d7827097d54588858b5b82",
+                                "uncompressed-sha256": "ca4e96591275fbf4a6454c1332f1051d6222e4e318399363eb28dc5f1f492fac"
                             }
                         }
                     }
@@ -716,129 +716,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-064627e21afeb2f12"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0bb70400719b230c5"
                         },
                         "ap-east-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-049528c32b0ae3e4a"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-05916aff210b8fc9f"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-092fd453bc3c91004"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-05c84e239941089a0"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-073d9002f61e2fc5d"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-07c6926d3d9b64c34"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-00f312b2878b68a03"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0fbc5b8d987f03266"
                         },
                         "ap-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-04387a79a1694ba27"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-01e2052f1eb207163"
                         },
                         "ap-south-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-08bce188fdc14b1da"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-05d190783c265d1ae"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0827169dd948e8f39"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-09d70fb10c6c01051"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0e7145dd7598b2695"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0676e6a2ccba306ce"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-09e39bc098c8ba55c"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0a716c66f8de96c2d"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-05fe1223a0b558a1d"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0a2521e9ae533d785"
                         },
                         "ca-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-093edcd4a2040cbf3"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0c738563da33494fc"
                         },
                         "eu-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0d4577217ac047128"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-062e2826a90d3178c"
                         },
                         "eu-central-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0030d403b19a3ae93"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-017ac6b6b0f133771"
                         },
                         "eu-north-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-059750fc435650a27"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0e20e9c5178e1c96f"
                         },
                         "eu-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-079e9e01d25939055"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0a4f741784be81c0e"
                         },
                         "eu-south-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0ed2459d2cffc3653"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-08ff9b30527e5815c"
                         },
                         "eu-west-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0a615535ce2629ec7"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0f1296e4e82f517f2"
                         },
                         "eu-west-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-044e71f99f1959e33"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0281b796c2ac0ec10"
                         },
                         "eu-west-3": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0f9a6e2efe65a1b78"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0f31150f3feaea76c"
                         },
                         "il-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0b07ddc0b9f81a9bf"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-082a2354a9eee6ff9"
                         },
                         "me-central-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0990f407b71be2e59"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-019ae5defbe9a2169"
                         },
                         "me-south-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-02866e07ddab396c7"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0f5d6b565ef3560c9"
                         },
                         "sa-east-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0943ad62408138bb7"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0e2a25825eff777c7"
                         },
                         "us-east-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-000752936b4d0cf4c"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-077c8eb925200ca2b"
                         },
                         "us-east-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-00d29c638027685ad"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-02d95ad063b1e7e3c"
                         },
                         "us-west-1": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0e8da5fe34b4b394f"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-0e72bdd1d075bafc4"
                         },
                         "us-west-2": {
-                            "release": "39.20231204.1.0",
-                            "image": "ami-0b9f1aa2768ecb0b0"
+                            "release": "39.20240104.1.0",
+                            "image": "ami-054dcbecca9935803"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20231204-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240104-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231204.1.0",
+                    "release": "39.20240104.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:18e3a5cc2a613245be2bf22de6aa020d0c13b1e4b4d64267ca68055b1fff4b66"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8fd28b850af34a20e06ffce252f1495084aab037345b5112c9a5f802b8fc6995"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,131 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2023-12-05T23:35:34Z",
+        "last-modified": "2024-01-08T04:03:16Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
+                "applehv": {
+                    "release": "39.20231204.3.3",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-applehv.aarch64.raw.gz.sig",
+                                "sha256": "cdf0e199101c5154c0685994c223de1fda872f7a7140329afa2ee6ee4b9e4ed8",
+                                "uncompressed-sha256": "d984a2b5d453b0e8c8307fe8631f764c580d35ad4f08ab5594962fc30fdcf7ae"
+                            }
+                        }
+                    }
+                },
                 "aws": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "794271047286a631c456e4e5368d443bac68adab459b8a40f82f6acd3c9810dd",
-                                "uncompressed-sha256": "41ac13849786a7ff7814db44ea7da71cacbef504c8c6a2fd7fdb0d975d3bb274"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5822dbe99c7fa8c13a2ab80fbea9a5728da4ad4265d0f1dd37db73a7e4cd3940",
+                                "uncompressed-sha256": "5049539b1a0094f5af2b0881ca32a5c8127cd88fd2dcb23081ef162a52f825eb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "85a557bfc803a2c3ecbafc65c59f8464df6262dcb7bbb2af448408542301b6c4",
-                                "uncompressed-sha256": "c7b552f950498251bd61acaac896f235db52579c607f2a6c8e58bf860d217ede"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b59c9094482e38d3e0c3d2c1dba0b9a1b3d714cd4d11b35073abcb83d31dc99d",
+                                "uncompressed-sha256": "3723b7844adf1ded92b2195cee0bd0d8d9d0362765b7729ec5029945d26bb861"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e57d9d1016e65b218353928348d628478b43981507096da753998e64cb3b2b39",
-                                "uncompressed-sha256": "780a2125d26ed1dd6ff2b11d668616ca13de2e999875edb00e60efff261e517e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-gcp.aarch64.tar.gz.sig",
+                                "sha256": "6209e9e050d48deba4c7d5906d9f4f02f3ea11c400914d3ea340452e5984d05f",
+                                "uncompressed-sha256": "72628d53cceb55f0cb159d9b819bc4c9c54c32a1a2d4a36bf5668899832bbeb3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "6be3a258be8fb0318606645dac5c85001099b90b1817da9727cd03cf52c7b746",
-                                "uncompressed-sha256": "cd314316febd6ba5c03dda17ae0e56736fbcf88201c5a0bd69ff23cf0ac93a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d66d644e2989877aaa49bcfccf70af4cf5bffb9953e92c779c9165ffff614719",
+                                "uncompressed-sha256": "24a7b49223d431e7ee3c7a220190095dacdb51f6fe3f828b84b13039b47faaa9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2bbde5fced749da06030336e41edaefb0609a532fac71ead5eea241b5346bd8d",
-                                "uncompressed-sha256": "bcdc7d20eebc6fc212d6300fa6625fb5331406bb1300e12bd3000b791bfebd25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2f834cf430048c5a42dd3b39dc4a41bcaf672b6d42ee7d41d48fd8bf5fc319fd",
+                                "uncompressed-sha256": "1e75b81fac17203d85101d11aadde01547c5369f9f93a817d6eea7692668d38f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live.aarch64.iso.sig",
-                                "sha256": "c3e90c40fdae52a7dd43231fb0694750e9149963d516cae03bfd51524e2d1943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live.aarch64.iso.sig",
+                                "sha256": "1968b9338d8650e30ad2e65f1aa583a5f56c562c514fb4c176ca54829a0d5fd4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-kernel-aarch64.sig",
-                                "sha256": "aaa5b752507227e97b7d1ce3e63d71fb0697b1b54ad1417db80c2977fd9952f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-kernel-aarch64.sig",
+                                "sha256": "7b8d0485c7b70cdd881b4b728d7d87a88a49847a17901292030ed9bbdfc217e9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "cc00387e8de66b5dedd160d4ade766d34026a17f7c30b6aad40a4095523cefbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-initramfs.aarch64.img.sig",
+                                "sha256": "f664021705586c1f0d635a67a7fb2128fb249c5baab1ab488d21ad12da40d91c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "e8bd8d960d500911257b52b832cbcbc0d98935da6d2a56b2c40eac99be2de4f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-rootfs.aarch64.img.sig",
+                                "sha256": "5f4b793b408e0b29ba638f0a6b57df4f0336a6f4b52ab72eefbafea158de3a5b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "53f77322b23ba48e045085c3ff47b0196888783c2e700437f5c389f0aace5baf",
-                                "uncompressed-sha256": "abc4444d468addd96777664cd27aab63dbf28acc74d1bb1c1147eddbd696d832"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal.aarch64.raw.xz.sig",
+                                "sha256": "43a4ac99b332cbc9ace50da5b613d5b2cef2f3096ee4b9521f9d1e38f49f0892",
+                                "uncompressed-sha256": "fed5298edaf28f4fdbebd99d783a32179bade3c6682f6d513881381daae4e21f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b3fda5eec6287b30f632e2addb7d343dafb3c89a34946a428c02c4d9ab798310",
-                                "uncompressed-sha256": "7b49785bffe3672065b9645c7b177ae227fbfa905bcfe7f8c62fcaa613ac1d40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8d3d60d4ccf338f138545b5380959e7c82af033921a326f1c5aafc862e15d597",
+                                "uncompressed-sha256": "713baf30a57f3d29616db0446c50101ce8e731b70c32959214de2bfde38b711f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/aarch64/fedora-coreos-39.20231119.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4d9a72f5d50ee9d9c136c431aac946845df6950583e17a10938c5b0c08587c7c",
-                                "uncompressed-sha256": "65f287f802f83052eca183049e6cb963937398275fa71220db9bcae6004fe501"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "aa1de4dacececdb37860ffa095ad23e58521b4ed0e57e5f323fd7a5c7e60968e",
+                                "uncompressed-sha256": "8fdb37a4ddbe4bebf2caf71abf88ba2aff0827c8985ce2afd218f4d045477c05"
                             }
                         }
                     }
@@ -135,209 +148,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-08884bb1e75ec0b1a"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0bf4cba8689b8055e"
                         },
                         "ap-east-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-02cb60c1e0b3445c0"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0eff44e89a72b96f0"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-047dc07807222209d"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0a4b36f47bb045fae"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0e9f6ae173538f4c7"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0af003dcf2faab2eb"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-096218078b7aad299"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-065b67c95887a7498"
                         },
                         "ap-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0cbd7be129df40865"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0479f58564058d009"
                         },
                         "ap-south-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0e7a5b7e4619b5535"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0453bbf7319becfc5"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0085305ab1ce3f690"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-06097421d42c1eb22"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0fcc12ee4a1916db4"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0886b34a7bd5ce602"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0eaddf91b7c2c5608"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-061ac7f1d67f16d2c"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-07271b92e05646edf"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-03915db0e632a1382"
                         },
                         "ca-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-00607d57f59bddfac"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-05ab7a9f9f80a2377"
                         },
                         "eu-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-04b08e15261dfdf2c"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-044b2fdf88227b57d"
                         },
                         "eu-central-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-07fb979019b3a594b"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0f03a28bc3a0ef9dc"
                         },
                         "eu-north-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0c7ba25a75ca323f0"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0e46017822a54b820"
                         },
                         "eu-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0cd04d6ddae9090fa"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-073e621f11a1878ae"
                         },
                         "eu-south-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0f2c8cbd336e9812d"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-026af31b8c9ff5694"
                         },
                         "eu-west-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-02b00285794a341d4"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0708baa98dcdf36b4"
                         },
                         "eu-west-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-089c38e60799dbc12"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-013b7502955a9958f"
                         },
                         "eu-west-3": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0f756fafeba8bd1aa"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-05fce37660160e062"
                         },
                         "il-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-04f888342905bce2a"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0fc5f69ab35c94732"
                         },
                         "me-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-04bb39ca5a01420e5"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-058767e895c2e9bfe"
                         },
                         "me-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-07eff12ef0b7b4ec8"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-00575b847a3c03b3a"
                         },
                         "sa-east-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0391bbd98bb461646"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-04dfdaab892da77f4"
                         },
                         "us-east-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-071f0bc129ecca4b0"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-07e2e4ce85964e973"
                         },
                         "us-east-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0067320da00fbff17"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-06ba59bf1d8825a49"
                         },
                         "us-west-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-05ec93939e264ce56"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-089d3cd3a7baabb49"
                         },
                         "us-west-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0ae563ba9813b5b55"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-062fd83aa7dbcaa4e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20231119-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20231204-3-3-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "abcd449f357d50d9e9ff9d1f2fcdd3ff814c9bab8a599e223d28eda68f6a685c",
-                                "uncompressed-sha256": "c3fc42c99df9664935a56d30c237420fff82830b49921a4ab40144c0a9a2f8db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "51ffea626a4eb4337c31b7b18adb0b883a328f1f31eed6d3b47f59e8820388dc",
+                                "uncompressed-sha256": "f1c53d7e726c2bd6013a46e44fc79b6a298b4cc2efea87e0a9380d0c62921fc0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live.ppc64le.iso.sig",
-                                "sha256": "7969533e2ecfbad0f9975b38fe4574a865911b35fdf947c287426469815c2ba8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live.ppc64le.iso.sig",
+                                "sha256": "ea6e2c4ac4ce29a7cf9803937549e8cf3c3790da9e4100e67db9bbf21ab462e7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "2111e9fa36b583c02ab90f05b80b6f3378cae24089cd4afa76fd603291138d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-kernel-ppc64le.sig",
+                                "sha256": "e2cdb0e0c84489ca5d1853a52b7cd17e3b65ae4f40a7ae975cc626b111723ecd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "7b67c08282e8d07b380b96aeb24c25e7df7e1f3f58e9100952c8dff656d46ec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-initramfs.ppc64le.img.sig",
+                                "sha256": "baaab5c1b1f737367539210e88f46ef53cd34a69cccdc5542bf06cdb036c0782"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "96e98c8afd8e59121bc4f9f2beee18be5d60dda90b4dcd02a4be39c4803f0f4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f25d8c4a7268be272676d5d458b4972f648f779ca6d03ed910a0bfb89a46d1cf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e5ea892ef3501d47aab6aed8d7137cd1ff16b0c4adaf644bc7fd22afc276214f",
-                                "uncompressed-sha256": "5d43db4baa6e9b427c3752a22382ac8951603df24632fbe0681ea9a70b592000"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal.ppc64le.raw.xz.sig",
+                                "sha256": "bbbfdf0adb37b50df43a6b01004eb13e5003dec68329611cc7b7604af51c9cfc",
+                                "uncompressed-sha256": "4a205762baebff53742022467ba93abd20fbb1a3e7054db853c7a5723fb2c852"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "272ad9114ba01afd11f7aeef864abd3835504192d359afffdc03bd96f8102af9",
-                                "uncompressed-sha256": "11395c641f49b93c2a35a3d1809ea400933717a13b6bd8dc1b654a6546b1d54a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f058e9330e6b01caf6d8bd164b111b2edf30788735964b85e2cb9afd9be7bb65",
+                                "uncompressed-sha256": "2d91e89ba862cd9e83c572b60e7fd494cd3058bd2d3433b2f1e8356dbf3d9d98"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "1e05d71f78337cb323857bb50ea644786ea88cbde0f1b6264f53dbcf63a019c0",
-                                "uncompressed-sha256": "052e14f041199b5c79500850bd447476b42925946e8d7d87dd6b130a7183af8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "aa209a290dd117b24389b871c47efb574a43d11f8950dddf22ab5150a82bb8d0",
+                                "uncompressed-sha256": "a1954a8f12c93045a50e2534f3fce35d02816fa88e22f8eafb6bde16e877efa6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/ppc64le/fedora-coreos-39.20231119.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "6ed938ef7b26ca1de461fee125a117130537a8cafef73b6f56b0b2d1e583d9ed",
-                                "uncompressed-sha256": "a9783a4b214e292c22c8fffdb7b869506d536739b4bd20a7789f2150d5cd1fe4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "8a72267be3b4e2afe4ee89a1c61ff6c0c097090406462643c82420c480775700",
+                                "uncompressed-sha256": "fb9991d11a58b8c14915ffe1e3833260fde11b4f681702f3f51a6a9b202c9cad"
                             }
                         }
                     }
@@ -348,85 +361,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ee51b8d06186e50b41d563da98e17fac9920dede92d104150bd8feadcc1f873a",
-                                "uncompressed-sha256": "e5a56e16d94fcc12a1691b49d878bc9c3692b69f3b3dcc25f7a5e496862e263e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ce53137aa82603b77d5cd392affc21ca76a0ea10104953de785140466f087be8",
+                                "uncompressed-sha256": "68141963761c7cfa6c252120dd08af79838bfb8abb89df811303b49289234374"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "961e6f4e5fa404b0cf3f26a60b1ebef8d08a0c7b309ee4d9b775cde192a78de7",
-                                "uncompressed-sha256": "663c02af0d052983f58a6f1dbe82a665e2b0ef9c049662bc34aaefbdb263b3ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal4k.s390x.raw.xz.sig",
+                                "sha256": "dea8c2d7c87b97a92f8a0a9d27bbb033759a4ded80f17ee8ff74adc598ce122a",
+                                "uncompressed-sha256": "070dd82989e88cb3096237a1eb2d804e21652603478d119dda3178e3cd4fbfb0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live.s390x.iso.sig",
-                                "sha256": "412fb1ff3f625ed3726d6af9b7fbe1d505a93df92d7ee4a300ba96438751a765"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live.s390x.iso.sig",
+                                "sha256": "cab8c896df85c348f426fec613ae33b824a7ed0e43cde1167e42e739bb472c7b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-kernel-s390x.sig",
-                                "sha256": "57fa889d4480a8e8e902be74df44d2a52b281019696890122d22e7ede1e5ca0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-kernel-s390x.sig",
+                                "sha256": "7e7f58c54b7f843a8391e7478a33826e152088422497416da0ea342301405dd0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "71f228513e0635fb53d2c9f893f6a56106bfe78f6689373bbc3814bd8b92c7cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-initramfs.s390x.img.sig",
+                                "sha256": "cac8e8d765198040f86e717b6fd9231495c6d6b03b98a793ea470d0e2b4b20cb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "436af260c83a38866c0aa1bd4f8671a3b869a496e49292bdd8cbf4cb37d039e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-rootfs.s390x.img.sig",
+                                "sha256": "16cbdcc2bf4ebe3cc850786592a5314786d1129ac4a1ad2f5ade618a96689e57"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "084fbd3003734db4effef91d46659375d4e48df8b0ce6e3efece06d5d36386d4",
-                                "uncompressed-sha256": "3c314d94edd188ce93290cf6387241281a09072e56d1374d24651c2da7072dec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal.s390x.raw.xz.sig",
+                                "sha256": "f8904de185afa71f9339ecd143de8e96f104540acd8dc8cdafe48b3af948ade1",
+                                "uncompressed-sha256": "935a446a9b240dbb1ed02ddac1278571db19009a747e0784b8d4783343cdae00"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "227d87943f1434c0bc842f03ca1501596a0e10e616ab72e22a178b171d78d9c9",
-                                "uncompressed-sha256": "8528c9c3b1385404624c0a0cbc592c2388284f528d7a456a29ccfe899f0a969f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "78796658909563e5e25144441026f409076264298ba2ce229445ed1e927c3798",
+                                "uncompressed-sha256": "a2306dd72e2b1aebc3c6f5d365813f5d295de3ad6232e1d8cd39e93696cbe423"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/s390x/fedora-coreos-39.20231119.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "34924160d4a7f416d0be83987d3eeb7667c7cf5c01879ea1957b45ef3b46604d",
-                                "uncompressed-sha256": "91b33f1d3344dc53f888b234e9c359b10d97024da18904074d69ba8172f00b73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9ea4e106bbc65b65c888b091c2ff79b2f610baac65508df2edab1ec10518cb51",
+                                "uncompressed-sha256": "000401ca7200c12565ef376110fea3307c9b82023a68481c4f6abb7880778e92"
                             }
                         }
                     }
@@ -437,250 +450,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b9ef12680e47d2e89ec42fc17972d7e5889613c8b1e78c30a0feaf81d6a22b1f",
-                                "uncompressed-sha256": "0409001d49da931105ef8c04d6beea77960a3e4f5d4714c0ae8d72cfba5b8ab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "54ea1de722cbf2f661b9604900c7c332049a0270941984ff5d3c751c67ad45bb",
+                                "uncompressed-sha256": "1fc4db7be47979e6c74065bd88acebc7364c1eb1ca24b4d6be8aa5d65709e18f"
+                            }
+                        }
+                    }
+                },
+                "applehv": {
+                    "release": "39.20231204.3.3",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ec99e8fa05d7c9d1fd9aee0e0d3b5ef4f9f4ce11467e2f6eb833611f985b28a1",
+                                "uncompressed-sha256": "279d026b50d92d3bb6cfea73c733c7f86a8e098f4722961d94be400f30382435"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c21624d61b4d660cd1c303a88e1a8da90502cbb21edb293c1e9ed89b196d4cf8",
-                                "uncompressed-sha256": "c6d3fa2433c3d11fba851f1fae42b2e178308fba15b3f4eaabc8c3f965799053"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f7ea6e4bd532757fde8e746b621ff81f09ec77dfc8156938896d569ef9ef3618",
+                                "uncompressed-sha256": "30c5cfce980c8cd601a29c24a22346f7f0f99e5140b4eeff8d70b73cad8c559a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "350f8f8d9fbf985ffcc8bae8ef996127210daeae5617ff490ef65ab0b376fe8a",
-                                "uncompressed-sha256": "7fbc1c5ba2f713ac423485731f47a91d73f3d15447453de2557b261025da7ce4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ffd81772115ff9316ccdf7fcf9b633f774842c35301de8c374c2ac9435e26a3e",
+                                "uncompressed-sha256": "8a1edbe03c51397bd55d55d32020b77ef10aec495fc8cb81dcf8227d5e92d1de"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "af538f4ad5266e0afed6ab8be7ebc7e15af77cc3cc7b89bc85ec4cc0f039aa4f",
-                                "uncompressed-sha256": "7b86712e01dbf247fdb5c7ac201836400598566cb2f870873bbef0e0cd726c5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ec9834f66bca6987417f567ad64b070ba4080f5554ff763c9fd37303c2c19aa2",
+                                "uncompressed-sha256": "d36ce2984b4e6707593e1c2501ce5e575dd34b6dd8caf78b0cf6d19688c9083d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ee4278cd8c9ca04e20d6ab1e71635021b4329983518d5ae286f582c08d6ab585",
-                                "uncompressed-sha256": "1a326302016cc0b002d3291817b372afcce4df2acede827980bbfbe29e1b552a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b8bd2e1aeb7a94e6f7d3943178591450e2ba79f3b91e13e863e1408a73d15414",
+                                "uncompressed-sha256": "406cc2751bd6b39120228dd54c03f3e59ef680cb7b4ca7e400c0972c0a10e42e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3af77a922247190552a07af251ebca55d06736c5c8fc21124d90656f6a7e74af",
-                                "uncompressed-sha256": "573f0386f1f577767732c4485404533cd9fabdd03989643f78616b75fcf638b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c064a38a674824503dfb3686a5b6828070a15314c7bdc87f22423434b73f2929",
+                                "uncompressed-sha256": "e411009b37d05121d8c2ff7395d49436914e6207c08b8a21b13c258ae4b6096f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cdaa5635abdbf519748672e043e67699fa47f8cca96cb63cc58e0427ee01d0e2",
-                                "uncompressed-sha256": "9701afe91ca9fbdc5e86fa86e7c30a596797b5697bdbd68c390b5dbad629a99a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-gcp.x86_64.tar.gz.sig",
+                                "sha256": "88aaa370ee74c1f38241a9f10a5ed51fdc1bcd6a88cbb18209e44de9291e1ce1",
+                                "uncompressed-sha256": "f584f80a9cbd254bcee532172f61fd856e9c4fde8f37d68b9cbddbf367566240"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "fd41576b0caac96fd62cdbed58ed15597758ced778e878cddb74f5007c573c70",
-                                "uncompressed-sha256": "38b95dfa97f6ae2af9a23224476e55e8276c743c58203e58bcddfc93a47b5220"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "b3ca8a329c112c3df757d71e77c29bc288aae5ffd298faa4776b432c1b0bbe8a",
+                                "uncompressed-sha256": "1ff0d081ddce4c53d0c6880dfb4417697f01a23d1bf713233dc363037ac56213"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f60f8bd3da9b3f747be02dad690a0e0fe51cf3d50a7f9c5d54effc430571ae90",
-                                "uncompressed-sha256": "e5bb19148a7b0a3734bc6f70724d4cd4618cd363ab79fa3e597f198421403626"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b9f2d544650c564001bd122da2fa9e960d9ce5636efa51366c1fb0f91901e80d",
+                                "uncompressed-sha256": "8a963cd298c2de4205a5fec12995ea50f675e1eef570f0eafa1dca95657f1ebd"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d968a8f1f3ee6c71d897e61864199586db4ecd9114875c27f923096f8a2ecff4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "aa1e16f85da0acf01fd6993060adc2081cf41101104b56092fde43efcdcdb335"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "31036a3fec74fb68f1c190f876104690c52b53b5416b0e4a9684b9c8126735b7",
-                                "uncompressed-sha256": "fe3de2289ee47a4e841bdfdf208af8addc0d5c69cbe87c18f83c8b20c6e70749"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "22654dbd04cf9e2ff37521ed9a310e4e132ba811c443103cdad334360a3166ea",
+                                "uncompressed-sha256": "e1b470429312bdcf800f2529a85744a917fbc5f05e3d3886357115e5ef932804"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live.x86_64.iso.sig",
-                                "sha256": "39d1170345ea1404549d39383885310a460d62068cfa77d60d2f8484ffacc889"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live.x86_64.iso.sig",
+                                "sha256": "0d92887c5e001ee4d0ce3d20b88599c6d5658304181fbf4106dc64ef2f0afd53"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-kernel-x86_64.sig",
-                                "sha256": "3efd416a625571345cbb330b434272b99813a1146cc9b4eaf7bfc8e29317c986"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-kernel-x86_64.sig",
+                                "sha256": "5490e2d24924f2f9a71b5cab901d6f9936ad9ad5190f3021b58adb4f2e7d1e09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e50a45a3da2face2a808cfccc3318f7d0a9ad8d04c3845f798dc19646bcf4138"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-initramfs.x86_64.img.sig",
+                                "sha256": "5b7523c13841bd938a43124c0b603fda6355ee411797716c97ffc7d7d926da34"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a7bbd175100d567cd7e27130834990a837b49bf3181d41106b9dd967d1c1058d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-rootfs.x86_64.img.sig",
+                                "sha256": "fe4b85ea35746f6f2efadb4909519bab9fd83c2e27fdf21ffa44721416567904"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c72d19faba67ed1a72424daec7303513b9f6dfc97d454537fef675f0c52ddbdb",
-                                "uncompressed-sha256": "11cbdcac328985d1fa8556f93c36c6b20b6e9700978355c29d54e06c35d2608f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal.x86_64.raw.xz.sig",
+                                "sha256": "5d36d285870f9285a08985ff6fbce83ef9315dd266065cd5755f7ddeca06f8f8",
+                                "uncompressed-sha256": "c570ab2739a193f0b926581d4bd08e4218fa2e4fc645e17751e94f06f64b1191"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d84fb06d56d212dcf44dff3dd607685504ff8198c5cfcab58937a1100f3f9745"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-nutanix.x86_64.qcow2.sig",
+                                "sha256": "728a876037cb25e1926578bcb45ecdadb032bdf6e898dfeafa96ed9617924ae0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5d494ca321d36a17c028446f5333053a769eb5538bce37fe4e944fe0c279ed0d",
-                                "uncompressed-sha256": "6eb19db3a49d10e5acdb2b2d35673e901086d771d13b0925c3eb39107a22f39d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e04c465000766f9e3d9d98b0d7e366072b16e616deaaf839d75621bcf77fee2a",
+                                "uncompressed-sha256": "b33bb3824705fee3c5058989c71583ed01b9e2f9ac6e8e2056c51b8d894f8b76"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "937a6137cf42afb09c6c25a9bee4bdbf596953d0e5c46c41afb5907846791f03",
-                                "uncompressed-sha256": "b4a561edf73c8860dfca73a058a29ac9f442436117c1a83f3e4ddc9fb31706ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "df4b55402472dcabe7f19e9215193643e5e34513d20afea6f1d7326ab5b3c239",
+                                "uncompressed-sha256": "33ed90f2c1b77af693cdaafb058482915639b5f093fbb44851f5820aadef77e9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "8d8c9a15412cf051f2d5dba3084a76ed207b4e5f72db02fdcf952f6af1fa7964"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-virtualbox.x86_64.ova.sig",
+                                "sha256": "a10724a0f0955ffc2bfa327f5e8efec07d5904305dd80ee3c75a24f2c5dca26e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "642fec61dec1ccde53903916b7546ade8b7b04ac87c714a6369396f1c3f92e5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vmware.x86_64.ova.sig",
+                                "sha256": "4a2db73ce121080de5b7ea1e1384f938874e79268cfb135cba411a28f59ca511"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231119.3.0/x86_64/fedora-coreos-39.20231119.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6c9074b9236f811cdc26d8e5bc694bfced8a2f2249c710083d91ffac2272d6c8",
-                                "uncompressed-sha256": "5c26f85e7ef9a7a39b2fa3c910921a3ac809147024c96d993e3630db25583c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6fd4349cf778fabcb7a149e0fef8b4fef88ad9e0ca43e09e29c6da7842d726e8",
+                                "uncompressed-sha256": "0b4cad168e9e3560d2787b2bd00f02ef2de77fd927643ce3c564cf7e9aa7df89"
                             }
                         }
                     }
@@ -690,129 +716,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0768b58f913b4c2c0"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0374c2c2c99b025f4"
                         },
                         "ap-east-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-00d83a0b4987c1033"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-00ef05e1947320eca"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0e14474b99609c859"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-041a51fb06cdf9ac5"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-05b22100093a294ae"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-084b22af326442922"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0c73c9ad1feb0b315"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0a8886590ac6edebe"
                         },
                         "ap-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0a4b2c9b747304948"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0e8e86e48f3356893"
                         },
                         "ap-south-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0b45351ede2b59e4c"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0c97f3b036d8cc316"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-05b663bfb8d56143b"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0d9f823426976e948"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-050054e04a23a6ef5"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0e88d462a4ec3df92"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-04c371ef6ec2fbebd"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-00c0e34681d3cbad1"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-037504e5da15d757d"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-01d543cc917375a9f"
                         },
                         "ca-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0f49cad9e7c9a344f"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-058e0992730b83906"
                         },
                         "eu-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0578516e98cb4f7fe"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-02e9608cba618ae1f"
                         },
                         "eu-central-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0891b31ee25090dae"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0f757b44e29484ffe"
                         },
                         "eu-north-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-01ed2f6fb774d75b1"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-05597fbd724541d79"
                         },
                         "eu-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-03eb4f80881bef3b1"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0ed35b69c942be0be"
                         },
                         "eu-south-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-04123fc310639a5bb"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-08d6a58e98b30e07f"
                         },
                         "eu-west-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0e800597d85495bd0"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-02a1b04757b6e95a5"
                         },
                         "eu-west-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-01f6d1c1277fc9e24"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0f2ac699db09839a2"
                         },
                         "eu-west-3": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-016d58eb81c1701a2"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0ae6e62dbc92d7a9f"
                         },
                         "il-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0e6d2faf414024000"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0b48ae7df16ec48c1"
                         },
                         "me-central-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-03407bb67d1305951"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-08cf62c281a64cd4f"
                         },
                         "me-south-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0d31ad54675825066"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-02814cbaed2da5b38"
                         },
                         "sa-east-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-000b678dcf4d6f701"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0783fc15516dda074"
                         },
                         "us-east-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0bba7c37b9de21f04"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0b279754b116c7fbe"
                         },
                         "us-east-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-07c4eee4a7d09aae7"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-046d1d609b6f00b34"
                         },
                         "us-west-1": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0abfc28120e7288b5"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0ee0f695249f081c2"
                         },
                         "us-west-2": {
-                            "release": "39.20231119.3.0",
-                            "image": "ami-0343bbc579715e364"
+                            "release": "39.20231204.3.3",
+                            "image": "ami-0626300ab248300b4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20231119-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20231204-3-3-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231119.3.0",
+                    "release": "39.20231204.3.3",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:44c540296ab2a7ba0e31dda531ca341f03942a8f67c7d1c99e80a32b3c5c042e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5bdbfa55cae52d877ccf115fe3dc6d56a8e866310950adb056442c60a0e7f42c"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2023-12-05T23:35:36Z",
+        "last-modified": "2024-01-08T04:03:16Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "6e2b333812da86d71c845c3e691fd9197144b7d5759f7d3e39d025bfccb24e6b",
-                                "uncompressed-sha256": "0d7a45f66bc0442853b513ffaf225952d0868e41d6594e69016dcb5a2f089541"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "a9f5be91d5a95c666adf7c014532616efc1b86c4953ff23603daf67a964b8d12",
+                                "uncompressed-sha256": "33b8c49ea3e8b0b04a3a1d66279337a6c6eb0ba6ea5d6b521912c2eec9cf1364"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "cd1ea550b5b44c6485c8a7756fe7754c038cf741c06b6757facece3d770e0eb5",
-                                "uncompressed-sha256": "b477c749c727ef6e4c620398722a050c583aefc54363be6f41fc933476a11a03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4925091cef472d7985b34a5ed3e8b601d5b327008e8c65767af2296b0d04aad4",
+                                "uncompressed-sha256": "132680e8ac8be76ff5041bd7d55f191e5a792f5b7889e9a63aad1e564d75a7b1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "fca2b5334282dffd4a391a2bd16ffa446a5eaa2524f6f972186783f985bb30b7",
-                                "uncompressed-sha256": "11ad8810622d1b7a8243efa94f475d952b363eed7170b1b5f83cc53fb6d7eabf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c2f043658470cf11bb48708af11f9fd183d88f070649fc9d1d59c6f9c92a7d4e",
+                                "uncompressed-sha256": "29b26b849acd20e1999f727b995efcf77e034761de5eabbbf9631f5169e3e520"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e686189446abb4f9186c899986ef344ed0ef243d509c4d0fcba9db83fa5e1178",
-                                "uncompressed-sha256": "f581a7864d0d31b2e8b05da11ca843afb066a6e147d900a6f4ac006b77a934f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3e92b2b6b6ae9ee8bab7a3a07d8897b3a48bb40a230a6fd9e7ec41dfe3c1b8ef",
+                                "uncompressed-sha256": "51208457f4aed4cc69158a377148421775c79a87854dab9c199044b5164b7fcc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ae6e0c780fe1d2ca81d29b0ec136172d2cfa559d338284f085f6716add400cd4",
-                                "uncompressed-sha256": "21d546c857538083153cd4ca22d50e683e83ce783f5667aee6044c0496327b37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "656752175cc4deb04c4331a6c48206ef3a05de0cc99d8ede4647b683d0b67f5e",
+                                "uncompressed-sha256": "4bf090ab5c0cd4e019199bd19977c56527746a6ac156fa39c05d053a593ab3fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "03d961376fa7a90ad1cd8ca50e0d861a6d0af31d6eaa0c92098943acc6293af8",
-                                "uncompressed-sha256": "060404684f23d7ec177b45b9e752bb7074ff6bed1c13d66c128b9ea2d133e81d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "221c840cc8aab28cd1b96006f45db45d89805f34795e7af2a888f3d0c64988f6",
+                                "uncompressed-sha256": "32b18e4abb3bbbe3da544de98ba925e0aa1e7e25529f118dd48a3c8407a2157f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live.aarch64.iso.sig",
-                                "sha256": "2b888f694104509a95c9dbd23a7d2dd38b41d5e6882797812191eb900960be9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live.aarch64.iso.sig",
+                                "sha256": "5ed2417a7ee5563a30eba8411339d7c308666eb8ed6b98c35fe71f555e5f3c99"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-kernel-aarch64.sig",
-                                "sha256": "7b8d0485c7b70cdd881b4b728d7d87a88a49847a17901292030ed9bbdfc217e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-kernel-aarch64.sig",
+                                "sha256": "79fc1bc34a8a726f61f33a96baa01c90cd5930b3da2ce2042ce1bafcf2b4f1f6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "de83b840351e68b544231f6660b23112859eb463aaaad99aa55863ed6c071e1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "306052d52bf3beab83ad4812e55da59f6a3b5908c979c47e5ef7160df6ac09ee"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "dc7ed865d99a5257852280f63e0d0f993a0e96b90346ebb7d6e732224cd58b97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "29f639151826ec8d143e3da3bc95093b3578e9cb60cb27829a23c0a62392d8ae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "583b4cc9c325a4fdca11f586d3e7aca7cb69ec417e5e924297ddd448371f0c9d",
-                                "uncompressed-sha256": "55c2fc9e022de87275f76978986a966cb3708fbb28985de17cfdbe461e6781b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "164cad0d78ccc810f10c0c3ee90e408e1f583ba424db61f58618697d1dcb4b9f",
+                                "uncompressed-sha256": "3b60c54e32f84239813e5e0e993d65774154e91d9c11537a45d4aeb51b408b07"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8a52330a6031c59708490a2e9e457a486190db8255a5d79d9a08e1462f46056c",
-                                "uncompressed-sha256": "1cb91d57d955e4550710ae864f1abc225b75a8c68b61085df25e603a92b6901a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f500154e22e66a58c143df530332c3a1f4dbf1d572704bb972501016538a7201",
+                                "uncompressed-sha256": "3def6351efb4468be1a27114d220081ae8cc49f045f1344b1fe6cb9b02a590da"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/aarch64/fedora-coreos-39.20231204.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "aebb1fad68948394755b3f8da16c54021c362c5984dad4beb270825fc738066e",
-                                "uncompressed-sha256": "d6c897bc0b0de4b0311833e1e1be3d13981b480e5ff8b1974450c7fd34a25e5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d62bcf81aa7550c0acb8861cba59b18722a63cf1937ee7c49bef67d4fd755331",
+                                "uncompressed-sha256": "84dc792f9ba862801abd8eab2e38e67547e713a57204930c11f350f358e5f888"
                             }
                         }
                     }
@@ -148,209 +148,209 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0cd17d18b77ff3797"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0e590ee74b99d4415"
                         },
                         "ap-east-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-032e89bffe9d55162"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0b0e77b54414b0c32"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0c1ad8e3289e54cec"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-02818ea95752ffc75"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0ecb61a47ed261b42"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-01730daceb6d58e66"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-055fdca31e57b0ab0"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-041c4a6971c361fee"
                         },
                         "ap-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0e5470c5a9b7f1124"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-071ce226b8699210b"
                         },
                         "ap-south-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-03e95a42473ace11c"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0029782e1d8bd71bc"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-04cc33952ce700eaf"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-08343da5170dd760e"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-08cd6aa8f550cf054"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0afeae7f7c324337f"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0f52700d78bf7a284"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0aff5ff4bb83a01c8"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0c7c53607c835b832"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-04edfe821c856d9c1"
                         },
                         "ca-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0a78d6253c7e1bc5d"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-01507b9b235993e6f"
                         },
                         "eu-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-06d2cf06b04a8bf41"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0e4027261a934fefa"
                         },
                         "eu-central-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-004e099ce07bfa6cb"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0a27acfb2a5b248ce"
                         },
                         "eu-north-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0a8121d3354a4d3de"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0f273d7af215930e5"
                         },
                         "eu-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-03dacd68236bdfcaa"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-020ef22f9bf44241a"
                         },
                         "eu-south-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-001dbd28c8929cd92"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-004d8a1dd1cb9b938"
                         },
                         "eu-west-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-074e67cd22c1c71bf"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0f8dbc64955518fe8"
                         },
                         "eu-west-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-092ffb2a95655df08"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-09221f721308f208f"
                         },
                         "eu-west-3": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0f91da153990f8bad"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0fdc15b3eb689080c"
                         },
                         "il-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-09e3d26d87a71dc8a"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-021e5ed1dad357d97"
                         },
                         "me-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0a5f5bed98c6bd7dc"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-07eaa1273df101b83"
                         },
                         "me-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0f25c7756619384ca"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0aefd9fdb03106828"
                         },
                         "sa-east-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-09e73d6981e6e0c7e"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-04d2754b54aed243f"
                         },
                         "us-east-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0a1a5cb4d80b8df26"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-01d497a80eefe6f73"
                         },
                         "us-east-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-08338cc6eb80e100c"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-06ac8591187a6e7be"
                         },
                         "us-west-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0a5dc39cbba9f731b"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0970d4e1027017ab1"
                         },
                         "us-west-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0b53a97600d8c8953"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0d24a467f25d5a2fb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20231204-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240104-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "55973e4de8a07aee9a16e3bbb8c152bcc732b61f2ae63fb9c2b76281d34071a0",
-                                "uncompressed-sha256": "5b633baa7b0776a79c910d87ba93ae3946119ac3977abd5e0629bd063cd721e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f8cce714a87f8c03abf1dde6c459d788496b997ec4a4e7ae52305ce9a5c91880",
+                                "uncompressed-sha256": "acbedb34be3b6cd650a87dbb8c8623099bc672292c9d9414b8cd48c486f3368a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live.ppc64le.iso.sig",
-                                "sha256": "7726ea129dba606c18c0b2263c5c664f29c699e0a2a1881ed53d432a786fdb39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live.ppc64le.iso.sig",
+                                "sha256": "ebffa5428f7a952d6e212e223f5a527744eafbf050cd5281fa20c03119ac775a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-kernel-ppc64le.sig",
-                                "sha256": "e2cdb0e0c84489ca5d1853a52b7cd17e3b65ae4f40a7ae975cc626b111723ecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "90132d5e3cefda2f7dc246d4ef579de4fa3e2e1d864170788e5e676034412a13"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f6e548df68de5619a6d59354cd95c52bc6fb0f7860a96a6b282684fb20cda572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e5151f8b1fd08b4cefb1bf31d3308c6881b54f7553d797a6bbac3f2f9e75a0ef"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "791dc0c931f6471cf8c4c1f0f31461cec463db799eb5552f549629267cec6ed4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c409a3915b45d82722c225778d2ce07a4ed14517be99911a0699071a57e1f929"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "cceab66ca498f850c917217484864b722afe1b8fd6e41cc1c8e0dcbc6da78a3b",
-                                "uncompressed-sha256": "6b736081208bab9edf16b13cda7d3900dfad624ac325e223521d0432f24030da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a7f33c529eec874632c27919939b84f86de8066a70ddb35dec94b66584e373b0",
+                                "uncompressed-sha256": "128ae42afcfc6d64c87b1b7cf8de4b26622f06606058c892523d8f9b787e3e57"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "64145a625ab5fb2f4a7d79c0d10ccf9fc4d54daf5fd1d82ba8af7d1664b86e90",
-                                "uncompressed-sha256": "b0f8cfe6eb3aada2ec1620bba9b6bff89ddbb14e03c664096ec93b440497a56a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "d5da2a3ac99f46bdba21bb5055a687db83d0478ba9a79db47240d97a2c30e2eb",
+                                "uncompressed-sha256": "1c702d327318aa211d4062dbc797bd54043eb4a653a6a20cdce194433dfa9cf2"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c567792cdb429e364cfe63ba9fba0ca4c9c2a2e1bb45c7230be899c1dd85f470",
-                                "uncompressed-sha256": "13fa32cf0344db263dc618532dd0b6ba3efd98b931a40e462ccebe655f1a7f6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "fe2569339d945f093cf99213793ce992c985aa6ff4a4c58127232e1f5d910b79",
+                                "uncompressed-sha256": "bf9042beab24a70cec2b5f815d8691399e1c152b38f970897608565d1a4710c6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/ppc64le/fedora-coreos-39.20231204.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5cb2c0637f6a3ca60df1ac35f9983a65e79ce8c0c0fcf83f262c7a8ddb8596a4",
-                                "uncompressed-sha256": "fae0f7cdea02d1bfe5129a7b2e3cfabf85eb4505b8aa0ce43cab6705d80f2db5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c0f1bf7e39153ba280bc6ed5921f05383cbfcc5047456fca68deb74dc5b28ee7",
+                                "uncompressed-sha256": "2f9baaf5cf545801ea8cf9c2aec70e2b95e66a4b5ca886465e46ff8d3a71b9af"
                             }
                         }
                     }
@@ -361,85 +361,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "81880e7fa9b4a2a6e73e1064dafa96c010bbdbbbf941c6528242599bc68fc6ab",
-                                "uncompressed-sha256": "cbb96e6651363e85a1a1be9a8e7edeef19e5c2b2496b177788b7f36f1d0c8091"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "1cffd6c90f2487673981ae7d282a283bbf0c7b06dd957e7fd81fee06ffbf34f5",
+                                "uncompressed-sha256": "b88d0c15367fc0970581d1e996daac0b90ed7b777569be49a1ca651ff32d5969"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2d31a1460699420fa6909e34d3ac71c705ef9c75fba35657e06417b951330e77",
-                                "uncompressed-sha256": "68a00f760691bd60dc527d43aa917a6b006d42c9ad239b5cefb872cd759c8583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e1a6ed880fd81495df40f407e9f7e117a88007a0fb83608e5a0bb031b2fc36f3",
+                                "uncompressed-sha256": "1af716299e29c0da6ef65aefe15d3667e133967be0b52c3434da424d0d76b4f5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live.s390x.iso.sig",
-                                "sha256": "92199680d52e40a5570c894b9daf6ed80cd9242d5761e5663d4a55c4c2074a8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live.s390x.iso.sig",
+                                "sha256": "1071f10868bed105b9586efa420a6df8b4360e5f076a130d1dc9e86f1fbc36f0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-kernel-s390x.sig",
-                                "sha256": "7e7f58c54b7f843a8391e7478a33826e152088422497416da0ea342301405dd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-kernel-s390x.sig",
+                                "sha256": "ee6a693814399eb97e9451034248cdafdd65b9a6ec245a25565f50e44318a5be"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "f9eb333c7f62df9808bf54f123c7da09cd38a1a6ee18b681ae72ccb3a6aa602c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "55e7cd6a0728fb23abb9eaf6eacd1e582a919707d391e922fde1639a75ef6c73"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "a6467ece416da50004116fdb030a6df051c5b1787c3740bd05a30155f1ad427e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "3a9266afa8e8fb88c996bd103d516e032f7a10405d6a0ce7af747ec91ef7937d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "4754c466ce4023009e3367c4d149b5a64ee718bafe4716447f8ca3a74715cf85",
-                                "uncompressed-sha256": "ac1747f7e0bffcbf4245b42a9263129306cfe35dd963ed46db4722b648b53684"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d4097dba3d223113493978a5b92dbb8a89d82f03b51f41883c849d9e47ead06e",
+                                "uncompressed-sha256": "dc5004df55ec926a233e7ee4f99f3e9c6935739beba99b023584a75611f3d008"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6b3f33ecab1eb1d0839de2e80efc547c665215d5c434da69d776faa7550a7370",
-                                "uncompressed-sha256": "fae3558c733d8446aeef38f4906b8014800db68d5c9e15b758597cbb313cddac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "587011441817701b565136fb498a34b2a6f943f37a2cabffbbaebb52ca4e2b7c",
+                                "uncompressed-sha256": "86ef4922ac8476845b3ae75b1e70c95cbf06b484535c0809517cbb1d706c4194"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/s390x/fedora-coreos-39.20231204.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d935f6119b735cbbab4ef1061b9b565f2516f07b9c51169b918061404cff3720",
-                                "uncompressed-sha256": "3a112dd5f209072263fddda2118d6cb99a122d20e4630623fc3fd49ca6b891be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "76ee578c972e3614ec2354d8ffab51621ff8b59fbca6313f6686aaaae42e8cad",
+                                "uncompressed-sha256": "15c4e64c3ade663fef2b0831ede992e5d023200ec5630760a757842e5e5739d0"
                             }
                         }
                     }
@@ -450,263 +450,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "97ca72820605f1da2e8f833cc697e1b6160a199c5450feabf3b661b9ac8448c7",
-                                "uncompressed-sha256": "7ee63bbbf687e20da0e0708c704f8ba72a30142d6ed3bd42c17fd2191212e089"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b71b3a0a7f5bda92dad6d1a571ab98bf2dc9c470f6d7f42d721842a4570426f0",
+                                "uncompressed-sha256": "60f016188dcc23f3613d2af94e011061a6b5fc6fe6f559b46c27e7767d70e040"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "e280aee1bb34174fa8a5d56a493b33a0621941ca9a2c81e2cd713980bba2de87",
-                                "uncompressed-sha256": "f393ea85a360dd7ac264c31dfab5023488d2479b2ba322d26fb6538eed2677da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "92741ecd2dcda50b6fadd4df9fbb752a417d749793a44b6d67765fbf494fdd5f",
+                                "uncompressed-sha256": "79cb0d957b494521842b3331d43eb091814c06179ff163523ef918194505ced7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4b75f034b7329b0aa13bca7d3eb66b398382e2010fe072943b36cc4631659ba1",
-                                "uncompressed-sha256": "ae2b6a268c34d9de4af0305db3f9116e4daf5780cb9512d3db777c558c6e8ca3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "fabe3d5bed81f2c3c8ee6be6dcc2560eefc79b9562edcbf7562b3927d5b3b756",
+                                "uncompressed-sha256": "86b95ad6fda64e1a87309007a0dee77e0017468d7c7650792d77c593f837dfa6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ca27ab913449d7abce0481fe23db2c00c9f898e1b8d749f5db17c434601d168b",
-                                "uncompressed-sha256": "bccb81754b2daec82be27b69745dcc9450d29ddd52c8826143fb41345b1b1cf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a2ba7792a1d2b9788e0a69ab4d423aa284370cd120242975d478d35e080f2746",
+                                "uncompressed-sha256": "8f7b545cb10d89b321320abd9f36b1b55369bb5934645824c7bc84a28d3dc92d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "786fb1c2b8b101f78f425727370af9131125e97207ff92f06a29f8b500b0e7e0",
-                                "uncompressed-sha256": "83e28f62d2d6bb72200dc99e84be5f045628747ba01f3537766b93fa13686bf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "38de9d7df030ce302eae888e914fa07bb06908ac4ba2125f28912d1a31ffd83e",
+                                "uncompressed-sha256": "f78f1cbe9456ca8cf4c9dd0b86f28ecca6070a2f380eb37b8e4be0b93588943d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "751ee7576d440a6233490daf0a1d50ec37d2665c8f890b7686160d4fcab688ee",
-                                "uncompressed-sha256": "282e9ca30105f047a7b6ddade41c0605b0cf65f20f1661eb181dfc7da8c16ac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "513b5c6832e34a260156b7ec501348710825dd74b466c401d059470df76fcb19",
+                                "uncompressed-sha256": "9050057bc7cd23b3493cacceaa70849ba4c2a3c5cd3368c389cf1c143714fe53"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "bab4611d6485c79bfcfbb1852aea01ba09fd54b3aa7dcac31039b0ad3c431458",
-                                "uncompressed-sha256": "d29c11b7bbded1e2a6987e82ad4f0498745a7d395d6c496de5c72b20678006a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "290ad890c0fd0797b52dc847917d7adf59eadbfec6fd37509594c0625ddb8459",
+                                "uncompressed-sha256": "33b286226170c208b418ce8389c2aea1bea2ee8898f02f65534588b205de86a2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "85977ae256184ae7a86a4a169e1a052e410b0be8912e3280f67aad4584f64955",
-                                "uncompressed-sha256": "c1f83ede47ac210523cce4fb70b38573eec6df212cca09661e760d9b7d25b515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "bd42d40a372c3abff5569805b227a1b83b49fce322bdda8448963723cabb90e1",
+                                "uncompressed-sha256": "980c14ee4dd861fab029410e399813af1f7c6891a62a7aeec10485fcba1cf1f7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2ad7ceab61d33044ab0c35924049806bcdcf4f1a64d580fb703ef8ed608353f3",
-                                "uncompressed-sha256": "c566917ba528c83b75216087f08682299e0501c9d3b6b4e3b159916066fc9c61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4b12d14965adfd13e821b9214e00351893704b2717d29ca497feae0630ace36d",
+                                "uncompressed-sha256": "2103f033fd7d0ef812b58471a2af2877ca7b72fc15403ccca2e006a96f4c1c1a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "fd8dc78473019ecad098386065371eba87c316703101b9108d8bfae59d3af3cc",
-                                "uncompressed-sha256": "b3cac37f53b1442d3d8da5fcd49c1ae710f0ba41dde3f31dec05c89ab4b90b5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6a86579c794e14ae7d7069c31608df796fb7ceeef2e53f9c91e2db19b80c6dd7",
+                                "uncompressed-sha256": "29112140a685de6530b3bd1c2a29bae421c2e4071ef33b5fabfb1652c5ff6fa8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "af404846cdc0f13e0c0254d5d0c7fc9aab6f4c5d57c11b39c0878193c66009e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "dbde345aaec1057b9b282fd304d775440c961db5b07eed9dde7b271608680293"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a325df83cf0c72338519918f7c473650454d4a70591700da10444e480a494dc6",
-                                "uncompressed-sha256": "3bb2adc63d7c4806ddde55d83afb8c6afa13eee9403ea3ae9c815d69578189cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6f78286f75bb51ac652b7f1f21a34a315096e8bbf8d068d491193358b241313d",
+                                "uncompressed-sha256": "c758f30a76c5336015fcb749946c1d0b6fa0ba040920c2814cef682dfee7a096"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live.x86_64.iso.sig",
-                                "sha256": "001274f9279f75162730dccf51aad39dae45d4cdfb18cdef2f2d19d558ee4748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live.x86_64.iso.sig",
+                                "sha256": "978d7aea0da1a7e6111d82fb60cb6177a2ea34ffc6a1cb851ff57066a7eb9178"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-kernel-x86_64.sig",
-                                "sha256": "5490e2d24924f2f9a71b5cab901d6f9936ad9ad5190f3021b58adb4f2e7d1e09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-kernel-x86_64.sig",
+                                "sha256": "6e82b0768a36a8ac0ab9cd5c31f2e53b4da91c773696cc5847a1db5db1953efb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "df5eacb37a385285f2ed1154c2d9d01775381fe1e97f7e5c6dbafc48667d6d01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6754f639ef3048e10d7517db84e1bb872c7281f0a65fd08aa5ea8953704cbae8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "420060172a43908e4599c2fa88bf2c5e3872cf8835cf16b434582db471145446"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "db565f62b728077c4703c7aa5c150b4aa8ceac079ea3d08991f6f0342cef052a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "bb92203eef2651043e6d75a5f77a30c095ee5aaace4be3364201c1a6a51e5eea",
-                                "uncompressed-sha256": "687128779e1dcbcaf0aeff8a53faf4fed60440e09ebd4019f4810709f29c52ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f88c1c3572ce05608f32eeb86f5dd27106aecb816983db35c082837d0010caee",
+                                "uncompressed-sha256": "7a8464c98d7a8ff11df4bd1b003deeb595c71e66ed3ad9bbeb4d265bee977a2c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "98ef36abf6d4c9a86abd57a773cc9e38930e1f6344603e0467bc42727f2bab0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "98131057659c3a7d9678b971a77dce61445a37baf0a6f491e06a8464f4f8963b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "04c040ea9c39a5236538d5e0adbabafe01a59e24b16953979ef21dbbee7f6f15",
-                                "uncompressed-sha256": "e760a1a8734881fa5aee5173072cc1251b5084f6e4cfbb7632e7f15395e7e83d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b4a9be7682bd81bac65fcf8caecc6e299ada24e8124facc5e91eb52829de0593",
+                                "uncompressed-sha256": "d6f01b526a1fb30b846c9f46812335ec0c695cce028c5693f8a425d7682a3f8d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c7f3422df0486509361a0f9325f6498e170e91c81a3912f41f37b54658493bc0",
-                                "uncompressed-sha256": "cf4e87241a1984087f5e4a892f3753d6adef635cd220757694f8e54353647cb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e3e71114a6a8a3c4630ee954c084b34dc2575b7cc2fa2200ee246acc340d860a",
+                                "uncompressed-sha256": "6a1a6b8b2fbfa1741866586c11b5c3faaad659a6108e05508d4267b7da5be53a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "ac2098e2ca3dc5f7fd6e82092e4a580f6158ce58dadfff5e005e12602a30b7c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "61025694eb98886cab0bd858d2093e7903f6f2f34475ac1a22c3543642972b61"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "c1c4730aa87143bc7ba9d5341ceb7afc91dace57ec2aad7814b58fa200801e51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "2541e658dfda3efed1b03d3c4fa28177d21ad8d19aa704f7032c194a662a55fe"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20231204.2.1/x86_64/fedora-coreos-39.20231204.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "790572e9dc5ea580ab691c456b68b482487bc650fb332538a1f468abab942d5b",
-                                "uncompressed-sha256": "e3f78c3731d71cd284629fccf3b02dc2e4fdf615f0936cc7a16f0b707492e4bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3d9e61692898ab4c191871954af5c9b5c204f343e4e0369460b4869a12658e6c",
+                                "uncompressed-sha256": "3af28957ccfb90d844dedf04c449509ce1b046bfb87d253960cb839f87009d61"
                             }
                         }
                     }
@@ -716,129 +716,129 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0129170683ff22ade"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0ebb9ccd0a91bc78d"
                         },
                         "ap-east-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-00a14625ad5d38aef"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0e0b3b1a237493604"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-03ae8f12a0ed0a749"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-07877e7b16e38210a"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0b598118d1eb19eec"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-03a3370ecf767e96d"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0e7fa9f0eb15b94f2"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-010348f490de4709e"
                         },
                         "ap-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-090fd217cf424049c"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0c178bb969f708775"
                         },
                         "ap-south-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-09862db0c06c70ed9"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0fc82f811dbb477cc"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0da4c9442cf9bb15b"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-05caa66b6c528fe8f"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-027d2a8bb50b124f6"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0337a1893432d4c98"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-05c000eaf7ca17517"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0d7774077296c7156"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0dc557abcc40de1a6"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-013a14208fea50ad4"
                         },
                         "ca-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-056ff545c81b621bb"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0e9bebe8b70ecff3a"
                         },
                         "eu-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0e380e8138c901c4e"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0ae504fb655fcb1bf"
                         },
                         "eu-central-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0d3d3f6f254c87627"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-06759fec1d13c2242"
                         },
                         "eu-north-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0ba1b1ba5c35a16a1"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-07f66c196a082da00"
                         },
                         "eu-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-07c63a7b92e72c490"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0504fe2724cbaf244"
                         },
                         "eu-south-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-012ec7825c29c679f"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-07f40bca335532c66"
                         },
                         "eu-west-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-01f8df741ffda961f"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-07801a846966cae88"
                         },
                         "eu-west-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0cf53b5ad66663516"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0e9599a04ee15b1ec"
                         },
                         "eu-west-3": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0d86af3970dab2176"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-07d2370a20876bc1c"
                         },
                         "il-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0a99e8dc21cb4e3c9"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0ac04890c3aeb40ad"
                         },
                         "me-central-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0f0cf952f96b63b36"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-073b6a6c8c460e8c0"
                         },
                         "me-south-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0ac644d774de33fa3"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-012ee7fd5d7290082"
                         },
                         "sa-east-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0d5147d6ba09d1981"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0b6ae6fddc5a5640c"
                         },
                         "us-east-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-09298a245efd33b5c"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0c511f4a0c6619a31"
                         },
                         "us-east-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0545201ecf06f624d"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0f15333aedfb9515e"
                         },
                         "us-west-1": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-0395bce1767eb2bb3"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-0a292cdb1a71ab946"
                         },
                         "us-west-2": {
-                            "release": "39.20231204.2.1",
-                            "image": "ami-088072110605fbab5"
+                            "release": "39.20240104.2.0",
+                            "image": "ami-03914b6e17fa99067"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20231204-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240104-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231204.2.1",
+                    "release": "39.20240104.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:28ef54f083056c0318dd204bb1109c4c4c608f39dce6a4150cc920fa7adfecb8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6198427627e09eb936db81a91b9653afd7b37524276145b9b485e735d3110faf"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2023-12-05T23:35:39Z"
+    "last-modified": "2024-01-08T04:03:18Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20231119.1.0",
+      "version": "39.20231204.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20231204.1.0",
+      "version": "39.20240104.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1701856800,
+          "start_epoch": 1704729600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2023-12-05T23:35:35Z"
+    "last-modified": "2024-01-08T04:03:16Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "39.20231101.3.0",
+      "version": "39.20231119.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "39.20231119.3.0",
+      "version": "39.20231204.3.3",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1701856800,
+          "start_epoch": 1704729600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2023-12-05T23:35:37Z"
+    "last-modified": "2024-01-08T04:03:17Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20231119.2.0",
+      "version": "39.20231204.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20231204.2.1",
+      "version": "39.20240104.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1701856800,
+          "start_epoch": 1704729600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).