### PR TITLE
Roll out testing 39.20240128.2.2, next 39.20240128.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-01-31T15:59:25Z",
+        "last-modified": "2024-02-06T17:02:08Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f51da60ea4c3d60ab88dfc25664f03e7383a1690d6932f8707787932e4044b1d",
-                                "uncompressed-sha256": "7b897f89b591a7de0448c968b589f149074812c7f0d8f8c7e300407e27ed923a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "4e1a8beb98f43d2a506ca36213240f594a0fdb36435e3e6d1f73383f9df87c18",
+                                "uncompressed-sha256": "0b8104006e879b0887d1a727ad9db12b131419e5f9daf7e8c4a6c904cfb7984f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e279ec325714a3f247ed952d0168489cae951b339c46553ab6c1fbde674f2cd9",
-                                "uncompressed-sha256": "2059fdcd27efff77075d15ec4a9b236ac64f91480b69aac0a1461350c7e64e49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c926f9740a76013b2b80f84150839847f16aaa6b47dd8c5eb94f4ac958bc160e",
+                                "uncompressed-sha256": "5e365330c61ed4a48235f5537d7cf655d048629918411f402ecb2f7a04d706d1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e4d71a5c34b61598432b4d533fefc11ffc78733f7d9d3a965867fc293d3c4c1f",
-                                "uncompressed-sha256": "e1325516bb2de29c80b0f14d1c687e278adc16cc398f5f4cf1d4dd6aa23c2d55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "67df2bcf017a83788a7190cd531eee6e53471161ba6f099c8e255d28b75e5645",
+                                "uncompressed-sha256": "4a22b2c86a9d93e39f55abb174b43305bc9bbd7a51e3e9de8cb2e0e1b84b2bfd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f93212d851092b24efe22ea3e5ddb71d73591aa7a13852423cc6c81ef0bd2ea1",
-                                "uncompressed-sha256": "f0ee05192242fad52496a22be2952acbc5906037ce81f57d69cfb23544d0ef10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "206a8260a628f10f0a4dcea47b98281f7ad5325b68584c1dc926d44b4b44cf62",
+                                "uncompressed-sha256": "068bdd516c593d9c2b6df15d771b8e6cb7aaef4d96c62f34288025d7d7d4ba81"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a1c8a566775ee3b7963ee305858a4a55647c370653333870cf351f54dd752a20",
-                                "uncompressed-sha256": "d856362fb75510d7af296f4b768a7ab01d091c54bcc482272b74bdc44715bdf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "708a2932b0e961aa5640ab3430a79ca7dfe485a1c18b2ee392cff88efc71ab24",
+                                "uncompressed-sha256": "fa797642d00ccc459c59ab12169c3ea9fa6d385637e57d8d4d5ca84b6d30a666"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bd1b1f1b5c5868a8f2b7c9e57bb099eb996feef2d29221fca8e866d9495c6fd9",
-                                "uncompressed-sha256": "77057117eaea9e56ef697b1d6a0ab47245e31cd67a4f2cbcf300d7699a8764d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "672973edff339c1de51d346982c75b646f6fc33be425ef7689f88af40762c7d4",
+                                "uncompressed-sha256": "c107cb4e7c2433f36ea81aee57bfa91bbd50ee32b97faf236aa2cfb7594e958b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live.aarch64.iso.sig",
-                                "sha256": "04216067703ffe530a74189191432fe887021741aa6d00485a374a2b03e2b2ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live.aarch64.iso.sig",
+                                "sha256": "acca3cea5937fdb5098547f41f0193516629b4fa4019e2bf97af964197d6637e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-kernel-aarch64.sig",
                                 "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "67572bcb809d05020b8c460f0c66eb0b8bde36d7a30f1263671a0448bf18a586"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "9780010693586ec0bde06c11479817bb946e3d973207e17b2b8900c44ab32857"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "58be0f42464c676ebc70cf1ed71b30fb0f386038d597f5d80f0348fe80d5e7f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "a4752e3429820aac7f5ec630fbd292ecccd714f8c57061ac89228d37ba0f1529"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7daf6fb5888518ae2a46df2b6903d1578e5ffa6b502b7ab4b53edded18f4ac3c",
-                                "uncompressed-sha256": "7003d0503aeb5b8ebcae2e54f91e9025f25c183baff461b861bc91ca7f3d430a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "79b19b556e9af987222735a9308ff88593eba2b1c814df27b4e574dcbaf7e495",
+                                "uncompressed-sha256": "c8b6e7cf495457c80dc5b554f3797b116518553775c1e009a2693b6bd61df8be"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "9011c1d29e9794ec5a7a06073060015d726461b6f7c21c10c1a7b57d347ab9ab",
-                                "uncompressed-sha256": "4f1d78154b918837d54435d582c71cbc4db6cb78f76084749f5ad6157f03fa82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f0121cf6cdcef646377a393df3e5d3a5eaeb5a4e4aefda2949e064dcca4a2f89",
+                                "uncompressed-sha256": "67db4376d440a251b9629406257eee36636700e6f27c9c388038add1ad7341f2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/aarch64/fedora-coreos-39.20240128.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0bd33f47a9b090b6fbe62ac9bdd7b8d4f5b6a69a9c82c7913e2de89eb99c2a2e",
-                                "uncompressed-sha256": "4f1bac343d1f89be5cbd34c91c3dac3f22c57d7f6484b55f8f97e193f3311b44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "dddc8d2fc57e8aa0140ee4212dea4293bc00cc4ed34b9500e432c1c31fad4fcc",
+                                "uncompressed-sha256": "81b68570c919d9831cbb55d21a45f44acc37e7fdcb7cb5978622aa533116f4b0"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0f0a35bc7d416d616"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0df6c3969e423a16e"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0b5508395be531c69"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-08fcab71901959654"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0942fa0be0d17c33a"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0785a13fb64eab5e1"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0d4ae81e1232e0d12"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0b504dd37a332a590"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-01023bfd94e3eb773"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0f45970701b47b914"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-054552b130722c2ca"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-02f0d0d9fc3bbeeeb"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-09f7b4d7105c46298"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-06304c932853cef5c"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0507da29e40c7b526"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0e22908767f1cc2c2"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0994590ec86c0c6da"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0541e008b396924ab"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0b05066ef69dfc42d"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0ebc3fe5bea5681dd"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0ca9e7a43bd47fc3f"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-08849433009e7816d"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-098e810e259b2174e"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-020f2a2843203dc75"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0f948f2c9832af2a0"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0f0598d566a9a420a"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0f8f7d1bda37bc913"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0aa3d6c12c353615c"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-071fa23e17c5a3456"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-014a2d63686a94d41"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-04aebb86745fb77f4"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-01fa4ee74331ac4ef"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-096ffcfa6faa25fb3"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-081d9755260b9ec25"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-090852d962b4363cb"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0714d704a74ce1972"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-035321216bb9cc834"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-04f3895184e806c80"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-04249c9331b03f826"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-064b676fd392c8bf4"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-097600ea5b0cd4c3b"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-06b4951eb49296e0d"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0acc7a4d7458cc19b"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0da311e0264473f71"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0cf2bd9639b663557"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0d339cece3d8ec5d0"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0437de2b1246b1919"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0d3b3b9ea8a0e2634"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-034f3593982e220c3"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0fba83e250a6d1015"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0e39eba7cbe899bac"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0d487bb55a0ee496b"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0180ff75ec5d4a1cd"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-00ca0357e0e102a66"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0ddf05804d17ecede"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0edd5a6f58a85dbea"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0e600acb1e2276bc3"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0ff8e2c25d724652e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20240128-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240128-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "aa9c9ddc80f4bae12958ab87aacc42fbdd0a070eb3aa931a822292ee53c6abc7",
-                                "uncompressed-sha256": "3033cc7fcbe3ae5eab4b31738d927c5fe566470c1cebe46486bc31ce8e17b99a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "438d61854b46f68fd02a77d0ff3907d91d7df03472b351c238b7fefef8173823",
+                                "uncompressed-sha256": "694f6550be85d81f22b9c37b999d003b01e739e01c11db9910f158731e76a409"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live.ppc64le.iso.sig",
-                                "sha256": "5224d844e8ea096b315130e96b02c71b4f6aa6e7ac4bec41afc90886255b28b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live.ppc64le.iso.sig",
+                                "sha256": "4871b9f0da5e3a8b28fa6ae3dc539ad24464394e839044faae2126be7f82b0bd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-kernel-ppc64le.sig",
                                 "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "92e1c243a95e8da54f49e1044b797ee36f8d3b219755ce165d0fe85ef9bcccc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5fc62cd9373ea347190b02f84b77baaeaf5672f87ec139ee9f52faf5d9163978"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "dfe8daac1fdcd9cede71c9217ad73ad948dc51238512b1a110b1479923e47536"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "de7b234714eb7436ca1d31c4dfb02e0a5812565707369035953e4ffba2c7861e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a6b094ff8bd2d19b5e3cf3330e3c8a92dd0272023f2226a0008c95144e8fafe3",
