### PR TITLE
Roll out stable 39.20240104.3.0, testing 39.20240112.2.0, next 39.20240112.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-01-08T04:03:17Z",
+        "last-modified": "2024-01-17T16:37:52Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d8e18fa2c6b87e9b0e53813ac84a776669446a13ddeece4adc5ca42d24539960",
-                                "uncompressed-sha256": "126946581a90d4e4429c7ff074d27d26fa38d6be13787ab762993274b86c7699"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "befa9ab329ca51eae7217f20b5f94ba55e19954ab1393b2a9d7510d6f832391b",
+                                "uncompressed-sha256": "0abf85c3258c0d1ba6ca7ec37ce58cf8033385bd5b480d520ff499dde2f4f46b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "27d0deeb2893be95e29f700fcd3d51b58ced8b6610be55e676f8dbff56ccc8a2",
-                                "uncompressed-sha256": "206ef0a9a41cfb107ad3de549b941dde6dab00bbba64bd42d75c8571754287f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "28bc78443d966bbfaf987bb11c69299839e532d3cd5af7ac791d9ae2e59c053e",
+                                "uncompressed-sha256": "d3aefa135e5a7c20b02e6d16c54a18bab06ad76e15b22fc9bf1d6cb2b428ba10"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cc3836a55688ae0ce8dd2d50d022acd4c8a758752b7fe6588fb5955d31c63344",
-                                "uncompressed-sha256": "0da1652185399ea1106091a68ce31f957bbf03fab9a6901faa0c4ac083506958"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c0911e32eff554b245f6d00122b892511cf26cafd062546e4a6744e0bb800014",
+                                "uncompressed-sha256": "fc2c340e80fa98cf19438493af6e9e26ffb94d408ea9ff650142c5fd989b7f48"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0c28602551cf4fe1a3c40bc2b3f607180a5b396d709e9df7c0798e6f2fcbb8c8",
-                                "uncompressed-sha256": "bab77c615904fbe6a6ddf325989a6bb0cbb7a254c5796b08e1262cbc70f400f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "4fe623b8249ab02011de1ec1d88c8c12dac4f53a6667997f05198c7cfc81c2e4",
+                                "uncompressed-sha256": "823bd61862b592236b536e4c84df4b0e670f7131b2590a22afb913792a728d82"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "8a7b00b74cc47fa7350cdfcb0b82b228ee4aa63014b5aba0360ad20a6ceecc7e",
-                                "uncompressed-sha256": "ed202ee1ef3d62a50382fe53763019cd47d953539a05aa3e944ed49d33e5e50d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7450fe5ac2c7a7a0b36f1e897ea53cc94b246d8c3d75d340649a2e9513b00197",
+                                "uncompressed-sha256": "2556c4576a7b5459d9815b26b50a25f3d67e5f33f0a2e4f70c4bffc02cb6925a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a286c3eafc47e90572ec82831ccaeeb51b635bc9d9c6ef457549a9fb8f03f3a7",
-                                "uncompressed-sha256": "2c01cadd0d16c2fcaa85f13455c8acf54ee7c73dbf6f010c0497d25c85e3fd85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e67095bf07b60b2880734951ede1f0e2be2ca319b61800650abdb2e984f421d3",
+                                "uncompressed-sha256": "9347a5803d5a221efc61468a390521415ea0355d80b53710a6cb122f9a9de498"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live.aarch64.iso.sig",
-                                "sha256": "ba4584bd7fdf358a877aa1e2af9522122d19853d7ed67923c7cddcccbacb6c60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live.aarch64.iso.sig",
+                                "sha256": "9cf489b29214ac325e5ea4d70bd03b1f887f21243aed6f96372dd3b6533d3e4b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-kernel-aarch64.sig",
-                                "sha256": "79fc1bc34a8a726f61f33a96baa01c90cd5930b3da2ce2042ce1bafcf2b4f1f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-kernel-aarch64.sig",
+                                "sha256": "608bca9610637faad7d468c5e03019ef81a903cd0a3ddc83cc4f693729b661d0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d3759e8a8c555fca54c89a2860575b04bbd36c0dd9dca13c853e34da21f7f463"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3032fdbefa2417328e607405b4752cc0b930fbc995501dad7363b3b6134333db"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "89267dbb4e7cb5071cf85c6f625955a31f382b360d975ed77e046670ec62832b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7d683fe7e58f8991fea49482603c4abda3deb692e3746dac98ac18e1edc68bee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "54ecd1792a3420d3b32ff2b0dc869532a7ac7f0a981acf1072bad0a9a3a6cc90",
-                                "uncompressed-sha256": "4aca18a2a8ac40abe208b9e4219ba2d194bed342facb86f0188aa5d091805636"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a3423516a2d7d4859962ba53f1f3c5e1e39c80e10f35d20406a95bd365534811",
+                                "uncompressed-sha256": "f493fad95983f1fb0a13435ed19b3ccbd9be74236c1a0290b3d024d7166e4671"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e995974c06862e34d71430fdbf0614df4de0ccb8760bb8f34e89ff2e003eff7c",
-                                "uncompressed-sha256": "2dda7b0fb73492b6d73b353e105a6d733044b40b5d5206fd063ca34459c080ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7b3a039bb17cf6b2b5e459e7b3d331059ed8b88c79034fa5c25674f7a2dbc19d",
+                                "uncompressed-sha256": "52d0056df4d7c8d847311f7170039b097270c5b770e8ecb93c01428998d8c41c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/aarch64/fedora-coreos-39.20240104.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e1cae1f7fccadf1bcb86d126703ff5a3b0e9f7ba572c2b50ca41a340fbb46a96",
-                                "uncompressed-sha256": "957e53724fc7a11797cc966738cfe474548afb2c85e969ab7846f5bd8969b800"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a68f7bb08b944edc9bbc353a218ce19970b75cbf36eb3b717a03d3d25b058c60",
+                                "uncompressed-sha256": "ec9ea34348b151b48829ce5273dd28c27cd7c29626fd3fbea6a317835c61feec"
                             }
                         }
                     }
@@ -148,209 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0c65df9649818fcb2"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0f2d9d61b94417269"
                         },
                         "ap-east-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0a054c31b3d209226"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-06307327a3a0eb389"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-02488a177959f009f"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0a5ce234b96b86236"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-006db12007a3fcf19"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-011409dc45e44e7f4"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-026a9d65016b04937"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0bd1fdfc5dcd05288"
                         },
                         "ap-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-01b040f084643dbc0"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-05f6484fb1bef518a"
                         },
                         "ap-south-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-08d8b4f135e670726"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-07771ccab707b44b0"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0eb7c131426c170d3"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-08e73c34c335206d3"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0677caed3e3c8f541"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0f5aec8206d90fd5b"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-063f161accdeb2e56"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-06fcddb2e4a962d85"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-04dacd014316d5ac1"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0412e89dfdfa01aa1"
                         },
                         "ca-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0da29289f23d5eb3f"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-04575dd52a116156f"
+                        },
+                        "ca-west-1": {
+                            "release": "39.20240112.1.0",
+                            "image": "ami-06b403d540e28f2af"
                         },
                         "eu-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0bbb40b6ae89e6a93"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-00d7451c9f5cc7ece"
                         },
                         "eu-central-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-017baba1031d243af"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-09ea23dfcab143d75"
                         },
                         "eu-north-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-026a2867784ea3a3b"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-05bfea2a9f4e3740c"
                         },
                         "eu-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0da74418940d2f35f"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0e60cc6e3fbdad370"
                         },
                         "eu-south-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-08684ab1e7955520e"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0d15d7fdf640b9095"
                         },
                         "eu-west-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0196dcbeefd699a4c"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-03caaa2bbd6be5a33"
                         },
                         "eu-west-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0863e70c9ada24059"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0c3aa06d9d33ac54f"
                         },
                         "eu-west-3": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0259dc7532a7f2d3a"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-08a491131fe73a634"
                         },
                         "il-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-07a4b5acf43be7077"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-05a8c0edca139332e"
                         },
                         "me-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0697fc13e65037092"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-034a52d8a9a72008c"
                         },
                         "me-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0cefb23c19abe70c9"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0e178cbd88f8214c6"
                         },
                         "sa-east-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-052847f081d5bd80e"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-02c058502cfb8a49c"
                         },
                         "us-east-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0876e400aec4bb6d0"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0a4e52a5f0463f732"
                         },
                         "us-east-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0e31a9f900abd56e6"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-03c49cc3aad69a1af"
                         },
                         "us-west-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0fc43e08a97716757"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-01eca85d79429467d"
                         },
                         "us-west-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-059a5c304da17b334"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-09a321106eb930048"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20240104-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240112-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "cc31c93d046045537fe293ec43dd1d2bec2c89eac195ba1d9ca05ecb30c5fa78",
-                                "uncompressed-sha256": "3e2e7b77da3e62e7b79f4f2feb5a98643901d9170e5e2268b61f7ea5e2d25775"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e380df1cf61f811fac3b0537501fa24cb15c032363997e7e9a87cccd1fabda5a",
+                                "uncompressed-sha256": "fb4ace8fd023c7f30e47e7ead87a2570c19959a2c468e03c4e06739ab32056e3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live.ppc64le.iso.sig",
-                                "sha256": "27cfc76b03d42a3f936ebc338593fb640d3aad35488b742683746cb81b141c53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live.ppc64le.iso.sig",
+                                "sha256": "e1be96283b81d47b409bbc523434eeffee3273b8b5fdb9ad6f5c17faac3ef9f3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "90132d5e3cefda2f7dc246d4ef579de4fa3e2e1d864170788e5e676034412a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "1ac57384bf7457f3a130dd6672a771e1e1df503f68ed16f1f70cfb05ea911aa7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "352d2db6fa1cdcab7902f4158d8937826311fc60ec5681cb658d392693b12855"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "21301d8ecff96ad84439bed452cd923e8edc2245de016419dd2543a7f619ceed"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d6aac9a43c8ebe77a7e450f0b34de222c6346bee775738c15070ed1a6a7c2c96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "fa3da6ea40422003a77a22483dc075350c8076d05bd53c109016c23d9a6ebc61"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "133795ad5628c816ada4559f1ee6470658a88eb0b2ee721cbec411c43f52c3a9",
-                                "uncompressed-sha256": "5edd7300816bcc50e197b015f58569eda55b4e4e0cf0e10b99fb29b613ca8b09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "afa14715123f49154d5e32ce6d31e97ae4825cf53a5f493bbf8b8e1449fb9a57",
+                                "uncompressed-sha256": "5036cd6113cecf0ef70cd824ca0605293945a2c47754bd3cb4eeb1fc23e21bbe"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "168bb8a8a2210aca9bbc020a0fe645f9f4d2c4f71fb2bb533ca3570c05ea6ed5",
-                                "uncompressed-sha256": "fe01c6d2670708dc0d10c11214e0833fbec54aeb3ddfd83401c23a52cc133610"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "68bc9a05e139ae9ee635ed6e64c2763190f578c4a37dafffb61459ab5baae522",
+                                "uncompressed-sha256": "2c126328255a51f46399410c717df3f374147f186ad238a0729a1e4f50976c58"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "89d486a4d50ba8b220b2c54b7f6b57757e5f47aabe91d5189375164421920a6d",
-                                "uncompressed-sha256": "53b997cc9e9dfb261925559a952c968f7a07a0bae8bac69d29d30ab7581a4a97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "d59e2e8112c16ad00877af088c9cee4e2f10e63ecf60ee4868333f60cdc3f531",
+                                "uncompressed-sha256": "c725edf71a3046ac5c4af3344099dad090e23800f4a736e82b6b2f331d0a7945"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/ppc64le/fedora-coreos-39.20240104.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5a4fe741077c243b920d5261aee2136090712fcc782e41fcba730ad4119ed6a9",
-                                "uncompressed-sha256": "068b9ebfd58f34a06aa79e18acd7feee8c7abcc4297b87d3a4df436ee69118e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9ca06af25cc3e3fd8fe77d9661da43fd0312858b9ecf79fa70f01eaa69d4e670",
+                                "uncompressed-sha256": "ac06d3e7544a8c5514bc538ab50152145f245894fd5a65f777d01eaad5673b6f"
                             }
                         }
                     }
