### PR TITLE
Roll out stable 39.20240112.3.0, testing 39.20240128.2.0, next 39.20240128.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-01-17T16:37:52Z",
+        "last-modified": "2024-01-31T15:59:25Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "befa9ab329ca51eae7217f20b5f94ba55e19954ab1393b2a9d7510d6f832391b",
-                                "uncompressed-sha256": "0abf85c3258c0d1ba6ca7ec37ce58cf8033385bd5b480d520ff499dde2f4f46b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f51da60ea4c3d60ab88dfc25664f03e7383a1690d6932f8707787932e4044b1d",
+                                "uncompressed-sha256": "7b897f89b591a7de0448c968b589f149074812c7f0d8f8c7e300407e27ed923a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "28bc78443d966bbfaf987bb11c69299839e532d3cd5af7ac791d9ae2e59c053e",
-                                "uncompressed-sha256": "d3aefa135e5a7c20b02e6d16c54a18bab06ad76e15b22fc9bf1d6cb2b428ba10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e279ec325714a3f247ed952d0168489cae951b339c46553ab6c1fbde674f2cd9",
+                                "uncompressed-sha256": "2059fdcd27efff77075d15ec4a9b236ac64f91480b69aac0a1461350c7e64e49"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c0911e32eff554b245f6d00122b892511cf26cafd062546e4a6744e0bb800014",
-                                "uncompressed-sha256": "fc2c340e80fa98cf19438493af6e9e26ffb94d408ea9ff650142c5fd989b7f48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "e4d71a5c34b61598432b4d533fefc11ffc78733f7d9d3a965867fc293d3c4c1f",
+                                "uncompressed-sha256": "e1325516bb2de29c80b0f14d1c687e278adc16cc398f5f4cf1d4dd6aa23c2d55"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "4fe623b8249ab02011de1ec1d88c8c12dac4f53a6667997f05198c7cfc81c2e4",
-                                "uncompressed-sha256": "823bd61862b592236b536e4c84df4b0e670f7131b2590a22afb913792a728d82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f93212d851092b24efe22ea3e5ddb71d73591aa7a13852423cc6c81ef0bd2ea1",
+                                "uncompressed-sha256": "f0ee05192242fad52496a22be2952acbc5906037ce81f57d69cfb23544d0ef10"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7450fe5ac2c7a7a0b36f1e897ea53cc94b246d8c3d75d340649a2e9513b00197",
-                                "uncompressed-sha256": "2556c4576a7b5459d9815b26b50a25f3d67e5f33f0a2e4f70c4bffc02cb6925a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "a1c8a566775ee3b7963ee305858a4a55647c370653333870cf351f54dd752a20",
+                                "uncompressed-sha256": "d856362fb75510d7af296f4b768a7ab01d091c54bcc482272b74bdc44715bdf6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e67095bf07b60b2880734951ede1f0e2be2ca319b61800650abdb2e984f421d3",
-                                "uncompressed-sha256": "9347a5803d5a221efc61468a390521415ea0355d80b53710a6cb122f9a9de498"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "bd1b1f1b5c5868a8f2b7c9e57bb099eb996feef2d29221fca8e866d9495c6fd9",
+                                "uncompressed-sha256": "77057117eaea9e56ef697b1d6a0ab47245e31cd67a4f2cbcf300d7699a8764d2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live.aarch64.iso.sig",
-                                "sha256": "9cf489b29214ac325e5ea4d70bd03b1f887f21243aed6f96372dd3b6533d3e4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live.aarch64.iso.sig",
+                                "sha256": "04216067703ffe530a74189191432fe887021741aa6d00485a374a2b03e2b2ad"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-kernel-aarch64.sig",
-                                "sha256": "608bca9610637faad7d468c5e03019ef81a903cd0a3ddc83cc4f693729b661d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-kernel-aarch64.sig",
+                                "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3032fdbefa2417328e607405b4752cc0b930fbc995501dad7363b3b6134333db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "67572bcb809d05020b8c460f0c66eb0b8bde36d7a30f1263671a0448bf18a586"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7d683fe7e58f8991fea49482603c4abda3deb692e3746dac98ac18e1edc68bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "58be0f42464c676ebc70cf1ed71b30fb0f386038d597f5d80f0348fe80d5e7f2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a3423516a2d7d4859962ba53f1f3c5e1e39c80e10f35d20406a95bd365534811",
-                                "uncompressed-sha256": "f493fad95983f1fb0a13435ed19b3ccbd9be74236c1a0290b3d024d7166e4671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7daf6fb5888518ae2a46df2b6903d1578e5ffa6b502b7ab4b53edded18f4ac3c",
+                                "uncompressed-sha256": "7003d0503aeb5b8ebcae2e54f91e9025f25c183baff461b861bc91ca7f3d430a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7b3a039bb17cf6b2b5e459e7b3d331059ed8b88c79034fa5c25674f7a2dbc19d",
-                                "uncompressed-sha256": "52d0056df4d7c8d847311f7170039b097270c5b770e8ecb93c01428998d8c41c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9011c1d29e9794ec5a7a06073060015d726461b6f7c21c10c1a7b57d347ab9ab",
+                                "uncompressed-sha256": "4f1d78154b918837d54435d582c71cbc4db6cb78f76084749f5ad6157f03fa82"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/aarch64/fedora-coreos-39.20240112.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a68f7bb08b944edc9bbc353a218ce19970b75cbf36eb3b717a03d3d25b058c60",
-                                "uncompressed-sha256": "ec9ea34348b151b48829ce5273dd28c27cd7c29626fd3fbea6a317835c61feec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0bd33f47a9b090b6fbe62ac9bdd7b8d4f5b6a69a9c82c7913e2de89eb99c2a2e",
+                                "uncompressed-sha256": "4f1bac343d1f89be5cbd34c91c3dac3f22c57d7f6484b55f8f97e193f3311b44"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0f2d9d61b94417269"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0f0a35bc7d416d616"
                         },
                         "ap-east-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-06307327a3a0eb389"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0b5508395be531c69"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0a5ce234b96b86236"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0942fa0be0d17c33a"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-011409dc45e44e7f4"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0d4ae81e1232e0d12"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0bd1fdfc5dcd05288"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-01023bfd94e3eb773"
                         },
                         "ap-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-05f6484fb1bef518a"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-054552b130722c2ca"
                         },
                         "ap-south-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-07771ccab707b44b0"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-09f7b4d7105c46298"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-08e73c34c335206d3"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0507da29e40c7b526"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0f5aec8206d90fd5b"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0994590ec86c0c6da"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-06fcddb2e4a962d85"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0b05066ef69dfc42d"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0412e89dfdfa01aa1"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0ca9e7a43bd47fc3f"
                         },
                         "ca-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-04575dd52a116156f"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-098e810e259b2174e"
                         },
                         "ca-west-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-06b403d540e28f2af"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0f948f2c9832af2a0"
                         },
                         "eu-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-00d7451c9f5cc7ece"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0f8f7d1bda37bc913"
                         },
                         "eu-central-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-09ea23dfcab143d75"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-071fa23e17c5a3456"
                         },
                         "eu-north-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-05bfea2a9f4e3740c"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-04aebb86745fb77f4"
                         },
                         "eu-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0e60cc6e3fbdad370"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-096ffcfa6faa25fb3"
                         },
                         "eu-south-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0d15d7fdf640b9095"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-090852d962b4363cb"
                         },
                         "eu-west-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-03caaa2bbd6be5a33"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-035321216bb9cc834"
                         },
                         "eu-west-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0c3aa06d9d33ac54f"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-04249c9331b03f826"
                         },
                         "eu-west-3": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-08a491131fe73a634"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-097600ea5b0cd4c3b"
                         },
                         "il-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-05a8c0edca139332e"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0acc7a4d7458cc19b"
                         },
                         "me-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-034a52d8a9a72008c"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0cf2bd9639b663557"
                         },
                         "me-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0e178cbd88f8214c6"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0437de2b1246b1919"
                         },
                         "sa-east-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-02c058502cfb8a49c"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-034f3593982e220c3"
                         },
                         "us-east-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0a4e52a5f0463f732"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0e39eba7cbe899bac"
                         },
                         "us-east-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-03c49cc3aad69a1af"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0180ff75ec5d4a1cd"
                         },
                         "us-west-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-01eca85d79429467d"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0ddf05804d17ecede"
                         },
                         "us-west-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-09a321106eb930048"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0e600acb1e2276bc3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20240112-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240128-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "e380df1cf61f811fac3b0537501fa24cb15c032363997e7e9a87cccd1fabda5a",