-                                "uncompressed-sha256": "565597a41d1bb570f4b69f801926de5171bc56600a51e0b82d210dbd2ae62fdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0833bb93d0f8e50400f87aa0c39c945310a8d7b705ecbdd4f211b37bb4fcf23d",
+                                "uncompressed-sha256": "3d3b4b08f4626237f20bc5140900bfd3a245e4da929caac2e9249c054c9eb4ae"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d7f3fb8a83d2e92a14044d21e1a42a8d9b1326e4c2accff85c26deebf22649ba",
-                                "uncompressed-sha256": "66b664c28a4ac84d53d8e1033519f0c7e355f3dbd93a64d885213260ad7aaa69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "53fed2ce0470f5b725814181a8e6e8ce3de120e2cfc914db1c60343cda05af13",
+                                "uncompressed-sha256": "b694fb7390ae477e3e27b7bcd23abe5391e9da312e1fb5f37912b7121a1c1246"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2a09068546749c41ec22c49b0c70943f55674054a0af567b79e7abe0d48f4c16",
-                                "uncompressed-sha256": "ce06631d2954a93aa7aa509b3a529b4d614aa2a5d12b3d6f7d80d56abc8ebcdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "874b18457dbc50f375450ee8643268b64002a62c4ed742cf3b642f48966df68c",
+                                "uncompressed-sha256": "6f64514da8452a4caf76fdbdf0cd3c7b78f88383a1754a82d6071f605d9f514e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/ppc64le/fedora-coreos-39.20240128.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c596aadb7b1552691fd1ead25bf31bfadc1995c1b1597cf935c7077ee301b4f1",
-                                "uncompressed-sha256": "bea3c6b2f164f848e4734c16e58d5b839205881ae7374e146efe322249ae3693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a406ed070e1e8d22b5c7a2334e7c5b90e1403a39614bd26d3145e5653945fa97",
+                                "uncompressed-sha256": "af00124ef94cb2d5c723c88faf7ddd7e924c3d0239b276ebc8ee3691cbf84f78"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "086568d0a644c1dcea95770d3c0aec6f406102cd83a4124ba372bd0513491145",
-                                "uncompressed-sha256": "b7af4ab09a36a01e5a47264d73f15eda94e250e0c36561e92206a065e5f4210f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "43e6565634d66d141dc58ad115f003e8316ce864799c6815129ec34d68deb420",
+                                "uncompressed-sha256": "6bcf023f1594b6e7697d28377c550a7f5e5655f6657e19af684b95d6c0707fbd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "253e705fb178d22b309a0acf8d187ee8da607f4117278a626d7bf09ada6db73d",
-                                "uncompressed-sha256": "1cb88c4de355f4b71d4503536ff6d77361d3b55df02b8bf3d225d582c3cd9ea9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b0ac3c4cd9e9f67f1c2ace25af70e0196ebffb861d2d8599e2552c765624ca9a",
+                                "uncompressed-sha256": "05089ad6ac151a661400d8acf5716628c54030a001abc1bc8ac979cf1a8bfc5b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live.s390x.iso.sig",
-                                "sha256": "f745c0792a07080795af4e3fd05c3af49c3ba0f4b529f746b4b1960f54dbfdeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live.s390x.iso.sig",
+                                "sha256": "1554dac67e50491d3aeea1c9a65d494436f2933c1314484b91167ab31646d23e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-kernel-s390x.sig",
                                 "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b3c7c74b6d2df2a168c4a9a873b0cc066962374c88c7655ff7a24c3ddd1b6929"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "80b830ac5ccf27384ebd25d724b9c3ca9e6f2b4f0f1b2b3471ede1a1a35d98a0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "2245b3ce56dd7c163665a6eb926d935eb939f50336a658f2c6ed31d1f14a396b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "8ff359b2a2c68ec64b08f7a1e1c53b002787acba731908c4435b5f1387dafeb8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e631d13c516c52a0dca2d083d0b3993929bbca5af298da0e73de00252143c7bc",