@@ -361,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ce65a50312aaa5167dbf010d043505827df0a51109b0a8981d35e8537c184d11",
-                                "uncompressed-sha256": "7406cb368be985673a1de308b058ec2ce7672ecfd7fab7335902d60a733eff1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5fa3b35d2b41d2cdbe3061b1eb03902a8d8c0b30636633172dda46e63b4a0dbc",
+                                "uncompressed-sha256": "735505395e21900faefd5814e9bfcf90cef0f2f5304c5c9e554c11157dd85e1c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c28952318cfd2eb64e4cf4ab16515b5c0fe08cb748bc79360e137f006fbeeaee",
-                                "uncompressed-sha256": "7572acf9e56afe43fd16a91e4887405da189aac5b6b5984204e7682cdc64d54b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1e92a441d04f39315aaeaa217e2d1d98e515803985b409b3bd003f3c2dd56174",
+                                "uncompressed-sha256": "f5277eba66fc443d96f0f5c28b1f6f8353a362160910f1e8733d6da741ba2268"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live.s390x.iso.sig",
-                                "sha256": "b2eb5eae51764393030a0c3978a945c2f3657cc932b8ca657b2618de0e64b6ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live.s390x.iso.sig",
+                                "sha256": "08d26bc459014a3675201214408851dcd4eabfc9880ecae957c47a33c830e328"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-kernel-s390x.sig",
-                                "sha256": "ee6a693814399eb97e9451034248cdafdd65b9a6ec245a25565f50e44318a5be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-kernel-s390x.sig",
+                                "sha256": "08c1bdfe60e2fcde9b226db19736e6a468aa128c8b39516e8548512209b1ffa1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "e1fc76b4c797bdbd3be6388242a46acf16e36ba4a31d7fe0799ecb78a8c06c42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3e0ebc3ce2ec7276e71e10ff64b78e8b982bd050cc0dddcab9cfabce8604dc8b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "502d78ad0f5ebd199c7a63ea4aa28bfb8db713d0a5fa5146198e7ee2909505a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "775dcbf5209886ec2fdb9920c030981c0e2a0d4955f565d28e8bf07c0aa90342"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e3186b1740d9d21c668ca0ea86a33ceff2ca6de98d062dbc3b1a4dbbaa41c8bd",
-                                "uncompressed-sha256": "192ef8aa6a25aa4c126ec82eddcdd0b04af13ff558be803187f776f59af578ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "48f4c885f1062618e56cc992671f7a54a274bcb9e2b7ff98544109a435e06b6a",
+                                "uncompressed-sha256": "08fb467c30c450416b24a215cf47d9663036945030beb2676d29e34ad449f0f4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "75edeb5bc53df2655659e22f77cff33e3ec2ea4469b818438fb96170cbb59c07",
-                                "uncompressed-sha256": "07e1b276d6422a74fa5e9604e9c756a7a2870663cb0b2982e51154645ee3f648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f4059ef682274475fe02f4ab7c47646f6f21d5a0baa4c2ce3ac86dbdc08164c1",
+                                "uncompressed-sha256": "a99fa4352759bbd1b7542afb49cce1e181c226a99cdaea1a418bcfd3af6cec7d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/s390x/fedora-coreos-39.20240104.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e9d4096d2345164f43b05fbabce218a08944fb9effd4b9a17d3ce0d09b24d4e8",
-                                "uncompressed-sha256": "2907e9b27894b5ccb1caa62649d57129c1e6329b733fbcf6c56a312a6b7bfdac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "66eed98703dde7f2fe06d6414ab14b374c501b94c4f0daf5378e095f2dca8771",
+                                "uncompressed-sha256": "0e5da7a0facbe56190dce6933df4204354de05929fddd238a43f9affe6e9d9eb"
                             }
                         }
                     }
@@ -450,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a13126f97eb49385ef055f9e545d18f404b854b6b399f488c68529c393c52ceb",
-                                "uncompressed-sha256": "29274d2ceaed598166d0f8691b6fe8d05863d9d261a974de071225da89b2b896"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9245153f4e4a96656aed3881c0ef09c7621f3333925928e335f7e70d8a37906c",
+                                "uncompressed-sha256": "ce07da29857a274fd9430636bd6a547cb8876d1f61037663bee9139556bcafe3"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "223e70e2becb278a4bf92737830599205d1f6ff031cbfec81c962dc721a1b2dd",
-                                "uncompressed-sha256": "28ce9bb7b52a9e00ef4a2d6c9a2daad91b840f5d4aa23242fe577bee712cfcf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "7d672bc8de00d81032acf3688c76d72430516cacc19bab281e3f04291898481d",
+                                "uncompressed-sha256": "6160fdd66516f21c54a2b5b0d322ad84fc878cfad1509e3bfdc8369449572de8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cf9e5adab94c7ccf35d535a9785ec7182f02772a509d9316f16109c7a9f7e968",
-                                "uncompressed-sha256": "5bb168af389c23a27aec07d3574f2ffad5946dec17a20dac1984f38c8372a6e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7d4078fb848e036c2d7818310450ed49445dc02de2b1b9093c3c418e229288e5",
+                                "uncompressed-sha256": "34ed42bbe7d6562ae2cff4e0ca43b0181d506778e618f03c4ae52e5f280803e2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8ccfdccd2b94a0f20b8faa4564a8ecac178f3a0b5f6688cbccdc701eb8859a2c",
-                                "uncompressed-sha256": "09bfb1942d023ea238926b7be08a88d3ab2d99266da3d7248c6406f47b15e18e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7f7d598b53b5f1d39b1b1355d0219feff3dcbd49dc07c04f4f3941c0f761020c",
+                                "uncompressed-sha256": "697eb6051a6bd7dd7fb92b3626ce5aeab1cc42f8ace6cc8384058ef47bd05649"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7134fde15e88420682d61e67f083702b33e406e485c45529dcaaf917a5a8fd83",
-                                "uncompressed-sha256": "83d4c9ba67dabc0816f009cdf72f4e1174f52b01ce0b1fdaadaa9719a36a551f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ae30bc718965e0ef0b953f15e62ee9c9716241b7d774a856cfd385b8582e9b55",
+                                "uncompressed-sha256": "8dcaa3db5f29fb7da1db880c77ef63aa869a0a063eec4d438e9d1d407d3a0cad"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "367e953a2b22f0b85cb37dffe540e3aa8602f644fe201128d8f052fe4835f8b1",
-                                "uncompressed-sha256": "3dfe65beec9430983222a9942a8587948df55cdbb5d34435e164e8ef48efa900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2970a8515f9f2d65f81fcd920e5773bf98785dd8a60999f47c76826dfe9555c1",
+                                "uncompressed-sha256": "6b0788a371d22555d0e671099bbdf9c64c268212e1d4dad5b3dc25f707409829"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "73bddc4a444c6a76385561fe79e3bcf32a9c0e711afb2a3cb7c241aad0a4dc14",
-                                "uncompressed-sha256": "79adbca86c0a9a75c35abd3ed449e4d6c26383793b586dee019e5851fcdff820"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e4cbadc3474a20a784891ab2eca8beadcc03b232ce773da4063ffea6f71e8b86",
+                                "uncompressed-sha256": "30cc8d4fdb8913104498b00d29035a3770f9a215657d1aa29cfba4ba36435004"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d3298e3e9505efedad11b91be5de5499a9607a8480263e62da5b565544272b47",
-                                "uncompressed-sha256": "2952d8b797fcdc08bfb1c8555c9ba66083e3c7533108de1df037a6ea7cfc1039"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c5d207a66c7c45b6eba698cec4016d0ff9233acb86be135d3d699e32f618b483",
+                                "uncompressed-sha256": "584880da90602fa82af236423312e0d65edd515697660f9ce1281f46a2a725b9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "29a8008f673bcf3e13ef98cd6f42b1eff49b33b5b52ff90515e69ff335fb5f40",
-                                "uncompressed-sha256": "289317ecb5271da1aa8ba489b6fedff92441f8f7e7175b15e49912d190595efb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0ee51d1711c198e81d127efec2d6dfca1858e9bdb85e8f2a27e56e71cf7bced5",
+                                "uncompressed-sha256": "ec482eb8237bc52ce67be520aa930a9c400dd6771d620e41d4633c04b3ef96a0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ff22acc11a320a51bc2bf99b2c30880bd657551a0fd0437932ef56c01cb42a39",
-                                "uncompressed-sha256": "0435ed4f7b28e29bfffb19f6b33a48ccdf9c6be27650d12bae45ea416c0671eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "94455404b0b7885caa659ffb58ac4a302e6d7fe003e29078c703a4cda4499ba6",
+                                "uncompressed-sha256": "700cf1e2c52b071bfd7954c8248e5487eb619dfe5ee439187598ea6ceb6dc20e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6ac4abfce322630afc3bb2282efc488338cea3da3e624c2377984598333b3f0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6e1e333e1ae3db41d9b42081b50db87ea5f66fb415b54a444b93d89ca543e9e7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3f1ab2a854e6e1f6a9835c1ac02caef256c39506e9a4e6b2ce1bd7eefb37a03f",
-                                "uncompressed-sha256": "55e35c53e16ee3578dc8e960f03cc9cf8615c30f03a30e637428dac0681abb17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e21026ff9c1143ee7fcf64fd17c1d0705a4e89ab7850aa10fc1a9ef818b6bd61",
+                                "uncompressed-sha256": "833ebda3f99ced75097fa2fafad8ebd8c40d1396ef5356dcff2b477b6da5846b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live.x86_64.iso.sig",
-                                "sha256": "330489d3272e10e5b20e086a5c4ae6639966cf8eb4b27cf415eed5bb3a092f6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live.x86_64.iso.sig",
+                                "sha256": "c370bebce47c17673099691dfb4baa8e8043edd77cdb188b4a3223455a4ff676"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-kernel-x86_64.sig",
-                                "sha256": "6e82b0768a36a8ac0ab9cd5c31f2e53b4da91c773696cc5847a1db5db1953efb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-kernel-x86_64.sig",
+                                "sha256": "ee39b5da6bf3bce33a573a2e5ceec012955d90378b11260472b0030f689d07bf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "840ae194690e1256cbe57f7b433a201bd0aee55b04a57e0293a943019c1e3074"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c9e288c1f0e942350b675e9588e5b59608de0d981da0895a481dfef0b32c9a9e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "59357847b38c3992d4c93fd2059064bff2e942f1487c483c1c3bcffe1ce5df45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f2b6ec88acb8ef68845f34f9923d686bf8b1c4faed88d802ed21a958a2c79745"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2952c02c869d5fcc235248a984180e17968b49672674a2dcb3c227ddefa93d18",
-                                "uncompressed-sha256": "07d1aa246c4ce6902bc29f080462a4c49fbccdf6e35860e31f189e8a03fdfc05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "11dc2c43cfd6becc3f50f70b18a7c74b27743134ac4b5f9cdd789f4670f36802",
+                                "uncompressed-sha256": "0a1d846fa58b68c7ee92c8629ea39d802dc47627a55078134d8b18d8395ea3e9"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8d0d973454eee4a2ddc0a80515020d89f518ff0d84df2220592650170d1d519e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d48990983a0e135eeca1e88c3163aa5125880046a157c6c23a47fef0899d61d2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ac36fc0d7ee973de8626d2a8386a9950cebd15847367bc81b6f4447f078de007",
-                                "uncompressed-sha256": "8f3f8765a19ba334f327161d9075bb7a68d296eb365083ac527318bc34d85c19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7c0178c5593b6b4e64a49aa93020d66f139dcd562bbbdff7b20449ad2fcd662d",
+                                "uncompressed-sha256": "077472ce14a7165aca772d728860f680a55039b1db06d4c7c69a7182bacbbaea"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e99983755d6aa9aa63e6dd38cdba5d83837b6f25cf259f9157c169ee43009d79",
-                                "uncompressed-sha256": "f4fde928ba3a86f24c56284ba13df210cc4a9cd1c10dbc9ea00099cf3b695a9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a342aecd9db03a9e27c94a89d436b1a2f6168509dca0ceeb9f645293650c3811",
+                                "uncompressed-sha256": "7513e7f8de75acd5548120a97333525bb17b0287c4ab0669591f0ebcccadfb05"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "9f2b3fefe442c5b18f73156a1baa0f8a3e6dd6bf222b0c3c49d1a12d60aafe33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "390dc51866f617f852e171c279e3c8016b97b49cc56e225c31d84ed28cf5dedf"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "a4528eb9848b7dd3b00ca165669f5e2626f4f17afcfe164e8a7d2915c77fb69e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "6db98b2ec32f73857059294f5c0f62dc16ce0f859f90731ab767f39c8e513185"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240104.1.0/x86_64/fedora-coreos-39.20240104.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4d0166738e7a6c115ee71abed640fa0308c12a13d4d7827097d54588858b5b82",
-                                "uncompressed-sha256": "ca4e96591275fbf4a6454c1332f1051d6222e4e318399363eb28dc5f1f492fac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "14cbf051cf0a72d820438185e24fa058ed3f8915908e3bd7daa6740a803367ae",
+                                "uncompressed-sha256": "887eb5b5d26bac1bb1bc8923f481f37bfba9874fdbcccd7d8ee1e49ec472aa31"
                             }
                         }
                     }