-                                "uncompressed-sha256": "fb4ace8fd023c7f30e47e7ead87a2570c19959a2c468e03c4e06739ab32056e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "aa9c9ddc80f4bae12958ab87aacc42fbdd0a070eb3aa931a822292ee53c6abc7",
+                                "uncompressed-sha256": "3033cc7fcbe3ae5eab4b31738d927c5fe566470c1cebe46486bc31ce8e17b99a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live.ppc64le.iso.sig",
-                                "sha256": "e1be96283b81d47b409bbc523434eeffee3273b8b5fdb9ad6f5c17faac3ef9f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live.ppc64le.iso.sig",
+                                "sha256": "5224d844e8ea096b315130e96b02c71b4f6aa6e7ac4bec41afc90886255b28b7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "1ac57384bf7457f3a130dd6672a771e1e1df503f68ed16f1f70cfb05ea911aa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "21301d8ecff96ad84439bed452cd923e8edc2245de016419dd2543a7f619ceed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "92e1c243a95e8da54f49e1044b797ee36f8d3b219755ce165d0fe85ef9bcccc5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "fa3da6ea40422003a77a22483dc075350c8076d05bd53c109016c23d9a6ebc61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "dfe8daac1fdcd9cede71c9217ad73ad948dc51238512b1a110b1479923e47536"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "afa14715123f49154d5e32ce6d31e97ae4825cf53a5f493bbf8b8e1449fb9a57",
-                                "uncompressed-sha256": "5036cd6113cecf0ef70cd824ca0605293945a2c47754bd3cb4eeb1fc23e21bbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a6b094ff8bd2d19b5e3cf3330e3c8a92dd0272023f2226a0008c95144e8fafe3",
+                                "uncompressed-sha256": "565597a41d1bb570f4b69f801926de5171bc56600a51e0b82d210dbd2ae62fdb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "68bc9a05e139ae9ee635ed6e64c2763190f578c4a37dafffb61459ab5baae522",
-                                "uncompressed-sha256": "2c126328255a51f46399410c717df3f374147f186ad238a0729a1e4f50976c58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "d7f3fb8a83d2e92a14044d21e1a42a8d9b1326e4c2accff85c26deebf22649ba",
+                                "uncompressed-sha256": "66b664c28a4ac84d53d8e1033519f0c7e355f3dbd93a64d885213260ad7aaa69"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d59e2e8112c16ad00877af088c9cee4e2f10e63ecf60ee4868333f60cdc3f531",
-                                "uncompressed-sha256": "c725edf71a3046ac5c4af3344099dad090e23800f4a736e82b6b2f331d0a7945"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2a09068546749c41ec22c49b0c70943f55674054a0af567b79e7abe0d48f4c16",
+                                "uncompressed-sha256": "ce06631d2954a93aa7aa509b3a529b4d614aa2a5d12b3d6f7d80d56abc8ebcdf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/ppc64le/fedora-coreos-39.20240112.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9ca06af25cc3e3fd8fe77d9661da43fd0312858b9ecf79fa70f01eaa69d4e670",
-                                "uncompressed-sha256": "ac06d3e7544a8c5514bc538ab50152145f245894fd5a65f777d01eaad5673b6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c596aadb7b1552691fd1ead25bf31bfadc1995c1b1597cf935c7077ee301b4f1",
+                                "uncompressed-sha256": "bea3c6b2f164f848e4734c16e58d5b839205881ae7374e146efe322249ae3693"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "5fa3b35d2b41d2cdbe3061b1eb03902a8d8c0b30636633172dda46e63b4a0dbc",
-                                "uncompressed-sha256": "735505395e21900faefd5814e9bfcf90cef0f2f5304c5c9e554c11157dd85e1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "086568d0a644c1dcea95770d3c0aec6f406102cd83a4124ba372bd0513491145",
+                                "uncompressed-sha256": "b7af4ab09a36a01e5a47264d73f15eda94e250e0c36561e92206a065e5f4210f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1e92a441d04f39315aaeaa217e2d1d98e515803985b409b3bd003f3c2dd56174",
-                                "uncompressed-sha256": "f5277eba66fc443d96f0f5c28b1f6f8353a362160910f1e8733d6da741ba2268"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "253e705fb178d22b309a0acf8d187ee8da607f4117278a626d7bf09ada6db73d",
+                                "uncompressed-sha256": "1cb88c4de355f4b71d4503536ff6d77361d3b55df02b8bf3d225d582c3cd9ea9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live.s390x.iso.sig",
-                                "sha256": "08d26bc459014a3675201214408851dcd4eabfc9880ecae957c47a33c830e328"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live.s390x.iso.sig",
+                                "sha256": "f745c0792a07080795af4e3fd05c3af49c3ba0f4b529f746b4b1960f54dbfdeb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-kernel-s390x.sig",
-                                "sha256": "08c1bdfe60e2fcde9b226db19736e6a468aa128c8b39516e8548512209b1ffa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-kernel-s390x.sig",
+                                "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3e0ebc3ce2ec7276e71e10ff64b78e8b982bd050cc0dddcab9cfabce8604dc8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b3c7c74b6d2df2a168c4a9a873b0cc066962374c88c7655ff7a24c3ddd1b6929"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "775dcbf5209886ec2fdb9920c030981c0e2a0d4955f565d28e8bf07c0aa90342"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "2245b3ce56dd7c163665a6eb926d935eb939f50336a658f2c6ed31d1f14a396b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "48f4c885f1062618e56cc992671f7a54a274bcb9e2b7ff98544109a435e06b6a",
-                                "uncompressed-sha256": "08fb467c30c450416b24a215cf47d9663036945030beb2676d29e34ad449f0f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e631d13c516c52a0dca2d083d0b3993929bbca5af298da0e73de00252143c7bc",
+                                "uncompressed-sha256": "7f790650c33b6027e3bfba694bcfddb24f7869449e9de6a1f1e88a43fe02005d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f4059ef682274475fe02f4ab7c47646f6f21d5a0baa4c2ce3ac86dbdc08164c1",
-                                "uncompressed-sha256": "a99fa4352759bbd1b7542afb49cce1e181c226a99cdaea1a418bcfd3af6cec7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8d5b1ebd51941237d20baf9586693741a66c07e53fe8351c65d8af69b841c523",
+                                "uncompressed-sha256": "72dbecd4c511555816ab2a9ac906c1e191c551edc45e00543929891e36806af3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/s390x/fedora-coreos-39.20240112.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "66eed98703dde7f2fe06d6414ab14b374c501b94c4f0daf5378e095f2dca8771",
-                                "uncompressed-sha256": "0e5da7a0facbe56190dce6933df4204354de05929fddd238a43f9affe6e9d9eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e1d1aca55f96d5de0fc406cac8ce205eb31cd8e32274c831b8c8ac0c63ece3c6",
+                                "uncompressed-sha256": "bfdc230f4266f5fbb774324f07508162a69c374493d33a6e858cdb31b6aa6a08"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9245153f4e4a96656aed3881c0ef09c7621f3333925928e335f7e70d8a37906c",
-                                "uncompressed-sha256": "ce07da29857a274fd9430636bd6a547cb8876d1f61037663bee9139556bcafe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3ab0c48999fece0d901dd80fa521bab125825ec08ca43d49933abf566aa90914",
+                                "uncompressed-sha256": "e7417e90fca94d32733e212d6b39146c9c507c8a0d98b93d0075014fe6a63520"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "7d672bc8de00d81032acf3688c76d72430516cacc19bab281e3f04291898481d",
-                                "uncompressed-sha256": "6160fdd66516f21c54a2b5b0d322ad84fc878cfad1509e3bfdc8369449572de8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ddd167bc934a91748a967bacaf283d90200efabfe16f9cedc0056ff6dfe2fc9a",
+                                "uncompressed-sha256": "e7a79b08caa78ea9b2a1aa7abc36ca95d9c21d4f3da0eb5b2780e5cedfa996c6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7d4078fb848e036c2d7818310450ed49445dc02de2b1b9093c3c418e229288e5",
-                                "uncompressed-sha256": "34ed42bbe7d6562ae2cff4e0ca43b0181d506778e618f03c4ae52e5f280803e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "79ed780910dfb6265d2f92a250e4e8854befb1983b3d2f4381a9c9eca7e2f094",
+                                "uncompressed-sha256": "70d30de0c20a3d0a9c75e5397e492d8952c706feb5bb3d2d061f50041aff27ca"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7f7d598b53b5f1d39b1b1355d0219feff3dcbd49dc07c04f4f3941c0f761020c",
-                                "uncompressed-sha256": "697eb6051a6bd7dd7fb92b3626ce5aeab1cc42f8ace6cc8384058ef47bd05649"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "35a0317031459a5936d3d23931445d383ddb4126b7da83a5e8cc5ddeac0f46ce",
+                                "uncompressed-sha256": "dbb78c32f9e68b1bb1e2be690b958b6838b8e7281da8c652435203ba6c090fda"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ae30bc718965e0ef0b953f15e62ee9c9716241b7d774a856cfd385b8582e9b55",
-                                "uncompressed-sha256": "8dcaa3db5f29fb7da1db880c77ef63aa869a0a063eec4d438e9d1d407d3a0cad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a947dead1bdcf71fa3181814e31154f94cd2dd8ba0457d09e0bac36b985aeedc",
+                                "uncompressed-sha256": "19eebd4e335ed60c8cbd02819e756ec32a061baff8b9dda946084aae9cf2ca03"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2970a8515f9f2d65f81fcd920e5773bf98785dd8a60999f47c76826dfe9555c1",
-                                "uncompressed-sha256": "6b0788a371d22555d0e671099bbdf9c64c268212e1d4dad5b3dc25f707409829"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c8a18e46feefc1de6d6e688e7a66cd07fb50bb46b648a7cf8e0335279208aa65",
+                                "uncompressed-sha256": "16bb968d3c58437197a14ef28f060966b3141bfa0eecc0428ac9502c33481e92"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e4cbadc3474a20a784891ab2eca8beadcc03b232ce773da4063ffea6f71e8b86",
-                                "uncompressed-sha256": "30cc8d4fdb8913104498b00d29035a3770f9a215657d1aa29cfba4ba36435004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7dcc963a7f373a7a1db72a8e3fe3229846ecc2aae12dd33af4e3c9795971715f",
+                                "uncompressed-sha256": "13f9cdbb577f04875e6bef2de334e95a64733efbb2a697d119f074a2972d2141"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c5d207a66c7c45b6eba698cec4016d0ff9233acb86be135d3d699e32f618b483",
-                                "uncompressed-sha256": "584880da90602fa82af236423312e0d65edd515697660f9ce1281f46a2a725b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a1f1addb822c4b418fc1a6ea34bcf2640d66980aed773d5986b897cd1da3cc49",
+                                "uncompressed-sha256": "ce22a836ce183fb97e6a7f49389d6196aabaa4ffa08bfae9082576eea0b374de"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0ee51d1711c198e81d127efec2d6dfca1858e9bdb85e8f2a27e56e71cf7bced5",
-                                "uncompressed-sha256": "ec482eb8237bc52ce67be520aa930a9c400dd6771d620e41d4633c04b3ef96a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7e634a322bab4b7a559c5e4da49ed2b91e8cce8d62c4bdf42237af0d26b3f7a2",
+                                "uncompressed-sha256": "08a97c15c57be3fb9a19578ceb01ff78eca21de8ddcb90e9bcdb64100540fde3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "94455404b0b7885caa659ffb58ac4a302e6d7fe003e29078c703a4cda4499ba6",
-                                "uncompressed-sha256": "700cf1e2c52b071bfd7954c8248e5487eb619dfe5ee439187598ea6ceb6dc20e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "184492ea500487f81f6127b7373a2e7754135f53d2c07b6fcf1cf4bd52b17e12",
+                                "uncompressed-sha256": "52a3c1aa4892e51bda1c057d91a5d0e12fe1e2b4fcf29e82551541e675017c2f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6e1e333e1ae3db41d9b42081b50db87ea5f66fb415b54a444b93d89ca543e9e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "72ded8cb0d799e932504093bbeb55a53800ae5a44aec468b5a7dc6a741679a59"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e21026ff9c1143ee7fcf64fd17c1d0705a4e89ab7850aa10fc1a9ef818b6bd61",
-                                "uncompressed-sha256": "833ebda3f99ced75097fa2fafad8ebd8c40d1396ef5356dcff2b477b6da5846b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "59f7ff7be3ad9b639bd57af5175159d4f6c226cc288a4c5eeda6aaf046c83114",
+                                "uncompressed-sha256": "74b41d6699238e6c8a9a2269ff863084db6f69129df2faf58e3e284a68ef39ed"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live.x86_64.iso.sig",
-                                "sha256": "c370bebce47c17673099691dfb4baa8e8043edd77cdb188b4a3223455a4ff676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live.x86_64.iso.sig",
+                                "sha256": "d64364d32d03ddfc0e64bee07cba49c0c9d897aebb1c81fa7d4866acdfa663ba"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-kernel-x86_64.sig",
-                                "sha256": "ee39b5da6bf3bce33a573a2e5ceec012955d90378b11260472b0030f689d07bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-kernel-x86_64.sig",
+                                "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c9e288c1f0e942350b675e9588e5b59608de0d981da0895a481dfef0b32c9a9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "30bc10acdb76950b5fef4ab066714336d869ae596f67e0c67789696c348b2091"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f2b6ec88acb8ef68845f34f9923d686bf8b1c4faed88d802ed21a958a2c79745"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "389c33191e51fd9e147a5a09479e5856409814d46e7ebfc2315dfbb1b178b0b8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "11dc2c43cfd6becc3f50f70b18a7c74b27743134ac4b5f9cdd789f4670f36802",
-                                "uncompressed-sha256": "0a1d846fa58b68c7ee92c8629ea39d802dc47627a55078134d8b18d8395ea3e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4a071d0d72292a3ef21f9ba8dce24664dd227af781f45f40e24d218d64300db0",
+                                "uncompressed-sha256": "605d3c321826635bbfe3e3cf0d230629838bac6dac4c2dc506d25e5d169b732a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d48990983a0e135eeca1e88c3163aa5125880046a157c6c23a47fef0899d61d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "5bbfdf90a284ec1795017e1c7af21a36451b0976a65506b73ef72772088fcaac"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7c0178c5593b6b4e64a49aa93020d66f139dcd562bbbdff7b20449ad2fcd662d",
-                                "uncompressed-sha256": "077472ce14a7165aca772d728860f680a55039b1db06d4c7c69a7182bacbbaea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8dee837228781262c7aacb564a3423bf32a0f16e3681931207cd89576ae12360",
+                                "uncompressed-sha256": "bcd0328cb77578a48a940878c84880a50ff8441fc4983b97160e9bc9d4d2676a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a342aecd9db03a9e27c94a89d436b1a2f6168509dca0ceeb9f645293650c3811",
-                                "uncompressed-sha256": "7513e7f8de75acd5548120a97333525bb17b0287c4ab0669591f0ebcccadfb05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "bf8bc502286fc6b6ba138eb4ba517c4ebc7e5999ca11248b758e13eb9f71ef2d",
+                                "uncompressed-sha256": "c1a065651427c65839e80c66f52703ae473a55f28d276037509d8ceefe6f0445"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "390dc51866f617f852e171c279e3c8016b97b49cc56e225c31d84ed28cf5dedf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "caa3343767a5349045841930fb1b79f97cbdb5866b98fb03947697d9c94c604e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "6db98b2ec32f73857059294f5c0f62dc16ce0f859f90731ab767f39c8e513185"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "3e80f04d43220dd4443062079f94eb84209c7836b2f5313057d9b8984fc8fc24"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240112.1.0/x86_64/fedora-coreos-39.20240112.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "14cbf051cf0a72d820438185e24fa058ed3f8915908e3bd7daa6740a803367ae",
-                                "uncompressed-sha256": "887eb5b5d26bac1bb1bc8923f481f37bfba9874fdbcccd7d8ee1e49ec472aa31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e253d8a35b625924207b9663bfba616dd07721b747d294f77d559f8edb3ddca8",
+                                "uncompressed-sha256": "4e9e008bc672e6bfbf2880593251f4470d091f797e180e4a93afb6905e099313"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-079d9e71669ad5f26"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0161e02f9ccfd5942"
                         },
                         "ap-east-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0d10c19e3980b1448"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-046f3a1079350dcba"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-05179772598ecbb75"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-048f386e0ddd5d64c"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0bbd2a5c4c25121eb"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0d55c0b10bebaaf5d"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-04696d9b7ba84e86c"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-07d5091948f537e14"
                         },
                         "ap-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-00aa477b5bb0ee8f2"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-05185308375d32b26"
                         },
                         "ap-south-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-088ea27fa57e65417"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0cf3f5fb8bd594eea"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-04d8344518fa4d0e1"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-097cdb267ff8eec32"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-004abcb4af1461c74"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0c5bca809f1630964"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-04ed617f694b4e382"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0148993f2eb57be9c"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-043223b18b659b46a"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-027b2853eac05c7de"
                         },
                         "ca-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-02f254519220018a7"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0b1b149c3cedda303"
                         },
                         "ca-west-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-08adf37e658a97939"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-028402dd8345ef34c"
                         },
                         "eu-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0562006fe0ce35a46"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-060cef59d3a4b3b2d"
                         },
                         "eu-central-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0c650fb751c2608c9"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0f12eaa90a02a5912"
                         },
                         "eu-north-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-047468500efaef515"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0385d3f14050638fb"
                         },
                         "eu-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0fe8db5e4fe82695f"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-05f90dcd65d26f0aa"
                         },
                         "eu-south-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-01a62f98d476f0b6e"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-06c4d4b222f149f0b"
                         },
                         "eu-west-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-010cca09474318af6"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0881553f217d2c16e"
                         },
                         "eu-west-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-05b613bc24c1ea6c3"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-079df31e26465a612"
                         },
                         "eu-west-3": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-07dc68c4ca89eb583"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0b71283b2f65659a0"
                         },
                         "il-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-087d75058cff85380"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0fcc3ad2fdbe4694d"
                         },
                         "me-central-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-03c60a84d7897d11e"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-098cc15e1a3ab68ba"
                         },
                         "me-south-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-00eb4a03cbb371753"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0b53a5e00c4ff7b5b"
                         },
                         "sa-east-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-00837b706dfe0fb0b"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-09ef872ef209a1550"
                         },
                         "us-east-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-08f763fdeffb22406"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-0f4711414c9da1533"
                         },
                         "us-east-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-0197bf5167b566ad5"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-043348bd8dbd945fa"
                         },
                         "us-west-1": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-00ba7383422398fb0"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-01e6d7ebc2db15071"
                         },
                         "us-west-2": {
-                            "release": "39.20240112.1.0",
-                            "image": "ami-06841eb2cff09f77c"
+                            "release": "39.20240128.1.0",
+                            "image": "ami-02f1df3759fd0c901"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20240112-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240128-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240112.1.0",
+                    "release": "39.20240128.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7efe2c68c7b711ff388932593902262805eb4ddfca2d790a5e1d1d978f81f9fb"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b7fcf547ec61482268f465696c0876b4a25ab2c4db4105b102132d87a94673c1"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-01-17T16:37:50Z",
+        "last-modified": "2024-01-31T15:59:20Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "3e8dbc1bd587b3b423cb81156424c96e5ed8e6a3d195d8bf27e8b7e7bf1605f3",
-                                "uncompressed-sha256": "19cb04dd25a6fecb2d1464579d9b71f2ef4a848227ad87916400eef9e3297a58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "aeeb456bfccbf1397b2c1f881ded420bfd0c18dd09cf1cfc1143d78334747fe0",
+                                "uncompressed-sha256": "9c4af96f95d8eb7371ccd5d2029f0272710e7bb400915f3f8c81b819e212923e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "77a6036f8466d23b6de1bb7be246881f473e89f8056b27fbcafe057b14898f44",
-                                "uncompressed-sha256": "19e3e30a087f90f6775d1338d6304359fe21689f3a8b66c47beb6f58f3074ba8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "aa99e18b37e7fc4eddc5ff4e190c3c35ee443855ce99800502839fd3e244bcbc",
+                                "uncompressed-sha256": "fad4de14c2e3422165dfe3a90bf8cd5447c22681479312db9cd2a50e12a8b996"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "384388c3da7ca83e36e53858de3284d8aa5d79faab007d89937ffbcb00d22372",
-                                "uncompressed-sha256": "e1521e68688c2fd2a97da7268c4fd8b3504f99419b174bb59adc3550361d7c3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ce80440bfd5dde6e3de28690fcf9a4941b8da06008b2bbf07a4e16bf7f286ea0",
+                                "uncompressed-sha256": "3157af69af86bcd55950b3f0daa55f84d2f68f3da0de134482bb3dded05dad56"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "56c2cb9b50d3fef94e327768269b2ffa60b1ba9f87b6dd60b53890035d2447f3",
-                                "uncompressed-sha256": "3b2d94b6e34a76b2e919c1e7a4c07529702cfd39a8ef70c2c03081f60a47139f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "9d85ee986179fc9dfb0ecfed8e378edd254cf37e49c1a90112fe91b8170883d3",
+                                "uncompressed-sha256": "5f8e9c1ccead3d5b422ba1ad4c7a2c8e98c414a44fb008807e841f3c7311033a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "579b3eacd18c3c42caffc50ad89430fe412154cd506b559eae716bc67964a6a9",
-                                "uncompressed-sha256": "8af79889e1c9ffe6a94e1bdf7274a659c7d9383a5121d561d695daac577c059e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "c609169da9d4d2a090d178591c9d33eff024b338211fba4579b1575d8a6728f4",
+                                "uncompressed-sha256": "54a1423c276f6ceeccd3f6cd7ba1fb020dc05a9531f5a40cc768acadf5ff73b0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3c9426a64842bfffe8605f911e57ca0565c2e5b8d814051cf0810c39cedc1c9d",
-                                "uncompressed-sha256": "13ed8a89ecda57ae654d929f86f6fd14a8ef523c71ada27b4073ec7ca074aadb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "116678f8b2c954426cca44afe0311920fcf159c3003aea25af2c750de841172e",
+                                "uncompressed-sha256": "4caa2f3c0818bac90d411ee870d0726f70336314e182375ba753ff4dd994c248"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live.aarch64.iso.sig",
-                                "sha256": "111345ee7551765d844255706fe4007b14d914dfd83a81470ad928ff684e2799"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live.aarch64.iso.sig",
+                                "sha256": "681c46279f821f51a2af21a677610487dae56559554fc83a13b98f7bf1d696ab"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-kernel-aarch64.sig",
-                                "sha256": "79fc1bc34a8a726f61f33a96baa01c90cd5930b3da2ce2042ce1bafcf2b4f1f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-kernel-aarch64.sig",
+                                "sha256": "608bca9610637faad7d468c5e03019ef81a903cd0a3ddc83cc4f693729b661d0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e162624b6d19f0ee15fa0316081961a734baeb9c55aefe284ea8eb9f5f063fa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "4a6a36d08414cd5fec0e915fa15b9815921041d0ab85a9f6b92093e629cb419c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "132e8c735b4e31a515260c5fe9b72395d969b3d150fe92124415b8598977eed3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "174f877651b660a8181333d4cc55fcaf9d96ac65957dc125923eec466feed742"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "db01cd8fe980c201eb5715698098a0b5708aa044e04a219e0c20f495ac181b36",
-                                "uncompressed-sha256": "980d70c1cc79f3800f0b004a301e1e09e72a051539015f3f99bd2de5fa76cf21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6ecb90b0528c5de45c2656554aed6ea6e914ed415f5ed9a07576583df7732281",
+                                "uncompressed-sha256": "5e2cfa7d1a04c1158d0ead832b9af2dab7a1c67ad686d9139878ab5ebce6e281"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3769519de0e9226e706a193fad814b8baa6266a18b952b2379de52ef9b6894cb",
-                                "uncompressed-sha256": "2f35d5048cc79bed8175986edbe128ec779bff67910c32081aae39ef3688e30f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "37f6ad55d207f2e89ff3e8cf4caecfa0661c15dbc8a96ebb0ab035751e32fb2e",
+                                "uncompressed-sha256": "39c7f9fc8254bc7a04b564de5230ade532bdb2ecf75e8e2f25fb61885280f419"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/aarch64/fedora-coreos-39.20240104.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c5acf53a3092d36694b9dd9e8bc0b4e878b2c93a29a06e13657b89bc6fa0a545",
-                                "uncompressed-sha256": "15101a263e532e2ce291d2f199628e446e39c607dd4c4d9408c5189f6e358f72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ea9496dba2a3ef031d7fa2c2f970a6f26fdac0c42983f169576d4c8a85726daf",
+                                "uncompressed-sha256": "ffc154e06e096f21fe92c6461edb14518216be0220c12b9784293c724e85c3a5"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0b4627f0195ee2505"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-053cf73c554d11f6d"
                         },
                         "ap-east-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0dd301a3732c16092"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0ac08fbae1f1247db"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-06389fe1ef3e19f99"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-082e61379d30e1b7f"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-019e03abbe9fbc05c"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0697587a1d890fbda"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-07ac7bc04e94bbe87"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0c8d43ed62104b847"
                         },
                         "ap-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-00cedb7100583877b"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0f6cbc57b9f01bec6"
                         },
                         "ap-south-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-024694064a7274d0b"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-03f4794cdd9d81384"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-06bd2c72726029e22"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-090af9adceb1b1cbd"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0ab883b0d5ffdb4ab"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0a6ecd045cc51bbef"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0d13e3ae971f07050"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0d5c9cb4eed2924be"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-09812e40723e5a2fc"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0978cef15ad866583"
                         },
                         "ca-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0cbb22ac0fc71752f"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-081fb4f58dffbefc3"
                         },
                         "ca-west-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0db6c8c5e190ef529"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-05fca6303f5d096a8"
                         },
                         "eu-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-08bbbc3decc4c73b9"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-078952ad811595167"
                         },
                         "eu-central-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-047872adcb8e8c03d"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0b93991c13d37ffc5"
                         },
                         "eu-north-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0eb3ebd568aed942e"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0298d6205ed226ef8"
                         },
                         "eu-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-021282597631d5f2b"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-00b2a25297a6af7da"
                         },
                         "eu-south-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-02a18493718c03c43"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0a4d6287aa1af7da5"
                         },
                         "eu-west-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0ebd5e12e7d6fd948"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-04b4bd5e032719ba6"
                         },
                         "eu-west-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-060fdd2fa01cbcfd8"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-025b273cd18e6dd91"
                         },
                         "eu-west-3": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0164be311fabd14af"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-02f5f6f098ae6ef25"
                         },
                         "il-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0a71f5ff54341efea"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-070f3d2f5bb3ba0a2"
                         },
                         "me-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-09b1405f091f16d19"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-041b243efbc255f7f"
                         },
                         "me-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0a98fca1eb3033fc8"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-084483dbe064d81a8"
                         },
                         "sa-east-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-04e14fdd778b244a1"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0d043a12103d4ae76"
                         },
                         "us-east-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-03c19bfaf31ff40b8"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0bf84607b1a7e2218"
                         },
                         "us-east-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-082cd5a129153145f"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0c8c03c6d6da33170"
                         },
                         "us-west-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-06b9f9b98b3ef96b7"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-051479cd56e25ba8c"
                         },
                         "us-west-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-05c1082cb7f162b6d"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0f1fbf51815534c9d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240104-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240112-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "96479cdc97f61ef827927172099df5d18f8d30b0859f44000862e991f220243a",