-                                "uncompressed-sha256": "7f790650c33b6027e3bfba694bcfddb24f7869449e9de6a1f1e88a43fe02005d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "18bc307cc0556960d2e474e426b5c7b6cd7818cada74e0cd654ef97f777faf51",
+                                "uncompressed-sha256": "44ed1103184136b5f8273a4d904ebf225e7da381f2684e87900792037ccebb59"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8d5b1ebd51941237d20baf9586693741a66c07e53fe8351c65d8af69b841c523",
-                                "uncompressed-sha256": "72dbecd4c511555816ab2a9ac906c1e191c551edc45e00543929891e36806af3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "eb922d5ad679eee3bb38fb8b287497c6ea5b67ca08b7e853084e882080afb042",
+                                "uncompressed-sha256": "4d7a39b43042eb8d2e7dc4568a812aebf1fdfd87a4bc9a5db3facba7dab3896e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/s390x/fedora-coreos-39.20240128.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e1d1aca55f96d5de0fc406cac8ce205eb31cd8e32274c831b8c8ac0c63ece3c6",
-                                "uncompressed-sha256": "bfdc230f4266f5fbb774324f07508162a69c374493d33a6e858cdb31b6aa6a08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5b73707d717f3ebf56a6a0075825bb7fe1316de6c5740463f8368fec427e04c7",
+                                "uncompressed-sha256": "0e3125a806434eed7e256ff658ddcf5e94a3c67deca9daabb00169752b1902a6"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3ab0c48999fece0d901dd80fa521bab125825ec08ca43d49933abf566aa90914",
-                                "uncompressed-sha256": "e7417e90fca94d32733e212d6b39146c9c507c8a0d98b93d0075014fe6a63520"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "18e429894994b5d9045bf34963029b7d637bdab9fbbcdacfad51b13838291a87",
+                                "uncompressed-sha256": "5c9f7295bd5e3fa81dcd6f7e30d2a57c1aef10080550cae60fce66fe49a6c825"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ddd167bc934a91748a967bacaf283d90200efabfe16f9cedc0056ff6dfe2fc9a",
-                                "uncompressed-sha256": "e7a79b08caa78ea9b2a1aa7abc36ca95d9c21d4f3da0eb5b2780e5cedfa996c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "d9cee9a9478eb30dcdd0c72e73a528a8d7f857aea41ee7eddf4879218bbc0d20",
+                                "uncompressed-sha256": "a9eb8954989a36fbb1d6c1c5904972b323cecbfe4df29f6af8c3af87d3c8cccd"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "79ed780910dfb6265d2f92a250e4e8854befb1983b3d2f4381a9c9eca7e2f094",
-                                "uncompressed-sha256": "70d30de0c20a3d0a9c75e5397e492d8952c706feb5bb3d2d061f50041aff27ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3027d9adeac13f63c5aa262a1c2ceeb7e681cd5f45719121472f95a34275405b",
+                                "uncompressed-sha256": "bd6128eb13ea66786b24912f17c15f29af690b087d7a75148532ea1aab6a538f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "35a0317031459a5936d3d23931445d383ddb4126b7da83a5e8cc5ddeac0f46ce",
-                                "uncompressed-sha256": "dbb78c32f9e68b1bb1e2be690b958b6838b8e7281da8c652435203ba6c090fda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "bdc059cb80cdfeec98b2c8aab5b9a268523ff760e8635d25d61df8255826f37c",
+                                "uncompressed-sha256": "4a5c490a32f92128a79393ba3ee9e221187b487efec95cc4472c78ddd1525ac6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a947dead1bdcf71fa3181814e31154f94cd2dd8ba0457d09e0bac36b985aeedc",
-                                "uncompressed-sha256": "19eebd4e335ed60c8cbd02819e756ec32a061baff8b9dda946084aae9cf2ca03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b8c826f47f2481982ec41e12797e245ea8dccb11e12beb4b0c50fc0e3e989bf0",
+                                "uncompressed-sha256": "46401a9e549eac36b44510a9fc081a6fa34476074788a83da5e8afbadf1ec490"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c8a18e46feefc1de6d6e688e7a66cd07fb50bb46b648a7cf8e0335279208aa65",
-                                "uncompressed-sha256": "16bb968d3c58437197a14ef28f060966b3141bfa0eecc0428ac9502c33481e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "fa32f62a54c4389030ec9ec1863df331f58015029ed6172bb586e7e302e3308c",
+                                "uncompressed-sha256": "73a6045c75b6078bf9ee77effc37b9fa02662323a1454d73f4b4bd53edef959c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7dcc963a7f373a7a1db72a8e3fe3229846ecc2aae12dd33af4e3c9795971715f",
-                                "uncompressed-sha256": "13f9cdbb577f04875e6bef2de334e95a64733efbb2a697d119f074a2972d2141"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2e322499269bedfe086fe42fcd6399479e1a9ed6cf2bd5e938abc91f13d36fb6",
+                                "uncompressed-sha256": "3395f7744ee4a813f7f2f3521ed45aa3d18d0b0e9d30270e05f7af3fcd4754e0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a1f1addb822c4b418fc1a6ea34bcf2640d66980aed773d5986b897cd1da3cc49",
-                                "uncompressed-sha256": "ce22a836ce183fb97e6a7f49389d6196aabaa4ffa08bfae9082576eea0b374de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3875a1634e05178227e955dcc37b3ce70083c479aed5208b4163f44df6083833",
+                                "uncompressed-sha256": "8eced852ef65291433e922ef186ba6478b38147501361e9ec585ff41121f108f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7e634a322bab4b7a559c5e4da49ed2b91e8cce8d62c4bdf42237af0d26b3f7a2",
-                                "uncompressed-sha256": "08a97c15c57be3fb9a19578ceb01ff78eca21de8ddcb90e9bcdb64100540fde3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "ae637fed2b9983ab3c1b90d88e87898a6f121b67c03cc51597e4ae3fd5a40da4",
+                                "uncompressed-sha256": "0eb17cf61886e6f2fd4770836c8126d0c666ef7bb053d6db948e8d3d152954d8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "184492ea500487f81f6127b7373a2e7754135f53d2c07b6fcf1cf4bd52b17e12",
-                                "uncompressed-sha256": "52a3c1aa4892e51bda1c057d91a5d0e12fe1e2b4fcf29e82551541e675017c2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2ec926f7d8ebd53157387877b5ee1d6c91dd946f988a8f4183bc9316bfe9d72f",
+                                "uncompressed-sha256": "2852631a4a61743c1d3f063c51a57ad32788d34c91f6ae499d2cdb6fcf3cb832"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "72ded8cb0d799e932504093bbeb55a53800ae5a44aec468b5a7dc6a741679a59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e257e95ae396b7ea03ad581aa8d1ac0ca65df969e959ded2db6ad66cada95a31"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "59f7ff7be3ad9b639bd57af5175159d4f6c226cc288a4c5eeda6aaf046c83114",
-                                "uncompressed-sha256": "74b41d6699238e6c8a9a2269ff863084db6f69129df2faf58e3e284a68ef39ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "82e22ab7d4448c0864c8962936bc33301c96956dde48c409d98a7b920d3494c7",
+                                "uncompressed-sha256": "db2a9c2b5e51b4954aeea0b84bd16aaa3798813c36eea4d9a75a0da34f1cda51"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live.x86_64.iso.sig",
-                                "sha256": "d64364d32d03ddfc0e64bee07cba49c0c9d897aebb1c81fa7d4866acdfa663ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live.x86_64.iso.sig",
+                                "sha256": "d46106ef61cdc5446dbdcb686c796bc86afd46f2f7146275f669b1aaf6222365"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-kernel-x86_64.sig",
                                 "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "30bc10acdb76950b5fef4ab066714336d869ae596f67e0c67789696c348b2091"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "808bbc4f78455af76415165bbb710152435e6e5b66166020095c7b74b4aed700"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "389c33191e51fd9e147a5a09479e5856409814d46e7ebfc2315dfbb1b178b0b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "669d6e121f733c79531ac198c325ae31efe30128b8c1ba3313706da68c369724"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4a071d0d72292a3ef21f9ba8dce24664dd227af781f45f40e24d218d64300db0",