@@ -716,129 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0bb70400719b230c5"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-079d9e71669ad5f26"
                         },
                         "ap-east-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-05916aff210b8fc9f"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0d10c19e3980b1448"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-05c84e239941089a0"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-05179772598ecbb75"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-07c6926d3d9b64c34"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0bbd2a5c4c25121eb"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0fbc5b8d987f03266"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-04696d9b7ba84e86c"
                         },
                         "ap-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-01e2052f1eb207163"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-00aa477b5bb0ee8f2"
                         },
                         "ap-south-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-05d190783c265d1ae"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-088ea27fa57e65417"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-09d70fb10c6c01051"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-04d8344518fa4d0e1"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0676e6a2ccba306ce"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-004abcb4af1461c74"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0a716c66f8de96c2d"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-04ed617f694b4e382"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0a2521e9ae533d785"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-043223b18b659b46a"
                         },
                         "ca-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0c738563da33494fc"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-02f254519220018a7"
+                        },
+                        "ca-west-1": {
+                            "release": "39.20240112.1.0",
+                            "image": "ami-08adf37e658a97939"
                         },
                         "eu-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-062e2826a90d3178c"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0562006fe0ce35a46"
                         },
                         "eu-central-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-017ac6b6b0f133771"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0c650fb751c2608c9"
                         },
                         "eu-north-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0e20e9c5178e1c96f"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-047468500efaef515"
                         },
                         "eu-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0a4f741784be81c0e"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0fe8db5e4fe82695f"
                         },
                         "eu-south-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-08ff9b30527e5815c"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-01a62f98d476f0b6e"
                         },
                         "eu-west-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0f1296e4e82f517f2"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-010cca09474318af6"
                         },
                         "eu-west-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0281b796c2ac0ec10"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-05b613bc24c1ea6c3"
                         },
                         "eu-west-3": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0f31150f3feaea76c"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-07dc68c4ca89eb583"
                         },
                         "il-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-082a2354a9eee6ff9"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-087d75058cff85380"
                         },
                         "me-central-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-019ae5defbe9a2169"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-03c60a84d7897d11e"
                         },
                         "me-south-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0f5d6b565ef3560c9"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-00eb4a03cbb371753"
                         },
                         "sa-east-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0e2a25825eff777c7"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-00837b706dfe0fb0b"
                         },
                         "us-east-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-077c8eb925200ca2b"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-08f763fdeffb22406"
                         },
                         "us-east-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-02d95ad063b1e7e3c"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-0197bf5167b566ad5"
                         },
                         "us-west-1": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-0e72bdd1d075bafc4"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-00ba7383422398fb0"
                         },
                         "us-west-2": {
-                            "release": "39.20240104.1.0",
-                            "image": "ami-054dcbecca9935803"
+                            "release": "39.20240112.1.0",
+                            "image": "ami-06841eb2cff09f77c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20240104-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240112-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240104.1.0",
+                    "release": "39.20240112.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8fd28b850af34a20e06ffce252f1495084aab037345b5112c9a5f802b8fc6995"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7efe2c68c7b711ff388932593902262805eb4ddfca2d790a5e1d1d978f81f9fb"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-01-08T04:03:16Z",
+        "last-modified": "2024-01-17T16:37:50Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-applehv.aarch64.raw.gz.sig",
-                                "sha256": "cdf0e199101c5154c0685994c223de1fda872f7a7140329afa2ee6ee4b9e4ed8",
-                                "uncompressed-sha256": "d984a2b5d453b0e8c8307fe8631f764c580d35ad4f08ab5594962fc30fdcf7ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "3e8dbc1bd587b3b423cb81156424c96e5ed8e6a3d195d8bf27e8b7e7bf1605f3",
+                                "uncompressed-sha256": "19cb04dd25a6fecb2d1464579d9b71f2ef4a848227ad87916400eef9e3297a58"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5822dbe99c7fa8c13a2ab80fbea9a5728da4ad4265d0f1dd37db73a7e4cd3940",
-                                "uncompressed-sha256": "5049539b1a0094f5af2b0881ca32a5c8127cd88fd2dcb23081ef162a52f825eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "77a6036f8466d23b6de1bb7be246881f473e89f8056b27fbcafe057b14898f44",
+                                "uncompressed-sha256": "19e3e30a087f90f6775d1338d6304359fe21689f3a8b66c47beb6f58f3074ba8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b59c9094482e38d3e0c3d2c1dba0b9a1b3d714cd4d11b35073abcb83d31dc99d",
-                                "uncompressed-sha256": "3723b7844adf1ded92b2195cee0bd0d8d9d0362765b7729ec5029945d26bb861"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "384388c3da7ca83e36e53858de3284d8aa5d79faab007d89937ffbcb00d22372",
+                                "uncompressed-sha256": "e1521e68688c2fd2a97da7268c4fd8b3504f99419b174bb59adc3550361d7c3b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-gcp.aarch64.tar.gz.sig",
-                                "sha256": "6209e9e050d48deba4c7d5906d9f4f02f3ea11c400914d3ea340452e5984d05f",
-                                "uncompressed-sha256": "72628d53cceb55f0cb159d9b819bc4c9c54c32a1a2d4a36bf5668899832bbeb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "56c2cb9b50d3fef94e327768269b2ffa60b1ba9f87b6dd60b53890035d2447f3",
+                                "uncompressed-sha256": "3b2d94b6e34a76b2e919c1e7a4c07529702cfd39a8ef70c2c03081f60a47139f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d66d644e2989877aaa49bcfccf70af4cf5bffb9953e92c779c9165ffff614719",
-                                "uncompressed-sha256": "24a7b49223d431e7ee3c7a220190095dacdb51f6fe3f828b84b13039b47faaa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "579b3eacd18c3c42caffc50ad89430fe412154cd506b559eae716bc67964a6a9",
+                                "uncompressed-sha256": "8af79889e1c9ffe6a94e1bdf7274a659c7d9383a5121d561d695daac577c059e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2f834cf430048c5a42dd3b39dc4a41bcaf672b6d42ee7d41d48fd8bf5fc319fd",
-                                "uncompressed-sha256": "1e75b81fac17203d85101d11aadde01547c5369f9f93a817d6eea7692668d38f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3c9426a64842bfffe8605f911e57ca0565c2e5b8d814051cf0810c39cedc1c9d",
+                                "uncompressed-sha256": "13ed8a89ecda57ae654d929f86f6fd14a8ef523c71ada27b4073ec7ca074aadb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live.aarch64.iso.sig",
-                                "sha256": "1968b9338d8650e30ad2e65f1aa583a5f56c562c514fb4c176ca54829a0d5fd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live.aarch64.iso.sig",
+                                "sha256": "111345ee7551765d844255706fe4007b14d914dfd83a81470ad928ff684e2799"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-kernel-aarch64.sig",
-                                "sha256": "7b8d0485c7b70cdd881b4b728d7d87a88a49847a17901292030ed9bbdfc217e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-kernel-aarch64.sig",
+                                "sha256": "79fc1bc34a8a726f61f33a96baa01c90cd5930b3da2ce2042ce1bafcf2b4f1f6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-initramfs.aarch64.img.sig",
-                                "sha256": "f664021705586c1f0d635a67a7fb2128fb249c5baab1ab488d21ad12da40d91c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e162624b6d19f0ee15fa0316081961a734baeb9c55aefe284ea8eb9f5f063fa5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-live-rootfs.aarch64.img.sig",
-                                "sha256": "5f4b793b408e0b29ba638f0a6b57df4f0336a6f4b52ab72eefbafea158de3a5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "132e8c735b4e31a515260c5fe9b72395d969b3d150fe92124415b8598977eed3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-metal.aarch64.raw.xz.sig",
-                                "sha256": "43a4ac99b332cbc9ace50da5b613d5b2cef2f3096ee4b9521f9d1e38f49f0892",
-                                "uncompressed-sha256": "fed5298edaf28f4fdbebd99d783a32179bade3c6682f6d513881381daae4e21f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "db01cd8fe980c201eb5715698098a0b5708aa044e04a219e0c20f495ac181b36",
+                                "uncompressed-sha256": "980d70c1cc79f3800f0b004a301e1e09e72a051539015f3f99bd2de5fa76cf21"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8d3d60d4ccf338f138545b5380959e7c82af033921a326f1c5aafc862e15d597",
-                                "uncompressed-sha256": "713baf30a57f3d29616db0446c50101ce8e731b70c32959214de2bfde38b711f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3769519de0e9226e706a193fad814b8baa6266a18b952b2379de52ef9b6894cb",
+                                "uncompressed-sha256": "2f35d5048cc79bed8175986edbe128ec779bff67910c32081aae39ef3688e30f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/aarch64/fedora-coreos-39.20231204.3.3-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "aa1de4dacececdb37860ffa095ad23e58521b4ed0e57e5f323fd7a5c7e60968e",
-                                "uncompressed-sha256": "8fdb37a4ddbe4bebf2caf71abf88ba2aff0827c8985ce2afd218f4d045477c05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c5acf53a3092d36694b9dd9e8bc0b4e878b2c93a29a06e13657b89bc6fa0a545",
+                                "uncompressed-sha256": "15101a263e532e2ce291d2f199628e446e39c607dd4c4d9408c5189f6e358f72"
                             }
                         }
                     }