-                                "uncompressed-sha256": "28d369aa74764a5e0ce725f877dba2105e5e76bab29e429b5a351134276425f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "9d24c611689423f7ed2120e72a167ddec949356d8cec2f15d80821ae240f4c69",
+                                "uncompressed-sha256": "1ce6178dedee1eb81e901ec57cf22730fb5f3cd9b7f35488654fcef95a2baca7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live.ppc64le.iso.sig",
-                                "sha256": "9c042e23bc8f6562d8510c85e9789858d90a2b5340ef96de7794b22da61d8a0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live.ppc64le.iso.sig",
+                                "sha256": "d87f321947a6bb76838737f51326deeca58fe9753872e91e3b4cd7b79530fa5c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "90132d5e3cefda2f7dc246d4ef579de4fa3e2e1d864170788e5e676034412a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "1ac57384bf7457f3a130dd6672a771e1e1df503f68ed16f1f70cfb05ea911aa7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "a52e6ecedfa3e75cf35b48464a097e31085033080da9e7fd9e7391df2846cb0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "d8657b8eea71acfe97c90672f27a66e2e1d8d4dffce8e5105ef6ce2fe702f381"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "91526d7513401e69d0083f0c535e5b99bc21deff521cfa14a524c862b9e42c21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "23d61a62d6223a41b1782b768aaad1d254a51d6dd6387c9ce17e542b1390e051"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "2b59436daf78d60c2ffd0d9bb63bf6488ec54bf95d061fa69a0c81e78406e75e",
-                                "uncompressed-sha256": "934b9201a600153593e96da21185f540c62c088c3dcba027bedc03a780a73016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a7d7ed17fc01539f05e8b71f2b3a942cd40f3d6acd349f1a4e488f5bcbda058f",
+                                "uncompressed-sha256": "ed0ca6530eb1f7fec3a2dc50464d313073621b59716843979d086747c132bab0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9df21a3f3853ad07ea77dbd8decbdd73521978a56968adb1079ea9060f867509",
-                                "uncompressed-sha256": "39302b75f0c7b092896c5025c3dd849d019a3d2fc670fa6d0c7997b4a3bcddc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "69194a1a261fae28f69fecf1b41808e72fcfdbcd10fe5b578c399455a077e49f",
+                                "uncompressed-sha256": "8d3a2224ef2e4cdbc1af002e22e1cc584449616eb52236626bc5b0a55e079160"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c88c155141e8a731e36222c03889d088715020a5706fa13ebec5a2074e7122f0",
-                                "uncompressed-sha256": "c508439cc2ae7e7693abe16d7df3453605cd65999d2321365881bfd167917fd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "3352f5a5efba03b91bc0a2bf45fdba8ca058c3db93583a8c00cc184123fd9689",
+                                "uncompressed-sha256": "f96213b03967c9f859ff119a676665007cc818507a2609f616277c9dc8a58a19"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/ppc64le/fedora-coreos-39.20240104.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2ce44c3f0a1b9a6933339c155c4dca48fc772eea3804d426e78b00a33c5054d7",
-                                "uncompressed-sha256": "59d6ac481c9a2eb24deca753ed312f9b53e48c42e9b606d60c3cdafee86cd7ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b95ed6c24d7a9100e03096ebe15c2452d24227830b67c6ba3e8107714b8a91fe",
+                                "uncompressed-sha256": "00eeb27ab7f683c7387958001f85d476b2f771599f67c26b94c50660a637664c"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "452879ac2ee96dcd56ca4647d7fb76263a958c69ca73df0c63f7b1cb0bacdc44",
-                                "uncompressed-sha256": "f7bf31a4a415e1b56ba507815f46a54a5982e4169d20f433bca62e6a0105fcd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "21efbadf531588117535c11c81acd52beb8fa4ac1ebd95e88644a7bf653af763",
+                                "uncompressed-sha256": "9ab4ff4994e94ce2edfe1b4ffb5c35314f1742f4baf45c164334e06792f47b60"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "10ebd278ce4822f25744acf1aa6f337d0bebeb715ea0979c4bf217495def45f8",
-                                "uncompressed-sha256": "504eac097840a7b580545a1de99edb06b1e43a339ee41b001061efba55e88f72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "9795345259e89b64e3a91c053bccd17e1127e1afcb2eb6d346241db69f60cd3b",
+                                "uncompressed-sha256": "c91a2f18714b82b81befec6446b1f2ec97ce71abbeaf0c844b7181fb9399c13a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live.s390x.iso.sig",
-                                "sha256": "779a36b070532b94188e9389961c1c3ff8de9ae614eeb7fe4ead6092836f0602"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live.s390x.iso.sig",
+                                "sha256": "97d5959734243428bdbbbd20a40f786337cc89e214d8ea3c842d9b4e8fec9510"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-kernel-s390x.sig",
-                                "sha256": "ee6a693814399eb97e9451034248cdafdd65b9a6ec245a25565f50e44318a5be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-kernel-s390x.sig",
+                                "sha256": "08c1bdfe60e2fcde9b226db19736e6a468aa128c8b39516e8548512209b1ffa1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "9b93d5c632d8d74baf45df5ad7bc184d4224544919b5d5beb34fff4d45509e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "bf6a6dc3e7a9b11f1b1efab5a26cf73fa287d7035d7da5faa1760c49d6a502b7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "663053ae515db5923335d3a48ab4171ac3dc087825d5e2ffb0fbd16380c3e772"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b1068ee07171dc6d8f2682ab4cf8eabe980e39122bf1558a63a3ed48b152c7f3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "660dc01ee0f7eaf839eb22695c7d5a4989440dedcdbf7887731f4a0d5ef3742d",
-                                "uncompressed-sha256": "2f2a5e112d24cfb6c748216f4c941c1b8291acb3e66fe79e61372a2d127ba0ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "2b5f3aa87a1c7f401e525ed99b57cb82061296d5ed8dd9e49a7d83b3dd15675a",
+                                "uncompressed-sha256": "ff6e32b30a763684e6624adb013fd71fe05ed7dae921a033f99a2027814fced7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0796d79083a30d7febe238100ff432aae7756beaa0be286f0b31f48b7558f9ca",
-                                "uncompressed-sha256": "4a46df1c8bb9f41a1edfa1eef4ba85571be07bf294bc4c00e327cabef481fbba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "dc3706d2828d9e6d11ce7b74ca7626fa3ee494acbf87b375eae742adb26961f4",
+                                "uncompressed-sha256": "ba7c8e2da6a739ae3ba7050cf1cebf590c4710bf354cc5a58559e5e231f90842"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/s390x/fedora-coreos-39.20240104.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ebee97c2308a24f50eff20b5974d6599e6c183c7035c4d4a17d3a3fbe997cb95",
-                                "uncompressed-sha256": "8112527848f01cd4531ba1ddc5bf17e9ed0105528ce34c9d1f8981dc0b61470d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7826deb756bf6f290ad1c394261efb6ec5920d46ca27533721294f343454b4aa",
+                                "uncompressed-sha256": "a605bcec75d47de533bb5fc88b26a8071010e9235e1c9ccbc1200f3ee48d4c26"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9b8b7d5100a3cb7cfc0cf8563afa55debee2305bf0d7a13c51f6871048bc7190",
-                                "uncompressed-sha256": "5617de11e457cf42034089624c0ec855cba2b65fda96a621dc2b721a982e5df4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "44664a4c888704217c3299eb0897957ceb2503a9473b3bca89ea184a505217aa",
+                                "uncompressed-sha256": "90c41e29acfbb0ff15fd4211da31dff133d6cb8fdb7697c2c24f5d0ae0a94802"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f82954d44344eaba3ec800a1d6a79ebe862905480fdee8b6bbb86284f03dfa9a",
-                                "uncompressed-sha256": "fff26ec770f50c8c9d1934d04ed3fb16cf363ba611b280503e5bcbc55ce0fc2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ec036b7076bfd5df7e4912a21312c2fe0c266775c1f6f48876facc848291475d",
+                                "uncompressed-sha256": "71223679452acaeaa6e62b9cdd824d620a34aed15afa539e52125be2223ef3d0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "795463a9a9dd2049a1acb95c4042824f988dc07900e288f5105b11a1656af0e9",
-                                "uncompressed-sha256": "05ef687cc93cf2007b1ca59259368e8b552b2ca16bc85e3a9d9a7a4e3fe31ca5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b307e61d48ce1773ffc9d31a58fe5e867df5d613f3ffd161eb994c21b1cc35a5",
+                                "uncompressed-sha256": "ddaea6a5fc74fb5a31897fa8dc23e9ae1c805be0052560e1fdaada5b3a940dfc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "aabbf4157b71314acb5f0e608652030cff877f9ebc25bf236007a85e66f0584c",
-                                "uncompressed-sha256": "a9da66ae5812c5bb66fce5bfd774bcdfee1a77cbe96adefec71412d36b0e7aae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2b0037e5dff3c790be93504cf925fb0dc3d731d02600bc606d1d28584f926a7a",
+                                "uncompressed-sha256": "76c73237865124036b3bc197333aa18c424df9e2163479bf6b1f1aee908d3b42"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "98a14a5a39b396b93d7f64cb475bae796e0b9e08881b4608256b616b98c7055d",
-                                "uncompressed-sha256": "c0ce812b3ba0ff91de8f2a0d99f940f62b9e005094de99423d262b52df83a991"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "09c26ccf17fa40880b37c757783bf1c133b8a94273090c70e58469f6eaa4e2b4",
+                                "uncompressed-sha256": "243b8a2b3e4423449c116b1341ae35da46a387da7063b4fcfe485be3edd8f3db"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "465b2f0d8eb9a82881ae2b38892fbf2913ea673c381d51a0dc1c7562d63aede1",
-                                "uncompressed-sha256": "6135c42b8a0e8ee5427549e212ecd43866aa521cbadbd0eec8452a493aa9ec9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "660eb32a56805363c90428caf309baf540e8268b0f06886c7b5f9104ee19177e",
+                                "uncompressed-sha256": "138b0af93a51f9db4617eb8d07b7a04392fa42da03add80bd1e4e84f26ea9a87"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3f0167f6e15e859addb6bf26cee04eea8c84115d7ab365ee566d0c34bb6f95f7",
-                                "uncompressed-sha256": "4039fc4ec9b71876cdce187fb48442bb272dfbeaae9b6733c7038738484e13f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3541fdddcb5d391a0195da0c772c99dc75a6b06bb55e1e8da2aadad05a406838",
+                                "uncompressed-sha256": "a1046d2da49350e2927a1baf3f6af9110851b3ea50f70b0631001fc093686c90"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6cf947f42bb78db37ca5437a6094f532858b4884ff2ae060ea9077289e16fe6b",
-                                "uncompressed-sha256": "37d1ecc310b00971fbcc4a950c43951ecc9f684c0ee5987ef88058cf73299b33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "0220cf007696df6719760a0404cce10d0db02b4abc21d9c191bbde38f1de7b8e",
+                                "uncompressed-sha256": "bba84bed4c4e5e572ed5e52996878a3349fb25a4e964b510cdcb4d462e216c1e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "28dbbc4524e0cb5317c41ccb4373a4cb8a3c1a01f9414a96bed4b47350bbef0e",
-                                "uncompressed-sha256": "16d1e0ef6721d30fa22b95045c8a79e80ca5b23d6ea4d7d96ae6c618f2bc889f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "19e9f7929ee50f0851f165865d8965fa4155eab91242fed561f50f7d8e2d37f9",
+                                "uncompressed-sha256": "f48f56f6f3a61e0493d41b19e5d14761d0092b07c30b1df2f19a2c73bf2b0db6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "705b6316e6c8c3aabef5bf0eb167f30fd40f3aa10cf8c1826b9edee0c091a200",
-                                "uncompressed-sha256": "d5275aa30b5c364ce377a3c12357836cf5ff429f5ad132d42c3f05af8c61af8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4b4286cabd90560f90656b4cd8434626b335914289091137dd549c6a5f377428",
+                                "uncompressed-sha256": "c76102135a4910d5072296aa1fbbacae300851618cc3c6ed7aed201e8d261105"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "57753468a6b482c7903fac3ee13d428c1751ef2927cbf314d01e2a77aeca8747"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "9053b61b84c472ceee5af8de18de89ca6351ee2d723542ea6057d2ab8023e36a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3d7e20480717973d5c660cfdb87b3cd5a723c17068ebaaaa141e54846be0ce24",
-                                "uncompressed-sha256": "77dfc0abfe91903a8191915179a92de11a75501f43c6d61974a31690097a7f2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c96da2aa328c6e3da261e98a2c4526c3b1aff4fcbdee82427cf774ca0a124573",
+                                "uncompressed-sha256": "fa82775555a852e75fa33d7eee8c3b9b0de039a6627d4c17918a6b61cb8f55ae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live.x86_64.iso.sig",
-                                "sha256": "8c8c602c96c98c3dfb5af11e3df562f335f07fe22f8f2aa5c908d728d2478dd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live.x86_64.iso.sig",
+                                "sha256": "d34520e35c75edf85df47a9d77e42f095253ec78e2dfc4ebdc497a5c790eda2d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-kernel-x86_64.sig",
-                                "sha256": "6e82b0768a36a8ac0ab9cd5c31f2e53b4da91c773696cc5847a1db5db1953efb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-kernel-x86_64.sig",
+                                "sha256": "ee39b5da6bf3bce33a573a2e5ceec012955d90378b11260472b0030f689d07bf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3bae21c245230a38b022f670d89f607f6e105d23e6d57969dae21f174ba96494"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "97edba3e5e7214bedfae920d95243e5f178b10d229d530135a694920a1788deb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "91e5c300f87243fdad6be468ad228ffac8b6b20dd29cd3c701eb5fdb6616ecad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f5fa8728f90ab19cf123c71efc42e7f8ed905c9c59fc81a7679466bebc27294b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "55a3f63a4bba46bb3a6cc26fc1d46bb2f4f6afd6d9811d066199c6a7b05c3b8a",
-                                "uncompressed-sha256": "217d91b17e24dec37deb68f354e8c6d69228e9c0c808db2ac787edf15b65ff56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "9d58d0b73dd2723b57516e07e0db2cbc754536b22182215fe5ae3bb3625fe562",
+                                "uncompressed-sha256": "30b3fa62ec95d3c016556f0ef84b19c633abc50b6d41a99994ebe315cdafda3a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9c407bea92b5406d8ffbe80b18041eb022d6a1bd296074639c27546002174184"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "cb35e286860b27f7cf48dc5388f40faa6e7b9fb89b63f6130143cbd2b6d2a29d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6ea16aa14590237f63efa3b0cc68a0deb26de5f4f1ae26a771a3150877bd45eb",
-                                "uncompressed-sha256": "98953e008e1e0ba88365ea7dc705527608123e87b161a721da8ca3a1cf899d9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1712561ab86b1e12e44dedf02eaeb390f6579bd257a12df5a8073e3e33643e13",
+                                "uncompressed-sha256": "e754600cc1f9357845beef76f71544db9662fd166113ace00432b476d18b47b8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b2e4c07b8ac0e96b39af58f7daef9829536b534ce6e774dc14d54bcce000a81c",
-                                "uncompressed-sha256": "280ee50c8b3f932fbe2cd903adb592b83de6f66910152bcd092e483d8cc193fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "58b62252e922f1a22225e44417cba4a4ea54f5da8369aaea627fe7f0cc0827f5",
+                                "uncompressed-sha256": "6d9d5fbe980fbe67568461e8916efcd3f586c3ee7270c9ed12cbf7dd68b5e3d3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "71fab5fb80d763325fa09fba10b22916c9b6c7934bad3c01f70bf478e6802552"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "bf1c4e09ca29b754e488d79688735ab3e2b602859a35abd39bb816ca801ce394"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "d562b49dfd8c39cfbd438ff9c332ab7b3fbff5b7275c12419680671ae24aee29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "6141232d09a5624a31fb56b4d958bd82ebedee79f6983c908a027d320644814a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240104.3.0/x86_64/fedora-coreos-39.20240104.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "edd7bbdd97986f1293bfa0822a16fa9bcdd33ba3a89eecbd11269c641b92e434",
-                                "uncompressed-sha256": "d70a8f96965124e3cb64eb735055255b0d999ec43b9fbb756a1563f3f05dfe4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "474ae3003f2e8f7e9ec740ceee78502ef5519a87d6918e1f561ff240d832860c",
+                                "uncompressed-sha256": "5dba1d3ee03eba1521b26e55671d4e2e2d8b2ab29c0f6c99e8c0b61d5c225bfc"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-06221efe62934b28d"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0c9c49ea6dab7dd53"
                         },
                         "ap-east-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0843172e925d739c5"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0d381c13b70780843"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-06cfd393abf09571b"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-05ba0dee540bec726"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-012dedbde605d3b29"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0d33dafc98271cfed"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-088ba4e1cd8a04415"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0c75737247cd1cd95"
                         },
                         "ap-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-04eae00021a933d86"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0cfffda68469ef9ba"
                         },
                         "ap-south-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-069f2a5a5878df7e5"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-06a9e9d6cd1e2be9c"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-01b7437de1b1ba5a3"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-03fb613dbe6c97918"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-061aca53ae6f96986"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-09f15ca8e136bf77f"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0803edab7665c3c14"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0ef05977f6c8da287"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0cfedbf201aeb8451"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0e40ca4dae495cf83"
                         },
                         "ca-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0757f261206dea0e3"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-00ccba9a62486dea8"
                         },
                         "ca-west-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-073959ed3c1f502ee"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0e11ab4f92a65c068"
                         },
                         "eu-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-02553390fbc866b75"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0c26333b53e21db01"
                         },
                         "eu-central-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0d01d72cc2ec16772"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-076bdbae1716b8707"
                         },
                         "eu-north-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-082baca36d3c5b8b5"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0708e97aacc8ce35a"
                         },
                         "eu-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0aead8a5bad6eb65c"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-08443c0017a641a57"
                         },
                         "eu-south-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0e520f880acfe649d"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-09ead1fb0ad2b9ae2"
                         },
                         "eu-west-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-07e74c60b3aa40682"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-030b283577a1952e8"
                         },
                         "eu-west-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-03897364e55b98062"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0b00f28c8aa40689b"
                         },
                         "eu-west-3": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0b59be704eaf46af8"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-042f6b09e5d20cad2"
                         },
                         "il-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-092e3262a185e6512"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0fbb5e346df3ba9cf"
                         },
                         "me-central-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0723fb8f3de07e910"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-082b2fa78cd202f9e"
                         },
                         "me-south-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-02084b29d06302e19"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-06c7746e01d806014"
                         },
                         "sa-east-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-07152fa34cbbca016"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0b20c5924042da658"
                         },
                         "us-east-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-07f6bd5eae6faa520"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-0e28c621aec36772a"
                         },
                         "us-east-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-0db4527520455e4e9"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-058298b7a39e71dee"
                         },
                         "us-west-1": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-026789f7c77caa129"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-01d1a17744988d96d"
                         },
                         "us-west-2": {
-                            "release": "39.20240104.3.0",
-                            "image": "ami-06bfc30ac7b5fbd32"
+                            "release": "39.20240112.3.0",
+                            "image": "ami-05fe9a391a16d16c3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240104-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240112-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240104.3.0",
+                    "release": "39.20240112.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:940a1844dd4549122bf449a841ece86a6822ba1f1304b95f7d6cc4d39dea7ebe"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bc076398e96b835a1d1cd06a91574bfabce0d14ff1cae7ad5449cf884b825299"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-01-17T16:37:51Z",
+        "last-modified": "2024-01-31T15:59:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "44acc22b1f7c6924a576bce81688b98419264507fcd1dd1b6052716189d4e39b",
-                                "uncompressed-sha256": "b372fc157d21a7b38c0c25c34b8fce1179de3f59e4b8d83422582ed27f43c829"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "6960c4aba20cf5d8319ebe015ca73f348320856c83133ccb6cccd0cdef2ad852",
+                                "uncompressed-sha256": "19eb647ba91aad585cf44e975575b41f6a002a61e22313e551c16a8f92ef6ea0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "523afe1b81da04e3e0446275c5b7fd2e081934b76f63569472d9006958f4bb4d",
-                                "uncompressed-sha256": "546921d1723079d694f9bc3589c77aa357402c59a4c7667e0fbcce854171fb4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "521f8a1eac6066dadf403f06a1eb4654d732925389470e0067b351231ddd22a5",
+                                "uncompressed-sha256": "4cd3e437f27d1a0a911c72ff3236efbd8fa6ec2aec00dfdca2a770e8d9113b42"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "684b2122bf5d6fea15fe5e9eaec22c51b077e25cb58668d08b4a80c4ad0ec506",
-                                "uncompressed-sha256": "1d9d88490acfe8265fa70bc64c775af1599f0595f583753b48fff1640de32178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "01c5ac87f8372d46fbf015046371a3d5a3fb565c37e4dec011153d8c4ea44aef",
+                                "uncompressed-sha256": "0271c95f6032b69d63a2ef17e9f3810a78d1d33c9176291b9ab60301eb484d05"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "25b34b8113af83233d02d8dab17986c4dae8438b7d417ad37919f7e89843f6eb",
-                                "uncompressed-sha256": "60af974eb0e1dc7dd7fbecb2215f4b92961396b77d445694cdea87c9a5a91479"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "ac809592f47edc95a61af71bec09e80795ac510a5c208049df26a3e7660b32f3",
+                                "uncompressed-sha256": "63d91c99bebfdf3eb0929d285bf25da0066392de54c004fe90265d434065ea34"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "9c7a6f587cd006327cb5ab77268d3b3f07c8630f929e6c2ce884e12f2701aa7d",
-                                "uncompressed-sha256": "109f82fedf971741b223f345e705ad3e316d5ee55c4e778fa0ce9cffc2ae931a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "55fb35e150ec6f0d9f7383b5b2cbb7192d15ac4aa2b9a7b9b8d1cdac3fb019c6",
+                                "uncompressed-sha256": "ff69d72dce0bd6a00d4a0da7dfbecb7feef1910100909b62823b04f0635aca6f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8fe25c5d5c89e6eebc725b71301accc9e0c46273a8127b31a6dca08f8b15198b",
-                                "uncompressed-sha256": "75a1986bfb1f6e1d03cb1139362ef5d9b3f9f42d947bc6d686ec4b847eaede2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "20c7578202051ac9ec72e4bfd6843c9edb89c59dde9f0e034df10e43b89372f4",
+                                "uncompressed-sha256": "af02f5d35430a9c348dd3ba7cbc7aea73f40f5ce097f1f9e44ff9270da062b3a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live.aarch64.iso.sig",
-                                "sha256": "f7338bbe6530bfbd621e6b64fc75b8e775185db08e4520abf93ba43d8c738446"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live.aarch64.iso.sig",
+                                "sha256": "4ef87c8ac5acbcbcc9cac614fa4c325362bcd5d93bb657e591bb1330605eed40"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-kernel-aarch64.sig",
-                                "sha256": "608bca9610637faad7d468c5e03019ef81a903cd0a3ddc83cc4f693729b661d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-kernel-aarch64.sig",
+                                "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "4992b50ace7634c711632a8560a7a8621b47aa4d4d86ccf6f399714cd25bb669"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "678be75b67c7dcc9108fdb753622351fb14fcbc3a42c5a178a6d63857ee2140c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "127afc4f07e0676137addbcc45a8f4cf2c18081c604f899d2b527f92523c4309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5b7f3c19307599a95f3e84ff24efc231483d35707c3ecbb5c1b5d25cabab00ea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f2b15feaebb94907c96400354d8bf22010a28117c92bf67afebf9ba2a91e36fa",
-                                "uncompressed-sha256": "e6e767999551542ac245874d35931b4a91e2b29324d40c2cbf4c810e34f61bbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "b9ee32f1b931c9698bf01874507a0fb2e6afce9e05ebaaff7240c37a5a961bba",
+                                "uncompressed-sha256": "5da0a41cde660002f3ff7de7924d5659f67e1ea2a2942c1a2b1869a79f21d18e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e86f31f0327077affd957ca9ad91ad5c652d21d5e8a08406a9552bedbacd2d53",
-                                "uncompressed-sha256": "66add86844f27deca1aed489278f8251006d9860c851823c3d909b1c6fa291ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e7e38e944b08deadd88fbf7b7cb3326314da84aee0d1c96192c4eb8314940ed1",
+                                "uncompressed-sha256": "3d00f20d932fce4367f59c194f546cad0044954003a898bdac7740ce6ada9c15"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/aarch64/fedora-coreos-39.20240112.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4b2df74ad4d684f4044ce796f4a8aab4cae62b72c167af5d7d8aabd03196186a",
-                                "uncompressed-sha256": "1f2004aab9f7177fa3bfa6bc7dc1c86a8c4dd26e6efaef739c9254f2fde35a82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b40963f631fd6df22f1a08726a1ca3d7047dc5b80787949befd10d31e3931f37",
+                                "uncompressed-sha256": "b84d5e0f86f2e51ad18a0a2b9a48b3f360072ab24dccc0734d59f4661ed626f9"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-061b920181195f921"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-002090be60dd32401"
                         },
                         "ap-east-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-003b35299ee0176ca"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0886a2ba677902e38"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-083719325e20262c7"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-04eddb1847450df3a"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-01345d19a14c9f0c1"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-01736742578192028"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-030e3aee8b314456c"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0bdbb5b04132917dc"
                         },
                         "ap-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-012b7ef31e56795f5"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0bee78a0aaa99cf0c"
                         },
                         "ap-south-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0d1765cf6225a0b66"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0b4d96c25de9fb819"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-01f5a398d14b53fe8"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-008deb01f0130637c"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-02118e41ab92ac7cd"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-07c701701304e98b3"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0e7cba6203ed0e886"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-065187b179c39b6b4"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-05a45357f5b7cd1d0"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0e408954c61c5cf97"
                         },
                         "ca-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0386d30945c6dfa5d"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0486a6c73036ff91e"
                         },
                         "ca-west-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0dd834eaae53e05a6"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-04711cc3dd696fd80"
                         },
                         "eu-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-06ee14386a144459c"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-01fc048cf694f54c0"
                         },
                         "eu-central-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-00e57ba426562edf1"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-08e20d80e867e1711"
                         },
                         "eu-north-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-022f32b5850273e66"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0c426f988811c7fc9"
                         },
                         "eu-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0200c87af9da7216d"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-09e27e7adc06912de"
                         },
                         "eu-south-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0c3b3942c29344621"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-032fbabe4a98ac843"
                         },
                         "eu-west-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0798087a33f5d4bb8"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-00b702dd37b63ba76"
                         },
                         "eu-west-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0918f19a06c15ce7c"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-01d823c0ba6a90d74"
                         },
                         "eu-west-3": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-06d5c020d4bb1a078"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0c844926cef64ac2b"
                         },
                         "il-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0f1477c3a3c1c09ce"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0b4a5224f51720aef"
                         },
                         "me-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0e115f77eba7ffeb6"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0b8b43250e0648512"
                         },
                         "me-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0e833c4aba080941c"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-077da6ed90617b13b"
                         },
                         "sa-east-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0d1fc539adac60eaf"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-086e52bbe0b184b8f"
                         },
                         "us-east-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0a41b268f64dc18b0"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0571cee39209cf1c9"
                         },
                         "us-east-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-04a0ee375379c0abe"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-05dbfaea03381eedd"
                         },
                         "us-west-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-07256e1c1d14257f5"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-035d772e9d1b093e9"
                         },
                         "us-west-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-08ed3ff4a2285099e"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0b6464d7563a54e8d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240112-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240128-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "cee14bae44b3fb207e339541f733caa2faa1893931516c0e7c759c349c568e64",