-                                "uncompressed-sha256": "605d3c321826635bbfe3e3cf0d230629838bac6dac4c2dc506d25e5d169b732a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "5d40692e2eacd700d18903d5d0a576ff67491ab7564504238b83169899e60a14",
+                                "uncompressed-sha256": "fef6c15e31dd85d842c6e2a90706f70fd10dfff798ec1656739fbc203f3cfd32"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "5bbfdf90a284ec1795017e1c7af21a36451b0976a65506b73ef72772088fcaac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "08648e44dcf9fcc0e3f0a7569387228c57c02d58c56a0f6682588d4a5ed9a014"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8dee837228781262c7aacb564a3423bf32a0f16e3681931207cd89576ae12360",
-                                "uncompressed-sha256": "bcd0328cb77578a48a940878c84880a50ff8441fc4983b97160e9bc9d4d2676a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a34b52d34caf0dc6305f9c7fef877669a461ac3819ac5868af5512c54da453de",
+                                "uncompressed-sha256": "0ec9879a0cd973a3da62e890e940653598ea828e75ae7466c579ae88e91b56a4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "bf8bc502286fc6b6ba138eb4ba517c4ebc7e5999ca11248b758e13eb9f71ef2d",
-                                "uncompressed-sha256": "c1a065651427c65839e80c66f52703ae473a55f28d276037509d8ceefe6f0445"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "80b3130b7e5fb8127b852752685f8fdcb79b676b7b4f69ce457a70d50f4767a0",
+                                "uncompressed-sha256": "dbf6a20fe84b247c29c084a1f6ce7f55be2164a6e4610c302d608a753087e801"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "caa3343767a5349045841930fb1b79f97cbdb5866b98fb03947697d9c94c604e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "277f29846398971ee7e0f8ead763045a755e67d33883bb7c0f816bc89d558548"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "3e80f04d43220dd4443062079f94eb84209c7836b2f5313057d9b8984fc8fc24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "41724bc8b46c69167509cbfa647b34ca54defc3ceea9f7ee2b7db7109c2afaaf"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.0/x86_64/fedora-coreos-39.20240128.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e253d8a35b625924207b9663bfba616dd07721b747d294f77d559f8edb3ddca8",
-                                "uncompressed-sha256": "4e9e008bc672e6bfbf2880593251f4470d091f797e180e4a93afb6905e099313"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ba573d287365fe0f0625d8b99df64835f3fe09f729bc88a4463dc872e9d9839c",
+                                "uncompressed-sha256": "ddf8f4aee2e96abc63e9bacd255e170c0b8b7bb92c8991cdc93b93c9f81e5940"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0161e02f9ccfd5942"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-08d565f5d12456946"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-046f3a1079350dcba"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0f1fb91c15cc3a1b7"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-048f386e0ddd5d64c"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-017b1f4172b564628"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0d55c0b10bebaaf5d"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-083f813128851db8c"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-07d5091948f537e14"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0f8c5e624a14c6ba2"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-05185308375d32b26"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0ad8b0e996c0b69c1"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0cf3f5fb8bd594eea"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0eacbd114eb553f7b"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-097cdb267ff8eec32"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-05d037e2963b2667d"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0c5bca809f1630964"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0480148205a2d3af6"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0148993f2eb57be9c"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-05fa55820ac2a49d9"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-027b2853eac05c7de"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0a67f0033728e6982"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0b1b149c3cedda303"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-02f0f57954976184f"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-028402dd8345ef34c"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-085296b77610bbb38"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-060cef59d3a4b3b2d"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-083e4fb0824b3be55"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0f12eaa90a02a5912"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0415dd8402bd50cfb"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0385d3f14050638fb"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0224da158972cc672"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-05f90dcd65d26f0aa"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-080d3e92fba31761d"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-06c4d4b222f149f0b"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0f8d8717981f70bc6"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0881553f217d2c16e"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0576aa23a8f5f82e9"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-079df31e26465a612"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-076a5bc2f9908743a"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0b71283b2f65659a0"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0f9e22ad1f34d04fa"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0fcc3ad2fdbe4694d"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0c2c9af5fbcdedd88"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-098cc15e1a3ab68ba"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0591b7a26dd35a2ac"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0b53a5e00c4ff7b5b"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-03ad0ee0a6c7cf68a"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-09ef872ef209a1550"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-081a42e4fbb9e2900"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-0f4711414c9da1533"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-077f5c5b927454d9d"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-043348bd8dbd945fa"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0bb737456530f0b4e"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-01e6d7ebc2db15071"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-000368d4e6eaf8f35"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.1.0",
-                            "image": "ami-02f1df3759fd0c901"
+                            "release": "39.20240128.1.1",
+                            "image": "ami-0fa7edb26caa88037"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20240128-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240128-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240128.1.0",
+                    "release": "39.20240128.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b7fcf547ec61482268f465696c0876b4a25ab2c4db4105b102132d87a94673c1"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0a814c56b7dc0776c555600127c5f2b19a79cae53f2fa31bfcc1108dd269254c"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-01-31T15:59:23Z",
+        "last-modified": "2024-02-06T17:02:05Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "6960c4aba20cf5d8319ebe015ca73f348320856c83133ccb6cccd0cdef2ad852",
-                                "uncompressed-sha256": "19eb647ba91aad585cf44e975575b41f6a002a61e22313e551c16a8f92ef6ea0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-applehv.aarch64.raw.gz.sig",
+                                "sha256": "b408ce2fc500957eb23bef3cc0395b1b9f7c473045afcebafe5cf470f7dd66a6",
+                                "uncompressed-sha256": "6506cac91b57f900ea49972563d7ca16da55a7ed6738b3946c9c5a7d36480bab"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "521f8a1eac6066dadf403f06a1eb4654d732925389470e0067b351231ddd22a5",
-                                "uncompressed-sha256": "4cd3e437f27d1a0a911c72ff3236efbd8fa6ec2aec00dfdca2a770e8d9113b42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2067ebae46bc3470ab625e544828535be2e906cc9a6f39863beecf1458fd19a2",
+                                "uncompressed-sha256": "24888905dda0e0d66c1e4d948f8c5987980efa768cad13d0993150e76bb1cff9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "01c5ac87f8372d46fbf015046371a3d5a3fb565c37e4dec011153d8c4ea44aef",
-                                "uncompressed-sha256": "0271c95f6032b69d63a2ef17e9f3810a78d1d33c9176291b9ab60301eb484d05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7c8b6acef1a7999b8fcd064f672c2fc351722a8d4c1ac8717388528c6cfae0c8",
+                                "uncompressed-sha256": "56796ce13b2308e7f17f4d68c4bb286dcd7f6e1f42174b95cfe97358f64ee118"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ac809592f47edc95a61af71bec09e80795ac510a5c208049df26a3e7660b32f3",
-                                "uncompressed-sha256": "63d91c99bebfdf3eb0929d285bf25da0066392de54c004fe90265d434065ea34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d6986873477ba3d519579b4ee1ec117c7e46d380e85bd17b23533fad6b596c0b",
+                                "uncompressed-sha256": "cab4971afc3d2eb327d37aa78d466db2657684da14eb1435754fe12a6d445fed"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "55fb35e150ec6f0d9f7383b5b2cbb7192d15ac4aa2b9a7b9b8d1cdac3fb019c6",
-                                "uncompressed-sha256": "ff69d72dce0bd6a00d4a0da7dfbecb7feef1910100909b62823b04f0635aca6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4b9c25b77a698518042cda4f82a468a529a29163032250995589542adb08e9e6",
+                                "uncompressed-sha256": "fb5667992f7e2579e73ba8a06bc9877b3618c5cc3d61c0566208bb9578038c2b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "20c7578202051ac9ec72e4bfd6843c9edb89c59dde9f0e034df10e43b89372f4",
-                                "uncompressed-sha256": "af02f5d35430a9c348dd3ba7cbc7aea73f40f5ce097f1f9e44ff9270da062b3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7a87bde76d33927ee678a8f9c54dd5b5598417cf7217173220b5d50de65ca0e4",
+                                "uncompressed-sha256": "fe6920c646712f72d4a43af4c604c67b9f2156aa75fb12313190454910355866"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live.aarch64.iso.sig",
-                                "sha256": "4ef87c8ac5acbcbcc9cac614fa4c325362bcd5d93bb657e591bb1330605eed40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live.aarch64.iso.sig",
+                                "sha256": "5844f2d5719cb7830bf5cd6393a1216e17f63a06967d9d768747de1861e3e8dd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-kernel-aarch64.sig",
                                 "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "678be75b67c7dcc9108fdb753622351fb14fcbc3a42c5a178a6d63857ee2140c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "c02c3b209f28e74e8901d7a250b258a5655454f93fc325fef696a7d24753fe66"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5b7f3c19307599a95f3e84ff24efc231483d35707c3ecbb5c1b5d25cabab00ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "bbce0ade618d512f4fbad886f4355aa5491b78fe236f86b021bedb9353933fdc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "b9ee32f1b931c9698bf01874507a0fb2e6afce9e05ebaaff7240c37a5a961bba",