@@ -148,209 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0bf4cba8689b8055e"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0b4627f0195ee2505"
                         },
                         "ap-east-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0eff44e89a72b96f0"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0dd301a3732c16092"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0a4b36f47bb045fae"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-06389fe1ef3e19f99"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0af003dcf2faab2eb"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-019e03abbe9fbc05c"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-065b67c95887a7498"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-07ac7bc04e94bbe87"
                         },
                         "ap-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0479f58564058d009"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-00cedb7100583877b"
                         },
                         "ap-south-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0453bbf7319becfc5"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-024694064a7274d0b"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-06097421d42c1eb22"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-06bd2c72726029e22"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0886b34a7bd5ce602"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0ab883b0d5ffdb4ab"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-061ac7f1d67f16d2c"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0d13e3ae971f07050"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-03915db0e632a1382"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-09812e40723e5a2fc"
                         },
                         "ca-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-05ab7a9f9f80a2377"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0cbb22ac0fc71752f"
+                        },
+                        "ca-west-1": {
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0db6c8c5e190ef529"
                         },
                         "eu-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-044b2fdf88227b57d"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-08bbbc3decc4c73b9"
                         },
                         "eu-central-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0f03a28bc3a0ef9dc"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-047872adcb8e8c03d"
                         },
                         "eu-north-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0e46017822a54b820"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0eb3ebd568aed942e"
                         },
                         "eu-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-073e621f11a1878ae"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-021282597631d5f2b"
                         },
                         "eu-south-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-026af31b8c9ff5694"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-02a18493718c03c43"
                         },
                         "eu-west-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0708baa98dcdf36b4"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0ebd5e12e7d6fd948"
                         },
                         "eu-west-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-013b7502955a9958f"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-060fdd2fa01cbcfd8"
                         },
                         "eu-west-3": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-05fce37660160e062"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0164be311fabd14af"
                         },
                         "il-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0fc5f69ab35c94732"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0a71f5ff54341efea"
                         },
                         "me-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-058767e895c2e9bfe"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-09b1405f091f16d19"
                         },
                         "me-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-00575b847a3c03b3a"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0a98fca1eb3033fc8"
                         },
                         "sa-east-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-04dfdaab892da77f4"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-04e14fdd778b244a1"
                         },
                         "us-east-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-07e2e4ce85964e973"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-03c19bfaf31ff40b8"
                         },
                         "us-east-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-06ba59bf1d8825a49"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-082cd5a129153145f"
                         },
                         "us-west-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-089d3cd3a7baabb49"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-06b9f9b98b3ef96b7"
                         },
                         "us-west-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-062fd83aa7dbcaa4e"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-05c1082cb7f162b6d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20231204-3-3-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240104-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "51ffea626a4eb4337c31b7b18adb0b883a328f1f31eed6d3b47f59e8820388dc",
-                                "uncompressed-sha256": "f1c53d7e726c2bd6013a46e44fc79b6a298b4cc2efea87e0a9380d0c62921fc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "96479cdc97f61ef827927172099df5d18f8d30b0859f44000862e991f220243a",
+                                "uncompressed-sha256": "28d369aa74764a5e0ce725f877dba2105e5e76bab29e429b5a351134276425f1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live.ppc64le.iso.sig",
-                                "sha256": "ea6e2c4ac4ce29a7cf9803937549e8cf3c3790da9e4100e67db9bbf21ab462e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live.ppc64le.iso.sig",
+                                "sha256": "9c042e23bc8f6562d8510c85e9789858d90a2b5340ef96de7794b22da61d8a0a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-kernel-ppc64le.sig",
-                                "sha256": "e2cdb0e0c84489ca5d1853a52b7cd17e3b65ae4f40a7ae975cc626b111723ecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "90132d5e3cefda2f7dc246d4ef579de4fa3e2e1d864170788e5e676034412a13"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-initramfs.ppc64le.img.sig",
-                                "sha256": "baaab5c1b1f737367539210e88f46ef53cd34a69cccdc5542bf06cdb036c0782"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "a52e6ecedfa3e75cf35b48464a097e31085033080da9e7fd9e7391df2846cb0f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f25d8c4a7268be272676d5d458b4972f648f779ca6d03ed910a0bfb89a46d1cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "91526d7513401e69d0083f0c535e5b99bc21deff521cfa14a524c862b9e42c21"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-metal.ppc64le.raw.xz.sig",
-                                "sha256": "bbbfdf0adb37b50df43a6b01004eb13e5003dec68329611cc7b7604af51c9cfc",
-                                "uncompressed-sha256": "4a205762baebff53742022467ba93abd20fbb1a3e7054db853c7a5723fb2c852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "2b59436daf78d60c2ffd0d9bb63bf6488ec54bf95d061fa69a0c81e78406e75e",
+                                "uncompressed-sha256": "934b9201a600153593e96da21185f540c62c088c3dcba027bedc03a780a73016"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f058e9330e6b01caf6d8bd164b111b2edf30788735964b85e2cb9afd9be7bb65",
-                                "uncompressed-sha256": "2d91e89ba862cd9e83c572b60e7fd494cd3058bd2d3433b2f1e8356dbf3d9d98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9df21a3f3853ad07ea77dbd8decbdd73521978a56968adb1079ea9060f867509",
+                                "uncompressed-sha256": "39302b75f0c7b092896c5025c3dd849d019a3d2fc670fa6d0c7997b4a3bcddc2"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "aa209a290dd117b24389b871c47efb574a43d11f8950dddf22ab5150a82bb8d0",
-                                "uncompressed-sha256": "a1954a8f12c93045a50e2534f3fce35d02816fa88e22f8eafb6bde16e877efa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c88c155141e8a731e36222c03889d088715020a5706fa13ebec5a2074e7122f0",
+                                "uncompressed-sha256": "c508439cc2ae7e7693abe16d7df3453605cd65999d2321365881bfd167917fd9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/ppc64le/fedora-coreos-39.20231204.3.3-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "8a72267be3b4e2afe4ee89a1c61ff6c0c097090406462643c82420c480775700",
-                                "uncompressed-sha256": "fb9991d11a58b8c14915ffe1e3833260fde11b4f681702f3f51a6a9b202c9cad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2ce44c3f0a1b9a6933339c155c4dca48fc772eea3804d426e78b00a33c5054d7",
+                                "uncompressed-sha256": "59d6ac481c9a2eb24deca753ed312f9b53e48c42e9b606d60c3cdafee86cd7ac"
                             }
                         }
                     }
@@ -361,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ce53137aa82603b77d5cd392affc21ca76a0ea10104953de785140466f087be8",
-                                "uncompressed-sha256": "68141963761c7cfa6c252120dd08af79838bfb8abb89df811303b49289234374"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "452879ac2ee96dcd56ca4647d7fb76263a958c69ca73df0c63f7b1cb0bacdc44",
+                                "uncompressed-sha256": "f7bf31a4a415e1b56ba507815f46a54a5982e4169d20f433bca62e6a0105fcd5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal4k.s390x.raw.xz.sig",
-                                "sha256": "dea8c2d7c87b97a92f8a0a9d27bbb033759a4ded80f17ee8ff74adc598ce122a",
-                                "uncompressed-sha256": "070dd82989e88cb3096237a1eb2d804e21652603478d119dda3178e3cd4fbfb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "10ebd278ce4822f25744acf1aa6f337d0bebeb715ea0979c4bf217495def45f8",
+                                "uncompressed-sha256": "504eac097840a7b580545a1de99edb06b1e43a339ee41b001061efba55e88f72"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live.s390x.iso.sig",
-                                "sha256": "cab8c896df85c348f426fec613ae33b824a7ed0e43cde1167e42e739bb472c7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live.s390x.iso.sig",
+                                "sha256": "779a36b070532b94188e9389961c1c3ff8de9ae614eeb7fe4ead6092836f0602"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-kernel-s390x.sig",
-                                "sha256": "7e7f58c54b7f843a8391e7478a33826e152088422497416da0ea342301405dd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-kernel-s390x.sig",
+                                "sha256": "ee6a693814399eb97e9451034248cdafdd65b9a6ec245a25565f50e44318a5be"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-initramfs.s390x.img.sig",
-                                "sha256": "cac8e8d765198040f86e717b6fd9231495c6d6b03b98a793ea470d0e2b4b20cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "9b93d5c632d8d74baf45df5ad7bc184d4224544919b5d5beb34fff4d45509e79"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-live-rootfs.s390x.img.sig",
-                                "sha256": "16cbdcc2bf4ebe3cc850786592a5314786d1129ac4a1ad2f5ade618a96689e57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "663053ae515db5923335d3a48ab4171ac3dc087825d5e2ffb0fbd16380c3e772"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-metal.s390x.raw.xz.sig",
-                                "sha256": "f8904de185afa71f9339ecd143de8e96f104540acd8dc8cdafe48b3af948ade1",
-                                "uncompressed-sha256": "935a446a9b240dbb1ed02ddac1278571db19009a747e0784b8d4783343cdae00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "660dc01ee0f7eaf839eb22695c7d5a4989440dedcdbf7887731f4a0d5ef3742d",
+                                "uncompressed-sha256": "2f2a5e112d24cfb6c748216f4c941c1b8291acb3e66fe79e61372a2d127ba0ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "78796658909563e5e25144441026f409076264298ba2ce229445ed1e927c3798",
-                                "uncompressed-sha256": "a2306dd72e2b1aebc3c6f5d365813f5d295de3ad6232e1d8cd39e93696cbe423"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0796d79083a30d7febe238100ff432aae7756beaa0be286f0b31f48b7558f9ca",
+                                "uncompressed-sha256": "4a46df1c8bb9f41a1edfa1eef4ba85571be07bf294bc4c00e327cabef481fbba"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/s390x/fedora-coreos-39.20231204.3.3-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9ea4e106bbc65b65c888b091c2ff79b2f610baac65508df2edab1ec10518cb51",
-                                "uncompressed-sha256": "000401ca7200c12565ef376110fea3307c9b82023a68481c4f6abb7880778e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ebee97c2308a24f50eff20b5974d6599e6c183c7035c4d4a17d3a3fbe997cb95",
+                                "uncompressed-sha256": "8112527848f01cd4531ba1ddc5bf17e9ed0105528ce34c9d1f8981dc0b61470d"
                             }
                         }
                     }