-                                "uncompressed-sha256": "031a6d2405bb12461eda69d6639946e308c089d458372627d6beb3324496b87d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "13b0ce127dfe3101ff558ca4adce82881c8d9252accdf8ab8b5fd7c327ca9998",
+                                "uncompressed-sha256": "dbe96f9883decef410bbba4b0a1042236d7d1c2a84ccd33b6fee1ecc68504629"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live.ppc64le.iso.sig",
-                                "sha256": "73420798e47e59fb7590decdb695d5699331ea24eb4157057f723744b7fc974b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live.ppc64le.iso.sig",
+                                "sha256": "fee0f242cd730e6f44de5e8803e3dd3ecd2bc1cabd70d2942725856b722dfecc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "1ac57384bf7457f3a130dd6672a771e1e1df503f68ed16f1f70cfb05ea911aa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "4e8912ba15341bad3c069f6312f104a124d91dafae301f5ca6e38ca32e2c0815"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b7a49be4e9933c35e9f449054784e9b8ffed380f2bdfe47d90c723c57542b5c9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "17a886e78bc08cb7d05ad020929f05708d414160964e87abf66233d9a846f4d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "fca31683d5845c4f41ac9f757a91701af166a028345f2875575a71b96c5fecb3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1a5d0c4236d12d75a8c5f28af537b0226d3e5b1eb0319983db96b2379e22c0e7",
-                                "uncompressed-sha256": "80c756bbaeb1190ed0d1f4297170e34bb357fc84d5438bfe719bd65655324f23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "72711aa3d464dddbbc02f93fae5fb13e1295606d6c6501303b801bb10f4c7253",
+                                "uncompressed-sha256": "4ad638607d356a502cb524ab92f0a693fde9c5046daca0dd7836c7e46a9313ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b73d2064ff7ab07bdcf6e89f7ecb713edaf9aec69fcc43c3fad8a04d36abc705",
-                                "uncompressed-sha256": "ff31d554cb9ee1b0363cc0afdea138061da03e339d891d73942527c164ad3b54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "be0a021aeaa492869c8f31aaa4e690f73c63b4251353095296abcdc3cf1abbd4",
+                                "uncompressed-sha256": "bc50c63e1c88b6f82589a7a53b61f410e326ad59e7393bc34b2ca9403081b089"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "791b509aea88095b65913e98c67cafb9d890adf254d279999639092572e434a5",
-                                "uncompressed-sha256": "ce9fb20a28333e7fbdbf7f3aabdfe8436abe86ab8e6b30f0ef76c533197fc8bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9b0a7ad5346539a723a3eb704b7447b1262c5269723595cbadf41a93e8fa695b",
+                                "uncompressed-sha256": "069cb7249c6a1ddf41249fb098ef91b795d77420430a1b78ac15ad1fa4acf32b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/ppc64le/fedora-coreos-39.20240112.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5e4007cf5aea2349d638e91686646fbff7eb1288811ea603d9f8c3c7e8534d40",
-                                "uncompressed-sha256": "a52650a0e32e6b4052b3d756eed8cff5733a6fc2b1c892e7c7809f896cdf7194"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c7c0368c8bc4b9bbfffdc66364fc675898237b8cbae800c32c1e5aee1319c1b8",
+                                "uncompressed-sha256": "7c6ac08728892c8b918d751445df7968e66334904aeaec1dfcf4b14765d17b38"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "164ce084ff2d59b290692f50aebd9779f6a4407a990e0bf93ea385168abf49dc",
-                                "uncompressed-sha256": "8923381550c895120c2fc64f494cbd847d3736a41e21c04ca0d77c5e15532349"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9cd4e7d64d4c4b0c55d00a11ba33c0ba7e63b3f2de56dc54c1e3596f26b6c49a",
+                                "uncompressed-sha256": "edda4866c18085d062801494afaf03553dae7354f1ab549003bb7c8e8782d6fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "76ee7a2e1eb025bdbcf578e43b618b0f4dc1ddec833995ca4786cd98fc4badb3",
-                                "uncompressed-sha256": "35808fb7b06ead62fb3714c8af4a0c07548f5c8d6a01e4c787605db214b33c5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e7bb5ef1b7c1a20c3feb526dc20c11d9d8a5e911476be239a2b9114fdd659b25",
+                                "uncompressed-sha256": "0376d3dfc129aa934a02d7c7d137a3a73e949b54e4649033bdab9ab4555d0e1f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live.s390x.iso.sig",
-                                "sha256": "4d27c2d5dc3cae8cb8b6a2e4e52724e0af09d33c9f203af727c10ba5640cf56d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live.s390x.iso.sig",
+                                "sha256": "e88a257c45b87da6116b3a1df34a0aca33d8fbc244968f73945a425b20b59c99"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-kernel-s390x.sig",
-                                "sha256": "08c1bdfe60e2fcde9b226db19736e6a468aa128c8b39516e8548512209b1ffa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-kernel-s390x.sig",
+                                "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "be3e384663e6be968fff075e0f26ab816b6864b515367e3cf5fc2b7dd50ae036"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "cc219934b7c60a0da917242eaed0d6b0fc03ec26ab36e1a0123f312d442f7941"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "58cc3eb73c39f3c498ff121ebcb5968375d90a8de45b491435c710fbf5bd9c6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "cbcf0d996bb92dca5c510116f1412207b0e99057942651bbbe4f738afe87a5c2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "02ac355fa28f8b29d70e7966860252ffbe8a3ad4f9cb5e9a4d7de5b7a37c94c5",
-                                "uncompressed-sha256": "b62db44cae8400d2348cedc3fc09df45c9610348e7760834f35ccfe27368965a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "20d02715a78c631d3a03fa4a64ff1c8cc7667c0d5f3663dab10e7a6689a14237",
+                                "uncompressed-sha256": "ad977b3792a862467a9082f9ccf38a31575b7ce9ce69250feea61167b6ef1ba2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "01789cd85aaa9c81147089bba3472711a96db58c4a23318bc2595dc93b4c1efa",
-                                "uncompressed-sha256": "ce03a51ca064679dd701a4e8c31d9b45e3561a92295166db949c502fea3578f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "03cccbbdfa3d4f57e1dd178b5aa998023226b63582b708895b6c710152136cea",
+                                "uncompressed-sha256": "41ee1decd4d464388fa3f86b3a58869b54b25e06133abc2006a3a378100d2ed8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/s390x/fedora-coreos-39.20240112.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c83b119c6fed84676872268690c402109b5c81fef45819e25fbba8a1b94b8db6",
-                                "uncompressed-sha256": "347f7a9734e04dd17c8d76ba675c53eb6412863dbda753a016dcfe2c639bfc1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b8446915bcfd7867808d6dcf99e84b3db7837dfc88e9e9362cb4c0109fbc69d4",
+                                "uncompressed-sha256": "1c17c5b8921bfcf509e34e9c7f8943229541909dd7943ca44379fb8b4a1aa32c"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4d3576e09b720532679715a852b93156502fe27cde06b24159857275edd1d8ee",
-                                "uncompressed-sha256": "cd5d344ab359831812ca9f7a3deea6132566f2effbe7a1f3906d68cf6c5047b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1253fc4951df038b93e813f60ad9a4fa34c89c291e92d6c789bc926f8706a0ad",
+                                "uncompressed-sha256": "acf4dc1f5b70873f9d66aaae2f08ce4d947269c738f7cc9fb7bea3269c967774"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ec494e47cce8352ce979d6ee5d65c66a06f433546d939537b9ff8ed35aca84e1",
-                                "uncompressed-sha256": "ae3714e675c3793f2d9e5d57e5148f4f8f2c630706c86e0a7dfac2640602faf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3b64c45ad8588d508b58d72523bb1d304367ee137b6880fe90acfe76a1875fd4",
+                                "uncompressed-sha256": "991546c75ac87f9fceebe82e1f10075ce194de2b758cbc2942a856cde636de04"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f449bb1ade3aca2835f14f54f9eb3394e2a786108ed349153b85f54149430351",
-                                "uncompressed-sha256": "2430fd078ec2653c543b2c3f9b0c4d94ef1a024c9ef619b2bdd3f57255580c5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d4343d1ac24e97783f1e43e0a668c65570531c3943a7619ab63aea44d3f1e8ed",
+                                "uncompressed-sha256": "5a7670307c86b648fdac996b4cfa06a0da19712949394ce986e9985f291bb96f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "896b0a3063781e4cd57a7c93e9e11eaa7b8654cc993f12d3b21eaf25e601a2fe",
-                                "uncompressed-sha256": "fcb47515ea7657f5dd816485b24def450742ce592ce4706ecb2b6a19dd5bd668"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a4d86d46f4dbc465eab595deadaa36dad827fa9aeb63a23ad235a10859bd76da",
+                                "uncompressed-sha256": "090a597b1c833c6fe5bf554d7bd493ab02631f7601a334813821451f864f699c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9398beb8a9fb76c3a817b598002dda1b956194eb614fb2f8cec689cda311c83c",
-                                "uncompressed-sha256": "a65d70cf08f6b1322f31317ec90aaf424d0a6db077ad27800f44fd0ded518428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b01d3b99ca328303269725afe4c07327e8599159a46a9188acb37a241a06974f",
+                                "uncompressed-sha256": "4e36741389901328fcf2c631d4fc8b4b2553f7bc28b54a406f7e4348a574ee87"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "cdb09b368e3f320b959ea08220bc212b462e367909aac4bf055f5a6469e44428",
-                                "uncompressed-sha256": "6cd1364604c1c8289e191f302e9a9709879843f31dc2fbe0f670e0cc03765944"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "12d1d245e4e4ad1e41a804444be3b0ac22c127019fc1668d0bf1a03d67cdb810",
+                                "uncompressed-sha256": "8bc498765c17c49099b21b78d8ffb1ffd5cf005448c147e291f0bb6165a9b791"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5774eb2b9a1443e77ffbbdac937964cc37d0f0cc6b3ac0f454c5a0f90b96ceef",
-                                "uncompressed-sha256": "2019236f382bd9fb7deb81e85a8e995d66f283982a299fd2aef314ede2be39ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ba09d359cccdaed3afbd91e1eab85239be084bcacc42e251f876515d07d64230",
+                                "uncompressed-sha256": "315eea3a5e11549cdd815d65ee5ab85a86dfe256272f1be072e0502a19f3fcaf"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0e457c35f8ea5f4d100621f16b300e132bbb6de6376c419eaea3cb2a2a31d5da",
-                                "uncompressed-sha256": "df1d17f38ce611b362d2315aea0c3a35bbfe11a3461715cbcd3c1805aa9dbf5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "003fa6b8b3dcbbf27e61e43ab26a396e2297fe20b89284293ae4ca44e355dbce",
+                                "uncompressed-sha256": "a096620bc0a5119a9d7f24818baa9e399e8f5cd49dbbcd1062a4896a2fd7615d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "90935db33b5e20382360fa850ef3b34fec0c9b5731c8c83e3df7e978401e2c33",
-                                "uncompressed-sha256": "6fc3b9990e7f4e0e6210299f24ad3c459db09e7aec1d1b5f63f51a64f7412588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7bc6dce5568d3e89ef4999a8469c2f528d96719ea3a36318dfb3fb3e40657a47",
+                                "uncompressed-sha256": "7677770b9c27451c551f7c44b4d471cd7b587cc0b4fbb03d70b9a00027aa7112"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1b78198a0bd83fa1e04f7324114ec0718406ece37d2ef1ffdad4f3173b29b30f",
-                                "uncompressed-sha256": "7c7677d0aaebde081703f37814e7f5d6ab02dfdb374cf031aa4d9480b4b9650a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "345a3f2ca506301ed1d1c1d79f9117a552bb5a027f728e6524513a64e74c251a",
+                                "uncompressed-sha256": "69ef47aabc95ac46f38d57f83415d643d41316a0e085fc18e999fab869ae4897"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2737cb6668a10973c5ac720170e95c02e9db7f3fc24477c66d3d0d6c6ac61d3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ed0844a42e0f75051b0e0641daa5200f0af5f4398027344b1ecea81b9b203a86"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "119cc8762cbc5f9c18f6254eecc6b17541ea707da47e5b43a85a45963842f83a",
-                                "uncompressed-sha256": "60b10ac4864adb32092d6878ebd19ca0a8266e86389da814b634087b3e15200c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f1e46c39d0a11022cf34cda0f07fb35cbb50e3a53b27995399690595433e6ade",
+                                "uncompressed-sha256": "6ca3a59cf56ebbbc9b6134fab898ffa223a1ebdcf8a0017b074ab6f651c3dc1b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live.x86_64.iso.sig",
-                                "sha256": "704e0f2bb202f13e2b987fbe62e546dcf646536fbab6839f65c3246a34d225f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live.x86_64.iso.sig",
+                                "sha256": "28cf2d9a4f73b7b58f2bf4bb3bb8de2a7e66106aad2f5987b6d5f15fce109437"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-kernel-x86_64.sig",
-                                "sha256": "ee39b5da6bf3bce33a573a2e5ceec012955d90378b11260472b0030f689d07bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-kernel-x86_64.sig",
+                                "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d200b165650fbab62115abfeb125c4f6ff9ab41ece7ab54f7d4d3460a04f808d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e172ed4c674844cce5c47c25fc7e853d8651ae3ab98cd0ee32d566184f7924a6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d308e1db764ce2473455fe2e7c609de841a27b27a3df5cde8ac4c0e442b33457"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "aa85dd7813199b97313320784dc054ca4f4d448131ffc459720c8d3a8749e550"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "aa26488e380ad91b881b683211ec53bf7f58675fad1b6e7171af6cdbba7f07ec",
-                                "uncompressed-sha256": "776fed95c7f7a2759a725eb8b99203c8d0ea928b7cdb8a73d995bb60d0b9e8e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c532b88c3595d519dd75eb7f2c1ebc49a5dbca5d04790bf14f67e9c8ddfd5b71",
+                                "uncompressed-sha256": "0aac25ac437a4d22d31152e33166feb2f80d37664107c7ade52f629229786376"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b48369883ae8e63ae865bd234ee99c17135a11bb477b9e7cb1eda02b13e9b025"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c5a915c534b44c539435e00b72c63f23d1386d2b5113b0ff5381962931d5d659"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2ec796302891ec9c2f252b3f5f3af1b8a0d9bced49a9798af610520ee10abb94",
-                                "uncompressed-sha256": "68af863f19f9d68f96a612a2061d700a2e0efc005b7709543d4f429e7a7ad583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e999dacb2409d9289c02d2dc074471c35e0a55fda697a38c9d869da79d2e0b6f",
+                                "uncompressed-sha256": "21c847fd1d92793af891ad1608ad94f4c9c59a9e096ea4d2ef5bac8bf2cdc3a0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "26a8d494569c92a90f92d46abc70a02e4d979cc8c39bf97c588f52b00a951b66",
-                                "uncompressed-sha256": "29b35bcfaf3bca7e635bc2ff0374627bb1bf3e21dd80126d5471b0b6e63fa7a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2d315e68f52b09ad20948aba1c7e17ff0d1b9149ff7ce64993fbeee60e28fee3",
+                                "uncompressed-sha256": "82f7dc122d70c8d31f02f695c0a1fe90938fa99e0c12f9223e9d00f354c392e2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "afeedcca1deb95c56c7a2ff268148930fd3003af71c6166ff7afd75fb4052e14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "30078950ed87056b3d3e2a57379d9267870058757d0966b9ad8eb386ac02b878"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "9e7068461eb307014cdbc788cdd5e856dd887830786309b03fbfb91014d683ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "43566a98f8426751a65e167ed3063bc43abb53c9ba4bf55a8024927894b693d0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240112.2.0/x86_64/fedora-coreos-39.20240112.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5ad89b08c15dfb9b4157d9fa0382d83e1ddf5bf07aa35af60a1be5c5e7a15b35",
-                                "uncompressed-sha256": "2900c6fefbad8a5a8cfc5b97d472da150cec1363f641a38a87c8a458eaf3b5ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "adbee9f0155d60af115203112b9e7790d302bc29e6d47d06f163d1a8d38def05",
+                                "uncompressed-sha256": "d3318f46d187d267146f3321f1d98013a3f93fd4521701c1bbb949b349641391"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-07670ff352914f9da"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-012d92645a75a9320"
                         },
                         "ap-east-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0e0821af920345802"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0923f0d3ecae3b630"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0968a1b882b25e9be"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-092462ccd67627715"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-04a598847d17c8c3d"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-064407f9f040a06db"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-02ac83d5d51a2534f"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0f7bf07c98cffdb9a"
                         },
                         "ap-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-07a31a4475d825c4d"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-065de6d414a541232"
                         },
                         "ap-south-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0c626d11f1ad909f6"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-066acaa3ff014344c"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0c6f3562d0d11846c"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0c4aa08026b0be5e9"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0eafdc08cf9e66908"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0d3f3a83a696490d2"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-05a1b6f14d7905128"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-07cfd463fead2a29c"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-05349330c2efb32a6"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0f1a1c6394fcb9b8b"
                         },
                         "ca-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0427d8c57ea54c76d"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-04d814639a60a35f3"
                         },
                         "ca-west-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-03fb7e4fdf6a217b6"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0a7159763c5211597"
                         },
                         "eu-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-00223e92ba8993b9e"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-06775182063e3627a"
                         },
                         "eu-central-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-058483f44f79cfc46"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-073199530ba01d26f"
                         },
                         "eu-north-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-066e7096adbf618e9"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0babee6576b7a2f5b"
                         },
                         "eu-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-070d87292b3313bbc"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0437dbe9a8a8ca820"
                         },
                         "eu-south-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0c8a1474e30b8b046"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0b4acb30c52fd28a2"
                         },
                         "eu-west-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0928c0c531816c49f"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0ea0efa5d8f30b67f"
                         },
                         "eu-west-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0b43d573d8a704c8c"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-05450b1247d93466f"
                         },
                         "eu-west-3": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0adffd39ca4a89e88"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-050da059b7b162033"
                         },
                         "il-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0e7e48163808bb9b5"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-071c13917f63210d1"
                         },
                         "me-central-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-030d725aad3e19877"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0575d2857be59f42b"
                         },
                         "me-south-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0cb3b9fc69f66d337"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0c5aaaa634abc4065"
                         },
                         "sa-east-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-04720198af099c3ec"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0d88825bd459fc6cb"
                         },
                         "us-east-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-06244db759caef9df"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-05a871ed3efe4af6b"
                         },
                         "us-east-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0a5464e05615ea9e3"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-039cfed6744506e57"
                         },
                         "us-west-1": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-02b45ee5858a883b6"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-03f358f4ceef64732"
                         },
                         "us-west-2": {
-                            "release": "39.20240112.2.0",
-                            "image": "ami-0024bdfc86624cda2"
+                            "release": "39.20240128.2.0",
+                            "image": "ami-0d014869032cb2094"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240112-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240128-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240112.2.0",
+                    "release": "39.20240128.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0f5c5dce8b9eda6f164ed6ae4050aa1c83e6c7398976511ea52a7c6810291488"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e5ef135097b0c90cf8d226c0d2e369c9bbf541d5264221368be5f808a90dd008"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-01-17T16:37:53Z"
+    "last-modified": "2024-01-31T15:59:25Z"
   },
   "releases": [
     {
@@ -95,9 +95,6 @@
     {
       "version": "39.20240104.1.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
@@ -107,8 +104,16 @@
       "version": "39.20240112.1.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "39.20240128.1.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1705518000,
+          "start_epoch": 1706720400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-01-17T16:37:51Z"
+    "last-modified": "2024-01-31T15:59:22Z"
   },
   "releases": [
     {
@@ -85,23 +85,23 @@
       }
     },
     {
-      "version": "39.20231204.3.3",
+      "version": "39.20240104.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
       }
     },
     {
-      "version": "39.20240104.3.0",
+      "version": "39.20240112.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1705518000,
+          "start_epoch": 1706720400,
           "start_percentage": 0.0
-        },
-        "barrier": {
-          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
       }
     }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-01-17T16:37:52Z"
+    "last-modified": "2024-01-31T15:59:24Z"
   },
   "releases": [
     {
@@ -103,9 +103,6 @@
     {
       "version": "39.20240104.2.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
@@ -115,8 +112,16 @@
       "version": "39.20240112.2.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "39.20240128.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1705518000,
+          "start_epoch": 1706720400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).