-                                "uncompressed-sha256": "5da0a41cde660002f3ff7de7924d5659f67e1ea2a2942c1a2b1869a79f21d18e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "5963e6398d7e1b5f9f299ca374d2d61ad7855010cb3161e821b0fcf3867120e3",
+                                "uncompressed-sha256": "490475710f041a61f16a6132dab6d37fa5ce3e7b2c5eaf74639bf028d6a80873"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e7e38e944b08deadd88fbf7b7cb3326314da84aee0d1c96192c4eb8314940ed1",
-                                "uncompressed-sha256": "3d00f20d932fce4367f59c194f546cad0044954003a898bdac7740ce6ada9c15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1e5da8ed10ae652352bd4fbf34f879eb12f870110943e409d2e02dbacc75407a",
+                                "uncompressed-sha256": "7b441dce8375c202bdfd5c48e2b7b0508b53844d7faad04b5f3b9f36ae4f8556"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/aarch64/fedora-coreos-39.20240128.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b40963f631fd6df22f1a08726a1ca3d7047dc5b80787949befd10d31e3931f37",
-                                "uncompressed-sha256": "b84d5e0f86f2e51ad18a0a2b9a48b3f360072ab24dccc0734d59f4661ed626f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b230cf32d731c8f5131d3f04f3d22bf17216c05cf778a75cb90cc01a4a2d5b2c",
+                                "uncompressed-sha256": "dfcf90ee8a31a1acaf688e901ff0772b3f99f2ebeac86e2d7c140bdee1d034b0"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-002090be60dd32401"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-00c82ee543e76c11d"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0886a2ba677902e38"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0c1b0e9c7f1ec21cb"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-04eddb1847450df3a"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0ee35ac389b5739d0"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-01736742578192028"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-04beef8251429bf3f"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0bdbb5b04132917dc"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0d090b3db112a8940"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0bee78a0aaa99cf0c"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-024debf8acf528fb5"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0b4d96c25de9fb819"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-053019c4b4feb1de3"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-008deb01f0130637c"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0a98510e9e8f6fac2"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-07c701701304e98b3"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-044ac7f9cc71e282b"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-065187b179c39b6b4"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-05fb6d934ab58a3cb"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0e408954c61c5cf97"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-00677ae6c600634b4"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0486a6c73036ff91e"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0dbefde27bcfffa02"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-04711cc3dd696fd80"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-07db56777eaab36c4"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-01fc048cf694f54c0"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0ed72b520d8642579"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-08e20d80e867e1711"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-08eeae36f4d603946"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0c426f988811c7fc9"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-034553f2e3ebe4cd6"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-09e27e7adc06912de"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0e2a8a2f197ad3169"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-032fbabe4a98ac843"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0c07a7894067c6562"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-00b702dd37b63ba76"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0f6162d814eb2d67d"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-01d823c0ba6a90d74"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0b6fa53f3080f1430"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0c844926cef64ac2b"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-044ee1cc8dd705f8e"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0b4a5224f51720aef"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0079adc890c072a76"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0b8b43250e0648512"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-02946ae12d55f62da"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-077da6ed90617b13b"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0a60449a566eb60f5"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-086e52bbe0b184b8f"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0388640549a4de87d"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0571cee39209cf1c9"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0b5f8b9b608260f33"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-05dbfaea03381eedd"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-084a81d7ed50813f3"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-035d772e9d1b093e9"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0a469ff392c329aef"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0b6464d7563a54e8d"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-016020b71f38f0441"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240128-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240128-2-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "13b0ce127dfe3101ff558ca4adce82881c8d9252accdf8ab8b5fd7c327ca9998",
-                                "uncompressed-sha256": "dbe96f9883decef410bbba4b0a1042236d7d1c2a84ccd33b6fee1ecc68504629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c20225d33d0c2b4d17ad7a0446a137fbf4cabe9593179e0d6543c0eca013fd04",
+                                "uncompressed-sha256": "546190e845a36512f5e5bd73249fe90fe0720761fea0f465650a244fab262c72"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live.ppc64le.iso.sig",
-                                "sha256": "fee0f242cd730e6f44de5e8803e3dd3ecd2bc1cabd70d2942725856b722dfecc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live.ppc64le.iso.sig",
+                                "sha256": "ff4a780bee7a3a9d6672876146ac1ff198af77ec7d96bf51de102c21320d6f05"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-kernel-ppc64le.sig",
                                 "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b7a49be4e9933c35e9f449054784e9b8ffed380f2bdfe47d90c723c57542b5c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "803e0ca0c46e0790aa0436bca55e9fa4192ef345ce30af8e3421dc1bd9494de9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "fca31683d5845c4f41ac9f757a91701af166a028345f2875575a71b96c5fecb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "badd68b39e99ef29f9c52a715f786de5d6da65a57fcf821314463a8d6990333d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "72711aa3d464dddbbc02f93fae5fb13e1295606d6c6501303b801bb10f4c7253",