@@ -450,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "54ea1de722cbf2f661b9604900c7c332049a0270941984ff5d3c751c67ad45bb",
-                                "uncompressed-sha256": "1fc4db7be47979e6c74065bd88acebc7364c1eb1ca24b4d6be8aa5d65709e18f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9b8b7d5100a3cb7cfc0cf8563afa55debee2305bf0d7a13c51f6871048bc7190",
+                                "uncompressed-sha256": "5617de11e457cf42034089624c0ec855cba2b65fda96a621dc2b721a982e5df4"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ec99e8fa05d7c9d1fd9aee0e0d3b5ef4f9f4ce11467e2f6eb833611f985b28a1",
-                                "uncompressed-sha256": "279d026b50d92d3bb6cfea73c733c7f86a8e098f4722961d94be400f30382435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f82954d44344eaba3ec800a1d6a79ebe862905480fdee8b6bbb86284f03dfa9a",
+                                "uncompressed-sha256": "fff26ec770f50c8c9d1934d04ed3fb16cf363ba611b280503e5bcbc55ce0fc2f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f7ea6e4bd532757fde8e746b621ff81f09ec77dfc8156938896d569ef9ef3618",
-                                "uncompressed-sha256": "30c5cfce980c8cd601a29c24a22346f7f0f99e5140b4eeff8d70b73cad8c559a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "795463a9a9dd2049a1acb95c4042824f988dc07900e288f5105b11a1656af0e9",
+                                "uncompressed-sha256": "05ef687cc93cf2007b1ca59259368e8b552b2ca16bc85e3a9d9a7a4e3fe31ca5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ffd81772115ff9316ccdf7fcf9b633f774842c35301de8c374c2ac9435e26a3e",
-                                "uncompressed-sha256": "8a1edbe03c51397bd55d55d32020b77ef10aec495fc8cb81dcf8227d5e92d1de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "aabbf4157b71314acb5f0e608652030cff877f9ebc25bf236007a85e66f0584c",
+                                "uncompressed-sha256": "a9da66ae5812c5bb66fce5bfd774bcdfee1a77cbe96adefec71412d36b0e7aae"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ec9834f66bca6987417f567ad64b070ba4080f5554ff763c9fd37303c2c19aa2",
-                                "uncompressed-sha256": "d36ce2984b4e6707593e1c2501ce5e575dd34b6dd8caf78b0cf6d19688c9083d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "98a14a5a39b396b93d7f64cb475bae796e0b9e08881b4608256b616b98c7055d",
+                                "uncompressed-sha256": "c0ce812b3ba0ff91de8f2a0d99f940f62b9e005094de99423d262b52df83a991"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b8bd2e1aeb7a94e6f7d3943178591450e2ba79f3b91e13e863e1408a73d15414",
-                                "uncompressed-sha256": "406cc2751bd6b39120228dd54c03f3e59ef680cb7b4ca7e400c0972c0a10e42e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "465b2f0d8eb9a82881ae2b38892fbf2913ea673c381d51a0dc1c7562d63aede1",
+                                "uncompressed-sha256": "6135c42b8a0e8ee5427549e212ecd43866aa521cbadbd0eec8452a493aa9ec9b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c064a38a674824503dfb3686a5b6828070a15314c7bdc87f22423434b73f2929",
-                                "uncompressed-sha256": "e411009b37d05121d8c2ff7395d49436914e6207c08b8a21b13c258ae4b6096f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3f0167f6e15e859addb6bf26cee04eea8c84115d7ab365ee566d0c34bb6f95f7",
+                                "uncompressed-sha256": "4039fc4ec9b71876cdce187fb48442bb272dfbeaae9b6733c7038738484e13f6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-gcp.x86_64.tar.gz.sig",
-                                "sha256": "88aaa370ee74c1f38241a9f10a5ed51fdc1bcd6a88cbb18209e44de9291e1ce1",
-                                "uncompressed-sha256": "f584f80a9cbd254bcee532172f61fd856e9c4fde8f37d68b9cbddbf367566240"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6cf947f42bb78db37ca5437a6094f532858b4884ff2ae060ea9077289e16fe6b",
+                                "uncompressed-sha256": "37d1ecc310b00971fbcc4a950c43951ecc9f684c0ee5987ef88058cf73299b33"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "b3ca8a329c112c3df757d71e77c29bc288aae5ffd298faa4776b432c1b0bbe8a",
-                                "uncompressed-sha256": "1ff0d081ddce4c53d0c6880dfb4417697f01a23d1bf713233dc363037ac56213"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "28dbbc4524e0cb5317c41ccb4373a4cb8a3c1a01f9414a96bed4b47350bbef0e",
+                                "uncompressed-sha256": "16d1e0ef6721d30fa22b95045c8a79e80ca5b23d6ea4d7d96ae6c618f2bc889f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b9f2d544650c564001bd122da2fa9e960d9ce5636efa51366c1fb0f91901e80d",
-                                "uncompressed-sha256": "8a963cd298c2de4205a5fec12995ea50f675e1eef570f0eafa1dca95657f1ebd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "705b6316e6c8c3aabef5bf0eb167f30fd40f3aa10cf8c1826b9edee0c091a200",
+                                "uncompressed-sha256": "d5275aa30b5c364ce377a3c12357836cf5ff429f5ad132d42c3f05af8c61af8a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "aa1e16f85da0acf01fd6993060adc2081cf41101104b56092fde43efcdcdb335"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "57753468a6b482c7903fac3ee13d428c1751ef2927cbf314d01e2a77aeca8747"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "22654dbd04cf9e2ff37521ed9a310e4e132ba811c443103cdad334360a3166ea",
-                                "uncompressed-sha256": "e1b470429312bdcf800f2529a85744a917fbc5f05e3d3886357115e5ef932804"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3d7e20480717973d5c660cfdb87b3cd5a723c17068ebaaaa141e54846be0ce24",
+                                "uncompressed-sha256": "77dfc0abfe91903a8191915179a92de11a75501f43c6d61974a31690097a7f2d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live.x86_64.iso.sig",
-                                "sha256": "0d92887c5e001ee4d0ce3d20b88599c6d5658304181fbf4106dc64ef2f0afd53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live.x86_64.iso.sig",
+                                "sha256": "8c8c602c96c98c3dfb5af11e3df562f335f07fe22f8f2aa5c908d728d2478dd7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-kernel-x86_64.sig",
-                                "sha256": "5490e2d24924f2f9a71b5cab901d6f9936ad9ad5190f3021b58adb4f2e7d1e09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-kernel-x86_64.sig",
+                                "sha256": "6e82b0768a36a8ac0ab9cd5c31f2e53b4da91c773696cc5847a1db5db1953efb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-initramfs.x86_64.img.sig",
-                                "sha256": "5b7523c13841bd938a43124c0b603fda6355ee411797716c97ffc7d7d926da34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3bae21c245230a38b022f670d89f607f6e105d23e6d57969dae21f174ba96494"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-live-rootfs.x86_64.img.sig",
-                                "sha256": "fe4b85ea35746f6f2efadb4909519bab9fd83c2e27fdf21ffa44721416567904"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "91e5c300f87243fdad6be468ad228ffac8b6b20dd29cd3c701eb5fdb6616ecad"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-metal.x86_64.raw.xz.sig",
-                                "sha256": "5d36d285870f9285a08985ff6fbce83ef9315dd266065cd5755f7ddeca06f8f8",
-                                "uncompressed-sha256": "c570ab2739a193f0b926581d4bd08e4218fa2e4fc645e17751e94f06f64b1191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "55a3f63a4bba46bb3a6cc26fc1d46bb2f4f6afd6d9811d066199c6a7b05c3b8a",
+                                "uncompressed-sha256": "217d91b17e24dec37deb68f354e8c6d69228e9c0c808db2ac787edf15b65ff56"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-nutanix.x86_64.qcow2.sig",
-                                "sha256": "728a876037cb25e1926578bcb45ecdadb032bdf6e898dfeafa96ed9617924ae0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9c407bea92b5406d8ffbe80b18041eb022d6a1bd296074639c27546002174184"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e04c465000766f9e3d9d98b0d7e366072b16e616deaaf839d75621bcf77fee2a",
-                                "uncompressed-sha256": "b33bb3824705fee3c5058989c71583ed01b9e2f9ac6e8e2056c51b8d894f8b76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6ea16aa14590237f63efa3b0cc68a0deb26de5f4f1ae26a771a3150877bd45eb",
+                                "uncompressed-sha256": "98953e008e1e0ba88365ea7dc705527608123e87b161a721da8ca3a1cf899d9b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "df4b55402472dcabe7f19e9215193643e5e34513d20afea6f1d7326ab5b3c239",
-                                "uncompressed-sha256": "33ed90f2c1b77af693cdaafb058482915639b5f093fbb44851f5820aadef77e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b2e4c07b8ac0e96b39af58f7daef9829536b534ce6e774dc14d54bcce000a81c",
+                                "uncompressed-sha256": "280ee50c8b3f932fbe2cd903adb592b83de6f66910152bcd092e483d8cc193fa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-virtualbox.x86_64.ova.sig",
-                                "sha256": "a10724a0f0955ffc2bfa327f5e8efec07d5904305dd80ee3c75a24f2c5dca26e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "71fab5fb80d763325fa09fba10b22916c9b6c7934bad3c01f70bf478e6802552"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vmware.x86_64.ova.sig",
-                                "sha256": "4a2db73ce121080de5b7ea1e1384f938874e79268cfb135cba411a28f59ca511"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "d562b49dfd8c39cfbd438ff9c332ab7b3fbff5b7275c12419680671ae24aee29"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20231204.3.3/x86_64/fedora-coreos-39.20231204.3.3-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6fd4349cf778fabcb7a149e0fef8b4fef88ad9e0ca43e09e29c6da7842d726e8",
-                                "uncompressed-sha256": "0b4cad168e9e3560d2787b2bd00f02ef2de77fd927643ce3c564cf7e9aa7df89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "edd7bbdd97986f1293bfa0822a16fa9bcdd33ba3a89eecbd11269c641b92e434",
+                                "uncompressed-sha256": "d70a8f96965124e3cb64eb735055255b0d999ec43b9fbb756a1563f3f05dfe4f"
                             }
                         }
                     }
@@ -716,129 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0374c2c2c99b025f4"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-06221efe62934b28d"
                         },
                         "ap-east-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-00ef05e1947320eca"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0843172e925d739c5"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-041a51fb06cdf9ac5"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-06cfd393abf09571b"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-084b22af326442922"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-012dedbde605d3b29"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0a8886590ac6edebe"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-088ba4e1cd8a04415"
                         },
                         "ap-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0e8e86e48f3356893"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-04eae00021a933d86"
                         },
                         "ap-south-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0c97f3b036d8cc316"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-069f2a5a5878df7e5"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0d9f823426976e948"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-01b7437de1b1ba5a3"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0e88d462a4ec3df92"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-061aca53ae6f96986"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-00c0e34681d3cbad1"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0803edab7665c3c14"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-01d543cc917375a9f"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0cfedbf201aeb8451"
                         },
                         "ca-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-058e0992730b83906"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0757f261206dea0e3"
+                        },
+                        "ca-west-1": {
+                            "release": "39.20240104.3.0",
+                            "image": "ami-073959ed3c1f502ee"
                         },
                         "eu-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-02e9608cba618ae1f"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-02553390fbc866b75"
                         },
                         "eu-central-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0f757b44e29484ffe"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0d01d72cc2ec16772"
                         },
                         "eu-north-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-05597fbd724541d79"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-082baca36d3c5b8b5"
                         },
                         "eu-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0ed35b69c942be0be"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0aead8a5bad6eb65c"
                         },
                         "eu-south-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-08d6a58e98b30e07f"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0e520f880acfe649d"
                         },
                         "eu-west-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-02a1b04757b6e95a5"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-07e74c60b3aa40682"
                         },
                         "eu-west-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0f2ac699db09839a2"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-03897364e55b98062"
                         },
                         "eu-west-3": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0ae6e62dbc92d7a9f"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0b59be704eaf46af8"
                         },
                         "il-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0b48ae7df16ec48c1"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-092e3262a185e6512"
                         },
                         "me-central-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-08cf62c281a64cd4f"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0723fb8f3de07e910"
                         },
                         "me-south-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-02814cbaed2da5b38"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-02084b29d06302e19"
                         },
                         "sa-east-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0783fc15516dda074"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-07152fa34cbbca016"
                         },
                         "us-east-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0b279754b116c7fbe"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-07f6bd5eae6faa520"
                         },
                         "us-east-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-046d1d609b6f00b34"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-0db4527520455e4e9"
                         },
                         "us-west-1": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0ee0f695249f081c2"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-026789f7c77caa129"
                         },
                         "us-west-2": {
-                            "release": "39.20231204.3.3",
-                            "image": "ami-0626300ab248300b4"
+                            "release": "39.20240104.3.0",
+                            "image": "ami-06bfc30ac7b5fbd32"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20231204-3-3-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240104-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20231204.3.3",
+                    "release": "39.20240104.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5bdbfa55cae52d877ccf115fe3dc6d56a8e866310950adb056442c60a0e7f42c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:940a1844dd4549122bf449a841ece86a6822ba1f1304b95f7d6cc4d39dea7ebe"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-01-08T04:03:16Z",
+        "last-modified": "2024-01-17T16:37:51Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a9f5be91d5a95c666adf7c014532616efc1b86c4953ff23603daf67a964b8d12",
-                                "uncompressed-sha256": "33b8c49ea3e8b0b04a3a1d66279337a6c6eb0ba6ea5d6b521912c2eec9cf1364"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "44acc22b1f7c6924a576bce81688b98419264507fcd1dd1b6052716189d4e39b",
+                                "uncompressed-sha256": "b372fc157d21a7b38c0c25c34b8fce1179de3f59e4b8d83422582ed27f43c829"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4925091cef472d7985b34a5ed3e8b601d5b327008e8c65767af2296b0d04aad4",
-                                "uncompressed-sha256": "132680e8ac8be76ff5041bd7d55f191e5a792f5b7889e9a63aad1e564d75a7b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "523afe1b81da04e3e0446275c5b7fd2e081934b76f63569472d9006958f4bb4d",
+                                "uncompressed-sha256": "546921d1723079d694f9bc3589c77aa357402c59a4c7667e0fbcce854171fb4c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c2f043658470cf11bb48708af11f9fd183d88f070649fc9d1d59c6f9c92a7d4e",
-                                "uncompressed-sha256": "29b26b849acd20e1999f727b995efcf77e034761de5eabbbf9631f5169e3e520"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "684b2122bf5d6fea15fe5e9eaec22c51b077e25cb58668d08b4a80c4ad0ec506",
+                                "uncompressed-sha256": "1d9d88490acfe8265fa70bc64c775af1599f0595f583753b48fff1640de32178"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3e92b2b6b6ae9ee8bab7a3a07d8897b3a48bb40a230a6fd9e7ec41dfe3c1b8ef",
-                                "uncompressed-sha256": "51208457f4aed4cc69158a377148421775c79a87854dab9c199044b5164b7fcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "25b34b8113af83233d02d8dab17986c4dae8438b7d417ad37919f7e89843f6eb",
+                                "uncompressed-sha256": "60af974eb0e1dc7dd7fbecb2215f4b92961396b77d445694cdea87c9a5a91479"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "656752175cc4deb04c4331a6c48206ef3a05de0cc99d8ede4647b683d0b67f5e",
-                                "uncompressed-sha256": "4bf090ab5c0cd4e019199bd19977c56527746a6ac156fa39c05d053a593ab3fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "9c7a6f587cd006327cb5ab77268d3b3f07c8630f929e6c2ce884e12f2701aa7d",
+                                "uncompressed-sha256": "109f82fedf971741b223f345e705ad3e316d5ee55c4e778fa0ce9cffc2ae931a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "221c840cc8aab28cd1b96006f45db45d89805f34795e7af2a888f3d0c64988f6",
-                                "uncompressed-sha256": "32b18e4abb3bbbe3da544de98ba925e0aa1e7e25529f118dd48a3c8407a2157f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8fe25c5d5c89e6eebc725b71301accc9e0c46273a8127b31a6dca08f8b15198b",
+                                "uncompressed-sha256": "75a1986bfb1f6e1d03cb1139362ef5d9b3f9f42d947bc6d686ec4b847eaede2a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live.aarch64.iso.sig",
-                                "sha256": "5ed2417a7ee5563a30eba8411339d7c308666eb8ed6b98c35fe71f555e5f3c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live.aarch64.iso.sig",
+                                "sha256": "f7338bbe6530bfbd621e6b64fc75b8e775185db08e4520abf93ba43d8c738446"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-kernel-aarch64.sig",
-                                "sha256": "79fc1bc34a8a726f61f33a96baa01c90cd5930b3da2ce2042ce1bafcf2b4f1f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-kernel-aarch64.sig",
+                                "sha256": "608bca9610637faad7d468c5e03019ef81a903cd0a3ddc83cc4f693729b661d0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "306052d52bf3beab83ad4812e55da59f6a3b5908c979c47e5ef7160df6ac09ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "4992b50ace7634c711632a8560a7a8621b47aa4d4d86ccf6f399714cd25bb669"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "29f639151826ec8d143e3da3bc95093b3578e9cb60cb27829a23c0a62392d8ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "127afc4f07e0676137addbcc45a8f4cf2c18081c604f899d2b527f92523c4309"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "164cad0d78ccc810f10c0c3ee90e408e1f583ba424db61f58618697d1dcb4b9f",
-                                "uncompressed-sha256": "3b60c54e32f84239813e5e0e993d65774154e91d9c11537a45d4aeb51b408b07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f2b15feaebb94907c96400354d8bf22010a28117c92bf67afebf9ba2a91e36fa",
+                                "uncompressed-sha256": "e6e767999551542ac245874d35931b4a91e2b29324d40c2cbf4c810e34f61bbc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f500154e22e66a58c143df530332c3a1f4dbf1d572704bb972501016538a7201",
-                                "uncompressed-sha256": "3def6351efb4468be1a27114d220081ae8cc49f045f1344b1fe6cb9b02a590da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e86f31f0327077affd957ca9ad91ad5c652d21d5e8a08406a9552bedbacd2d53",
+                                "uncompressed-sha256": "66add86844f27deca1aed489278f8251006d9860c851823c3d909b1c6fa291ac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/aarch64/fedora-coreos-39.20240104.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d62bcf81aa7550c0acb8861cba59b18722a63cf1937ee7c49bef67d4fd755331",
-                                "uncompressed-sha256": "84dc792f9ba862801abd8eab2e38e67547e713a57204930c11f350f358e5f888"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4b2df74ad4d684f4044ce796f4a8aab4cae62b72c167af5d7d8aabd03196186a",
+                                "uncompressed-sha256": "1f2004aab9f7177fa3bfa6bc7dc1c86a8c4dd26e6efaef739c9254f2fde35a82"
                             }
                         }
                     }
@@ -148,209 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0e590ee74b99d4415"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-061b920181195f921"
                         },
                         "ap-east-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0b0e77b54414b0c32"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-003b35299ee0176ca"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-02818ea95752ffc75"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-083719325e20262c7"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-01730daceb6d58e66"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-01345d19a14c9f0c1"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-041c4a6971c361fee"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-030e3aee8b314456c"
                         },
                         "ap-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-071ce226b8699210b"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-012b7ef31e56795f5"
                         },
                         "ap-south-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0029782e1d8bd71bc"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0d1765cf6225a0b66"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-08343da5170dd760e"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-01f5a398d14b53fe8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0afeae7f7c324337f"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-02118e41ab92ac7cd"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0aff5ff4bb83a01c8"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0e7cba6203ed0e886"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-04edfe821c856d9c1"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-05a45357f5b7cd1d0"
                         },
                         "ca-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-01507b9b235993e6f"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0386d30945c6dfa5d"