-                                "uncompressed-sha256": "4ad638607d356a502cb524ab92f0a693fde9c5046daca0dd7836c7e46a9313ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "84493b93f499f9d4d3b901c23514de07ccadc60157088be056597bd0cb4d2dbd",
+                                "uncompressed-sha256": "c35d1816e715a59d48aef131612e0b31221e770e5a16a0f1eba57ae651f555f3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "be0a021aeaa492869c8f31aaa4e690f73c63b4251353095296abcdc3cf1abbd4",
-                                "uncompressed-sha256": "bc50c63e1c88b6f82589a7a53b61f410e326ad59e7393bc34b2ca9403081b089"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "82444afdf00c1b7a486a127a3be89a06b0c1adb29ed7f8421d6312a877d381fa",
+                                "uncompressed-sha256": "902a48daab5640b2c57c7a380f201d466612394adff7865736e2eadb36b3c28d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "9b0a7ad5346539a723a3eb704b7447b1262c5269723595cbadf41a93e8fa695b",
-                                "uncompressed-sha256": "069cb7249c6a1ddf41249fb098ef91b795d77420430a1b78ac15ad1fa4acf32b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2c18b1bc6013215041f87875e99ea09afbeb084ec3a3651087bb41fa7e278c75",
+                                "uncompressed-sha256": "11945aa1110f4b15a74feac444bca7686e8216f1e05c541c476f7619f45f1f1e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/ppc64le/fedora-coreos-39.20240128.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c7c0368c8bc4b9bbfffdc66364fc675898237b8cbae800c32c1e5aee1319c1b8",
-                                "uncompressed-sha256": "7c6ac08728892c8b918d751445df7968e66334904aeaec1dfcf4b14765d17b38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2b1fd298a1096532f84b13450b580e155a10306c9634e50a301ced0f1ed57191",
+                                "uncompressed-sha256": "9cfa2ad094f06cb2d6c29bc6365d34d78ddeffc875c2224ae1a25924d790349c"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9cd4e7d64d4c4b0c55d00a11ba33c0ba7e63b3f2de56dc54c1e3596f26b6c49a",
-                                "uncompressed-sha256": "edda4866c18085d062801494afaf03553dae7354f1ab549003bb7c8e8782d6fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3811b5e572571c99dc66a49bb3eaf878d7d1c0eed21582ce9254dc11069678b5",
+                                "uncompressed-sha256": "f636a99a4475cb633b697b91faa817a86f39b6a03eca6dbb97f83187ef8cca79"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e7bb5ef1b7c1a20c3feb526dc20c11d9d8a5e911476be239a2b9114fdd659b25",
-                                "uncompressed-sha256": "0376d3dfc129aa934a02d7c7d137a3a73e949b54e4649033bdab9ab4555d0e1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "95d84b3565e4e642c9d4f450e29f1b3d628dce025f4aa90ba5a244e8ccf97ef8",
+                                "uncompressed-sha256": "21d4a66b87a36f873b9b55108ea94346f3ba8d57e668a2c7794be14660d524ef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live.s390x.iso.sig",
-                                "sha256": "e88a257c45b87da6116b3a1df34a0aca33d8fbc244968f73945a425b20b59c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live.s390x.iso.sig",
+                                "sha256": "3be8dca7473b00acc581ca744c6ac3f029f73af3b00a4c39b25ddd2b0114bedc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-kernel-s390x.sig",
                                 "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "cc219934b7c60a0da917242eaed0d6b0fc03ec26ab36e1a0123f312d442f7941"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-initramfs.s390x.img.sig",