+                        },
+                        "ca-west-1": {
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0dd834eaae53e05a6"
                         },
                         "eu-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0e4027261a934fefa"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-06ee14386a144459c"
                         },
                         "eu-central-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0a27acfb2a5b248ce"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-00e57ba426562edf1"
                         },
                         "eu-north-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0f273d7af215930e5"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-022f32b5850273e66"
                         },
                         "eu-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-020ef22f9bf44241a"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0200c87af9da7216d"
                         },
                         "eu-south-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-004d8a1dd1cb9b938"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0c3b3942c29344621"
                         },
                         "eu-west-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0f8dbc64955518fe8"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0798087a33f5d4bb8"
                         },
                         "eu-west-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-09221f721308f208f"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0918f19a06c15ce7c"
                         },
                         "eu-west-3": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0fdc15b3eb689080c"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-06d5c020d4bb1a078"
                         },
                         "il-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-021e5ed1dad357d97"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0f1477c3a3c1c09ce"
                         },
                         "me-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-07eaa1273df101b83"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0e115f77eba7ffeb6"
                         },
                         "me-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0aefd9fdb03106828"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0e833c4aba080941c"
                         },
                         "sa-east-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-04d2754b54aed243f"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0d1fc539adac60eaf"
                         },
                         "us-east-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-01d497a80eefe6f73"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0a41b268f64dc18b0"
                         },
                         "us-east-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-06ac8591187a6e7be"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-04a0ee375379c0abe"
                         },
                         "us-west-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0970d4e1027017ab1"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-07256e1c1d14257f5"
                         },
                         "us-west-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0d24a467f25d5a2fb"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-08ed3ff4a2285099e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240104-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240112-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f8cce714a87f8c03abf1dde6c459d788496b997ec4a4e7ae52305ce9a5c91880",
-                                "uncompressed-sha256": "acbedb34be3b6cd650a87dbb8c8623099bc672292c9d9414b8cd48c486f3368a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "cee14bae44b3fb207e339541f733caa2faa1893931516c0e7c759c349c568e64",
+                                "uncompressed-sha256": "031a6d2405bb12461eda69d6639946e308c089d458372627d6beb3324496b87d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live.ppc64le.iso.sig",
-                                "sha256": "ebffa5428f7a952d6e212e223f5a527744eafbf050cd5281fa20c03119ac775a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live.ppc64le.iso.sig",
+                                "sha256": "73420798e47e59fb7590decdb695d5699331ea24eb4157057f723744b7fc974b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "90132d5e3cefda2f7dc246d4ef579de4fa3e2e1d864170788e5e676034412a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "1ac57384bf7457f3a130dd6672a771e1e1df503f68ed16f1f70cfb05ea911aa7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e5151f8b1fd08b4cefb1bf31d3308c6881b54f7553d797a6bbac3f2f9e75a0ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "4e8912ba15341bad3c069f6312f104a124d91dafae301f5ca6e38ca32e2c0815"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c409a3915b45d82722c225778d2ce07a4ed14517be99911a0699071a57e1f929"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "17a886e78bc08cb7d05ad020929f05708d414160964e87abf66233d9a846f4d6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a7f33c529eec874632c27919939b84f86de8066a70ddb35dec94b66584e373b0",
-                                "uncompressed-sha256": "128ae42afcfc6d64c87b1b7cf8de4b26622f06606058c892523d8f9b787e3e57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1a5d0c4236d12d75a8c5f28af537b0226d3e5b1eb0319983db96b2379e22c0e7",
+                                "uncompressed-sha256": "80c756bbaeb1190ed0d1f4297170e34bb357fc84d5438bfe719bd65655324f23"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d5da2a3ac99f46bdba21bb5055a687db83d0478ba9a79db47240d97a2c30e2eb",
-                                "uncompressed-sha256": "1c702d327318aa211d4062dbc797bd54043eb4a653a6a20cdce194433dfa9cf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "b73d2064ff7ab07bdcf6e89f7ecb713edaf9aec69fcc43c3fad8a04d36abc705",
+                                "uncompressed-sha256": "ff31d554cb9ee1b0363cc0afdea138061da03e339d891d73942527c164ad3b54"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "fe2569339d945f093cf99213793ce992c985aa6ff4a4c58127232e1f5d910b79",
-                                "uncompressed-sha256": "bf9042beab24a70cec2b5f815d8691399e1c152b38f970897608565d1a4710c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "791b509aea88095b65913e98c67cafb9d890adf254d279999639092572e434a5",
+                                "uncompressed-sha256": "ce9fb20a28333e7fbdbf7f3aabdfe8436abe86ab8e6b30f0ef76c533197fc8bb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/ppc64le/fedora-coreos-39.20240104.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c0f1bf7e39153ba280bc6ed5921f05383cbfcc5047456fca68deb74dc5b28ee7",
-                                "uncompressed-sha256": "2f9baaf5cf545801ea8cf9c2aec70e2b95e66a4b5ca886465e46ff8d3a71b9af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5e4007cf5aea2349d638e91686646fbff7eb1288811ea603d9f8c3c7e8534d40",
+                                "uncompressed-sha256": "a52650a0e32e6b4052b3d756eed8cff5733a6fc2b1c892e7c7809f896cdf7194"
                             }
                         }
                     }
@@ -361,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "1cffd6c90f2487673981ae7d282a283bbf0c7b06dd957e7fd81fee06ffbf34f5",
-                                "uncompressed-sha256": "b88d0c15367fc0970581d1e996daac0b90ed7b777569be49a1ca651ff32d5969"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "164ce084ff2d59b290692f50aebd9779f6a4407a990e0bf93ea385168abf49dc",
+                                "uncompressed-sha256": "8923381550c895120c2fc64f494cbd847d3736a41e21c04ca0d77c5e15532349"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e1a6ed880fd81495df40f407e9f7e117a88007a0fb83608e5a0bb031b2fc36f3",
-                                "uncompressed-sha256": "1af716299e29c0da6ef65aefe15d3667e133967be0b52c3434da424d0d76b4f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "76ee7a2e1eb025bdbcf578e43b618b0f4dc1ddec833995ca4786cd98fc4badb3",
+                                "uncompressed-sha256": "35808fb7b06ead62fb3714c8af4a0c07548f5c8d6a01e4c787605db214b33c5b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live.s390x.iso.sig",
-                                "sha256": "1071f10868bed105b9586efa420a6df8b4360e5f076a130d1dc9e86f1fbc36f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live.s390x.iso.sig",
+                                "sha256": "4d27c2d5dc3cae8cb8b6a2e4e52724e0af09d33c9f203af727c10ba5640cf56d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-kernel-s390x.sig",
-                                "sha256": "ee6a693814399eb97e9451034248cdafdd65b9a6ec245a25565f50e44318a5be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-kernel-s390x.sig",
+                                "sha256": "08c1bdfe60e2fcde9b226db19736e6a468aa128c8b39516e8548512209b1ffa1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "55e7cd6a0728fb23abb9eaf6eacd1e582a919707d391e922fde1639a75ef6c73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "be3e384663e6be968fff075e0f26ab816b6864b515367e3cf5fc2b7dd50ae036"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "3a9266afa8e8fb88c996bd103d516e032f7a10405d6a0ce7af747ec91ef7937d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "58cc3eb73c39f3c498ff121ebcb5968375d90a8de45b491435c710fbf5bd9c6c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d4097dba3d223113493978a5b92dbb8a89d82f03b51f41883c849d9e47ead06e",
-                                "uncompressed-sha256": "dc5004df55ec926a233e7ee4f99f3e9c6935739beba99b023584a75611f3d008"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "02ac355fa28f8b29d70e7966860252ffbe8a3ad4f9cb5e9a4d7de5b7a37c94c5",
+                                "uncompressed-sha256": "b62db44cae8400d2348cedc3fc09df45c9610348e7760834f35ccfe27368965a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "587011441817701b565136fb498a34b2a6f943f37a2cabffbbaebb52ca4e2b7c",
-                                "uncompressed-sha256": "86ef4922ac8476845b3ae75b1e70c95cbf06b484535c0809517cbb1d706c4194"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "01789cd85aaa9c81147089bba3472711a96db58c4a23318bc2595dc93b4c1efa",
+                                "uncompressed-sha256": "ce03a51ca064679dd701a4e8c31d9b45e3561a92295166db949c502fea3578f6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/s390x/fedora-coreos-39.20240104.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "76ee578c972e3614ec2354d8ffab51621ff8b59fbca6313f6686aaaae42e8cad",
-                                "uncompressed-sha256": "15c4e64c3ade663fef2b0831ede992e5d023200ec5630760a757842e5e5739d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c83b119c6fed84676872268690c402109b5c81fef45819e25fbba8a1b94b8db6",
+                                "uncompressed-sha256": "347f7a9734e04dd17c8d76ba675c53eb6412863dbda753a016dcfe2c639bfc1a"
                             }
                         }
                     }
@@ -450,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b71b3a0a7f5bda92dad6d1a571ab98bf2dc9c470f6d7f42d721842a4570426f0",
-                                "uncompressed-sha256": "60f016188dcc23f3613d2af94e011061a6b5fc6fe6f559b46c27e7767d70e040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4d3576e09b720532679715a852b93156502fe27cde06b24159857275edd1d8ee",
+                                "uncompressed-sha256": "cd5d344ab359831812ca9f7a3deea6132566f2effbe7a1f3906d68cf6c5047b3"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "92741ecd2dcda50b6fadd4df9fbb752a417d749793a44b6d67765fbf494fdd5f",
-                                "uncompressed-sha256": "79cb0d957b494521842b3331d43eb091814c06179ff163523ef918194505ced7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ec494e47cce8352ce979d6ee5d65c66a06f433546d939537b9ff8ed35aca84e1",
+                                "uncompressed-sha256": "ae3714e675c3793f2d9e5d57e5148f4f8f2c630706c86e0a7dfac2640602faf0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "fabe3d5bed81f2c3c8ee6be6dcc2560eefc79b9562edcbf7562b3927d5b3b756",
-                                "uncompressed-sha256": "86b95ad6fda64e1a87309007a0dee77e0017468d7c7650792d77c593f837dfa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f449bb1ade3aca2835f14f54f9eb3394e2a786108ed349153b85f54149430351",
+                                "uncompressed-sha256": "2430fd078ec2653c543b2c3f9b0c4d94ef1a024c9ef619b2bdd3f57255580c5c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a2ba7792a1d2b9788e0a69ab4d423aa284370cd120242975d478d35e080f2746",
-                                "uncompressed-sha256": "8f7b545cb10d89b321320abd9f36b1b55369bb5934645824c7bc84a28d3dc92d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "896b0a3063781e4cd57a7c93e9e11eaa7b8654cc993f12d3b21eaf25e601a2fe",
+                                "uncompressed-sha256": "fcb47515ea7657f5dd816485b24def450742ce592ce4706ecb2b6a19dd5bd668"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "38de9d7df030ce302eae888e914fa07bb06908ac4ba2125f28912d1a31ffd83e",
-                                "uncompressed-sha256": "f78f1cbe9456ca8cf4c9dd0b86f28ecca6070a2f380eb37b8e4be0b93588943d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "9398beb8a9fb76c3a817b598002dda1b956194eb614fb2f8cec689cda311c83c",
+                                "uncompressed-sha256": "a65d70cf08f6b1322f31317ec90aaf424d0a6db077ad27800f44fd0ded518428"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "513b5c6832e34a260156b7ec501348710825dd74b466c401d059470df76fcb19",
-                                "uncompressed-sha256": "9050057bc7cd23b3493cacceaa70849ba4c2a3c5cd3368c389cf1c143714fe53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cdb09b368e3f320b959ea08220bc212b462e367909aac4bf055f5a6469e44428",
+                                "uncompressed-sha256": "6cd1364604c1c8289e191f302e9a9709879843f31dc2fbe0f670e0cc03765944"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "290ad890c0fd0797b52dc847917d7adf59eadbfec6fd37509594c0625ddb8459",
-                                "uncompressed-sha256": "33b286226170c208b418ce8389c2aea1bea2ee8898f02f65534588b205de86a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5774eb2b9a1443e77ffbbdac937964cc37d0f0cc6b3ac0f454c5a0f90b96ceef",
+                                "uncompressed-sha256": "2019236f382bd9fb7deb81e85a8e995d66f283982a299fd2aef314ede2be39ca"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "bd42d40a372c3abff5569805b227a1b83b49fce322bdda8448963723cabb90e1",
-                                "uncompressed-sha256": "980c14ee4dd861fab029410e399813af1f7c6891a62a7aeec10485fcba1cf1f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "0e457c35f8ea5f4d100621f16b300e132bbb6de6376c419eaea3cb2a2a31d5da",
+                                "uncompressed-sha256": "df1d17f38ce611b362d2315aea0c3a35bbfe11a3461715cbcd3c1805aa9dbf5d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "4b12d14965adfd13e821b9214e00351893704b2717d29ca497feae0630ace36d",
-                                "uncompressed-sha256": "2103f033fd7d0ef812b58471a2af2877ca7b72fc15403ccca2e006a96f4c1c1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "90935db33b5e20382360fa850ef3b34fec0c9b5731c8c83e3df7e978401e2c33",
+                                "uncompressed-sha256": "6fc3b9990e7f4e0e6210299f24ad3c459db09e7aec1d1b5f63f51a64f7412588"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6a86579c794e14ae7d7069c31608df796fb7ceeef2e53f9c91e2db19b80c6dd7",
-                                "uncompressed-sha256": "29112140a685de6530b3bd1c2a29bae421c2e4071ef33b5fabfb1652c5ff6fa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1b78198a0bd83fa1e04f7324114ec0718406ece37d2ef1ffdad4f3173b29b30f",
+                                "uncompressed-sha256": "7c7677d0aaebde081703f37814e7f5d6ab02dfdb374cf031aa4d9480b4b9650a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "dbde345aaec1057b9b282fd304d775440c961db5b07eed9dde7b271608680293"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2737cb6668a10973c5ac720170e95c02e9db7f3fc24477c66d3d0d6c6ac61d3d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6f78286f75bb51ac652b7f1f21a34a315096e8bbf8d068d491193358b241313d",
-                                "uncompressed-sha256": "c758f30a76c5336015fcb749946c1d0b6fa0ba040920c2814cef682dfee7a096"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "119cc8762cbc5f9c18f6254eecc6b17541ea707da47e5b43a85a45963842f83a",
+                                "uncompressed-sha256": "60b10ac4864adb32092d6878ebd19ca0a8266e86389da814b634087b3e15200c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live.x86_64.iso.sig",
-                                "sha256": "978d7aea0da1a7e6111d82fb60cb6177a2ea34ffc6a1cb851ff57066a7eb9178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live.x86_64.iso.sig",
+                                "sha256": "704e0f2bb202f13e2b987fbe62e546dcf646536fbab6839f65c3246a34d225f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-kernel-x86_64.sig",
-                                "sha256": "6e82b0768a36a8ac0ab9cd5c31f2e53b4da91c773696cc5847a1db5db1953efb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-kernel-x86_64.sig",
+                                "sha256": "ee39b5da6bf3bce33a573a2e5ceec012955d90378b11260472b0030f689d07bf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "6754f639ef3048e10d7517db84e1bb872c7281f0a65fd08aa5ea8953704cbae8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d200b165650fbab62115abfeb125c4f6ff9ab41ece7ab54f7d4d3460a04f808d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "db565f62b728077c4703c7aa5c150b4aa8ceac079ea3d08991f6f0342cef052a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d308e1db764ce2473455fe2e7c609de841a27b27a3df5cde8ac4c0e442b33457"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f88c1c3572ce05608f32eeb86f5dd27106aecb816983db35c082837d0010caee",
-                                "uncompressed-sha256": "7a8464c98d7a8ff11df4bd1b003deeb595c71e66ed3ad9bbeb4d265bee977a2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "aa26488e380ad91b881b683211ec53bf7f58675fad1b6e7171af6cdbba7f07ec",
+                                "uncompressed-sha256": "776fed95c7f7a2759a725eb8b99203c8d0ea928b7cdb8a73d995bb60d0b9e8e3"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "98131057659c3a7d9678b971a77dce61445a37baf0a6f491e06a8464f4f8963b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b48369883ae8e63ae865bd234ee99c17135a11bb477b9e7cb1eda02b13e9b025"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b4a9be7682bd81bac65fcf8caecc6e299ada24e8124facc5e91eb52829de0593",
-                                "uncompressed-sha256": "d6f01b526a1fb30b846c9f46812335ec0c695cce028c5693f8a425d7682a3f8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2ec796302891ec9c2f252b3f5f3af1b8a0d9bced49a9798af610520ee10abb94",
+                                "uncompressed-sha256": "68af863f19f9d68f96a612a2061d700a2e0efc005b7709543d4f429e7a7ad583"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e3e71114a6a8a3c4630ee954c084b34dc2575b7cc2fa2200ee246acc340d860a",
-                                "uncompressed-sha256": "6a1a6b8b2fbfa1741866586c11b5c3faaad659a6108e05508d4267b7da5be53a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "26a8d494569c92a90f92d46abc70a02e4d979cc8c39bf97c588f52b00a951b66",
+                                "uncompressed-sha256": "29b35bcfaf3bca7e635bc2ff0374627bb1bf3e21dd80126d5471b0b6e63fa7a3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "61025694eb98886cab0bd858d2093e7903f6f2f34475ac1a22c3543642972b61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "afeedcca1deb95c56c7a2ff268148930fd3003af71c6166ff7afd75fb4052e14"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "2541e658dfda3efed1b03d3c4fa28177d21ad8d19aa704f7032c194a662a55fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "9e7068461eb307014cdbc788cdd5e856dd887830786309b03fbfb91014d683ea"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240104.2.0/x86_64/fedora-coreos-39.20240104.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3d9e61692898ab4c191871954af5c9b5c204f343e4e0369460b4869a12658e6c",
-                                "uncompressed-sha256": "3af28957ccfb90d844dedf04c449509ce1b046bfb87d253960cb839f87009d61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5ad89b08c15dfb9b4157d9fa0382d83e1ddf5bf07aa35af60a1be5c5e7a15b35",
+                                "uncompressed-sha256": "2900c6fefbad8a5a8cfc5b97d472da150cec1363f641a38a87c8a458eaf3b5ff"
                             }
                         }
                     }
@@ -716,129 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0ebb9ccd0a91bc78d"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-07670ff352914f9da"
                         },
                         "ap-east-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0e0b3b1a237493604"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0e0821af920345802"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-07877e7b16e38210a"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0968a1b882b25e9be"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-03a3370ecf767e96d"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-04a598847d17c8c3d"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-010348f490de4709e"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-02ac83d5d51a2534f"
                         },
                         "ap-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0c178bb969f708775"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-07a31a4475d825c4d"
                         },
                         "ap-south-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0fc82f811dbb477cc"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0c626d11f1ad909f6"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-05caa66b6c528fe8f"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0c6f3562d0d11846c"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0337a1893432d4c98"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0eafdc08cf9e66908"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0d7774077296c7156"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-05a1b6f14d7905128"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-013a14208fea50ad4"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-05349330c2efb32a6"
                         },
                         "ca-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0e9bebe8b70ecff3a"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0427d8c57ea54c76d"
+                        },
+                        "ca-west-1": {
+                            "release": "39.20240112.2.0",
+                            "image": "ami-03fb7e4fdf6a217b6"
                         },
                         "eu-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0ae504fb655fcb1bf"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-00223e92ba8993b9e"
                         },
                         "eu-central-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-06759fec1d13c2242"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-058483f44f79cfc46"
                         },
                         "eu-north-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-07f66c196a082da00"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-066e7096adbf618e9"
                         },
                         "eu-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0504fe2724cbaf244"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-070d87292b3313bbc"
                         },
                         "eu-south-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-07f40bca335532c66"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0c8a1474e30b8b046"
                         },
                         "eu-west-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-07801a846966cae88"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0928c0c531816c49f"
                         },
                         "eu-west-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0e9599a04ee15b1ec"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0b43d573d8a704c8c"
                         },
                         "eu-west-3": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-07d2370a20876bc1c"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0adffd39ca4a89e88"
                         },
                         "il-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0ac04890c3aeb40ad"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0e7e48163808bb9b5"
                         },
                         "me-central-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-073b6a6c8c460e8c0"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-030d725aad3e19877"
                         },
                         "me-south-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-012ee7fd5d7290082"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0cb3b9fc69f66d337"
                         },
                         "sa-east-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0b6ae6fddc5a5640c"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-04720198af099c3ec"
                         },
                         "us-east-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0c511f4a0c6619a31"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-06244db759caef9df"
                         },
                         "us-east-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0f15333aedfb9515e"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0a5464e05615ea9e3"
                         },
                         "us-west-1": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-0a292cdb1a71ab946"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-02b45ee5858a883b6"
                         },
                         "us-west-2": {
-                            "release": "39.20240104.2.0",
-                            "image": "ami-03914b6e17fa99067"
+                            "release": "39.20240112.2.0",
+                            "image": "ami-0024bdfc86624cda2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240104-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240112-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240104.2.0",
+                    "release": "39.20240112.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6198427627e09eb936db81a91b9653afd7b37524276145b9b485e735d3110faf"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0f5c5dce8b9eda6f164ed6ae4050aa1c83e6c7398976511ea52a7c6810291488"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-01-08T04:03:18Z"
+    "last-modified": "2024-01-17T16:37:53Z"
   },
   "releases": [
     {
@@ -93,23 +93,23 @@
       }
     },
     {
-      "version": "39.20231204.1.0",
+      "version": "39.20240104.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
       }
     },
     {
-      "version": "39.20240104.1.0",
+      "version": "39.20240112.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1704729600,
+          "start_epoch": 1705518000,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
       }
     }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-01-08T04:03:16Z"
+    "last-modified": "2024-01-17T16:37:51Z"
   },
   "releases": [
     {
@@ -85,7 +85,7 @@
       }
     },
     {
-      "version": "39.20231119.3.0",
+      "version": "39.20231204.3.3",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -93,11 +93,11 @@
       }
     },
     {
-      "version": "39.20231204.3.3",
+      "version": "39.20240104.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1704729600,
+          "start_epoch": 1705518000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-01-08T04:03:17Z"
+    "last-modified": "2024-01-17T16:37:52Z"
   },
   "releases": [
     {
@@ -101,23 +101,23 @@
       }
     },
     {
-      "version": "39.20231204.2.1",
+      "version": "39.20240104.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
       }
     },
     {
-      "version": "39.20240104.2.0",
+      "version": "39.20240112.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1704729600,
+          "start_epoch": 1705518000,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
       }
     }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).