+                                "sha256": "7d6106f22533cff575b5ea46821f5e0baad4edaa4f3765de7fe2c557dd8d0060"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cbcf0d996bb92dca5c510116f1412207b0e99057942651bbbe4f738afe87a5c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-rootfs.s390x.img.sig",
+                                "sha256": "3d17b71b9bae6dbab11834c64041542a89e3e9a3ff8af0a51d725f2134d68385"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "20d02715a78c631d3a03fa4a64ff1c8cc7667c0d5f3663dab10e7a6689a14237",
-                                "uncompressed-sha256": "ad977b3792a862467a9082f9ccf38a31575b7ce9ce69250feea61167b6ef1ba2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal.s390x.raw.xz.sig",
+                                "sha256": "c7f7aaaecc67195eafe1195bf7984e7c6828735159e50c984f696baa067135ac",
+                                "uncompressed-sha256": "b00a8fb2369e398d004a1d7301c968f9a23d69357dc6677533e307af3d973b55"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "03cccbbdfa3d4f57e1dd178b5aa998023226b63582b708895b6c710152136cea",
-                                "uncompressed-sha256": "41ee1decd4d464388fa3f86b3a58869b54b25e06133abc2006a3a378100d2ed8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4b3ceabaf0a9c12c3f49e83fef6551ed771e347c21b33cf2017cac8f335e0d75",
+                                "uncompressed-sha256": "2577cf6130bbab3f63d07c654701d4f39059429ac1a7493f2fe097875c430a7f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/s390x/fedora-coreos-39.20240128.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b8446915bcfd7867808d6dcf99e84b3db7837dfc88e9e9362cb4c0109fbc69d4",
-                                "uncompressed-sha256": "1c17c5b8921bfcf509e34e9c7f8943229541909dd7943ca44379fb8b4a1aa32c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "55dc7cd851e8b719086134dcb65204ee17b0cdae63418de33f81bcf27b0ed633",
+                                "uncompressed-sha256": "b598aba82ace3122ef1292cf78efa6e826c31a23f5667ce0f888be2a4fbf6dc7"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1253fc4951df038b93e813f60ad9a4fa34c89c291e92d6c789bc926f8706a0ad",
-                                "uncompressed-sha256": "acf4dc1f5b70873f9d66aaae2f08ce4d947269c738f7cc9fb7bea3269c967774"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d092e6d54b02ffa3210979e6a240e4ce088022d42f99ab7606de1c7f1e39f75d",
+                                "uncompressed-sha256": "b213d682f63bd926777c6426855176882bfb50e297775576effb61f9f934684f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3b64c45ad8588d508b58d72523bb1d304367ee137b6880fe90acfe76a1875fd4",
-                                "uncompressed-sha256": "991546c75ac87f9fceebe82e1f10075ce194de2b758cbc2942a856cde636de04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-applehv.x86_64.raw.gz.sig",
+                                "sha256": "07496201699decffb3213366905cf6319039cd0f11d820bfa7b41a3f0bdd097d",
+                                "uncompressed-sha256": "f1e5f98d02bf9b2b9e755f4b76ae8d7ee065ee753d7ce3b1c3457fb9437819a4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d4343d1ac24e97783f1e43e0a668c65570531c3943a7619ab63aea44d3f1e8ed",
-                                "uncompressed-sha256": "5a7670307c86b648fdac996b4cfa06a0da19712949394ce986e9985f291bb96f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "122f507a96df4090359ad400da44be6c52f6a8870145a0deddcd520e628fc9a2",
+                                "uncompressed-sha256": "0087a924da964fa3bb6609c3e3214d699369069946c4b3f5fe86062f84e31809"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a4d86d46f4dbc465eab595deadaa36dad827fa9aeb63a23ad235a10859bd76da",
-                                "uncompressed-sha256": "090a597b1c833c6fe5bf554d7bd493ab02631f7601a334813821451f864f699c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "48e911c6e40451d26f0d732c44eeb1dbb54aee307b53b50384b5b9c4039fbda8",
+                                "uncompressed-sha256": "45fbf3ed02e794a10eba15279b0842796ebc829de8a762ee9e4fae4c7bd24834"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b01d3b99ca328303269725afe4c07327e8599159a46a9188acb37a241a06974f",
-                                "uncompressed-sha256": "4e36741389901328fcf2c631d4fc8b4b2553f7bc28b54a406f7e4348a574ee87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "798249bf6afb8316b8bfdd766be4f619db5218bb835eb00d9492309c04e0a9e0",
+                                "uncompressed-sha256": "c86462ef669a2d81d1a440b58de25d6116780854bc322d460ad99d093cf19d69"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "12d1d245e4e4ad1e41a804444be3b0ac22c127019fc1668d0bf1a03d67cdb810",
-                                "uncompressed-sha256": "8bc498765c17c49099b21b78d8ffb1ffd5cf005448c147e291f0bb6165a9b791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a75064509cf4b1039ff54f5c7934b5a128ee907c2f123fac612ac8d2ff6a0cb1",
+                                "uncompressed-sha256": "a10dc373a8c614f4e27cca8b8c0cb738d89a6521094cbccb889c304de281f833"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ba09d359cccdaed3afbd91e1eab85239be084bcacc42e251f876515d07d64230",
-                                "uncompressed-sha256": "315eea3a5e11549cdd815d65ee5ab85a86dfe256272f1be072e0502a19f3fcaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "31b45428fd21e6389c2a63f25f6fa65bef96ea74e1a717348e82017852f50c90",
+                                "uncompressed-sha256": "e49d8b0ac15542a41898da415dcb4b42660e816eb63730bc7a8d458d64476948"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "003fa6b8b3dcbbf27e61e43ab26a396e2297fe20b89284293ae4ca44e355dbce",
-                                "uncompressed-sha256": "a096620bc0a5119a9d7f24818baa9e399e8f5cd49dbbcd1062a4896a2fd7615d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7a00def6a308f7a2702551899b4023a1deb9d1be103c359b67553a44629379d2",
+                                "uncompressed-sha256": "670af9f323f51dfaa6e5de214471822971b4181287fbd5e1a31015de06e1d8b1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7bc6dce5568d3e89ef4999a8469c2f528d96719ea3a36318dfb3fb3e40657a47",
-                                "uncompressed-sha256": "7677770b9c27451c551f7c44b4d471cd7b587cc0b4fbb03d70b9a00027aa7112"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "34a092e7e8f437505413711626f6a35093969d98ec053a43a8f6801bcc7cdde3",
+                                "uncompressed-sha256": "8270a287136b9a6b85b9e1c611b3d213df122fa621cd8cff6c69a9d7533cef76"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "345a3f2ca506301ed1d1c1d79f9117a552bb5a027f728e6524513a64e74c251a",
-                                "uncompressed-sha256": "69ef47aabc95ac46f38d57f83415d643d41316a0e085fc18e999fab869ae4897"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "da869b4a47cbf1fea5d73f0ce728459cea1e39d78603fe5360d9a785512c95f3",
+                                "uncompressed-sha256": "3929ddbcaf04091007a938dff8a23df86271bcae2c1c75ae626a4ce4e86f95cf"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ed0844a42e0f75051b0e0641daa5200f0af5f4398027344b1ecea81b9b203a86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "9e6624d7ca86f7b44617f133a4bc740af1fdb8596d7c6f27f0b22256607b7f9d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f1e46c39d0a11022cf34cda0f07fb35cbb50e3a53b27995399690595433e6ade",
-                                "uncompressed-sha256": "6ca3a59cf56ebbbc9b6134fab898ffa223a1ebdcf8a0017b074ab6f651c3dc1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "576e571a752a4032cec277efb95099d6fec2e198978257a0acda491a9451b6c4",
+                                "uncompressed-sha256": "38c89373909f0521ef14ad263cba4e9f725ae7bc371c811d73693069f2a37b9b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live.x86_64.iso.sig",
-                                "sha256": "28cf2d9a4f73b7b58f2bf4bb3bb8de2a7e66106aad2f5987b6d5f15fce109437"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live.x86_64.iso.sig",
+                                "sha256": "79e2e99624c1130b883448715e7b4aeef532573ac48e659f2574b5f318e0ed3a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-kernel-x86_64.sig",
                                 "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e172ed4c674844cce5c47c25fc7e853d8651ae3ab98cd0ee32d566184f7924a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "a8d26590c0f6e2e6a503b02f9a1fe1afa84ed2d3cb60483c29b042b190a0ccfb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "aa85dd7813199b97313320784dc054ca4f4d448131ffc459720c8d3a8749e550"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "dc04122825cbd549a3c00006b1f705e4487d5937ad54043c36070b3f5f925b1c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c532b88c3595d519dd75eb7f2c1ebc49a5dbca5d04790bf14f67e9c8ddfd5b71",
-                                "uncompressed-sha256": "0aac25ac437a4d22d31152e33166feb2f80d37664107c7ade52f629229786376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "fe53fb32acb5d8d46c0af07eefab5ae4d99fd8c3d23d7ebb23dc98c691758e30",
+                                "uncompressed-sha256": "d65685380aa1d58e563caf04bc90349037683681dd14af0773b0d06b8dd80d21"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c5a915c534b44c539435e00b72c63f23d1386d2b5113b0ff5381962931d5d659"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "57a398bec7caf6f0d970a36b575a808f43346dde31949e6a4e5c2371f0ae2603"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e999dacb2409d9289c02d2dc074471c35e0a55fda697a38c9d869da79d2e0b6f",
-                                "uncompressed-sha256": "21c847fd1d92793af891ad1608ad94f4c9c59a9e096ea4d2ef5bac8bf2cdc3a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "45fe67e328c6dacd0c004712603919328b5d69fcc7421e9f54c87d061e776e1d",
+                                "uncompressed-sha256": "bdb9b792a2d3c641004ed75962c5d1e9fcdb01121a5fc5d05ecf24698448743a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2d315e68f52b09ad20948aba1c7e17ff0d1b9149ff7ce64993fbeee60e28fee3",
-                                "uncompressed-sha256": "82f7dc122d70c8d31f02f695c0a1fe90938fa99e0c12f9223e9d00f354c392e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f3e06ea3e1c3c368ac228bbd9428d13bd85211e1ae4f5625c67ca5c446ef0768",
+                                "uncompressed-sha256": "f638fb37dddd094d917e58851b0b229caaef818b8cf7b32aa2f549ead602c98a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "30078950ed87056b3d3e2a57379d9267870058757d0966b9ad8eb386ac02b878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "735076710fe36a161ff7add140ab615ec1aae9b914dfd9de5006cf4d1f6ad1d6"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "43566a98f8426751a65e167ed3063bc43abb53c9ba4bf55a8024927894b693d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "9aff31d3fba3c59174c3216ed1e0b0a86b773a3beff2498c241380363cd989bf"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.0/x86_64/fedora-coreos-39.20240128.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "adbee9f0155d60af115203112b9e7790d302bc29e6d47d06f163d1a8d38def05",
-                                "uncompressed-sha256": "d3318f46d187d267146f3321f1d98013a3f93fd4521701c1bbb949b349641391"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e46fae7abebc2073e2acae1bc2618b5cd55545413b5aade2de2f26afe2a1a8f3",
+                                "uncompressed-sha256": "8866ee35e3829c0c32ed4c8fe96687f2f53087b7436cb357e67c2cce413b4c1c"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-012d92645a75a9320"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0b4e743d88f94d7d0"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0923f0d3ecae3b630"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0bc361c1e05ad4456"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-092462ccd67627715"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0921742826c809d12"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-064407f9f040a06db"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0ecdd810f973887ad"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0f7bf07c98cffdb9a"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0db1d1500565165b4"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-065de6d414a541232"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0c075d3c3bb4eba52"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-066acaa3ff014344c"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0682fd49c714ce62a"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0c4aa08026b0be5e9"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0cf856ea450c6a7d3"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0d3f3a83a696490d2"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0c62d60edef67d1a7"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-07cfd463fead2a29c"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-07a2a19ca47f7a5ca"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0f1a1c6394fcb9b8b"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0183491e47b69a243"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-04d814639a60a35f3"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-05d9aea491c662e6c"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0a7159763c5211597"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0a3eb9a52a4c78609"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-06775182063e3627a"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0be6dcc68e17643ec"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-073199530ba01d26f"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0a9444ace0e689fbd"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0babee6576b7a2f5b"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-04d2bf4b3ba4c9bd8"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0437dbe9a8a8ca820"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0e96a17366e638df3"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0b4acb30c52fd28a2"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0fded04366c51f6cf"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0ea0efa5d8f30b67f"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0408d90917a84c0fd"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-05450b1247d93466f"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-024cfc20e09220d68"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-050da059b7b162033"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0d693714d9512a09e"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-071c13917f63210d1"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-00dda5687cac89556"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0575d2857be59f42b"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0146110d6af817757"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0c5aaaa634abc4065"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0827470938d747f4b"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0d88825bd459fc6cb"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0071d5aae317cfd31"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-05a871ed3efe4af6b"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-0d6c7d91285e70279"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-039cfed6744506e57"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-097a2082699dc41d7"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-03f358f4ceef64732"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-03532b2d8a036351f"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.2.0",
-                            "image": "ami-0d014869032cb2094"
+                            "release": "39.20240128.2.2",
+                            "image": "ami-057ec041095b9f979"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240128-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240128-2-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240128.2.0",
+                    "release": "39.20240128.2.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e5ef135097b0c90cf8d226c0d2e369c9bbf541d5264221368be5f808a90dd008"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:41342a7a44599b10fe542302e046658bc5a9075ecd0e4f6a65d4b940792fb473"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-01-31T15:59:25Z"
+    "last-modified": "2024-02-06T17:02:08Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20240112.1.0",
+      "version": "39.20240128.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20240128.1.0",
+      "version": "39.20240128.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1706720400,
+          "start_epoch": 1707239400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-01-31T15:59:24Z"
+    "last-modified": "2024-02-06T17:02:07Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "39.20240112.2.0",
+      "version": "39.20240128.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "39.20240128.2.0",
+      "version": "39.20240128.2.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1706720400,
+          "start_epoch": 1707239400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @ravanelli via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).