### PR TITLE
Roll out stable 39.20240128.3.0, testing 39.20240210.2.0, next 39.20240210.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-02-06T17:02:08Z",
+        "last-modified": "2024-02-13T10:25:34Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "4e1a8beb98f43d2a506ca36213240f594a0fdb36435e3e6d1f73383f9df87c18",
-                                "uncompressed-sha256": "0b8104006e879b0887d1a727ad9db12b131419e5f9daf7e8c4a6c904cfb7984f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "b7f00359c1d0b12e14dcfa506c61e592c7e4e73a2c4a2939bb7f8d94f03f87d3",
+                                "uncompressed-sha256": "2e609696edb160505fe42be69427f177a4e1a64a258e2035fa0539db5af22343"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c926f9740a76013b2b80f84150839847f16aaa6b47dd8c5eb94f4ac958bc160e",
-                                "uncompressed-sha256": "5e365330c61ed4a48235f5537d7cf655d048629918411f402ecb2f7a04d706d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "04909682bc9cd9eba7bea7f125773ed34f01f7918575961423e12e18630aa415",
+                                "uncompressed-sha256": "1132671c711914d01f1dba8d3e24190210d0e3a92d14d3f51a1e7edb5f1c5a05"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "67df2bcf017a83788a7190cd531eee6e53471161ba6f099c8e255d28b75e5645",
-                                "uncompressed-sha256": "4a22b2c86a9d93e39f55abb174b43305bc9bbd7a51e3e9de8cb2e0e1b84b2bfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "80722b7b073bf1d8663f31652ee63b15fa87523f29663b09d83773a00030adbb",
+                                "uncompressed-sha256": "98e3c984f25dfcfef9d92a97588e4fc8e7728ba1cfa821777612260a23d4a509"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "206a8260a628f10f0a4dcea47b98281f7ad5325b68584c1dc926d44b4b44cf62",
-                                "uncompressed-sha256": "068bdd516c593d9c2b6df15d771b8e6cb7aaef4d96c62f34288025d7d7d4ba81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0b3bedf5a3b9db87aeb9dc3b547f4f0346b773157c0e52a9a614076a44f3f563",
+                                "uncompressed-sha256": "74f4d0afe7d8f614182c21cf0cf59950875045acd755b7dcf8bf54f2cf710586"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "708a2932b0e961aa5640ab3430a79ca7dfe485a1c18b2ee392cff88efc71ab24",
-                                "uncompressed-sha256": "fa797642d00ccc459c59ab12169c3ea9fa6d385637e57d8d4d5ca84b6d30a666"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "733960dfc2504e920c0cf703d42449d31030551753c458f4c33d81a76840a51a",
+                                "uncompressed-sha256": "c44d3ba77608a6b8d2084fe6c8859284bb0e8de3c09747be411b90557126efb4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "672973edff339c1de51d346982c75b646f6fc33be425ef7689f88af40762c7d4",
-                                "uncompressed-sha256": "c107cb4e7c2433f36ea81aee57bfa91bbd50ee32b97faf236aa2cfb7594e958b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a8ff43255766eaa6985ddb9cb3be62ca09f4afc8d584644f13969ea0fe5d4725",
+                                "uncompressed-sha256": "8e7f90f9ccd53eab537d77a2a8b40b6d9ac6fdcdb666c8cb396fc3417f3fa9cb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live.aarch64.iso.sig",
-                                "sha256": "acca3cea5937fdb5098547f41f0193516629b4fa4019e2bf97af964197d6637e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live.aarch64.iso.sig",
+                                "sha256": "1cc98581ee356a0bf080cb3b416465f801a232701e18c71037482d0b39191aa7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-kernel-aarch64.sig",
-                                "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live-kernel-aarch64.sig",
+                                "sha256": "ac596100dadedde9b11bae2f0c37e05aa403de2899fde21355611b691dc0e110"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "9780010693586ec0bde06c11479817bb946e3d973207e17b2b8900c44ab32857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "be1c1d2ea030c897c9346b4a38d577b748463e5faaf357cb53179ea0b36793f3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a4752e3429820aac7f5ec630fbd292ecccd714f8c57061ac89228d37ba0f1529"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "21c0e4564e76cfbf1ab409d383e52a89f6c80b69f9ccc2409af0a2397e669750"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "79b19b556e9af987222735a9308ff88593eba2b1c814df27b4e574dcbaf7e495",
-                                "uncompressed-sha256": "c8b6e7cf495457c80dc5b554f3797b116518553775c1e009a2693b6bd61df8be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "b46d5c97cbc525ee4145dbcd190673755d890d4f83e59d233e139148b9ed3a47",
+                                "uncompressed-sha256": "00f3fd7ac5873201d1aafa942ab236f477d561d765b7ba63923dda4aee226fe1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f0121cf6cdcef646377a393df3e5d3a5eaeb5a4e4aefda2949e064dcca4a2f89",
-                                "uncompressed-sha256": "67db4376d440a251b9629406257eee36636700e6f27c9c388038add1ad7341f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6c18622a7f617916d317f182f59615580874ccd7d1a0b91d6d423c61dff91669",
+                                "uncompressed-sha256": "ac30f30205f4ab04c8dd153f8f498527c765af210e2bd729b4f05282440943e3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/aarch64/fedora-coreos-39.20240128.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "dddc8d2fc57e8aa0140ee4212dea4293bc00cc4ed34b9500e432c1c31fad4fcc",
-                                "uncompressed-sha256": "81b68570c919d9831cbb55d21a45f44acc37e7fdcb7cb5978622aa533116f4b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/aarch64/fedora-coreos-39.20240210.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a25d951e64175dc49bbc35d15faf6884b1d29e3a4c9e66094c984cfbc269cbc9",
+                                "uncompressed-sha256": "3417f0ed5d9e6e99ba4d0b35c28eb9a526806f6713c3aafff50b874ca3b94ef4"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0df6c3969e423a16e"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-001523280cf79ba17"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-08fcab71901959654"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-015486456fb008cfe"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0785a13fb64eab5e1"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0903a1fbf3c92506c"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0b504dd37a332a590"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0d577466ee3f76544"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0f45970701b47b914"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-06412c2a07082ab93"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-02f0d0d9fc3bbeeeb"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0dd1d61a449f08503"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-06304c932853cef5c"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-04e005db382223674"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0e22908767f1cc2c2"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0c4064c1aac1e9316"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0541e008b396924ab"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0427e7beb38fd7a56"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0ebc3fe5bea5681dd"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-09688802a23fbe1b2"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-08849433009e7816d"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-02655abbfe9e3eca8"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-020f2a2843203dc75"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0b559cdfb9f9c87b0"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0f0598d566a9a420a"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-05928d74ef795df7d"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0aa3d6c12c353615c"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-08a5041096a3ff8aa"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-014a2d63686a94d41"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-06bcb6f5a89bc88e0"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-01fa4ee74331ac4ef"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0b3d04ebb9629a84e"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-081d9755260b9ec25"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0bdec3a52fd1c80cc"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0714d704a74ce1972"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0ca582c65c645a1a5"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-04f3895184e806c80"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-029639fc11a66d273"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-064b676fd392c8bf4"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0fb4ce889437cca71"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-06b4951eb49296e0d"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-001c2e00b26bd9302"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0da311e0264473f71"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-05e5eb53cbcf3ffa3"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0d339cece3d8ec5d0"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0e8ff61279a902dfd"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0d3b3b9ea8a0e2634"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-003531c522ed7a05c"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0fba83e250a6d1015"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-043593095ca8515e9"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0d487bb55a0ee496b"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0ad910d51f8bc211a"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-00ca0357e0e102a66"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0ef587eaec80c027a"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0edd5a6f58a85dbea"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0e1286ea979ffc317"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0ff8e2c25d724652e"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0a164997bde0ee02a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20240128-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240210-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "438d61854b46f68fd02a77d0ff3907d91d7df03472b351c238b7fefef8173823",
-                                "uncompressed-sha256": "694f6550be85d81f22b9c37b999d003b01e739e01c11db9910f158731e76a409"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3c10d315afa64d99f7387495c3ead1961f366691c0fe935f6c429772982a7dc4",
+                                "uncompressed-sha256": "cb67f5a029c0a9138f52229721f7465aed9cd7b41e7e87e2c9bb69a994eff754"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live.ppc64le.iso.sig",
-                                "sha256": "4871b9f0da5e3a8b28fa6ae3dc539ad24464394e839044faae2126be7f82b0bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live.ppc64le.iso.sig",
+                                "sha256": "3b20a4f938fe585d98e4a8c43e25cab2c49005e36118a869b44ff94fb9ff4fb9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "50aab873c1577431233890b4c36a4237b1f8b0f63a551d79031a1b6b4501d6b3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5fc62cd9373ea347190b02f84b77baaeaf5672f87ec139ee9f52faf5d9163978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "993072ab8cabbad8ac6c34adf1325ceef181786db75463bffc56d99bd2761797"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "de7b234714eb7436ca1d31c4dfb02e0a5812565707369035953e4ffba2c7861e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d6f52bdc1ce4d63f7717c03aa183a61353617febe788d1bccbf943a41ef99a04"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "0833bb93d0f8e50400f87aa0c39c945310a8d7b705ecbdd4f211b37bb4fcf23d",
-                                "uncompressed-sha256": "3d3b4b08f4626237f20bc5140900bfd3a245e4da929caac2e9249c054c9eb4ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "88ef702f2e470e28fa2fe8300fb5ea609a62057fdc047b01547db07333043ee9",
+                                "uncompressed-sha256": "a415b4c09077ff456e509757f1447b92b100671a581d42a871a131d291e0d8da"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "53fed2ce0470f5b725814181a8e6e8ce3de120e2cfc914db1c60343cda05af13",
-                                "uncompressed-sha256": "b694fb7390ae477e3e27b7bcd23abe5391e9da312e1fb5f37912b7121a1c1246"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "68d5fb423ac905a7eabfca0209e610e38af545a3e2bb66b76ac0e54f7e3bc9bc",
+                                "uncompressed-sha256": "571c71a7881140da5f2e9af1972cec2d770b701bac55aa062bef55f7377b2fca"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "874b18457dbc50f375450ee8643268b64002a62c4ed742cf3b642f48966df68c",
-                                "uncompressed-sha256": "6f64514da8452a4caf76fdbdf0cd3c7b78f88383a1754a82d6071f605d9f514e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "fcb6d5c5396bedc1f62cc78a97fd04a31faf9f1722d05409a10a58811bc732c1",
+                                "uncompressed-sha256": "11748cdf8619bd215d43df84f8949a060079f82ab1ae37f956fc884450d6e376"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/ppc64le/fedora-coreos-39.20240128.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a406ed070e1e8d22b5c7a2334e7c5b90e1403a39614bd26d3145e5653945fa97",
-                                "uncompressed-sha256": "af00124ef94cb2d5c723c88faf7ddd7e924c3d0239b276ebc8ee3691cbf84f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/ppc64le/fedora-coreos-39.20240210.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "8cfd3c7a2097e131e765f88584be09ff78730f481856b36c5ab2c10fcbb47b5f",
+                                "uncompressed-sha256": "056d448a81cdb68624840de194c551d637462bcb1eace2a390087d92a8a803cf"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "43e6565634d66d141dc58ad115f003e8316ce864799c6815129ec34d68deb420",
-                                "uncompressed-sha256": "6bcf023f1594b6e7697d28377c550a7f5e5655f6657e19af684b95d6c0707fbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cd91a0b63dd02baa0353dcb394514aabebedebb1f639ba6845f49a1421e1dd2d",
+                                "uncompressed-sha256": "d90579afb05193520323252a44e2e4d71e3aec00902d696ad88ca442656b51ff"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b0ac3c4cd9e9f67f1c2ace25af70e0196ebffb861d2d8599e2552c765624ca9a",
-                                "uncompressed-sha256": "05089ad6ac151a661400d8acf5716628c54030a001abc1bc8ac979cf1a8bfc5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "adbe6d6c6460d3c7758905e72541eab534cc277d56c7bf46e39d0b9fae35aebc",
+                                "uncompressed-sha256": "8b3cc1e1a1c332fc77268e5da765b28a00dc616119e741674aa6af3b51a30b2b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live.s390x.iso.sig",
-                                "sha256": "1554dac67e50491d3aeea1c9a65d494436f2933c1314484b91167ab31646d23e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live.s390x.iso.sig",
+                                "sha256": "7ff710caf2547abcd5a9581417bd84dde52c304a50e234ab5ba3ce2f6c84a994"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-kernel-s390x.sig",
-                                "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live-kernel-s390x.sig",
+                                "sha256": "14384c7a53470dc2a089425a7562f78bc6daedffeaf3ad24d6eb44d801284232"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "80b830ac5ccf27384ebd25d724b9c3ca9e6f2b4f0f1b2b3471ede1a1a35d98a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d472be868224791543bfead8bc36f7f187effde00c7753310198836423a2579c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "8ff359b2a2c68ec64b08f7a1e1c53b002787acba731908c4435b5f1387dafeb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c379367fd754c526576c5b2ad71b518405e769c204bd20452c74e5155e2695a2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "18bc307cc0556960d2e474e426b5c7b6cd7818cada74e0cd654ef97f777faf51",
-                                "uncompressed-sha256": "44ed1103184136b5f8273a4d904ebf225e7da381f2684e87900792037ccebb59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "86d597bfce8bd2d95910f5a24528336d42f9326a590b52f310c5fd52a3bd0111",
+                                "uncompressed-sha256": "9fe5bf2483213e5caaab0e990d650d318fa82cd5e4e63df91a16b554f4c2baff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "eb922d5ad679eee3bb38fb8b287497c6ea5b67ca08b7e853084e882080afb042",
-                                "uncompressed-sha256": "4d7a39b43042eb8d2e7dc4568a812aebf1fdfd87a4bc9a5db3facba7dab3896e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "71154ebf469dd085f29c43cbc9bf30f0de896cac2842ebaa1f8b08b497b1466e",
+                                "uncompressed-sha256": "bb644dcaaa01b2dd0697541ad19f9e7b241174db0fc2f81f71b64039e983aeb3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/s390x/fedora-coreos-39.20240128.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5b73707d717f3ebf56a6a0075825bb7fe1316de6c5740463f8368fec427e04c7",
-                                "uncompressed-sha256": "0e3125a806434eed7e256ff658ddcf5e94a3c67deca9daabb00169752b1902a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/s390x/fedora-coreos-39.20240210.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "26c9fff9dae90394ad4fe78af7b4cbb6c4e07d720e77b7f31cd72ab62c2fcda8",
+                                "uncompressed-sha256": "a5df58f4f95c6a7b2436837eb46d50a4158b3f75c76cb82feb08f171fab26d2b"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "18e429894994b5d9045bf34963029b7d637bdab9fbbcdacfad51b13838291a87",
-                                "uncompressed-sha256": "5c9f7295bd5e3fa81dcd6f7e30d2a57c1aef10080550cae60fce66fe49a6c825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d7b47bc741cb4f79b63c90de5979f63c8e9f605cf280293e307bd3bd8c516f67",
+                                "uncompressed-sha256": "31babd73ceaf0e9217bb9bdf963ccf410d90a152c50ddbf50b72a5550c2aa693"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "d9cee9a9478eb30dcdd0c72e73a528a8d7f857aea41ee7eddf4879218bbc0d20",
-                                "uncompressed-sha256": "a9eb8954989a36fbb1d6c1c5904972b323cecbfe4df29f6af8c3af87d3c8cccd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f0d3151875e5b41dc13d2482eb1f3e5a378a31e40c0aab4ad445617f7f6aa1d0",
+                                "uncompressed-sha256": "eb199be1de641514109841693b1c9fb88ff990a3cd9c7e9d491b71e09d42a576"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3027d9adeac13f63c5aa262a1c2ceeb7e681cd5f45719121472f95a34275405b",
-                                "uncompressed-sha256": "bd6128eb13ea66786b24912f17c15f29af690b087d7a75148532ea1aab6a538f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bd03e5edccf50047961a7f4eede9274b17b3c0ceba3e30ac8da7d4266d92f0df",
+                                "uncompressed-sha256": "5fc0159dec58d12048543da0ee62d1a58971727350843e4efdb4c71b1286f0bc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "bdc059cb80cdfeec98b2c8aab5b9a268523ff760e8635d25d61df8255826f37c",
-                                "uncompressed-sha256": "4a5c490a32f92128a79393ba3ee9e221187b487efec95cc4472c78ddd1525ac6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "08da9438abc333c918c08378519254bebe3205ea527722e6beea960bc9d852e5",
+                                "uncompressed-sha256": "4a654b9bf1b9105cf092a83a7e35ba4d8270610f3f0632d1001fc35d8d80451a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b8c826f47f2481982ec41e12797e245ea8dccb11e12beb4b0c50fc0e3e989bf0",
-                                "uncompressed-sha256": "46401a9e549eac36b44510a9fc081a6fa34476074788a83da5e8afbadf1ec490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4dcc0eee4ac16680845e531b4c4758ff37b2942e723841f7cc2d7b3de367fe05",
+                                "uncompressed-sha256": "ef109d01168e9c61c93d22a1758e8aa35468e26aaab6dd677109c70e0ad01408"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "fa32f62a54c4389030ec9ec1863df331f58015029ed6172bb586e7e302e3308c",
-                                "uncompressed-sha256": "73a6045c75b6078bf9ee77effc37b9fa02662323a1454d73f4b4bd53edef959c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "05067536657c323ca14a53168f597dddc5b2b961a3018481174894046bfe9358",
+                                "uncompressed-sha256": "1f8f50bfd5698efe125b9d66bbdb44d0a0fb67c66c4e4e2b9af64f9067a9e30e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2e322499269bedfe086fe42fcd6399479e1a9ed6cf2bd5e938abc91f13d36fb6",
-                                "uncompressed-sha256": "3395f7744ee4a813f7f2f3521ed45aa3d18d0b0e9d30270e05f7af3fcd4754e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "59699e5b8adf50682a15fc53c7d97bda95d229b088dc1da786af209e54ae4e46",
+                                "uncompressed-sha256": "b14be26f1768dc8c117f2fe1f1bf4eec12ad685a1ef4ee9113208f9912ad28b8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3875a1634e05178227e955dcc37b3ce70083c479aed5208b4163f44df6083833",
-                                "uncompressed-sha256": "8eced852ef65291433e922ef186ba6478b38147501361e9ec585ff41121f108f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "922aace8d0632f3c7ca072158933d2874727e9ee4dfb5b0b808ea55d10b3573b",
+                                "uncompressed-sha256": "93c99d175a1a22e9195bd10558ae6fe40f35e33fb05c7a8840e80966a7b2f4de"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ae637fed2b9983ab3c1b90d88e87898a6f121b67c03cc51597e4ae3fd5a40da4",
-                                "uncompressed-sha256": "0eb17cf61886e6f2fd4770836c8126d0c666ef7bb053d6db948e8d3d152954d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c3b3009b6993d5d180741d057aacbdb8e44c9b5dea446717f9fbe2efc5923c67",
+                                "uncompressed-sha256": "763c8a4a965c615e411c60652e1b3f7d0631f4dae65765b6ab4ceeca9b4fd8fe"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2ec926f7d8ebd53157387877b5ee1d6c91dd946f988a8f4183bc9316bfe9d72f",
-                                "uncompressed-sha256": "2852631a4a61743c1d3f063c51a57ad32788d34c91f6ae499d2cdb6fcf3cb832"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4e32177a66850450c5c43801fed9a6e55ced851676635b4e3f0815b3a1e87443",
+                                "uncompressed-sha256": "a79166a7cea4ea65b8ac45249bd179fd48a97bafd1928272bd85f6b999bbb86d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e257e95ae396b7ea03ad581aa8d1ac0ca65df969e959ded2db6ad66cada95a31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "906dadfcc358166f9141236456222e533a57bb1377417a10b30073ad15bc035c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "82e22ab7d4448c0864c8962936bc33301c96956dde48c409d98a7b920d3494c7",
-                                "uncompressed-sha256": "db2a9c2b5e51b4954aeea0b84bd16aaa3798813c36eea4d9a75a0da34f1cda51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6b42a0e6e75effc50a4823cb7fd94f7eca8a252f4381bac635db989da89ca197",
+                                "uncompressed-sha256": "5804b778d718ef9dc39302d9cad58302b36a0d6843ccf7029773b48b73920551"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live.x86_64.iso.sig",
-                                "sha256": "d46106ef61cdc5446dbdcb686c796bc86afd46f2f7146275f669b1aaf6222365"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live.x86_64.iso.sig",
+                                "sha256": "651bd1779947ed4f7c450bcbb7dbd660cad74052cb4cc2afd2104ec4488f2883"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-kernel-x86_64.sig",
-                                "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live-kernel-x86_64.sig",
+                                "sha256": "c835ffef4f5c8a3372c979271a27d3ceb63bb94fc09df1a610e0004667935ae7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "808bbc4f78455af76415165bbb710152435e6e5b66166020095c7b74b4aed700"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "bb6473f2ab19104d851b091ba9e59a930ba5aaff01ce4c2f1c8bcbea318eb43b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "669d6e121f733c79531ac198c325ae31efe30128b8c1ba3313706da68c369724"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "52d216749efff34609ba183ae58c1ac5f17db8fae911270cc4bd923d9734d5d6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "5d40692e2eacd700d18903d5d0a576ff67491ab7564504238b83169899e60a14",
-                                "uncompressed-sha256": "fef6c15e31dd85d842c6e2a90706f70fd10dfff798ec1656739fbc203f3cfd32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "fd947ad9ecf0bd90ee72ba2ceb2216777aeafd1c18cbffcb16a74b091c14cae0",
+                                "uncompressed-sha256": "83242def5328c1553cddb651d87b91263994bc3f0365ae30814578e3387ec7e7"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "08648e44dcf9fcc0e3f0a7569387228c57c02d58c56a0f6682588d4a5ed9a014"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a48bb0f6d54040a8c751a5f32196028864b45b4c94992ae94638278a09184827"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a34b52d34caf0dc6305f9c7fef877669a461ac3819ac5868af5512c54da453de",
-                                "uncompressed-sha256": "0ec9879a0cd973a3da62e890e940653598ea828e75ae7466c579ae88e91b56a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e33a59ab001ca70e46d8b23023fe407c5137869794e2de98c65a0eeb750cb710",
+                                "uncompressed-sha256": "c46c0b9cab7ff6a8ff571da075d690e5090d43e10a8b569caa5981b788226027"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "80b3130b7e5fb8127b852752685f8fdcb79b676b7b4f69ce457a70d50f4767a0",
-                                "uncompressed-sha256": "dbf6a20fe84b247c29c084a1f6ce7f55be2164a6e4610c302d608a753087e801"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7d438132c9a65ad4bec543e18e00cf525c10fd1eb51549d734ecf996e4703ede",
+                                "uncompressed-sha256": "d01efa3f3ac23df727d5331d573bb3bf274b15a77f4b4b383bef07ad3b537a8c"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "277f29846398971ee7e0f8ead763045a755e67d33883bb7c0f816bc89d558548"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "af7978e49697fad6ad1c576561d68d94116166ece56163f3c2aebe2770c6255b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "41724bc8b46c69167509cbfa647b34ca54defc3ceea9f7ee2b7db7109c2afaaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "cae6673c267ee1ed2d753fa517926192f01d49fdc1f188eabab76f6174a2dfab"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240128.1.1/x86_64/fedora-coreos-39.20240128.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ba573d287365fe0f0625d8b99df64835f3fe09f729bc88a4463dc872e9d9839c",
-                                "uncompressed-sha256": "ddf8f4aee2e96abc63e9bacd255e170c0b8b7bb92c8991cdc93b93c9f81e5940"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240210.1.0/x86_64/fedora-coreos-39.20240210.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "25f78ed860e691979f494e8fb79180f37e45c16dd1f292e13cd095f7f0123bbe",
+                                "uncompressed-sha256": "a8dd3d4760b2e59fb962910479f0012019269769125cffea0d1c6437807749d4"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-08d565f5d12456946"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0440ebc25723c996d"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0f1fb91c15cc3a1b7"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-00046747218ffdab7"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-017b1f4172b564628"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0844358cc6fefef84"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-083f813128851db8c"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0c075e18103f9ad4d"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0f8c5e624a14c6ba2"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0887cde085e5257f8"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0ad8b0e996c0b69c1"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-03c83affe7ce239c0"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0eacbd114eb553f7b"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-07633437857aa1923"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-05d037e2963b2667d"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0ffdcfcbc3b69b1e2"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0480148205a2d3af6"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-08c43c1ec69999c55"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-05fa55820ac2a49d9"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-021587ccc78cb47e6"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0a67f0033728e6982"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-08df993862f1e381b"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-02f0f57954976184f"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-030fe868b9b03c6f3"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-085296b77610bbb38"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-03422c8ad844847b9"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-083e4fb0824b3be55"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-07151692381abec0d"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0415dd8402bd50cfb"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0004f9916ac63a0f2"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0224da158972cc672"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-05c382c096e9cf75c"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-080d3e92fba31761d"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-05db9282b0fb99b07"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0f8d8717981f70bc6"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-019f253e425128c19"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0576aa23a8f5f82e9"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-05bdf1a29a02d1605"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-076a5bc2f9908743a"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-03a073e6f7ffae774"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0f9e22ad1f34d04fa"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-00816fea530dc610a"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0c2c9af5fbcdedd88"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0a99645b74b16f37c"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0591b7a26dd35a2ac"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-0e79915110e6a1536"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-03ad0ee0a6c7cf68a"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-035dde6c96303a1fd"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-081a42e4fbb9e2900"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-090379e3cf168bdb5"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-077f5c5b927454d9d"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-087db0894c412a6fb"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0bb737456530f0b4e"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-09142952d97a8b866"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-000368d4e6eaf8f35"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-083f665f7baccb3af"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.1.1",
-                            "image": "ami-0fa7edb26caa88037"
+                            "release": "39.20240210.1.0",
+                            "image": "ami-02d327e5900019d68"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20240128-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240210-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240128.1.1",
+                    "release": "39.20240210.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0a814c56b7dc0776c555600127c5f2b19a79cae53f2fa31bfcc1108dd269254c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2508106d70475ce8d1fca5626ed1ef5b8af8555c5cfb3f50b463fc33284c73a4"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-01-31T15:59:20Z",
+        "last-modified": "2024-02-13T10:25:31Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "aeeb456bfccbf1397b2c1f881ded420bfd0c18dd09cf1cfc1143d78334747fe0",
-                                "uncompressed-sha256": "9c4af96f95d8eb7371ccd5d2029f0272710e7bb400915f3f8c81b819e212923e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c52532d5bd38316886a5d57848524f6184fea9e20b5f9e38b26325b5a2bd3501",
+                                "uncompressed-sha256": "d475d47fe991dd9be0564e11db90eeea0840f246897521680ab2bb0dd3e75f4b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "aa99e18b37e7fc4eddc5ff4e190c3c35ee443855ce99800502839fd3e244bcbc",
-                                "uncompressed-sha256": "fad4de14c2e3422165dfe3a90bf8cd5447c22681479312db9cd2a50e12a8b996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ccf45e71bef5534ac505c8183731cad323e7e945523ee3a2e478e11941f00727",
+                                "uncompressed-sha256": "7f020783fbeca1ce1844d1cea89c7a306c4ee6372e1696690745e8ad370eddb9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ce80440bfd5dde6e3de28690fcf9a4941b8da06008b2bbf07a4e16bf7f286ea0",
-                                "uncompressed-sha256": "3157af69af86bcd55950b3f0daa55f84d2f68f3da0de134482bb3dded05dad56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "3794e9a8832f677293d630f7cabf56cdfb2d375ff12c003269bde1889154dd60",
+                                "uncompressed-sha256": "29ade5039287623c8886237ba950253e9f806e22681c1d96eb45639252b5c052"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "9d85ee986179fc9dfb0ecfed8e378edd254cf37e49c1a90112fe91b8170883d3",
-                                "uncompressed-sha256": "5f8e9c1ccead3d5b422ba1ad4c7a2c8e98c414a44fb008807e841f3c7311033a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "7e232a8532f1b0ae54c0ab5eb61a0fc1124289fa4ec91ef2dc2a7d35d648f1b5",
+                                "uncompressed-sha256": "ad913d3d8695304a0aff0f4761b70d241ae9d4ef96c9557d79cf1266b9b236e8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "c609169da9d4d2a090d178591c9d33eff024b338211fba4579b1575d8a6728f4",
-                                "uncompressed-sha256": "54a1423c276f6ceeccd3f6cd7ba1fb020dc05a9531f5a40cc768acadf5ff73b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6e72999948722b3ee554a41f5b61015fd934b54f9ecf7ca6e37aef3ac1af89e8",
+                                "uncompressed-sha256": "897ed8521661d174b03d42d279403ee2e0253c049062c5090af01ff61f676f82"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "116678f8b2c954426cca44afe0311920fcf159c3003aea25af2c750de841172e",
-                                "uncompressed-sha256": "4caa2f3c0818bac90d411ee870d0726f70336314e182375ba753ff4dd994c248"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b3fc5003b27085c108924698a6ee0379a5c04ede39805282a6d4ae47fb073c5d",
+                                "uncompressed-sha256": "a1299785985c2146dc0426bbc053cd2748f04c2dc21b3f58606da1e6a9431907"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live.aarch64.iso.sig",
-                                "sha256": "681c46279f821f51a2af21a677610487dae56559554fc83a13b98f7bf1d696ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live.aarch64.iso.sig",
+                                "sha256": "e0904ae279d3516fc37a86aadfcb12055dfd522950b6fca4bc2c85f2ecbb6b09"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-kernel-aarch64.sig",
-                                "sha256": "608bca9610637faad7d468c5e03019ef81a903cd0a3ddc83cc4f693729b661d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live-kernel-aarch64.sig",
+                                "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "4a6a36d08414cd5fec0e915fa15b9815921041d0ab85a9f6b92093e629cb419c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "74597e20876c692e17ff2eae08cccc46ba56ba20ca0d2007b5515ada574e3759"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "174f877651b660a8181333d4cc55fcaf9d96ac65957dc125923eec466feed742"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c8b1533c1f6fdf5cae6c3dd77469a87b130eddee8aefdcf9430c6e67e4c19be8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "6ecb90b0528c5de45c2656554aed6ea6e914ed415f5ed9a07576583df7732281",
-                                "uncompressed-sha256": "5e2cfa7d1a04c1158d0ead832b9af2dab7a1c67ad686d9139878ab5ebce6e281"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "353445c94e3a075f25254bc94a1a48b58663ef9fe5168edeaec3558267376bdd",
+                                "uncompressed-sha256": "c62cf7fb2a6e33328a573293e8fdaab37e7098ea556684a6fe0b7999bd1334df"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "37f6ad55d207f2e89ff3e8cf4caecfa0661c15dbc8a96ebb0ab035751e32fb2e",
-                                "uncompressed-sha256": "39c7f9fc8254bc7a04b564de5230ade532bdb2ecf75e8e2f25fb61885280f419"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d971736a63c81be5e3ede429a3fb3c735982e0df00abec2286aed53afda4324e",
+                                "uncompressed-sha256": "6eade77e936118bc8c61ba0f67d4a40fcdb46006dc6e8526ed67188c5ba65675"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/aarch64/fedora-coreos-39.20240112.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ea9496dba2a3ef031d7fa2c2f970a6f26fdac0c42983f169576d4c8a85726daf",
-                                "uncompressed-sha256": "ffc154e06e096f21fe92c6461edb14518216be0220c12b9784293c724e85c3a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/aarch64/fedora-coreos-39.20240128.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d4c1694fec345b2d3b0280ed6d0e1d5554383e82462d1536ed5e7d705b4fa440",
+                                "uncompressed-sha256": "3ebc50bda70b124a0590d3e58052e2fa5abd1f38bd8c24b1e3e06811930230d4"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-053cf73c554d11f6d"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-095255eb58d377cb2"
                         },
                         "ap-east-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0ac08fbae1f1247db"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0d7a826149850ea7d"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-082e61379d30e1b7f"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-05984bfa43fba6430"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0697587a1d890fbda"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0ada9c8a82ea43856"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0c8d43ed62104b847"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0b5292178294b9d5c"
                         },
                         "ap-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0f6cbc57b9f01bec6"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0cfd4f0ff01a2a799"
                         },
                         "ap-south-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-03f4794cdd9d81384"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0dfab94c2c192a193"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-090af9adceb1b1cbd"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-07cb35fb59d349edc"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0a6ecd045cc51bbef"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-06be2b1e1d8b4c2d5"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0d5c9cb4eed2924be"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-02bcfa3a9b98b133f"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0978cef15ad866583"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-05e3cd971876fdc97"
                         },
                         "ca-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-081fb4f58dffbefc3"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-07bfb51d97b3ae43c"
                         },
                         "ca-west-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-05fca6303f5d096a8"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-09b17b78e359763d3"
                         },
                         "eu-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-078952ad811595167"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0509e26dc3d0bde90"
                         },
                         "eu-central-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0b93991c13d37ffc5"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-01b5c61b64ee8130f"
                         },
                         "eu-north-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0298d6205ed226ef8"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-061f9525711367679"
                         },
                         "eu-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-00b2a25297a6af7da"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0eefb6a58d7425dc9"
                         },
                         "eu-south-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0a4d6287aa1af7da5"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0263f44de5a1af8cb"
                         },
                         "eu-west-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-04b4bd5e032719ba6"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-087ba16f4ca6e8b43"
                         },
                         "eu-west-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-025b273cd18e6dd91"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-05ca04baf3198cd13"
                         },
                         "eu-west-3": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-02f5f6f098ae6ef25"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-04c82f8898d40db74"
                         },
                         "il-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-070f3d2f5bb3ba0a2"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-04e9012e7977e17bc"
                         },
                         "me-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-041b243efbc255f7f"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-095569099211ceed0"
                         },
                         "me-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-084483dbe064d81a8"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-05c46f53abd5c9d73"
                         },
                         "sa-east-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0d043a12103d4ae76"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-075da8b7bc79df75f"
                         },
                         "us-east-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0bf84607b1a7e2218"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-012c9622d990588e0"
                         },
                         "us-east-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0c8c03c6d6da33170"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-04a29314db0af6add"
                         },
                         "us-west-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-051479cd56e25ba8c"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-057fcfd6ac83bd0c5"
                         },
                         "us-west-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0f1fbf51815534c9d"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0e7c31f1402966672"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240112-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240128-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "9d24c611689423f7ed2120e72a167ddec949356d8cec2f15d80821ae240f4c69",
-                                "uncompressed-sha256": "1ce6178dedee1eb81e901ec57cf22730fb5f3cd9b7f35488654fcef95a2baca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e0555ca7d9c20d6435f9b3719981e8b04cdef95d386ecf96b658e6a34e6279c6",
+                                "uncompressed-sha256": "0ae2534baddad230b74c1bf2344c542ce0cd271cbc01922fca888d1795c4dc41"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live.ppc64le.iso.sig",
-                                "sha256": "d87f321947a6bb76838737f51326deeca58fe9753872e91e3b4cd7b79530fa5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live.ppc64le.iso.sig",
+                                "sha256": "240f101ff47c829ce64eb7c634b78b34f37d7c44679771bcd7518c75e74a72a4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "1ac57384bf7457f3a130dd6672a771e1e1df503f68ed16f1f70cfb05ea911aa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "d8657b8eea71acfe97c90672f27a66e2e1d8d4dffce8e5105ef6ce2fe702f381"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1151800e4d80702bfc78ad19fa6bbbf91d3f0169fe59088a05c938b4db29c101"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "23d61a62d6223a41b1782b768aaad1d254a51d6dd6387c9ce17e542b1390e051"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "03a25d011f1132354b33ff52edae4ac624a8b7bd18699893647fdaedd163d431"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a7d7ed17fc01539f05e8b71f2b3a942cd40f3d6acd349f1a4e488f5bcbda058f",
-                                "uncompressed-sha256": "ed0ca6530eb1f7fec3a2dc50464d313073621b59716843979d086747c132bab0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3d210593b8920584be13fc2216e0b118f7c4745fa50a185239aea84eb0cd96e7",
+                                "uncompressed-sha256": "a22358fd667505bbabfdf6c1c7b6f5b321be7b8f6752409d077937d509e5b58c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "69194a1a261fae28f69fecf1b41808e72fcfdbcd10fe5b578c399455a077e49f",
-                                "uncompressed-sha256": "8d3a2224ef2e4cdbc1af002e22e1cc584449616eb52236626bc5b0a55e079160"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "5812c4c79f425316b9ae955527c4d863bd89fd49d8596b7d57c5214a90faa517",
+                                "uncompressed-sha256": "cca7865f8cda748ce249b6354a37f7f816d59030a2b716a7c27150746c59ec7a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "3352f5a5efba03b91bc0a2bf45fdba8ca058c3db93583a8c00cc184123fd9689",
-                                "uncompressed-sha256": "f96213b03967c9f859ff119a676665007cc818507a2609f616277c9dc8a58a19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "4487c6a3cd0e881d60456f054a8a53293e6d867ec48bbe53a21408227430e12c",
+                                "uncompressed-sha256": "10373cb20a484fee0848dcd617a19d041c9b7e4499f3ad5e1db52379a20a77eb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/ppc64le/fedora-coreos-39.20240112.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b95ed6c24d7a9100e03096ebe15c2452d24227830b67c6ba3e8107714b8a91fe",
-                                "uncompressed-sha256": "00eeb27ab7f683c7387958001f85d476b2f771599f67c26b94c50660a637664c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/ppc64le/fedora-coreos-39.20240128.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "493d0ae137213c0e1f26dbeeff12c3dda053ad5970dded5a33109890a7e0dfd7",
+                                "uncompressed-sha256": "e87f38865a61d25b12afb047ee812b0a929cd4ed654112bc9315ab6958a96e7b"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "21efbadf531588117535c11c81acd52beb8fa4ac1ebd95e88644a7bf653af763",
-                                "uncompressed-sha256": "9ab4ff4994e94ce2edfe1b4ffb5c35314f1742f4baf45c164334e06792f47b60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7efb9513b52ee4c4b1860bb6bba2a3e0aa336ade9186b2c4a8f65a3f78d8b4e9",
+                                "uncompressed-sha256": "99b125430d67bef7249e8d02be02d84a9f80ad3663ec12f3bd8d592d34438fcd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "9795345259e89b64e3a91c053bccd17e1127e1afcb2eb6d346241db69f60cd3b",
-                                "uncompressed-sha256": "c91a2f18714b82b81befec6446b1f2ec97ce71abbeaf0c844b7181fb9399c13a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "74c5f249753d6d542a1b36446ac6878250b7677aa012ee44c0c135bd3a929fe9",
+                                "uncompressed-sha256": "fe3db74f174cc95ad44d62de6f665b33186edc1d4f6a105947d57cc844ea104d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live.s390x.iso.sig",
-                                "sha256": "97d5959734243428bdbbbd20a40f786337cc89e214d8ea3c842d9b4e8fec9510"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live.s390x.iso.sig",
+                                "sha256": "973e6576322fdd0b2742d8aa921e575122a8eec3e41726052eddc547f0aee38b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-kernel-s390x.sig",
-                                "sha256": "08c1bdfe60e2fcde9b226db19736e6a468aa128c8b39516e8548512209b1ffa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live-kernel-s390x.sig",
+                                "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "bf6a6dc3e7a9b11f1b1efab5a26cf73fa287d7035d7da5faa1760c49d6a502b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "827dbba78d2a07d0f46d018d9c6e481066ebec7e4f4f05bf5f096f25b7043e21"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b1068ee07171dc6d8f2682ab4cf8eabe980e39122bf1558a63a3ed48b152c7f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "416cf0bd9a911a56d92c90d5cfa0f90ec2708d653d51fa21769365ae0a517279"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "2b5f3aa87a1c7f401e525ed99b57cb82061296d5ed8dd9e49a7d83b3dd15675a",
-                                "uncompressed-sha256": "ff6e32b30a763684e6624adb013fd71fe05ed7dae921a033f99a2027814fced7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c30337e9fb8c61702d9ad69351393e360beee3afa3303fb291abd51df9420f90",
+                                "uncompressed-sha256": "ac7503b361e949c2c8c1a99e1b78e851f630799a744901f2342d117356f12078"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "dc3706d2828d9e6d11ce7b74ca7626fa3ee494acbf87b375eae742adb26961f4",
-                                "uncompressed-sha256": "ba7c8e2da6a739ae3ba7050cf1cebf590c4710bf354cc5a58559e5e231f90842"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8e11937d946fb2c2dec48dde088b796d9be0c9a9cb63d18a37d7aa47a1c5a2c9",
+                                "uncompressed-sha256": "09bd65e6820facc4038c9503b3d32eb2e0b536fd38c129ca64eb78f698ef4b28"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/s390x/fedora-coreos-39.20240112.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7826deb756bf6f290ad1c394261efb6ec5920d46ca27533721294f343454b4aa",
-                                "uncompressed-sha256": "a605bcec75d47de533bb5fc88b26a8071010e9235e1c9ccbc1200f3ee48d4c26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/s390x/fedora-coreos-39.20240128.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "319471d45fcc3663c0eb3b5aabd7704aacb993da7116e866435f9a0cbc7dd30b",
+                                "uncompressed-sha256": "4f92d5adacb1225383365a9ee08a9cd8bbaacfeb1b94d880a4301587c3222a18"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "44664a4c888704217c3299eb0897957ceb2503a9473b3bca89ea184a505217aa",
-                                "uncompressed-sha256": "90c41e29acfbb0ff15fd4211da31dff133d6cb8fdb7697c2c24f5d0ae0a94802"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4726d12d4cfc081c6d1470237eb252c046dd645a6229020e5023ba7c788edb4b",
+                                "uncompressed-sha256": "73a3ccf4d49982661b73da6e101382906fc8c1206f0121e3a0cf3dcfa749c566"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ec036b7076bfd5df7e4912a21312c2fe0c266775c1f6f48876facc848291475d",
-                                "uncompressed-sha256": "71223679452acaeaa6e62b9cdd824d620a34aed15afa539e52125be2223ef3d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "24ef5a14f127d7de5e7af6b0d6d16df9cf054476047a739e2644b6c6bf412599",
+                                "uncompressed-sha256": "9ae875cd46203462a953449cf3cdafb384f2f5c464b6c92f114f660b967b606a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b307e61d48ce1773ffc9d31a58fe5e867df5d613f3ffd161eb994c21b1cc35a5",
-                                "uncompressed-sha256": "ddaea6a5fc74fb5a31897fa8dc23e9ae1c805be0052560e1fdaada5b3a940dfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bbbd31b197e147cce840997db34a212041d497a609b2f27fa2ff4201e32bda43",
+                                "uncompressed-sha256": "583b006f1cf6b82a3cd82a25350fad828666135f6e3decfd2e9bf7ae34895113"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2b0037e5dff3c790be93504cf925fb0dc3d731d02600bc606d1d28584f926a7a",
-                                "uncompressed-sha256": "76c73237865124036b3bc197333aa18c424df9e2163479bf6b1f1aee908d3b42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "16a1d2f5df585beb3c5f4acfe93850c73299fbf97d0b97d663ff29e2eb40ea20",
+                                "uncompressed-sha256": "bb9d9c96fc87e971a7d4070be50899bff8b1935f4b1f0fecac7152dcb6ac2c40"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "09c26ccf17fa40880b37c757783bf1c133b8a94273090c70e58469f6eaa4e2b4",
-                                "uncompressed-sha256": "243b8a2b3e4423449c116b1341ae35da46a387da7063b4fcfe485be3edd8f3db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f95fd463b7e560d8836be7458e7160a0e014aa91fa519225fc165eeca8bde530",
+                                "uncompressed-sha256": "9796ba8aedf55b5c19dac46ccaa1c01f0cf9b786659e2b3e0feadbf2d749c4c8"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "660eb32a56805363c90428caf309baf540e8268b0f06886c7b5f9104ee19177e",
-                                "uncompressed-sha256": "138b0af93a51f9db4617eb8d07b7a04392fa42da03add80bd1e4e84f26ea9a87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d36fa6e45d8ca056be27f14e37bc912861f90411cab54712c8f9fbcefaa2af57",
+                                "uncompressed-sha256": "f91dfe912c9344a7b5f8603502043cc450eed5eec48d9e1e28c56a208312b8c6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3541fdddcb5d391a0195da0c772c99dc75a6b06bb55e1e8da2aadad05a406838",
-                                "uncompressed-sha256": "a1046d2da49350e2927a1baf3f6af9110851b3ea50f70b0631001fc093686c90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "369de62d266a85c11161b9b5a34b6c0679baae1dfa7b2c973f6e94c12746c0b2",
+                                "uncompressed-sha256": "a2b66703c3db4f20e893e59729f56d8730d9f90a2994abf6a980e4b6e9c45d1c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0220cf007696df6719760a0404cce10d0db02b4abc21d9c191bbde38f1de7b8e",
-                                "uncompressed-sha256": "bba84bed4c4e5e572ed5e52996878a3349fb25a4e964b510cdcb4d462e216c1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "140c3f282e2c307b987e7f4acd9a9f1f9f138d307da82433e385c1da1280edc4",
+                                "uncompressed-sha256": "ba61a88c7d5d6943107068dac0b7697cb973b8b0d707d7f78a971939d09e6052"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "19e9f7929ee50f0851f165865d8965fa4155eab91242fed561f50f7d8e2d37f9",
-                                "uncompressed-sha256": "f48f56f6f3a61e0493d41b19e5d14761d0092b07c30b1df2f19a2c73bf2b0db6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "d8db96ae3c13409ca74328ba3fcc15298509503703bdbde8127a9e78040cb13e",
+                                "uncompressed-sha256": "cbff62529c878ab5bd76b995b9463ea3d5e56124ab9d564730c7b1760209578b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4b4286cabd90560f90656b4cd8434626b335914289091137dd549c6a5f377428",
-                                "uncompressed-sha256": "c76102135a4910d5072296aa1fbbacae300851618cc3c6ed7aed201e8d261105"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c47c7539eef8296bd619493b706ce8eab94342f6df6b8c2dae7206f19c51b4c9",
+                                "uncompressed-sha256": "409b69da581174456749c9754ec860ea8d30fcc021417be7c635a51db62c2468"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "9053b61b84c472ceee5af8de18de89ca6351ee2d723542ea6057d2ab8023e36a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "4f496692916d576ea8a00d8a54ebef285ba1963a5bc589ce5d5b89c6431f5020"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c96da2aa328c6e3da261e98a2c4526c3b1aff4fcbdee82427cf774ca0a124573",
-                                "uncompressed-sha256": "fa82775555a852e75fa33d7eee8c3b9b0de039a6627d4c17918a6b61cb8f55ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "05a6de7006d44f3c177bd241722f2f216897e5f3ec22eac5ec61040a537ecdfb",
+                                "uncompressed-sha256": "aabb622b6248fabbcff78628f083996aed5279ef047619df9305c921801c1ab2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live.x86_64.iso.sig",
-                                "sha256": "d34520e35c75edf85df47a9d77e42f095253ec78e2dfc4ebdc497a5c790eda2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live.x86_64.iso.sig",
+                                "sha256": "1e48c8b45bdec65818a933d3da04c975e6900d446a85d54d850f77f1a366cbbb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-kernel-x86_64.sig",
-                                "sha256": "ee39b5da6bf3bce33a573a2e5ceec012955d90378b11260472b0030f689d07bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live-kernel-x86_64.sig",
+                                "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "97edba3e5e7214bedfae920d95243e5f178b10d229d530135a694920a1788deb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0b1e5f6ba6b9c3681be9ef802adea0aade2cc69ddd45701a651e24f04cf54a45"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f5fa8728f90ab19cf123c71efc42e7f8ed905c9c59fc81a7679466bebc27294b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1a46bb7030f626fcd2993bfdfdb94778ffdc32911b414754bcd175c6e2c3e803"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "9d58d0b73dd2723b57516e07e0db2cbc754536b22182215fe5ae3bb3625fe562",
-                                "uncompressed-sha256": "30b3fa62ec95d3c016556f0ef84b19c633abc50b6d41a99994ebe315cdafda3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3e86db1b18e270560b2cb8115aec8392c3d70e16e8fa5010940161a61f4ff058",
+                                "uncompressed-sha256": "93d876e38d360b4f85655f65adc608e1e2cb1f2980b74545e9ce74c695e00819"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "cb35e286860b27f7cf48dc5388f40faa6e7b9fb89b63f6130143cbd2b6d2a29d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "14f21373965fbc1610640426d9e4a20d389d5dc3b986cc59b626e81da4e6f728"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1712561ab86b1e12e44dedf02eaeb390f6579bd257a12df5a8073e3e33643e13",
-                                "uncompressed-sha256": "e754600cc1f9357845beef76f71544db9662fd166113ace00432b476d18b47b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "dcea3cced0a81274514bfbcf4c805ccb40f492ced5067905c5a1be214613485e",
+                                "uncompressed-sha256": "705c09f88a3d88a57f85b635e4cd706929ef42fad92e214f31166a70377ff075"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "58b62252e922f1a22225e44417cba4a4ea54f5da8369aaea627fe7f0cc0827f5",
-                                "uncompressed-sha256": "6d9d5fbe980fbe67568461e8916efcd3f586c3ee7270c9ed12cbf7dd68b5e3d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "76d7c69235477bfe184d64ea143f85545ed82e8bce0a155b890646d96e4cb6c9",
+                                "uncompressed-sha256": "c877c56e4dd11e6650e623cfee3c71a4a1a8c9fcf10d0e01b8525fd3edd16d3e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "bf1c4e09ca29b754e488d79688735ab3e2b602859a35abd39bb816ca801ce394"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "9d2e70ff4e6fa432ed5d6977f33b3040a2a27952abc17dd8eb5ccd1f572c7761"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "6141232d09a5624a31fb56b4d958bd82ebedee79f6983c908a027d320644814a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "5ca9814baf9abecbf37dc7350f5c0a00deafe636d4e09e279a03a0318204180c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240112.3.0/x86_64/fedora-coreos-39.20240112.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "474ae3003f2e8f7e9ec740ceee78502ef5519a87d6918e1f561ff240d832860c",
-                                "uncompressed-sha256": "5dba1d3ee03eba1521b26e55671d4e2e2d8b2ab29c0f6c99e8c0b61d5c225bfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240128.3.0/x86_64/fedora-coreos-39.20240128.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3310049aa12db104df4c9056846586788f42d13568ed065bc1060042eb508865",
+                                "uncompressed-sha256": "4213d6602634f3220a05d747b63e692788a72803f44760b0fcb41bd7e2ca1819"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0c9c49ea6dab7dd53"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-097ca8cd78c3301fa"
                         },
                         "ap-east-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0d381c13b70780843"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-09a4aa66601627e0c"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-05ba0dee540bec726"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0d6a65f1a2f06b336"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0d33dafc98271cfed"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0382e4634c6da7fa2"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0c75737247cd1cd95"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-06b1c9cd82dedea30"
                         },
                         "ap-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0cfffda68469ef9ba"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0c35be7ed658ac0a2"
                         },
                         "ap-south-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-06a9e9d6cd1e2be9c"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0c40b7eb058f71a78"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-03fb613dbe6c97918"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0ed2f219ab6f1226f"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-09f15ca8e136bf77f"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0b6e0cb2f2718721d"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0ef05977f6c8da287"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-00c30fb6bcfba3ab6"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0e40ca4dae495cf83"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0dd1ce49d01b9e3d7"
                         },
                         "ca-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-00ccba9a62486dea8"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-03eca2819c77e4bd3"
                         },
                         "ca-west-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0e11ab4f92a65c068"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0c5f8e9e9c0e72906"
                         },
                         "eu-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0c26333b53e21db01"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-025d9aa0d78e16573"
                         },
                         "eu-central-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-076bdbae1716b8707"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0e8c1d4adb87caf62"
                         },
                         "eu-north-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0708e97aacc8ce35a"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-039d0604c3d374bbb"
                         },
                         "eu-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-08443c0017a641a57"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-048d69d8bbcf25017"
                         },
                         "eu-south-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-09ead1fb0ad2b9ae2"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0e1698b93f5ca1682"
                         },
                         "eu-west-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-030b283577a1952e8"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0cc3135427b8214f1"
                         },
                         "eu-west-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0b00f28c8aa40689b"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0b36a6edce7741346"
                         },
                         "eu-west-3": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-042f6b09e5d20cad2"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0d816ce7658f19251"
                         },
                         "il-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0fbb5e346df3ba9cf"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-06f3a5dd9640df301"
                         },
                         "me-central-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-082b2fa78cd202f9e"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0bbbcac38c4e848ea"
                         },
                         "me-south-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-06c7746e01d806014"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-096c71cb54750c45b"
                         },
                         "sa-east-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0b20c5924042da658"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0521a6f2298950a60"
                         },
                         "us-east-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-0e28c621aec36772a"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-07285ae2c326d8acf"
                         },
                         "us-east-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-058298b7a39e71dee"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-04e8a5807feb997d9"
                         },
                         "us-west-1": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-01d1a17744988d96d"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-0154c61f7eaf3603e"
                         },
                         "us-west-2": {
-                            "release": "39.20240112.3.0",
-                            "image": "ami-05fe9a391a16d16c3"
+                            "release": "39.20240128.3.0",
+                            "image": "ami-074044cd8432729e2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240112-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240128-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240112.3.0",
+                    "release": "39.20240128.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bc076398e96b835a1d1cd06a91574bfabce0d14ff1cae7ad5449cf884b825299"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:855a59927531c00f9f9d4e1b6dcdffbfd2c492951b53c217df8a234cb537ac71"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-02-06T17:02:05Z",
+        "last-modified": "2024-02-13T10:25:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b408ce2fc500957eb23bef3cc0395b1b9f7c473045afcebafe5cf470f7dd66a6",
-                                "uncompressed-sha256": "6506cac91b57f900ea49972563d7ca16da55a7ed6738b3946c9c5a7d36480bab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "3fa7a05c7cf9bd04e482454d9513a142f98b4fec0b8755766f104120fd4d4e3d",
+                                "uncompressed-sha256": "75532a77d02a4010f2db8a6b19324afd05f0cdae0322d4d84e3577e8db78e89b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2067ebae46bc3470ab625e544828535be2e906cc9a6f39863beecf1458fd19a2",
-                                "uncompressed-sha256": "24888905dda0e0d66c1e4d948f8c5987980efa768cad13d0993150e76bb1cff9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3a8dafa90f30aad8db64e78d35b6e7da9b0c07351218ad93abaf02b50b6f7ebb",
+                                "uncompressed-sha256": "bb3cbca950edaf289e1b43d7828b5bdb11c012e726e9dcb8bba7c5a4ac4db4d7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7c8b6acef1a7999b8fcd064f672c2fc351722a8d4c1ac8717388528c6cfae0c8",
-                                "uncompressed-sha256": "56796ce13b2308e7f17f4d68c4bb286dcd7f6e1f42174b95cfe97358f64ee118"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "fa49db736dd9326ddcd5bde68163b7604dae6436c37ce0da1ec498eb7393f005",
+                                "uncompressed-sha256": "9b2707fa84c08da5410d16098b4aa7c1dc66f458a440574af2536410667e5ddd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d6986873477ba3d519579b4ee1ec117c7e46d380e85bd17b23533fad6b596c0b",
-                                "uncompressed-sha256": "cab4971afc3d2eb327d37aa78d466db2657684da14eb1435754fe12a6d445fed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f1be60b95a99c97487e68f5c31d57471da8364105c5b51609a7a5e68ab392844",
+                                "uncompressed-sha256": "5def026eb8f35ef05e637a97c4b8f6e0feb9d7d6c11671e3cd6269a2d5496a66"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "4b9c25b77a698518042cda4f82a468a529a29163032250995589542adb08e9e6",
-                                "uncompressed-sha256": "fb5667992f7e2579e73ba8a06bc9877b3618c5cc3d61c0566208bb9578038c2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0499a74de3225a5bbdc5702d1ae91f53792ff85c62ea47a422a1c325164aa383",
+                                "uncompressed-sha256": "b5c487167d9090d927f512d95247e6f3ec2f9af0fa8aa04d29e32957da422fb1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7a87bde76d33927ee678a8f9c54dd5b5598417cf7217173220b5d50de65ca0e4",
-                                "uncompressed-sha256": "fe6920c646712f72d4a43af4c604c67b9f2156aa75fb12313190454910355866"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "137a55778618b4fee83e37d11cd713e40a8b2d6a5ab6094199635aa77d27fb08",
+                                "uncompressed-sha256": "9b18c46d4ff92df58578e520a88cc96da65ebc2852155a23d6a4e6fe35f184ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live.aarch64.iso.sig",
-                                "sha256": "5844f2d5719cb7830bf5cd6393a1216e17f63a06967d9d768747de1861e3e8dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live.aarch64.iso.sig",
+                                "sha256": "7af963cdf30eb145d8663c22c7f3e322e5d0e8944ccc63f82712a7c6f999d537"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-kernel-aarch64.sig",
-                                "sha256": "d8f05968050e516fb76d056353768b8727b49868d2eb7d0d8a570d80b9a12e7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live-kernel-aarch64.sig",
+                                "sha256": "ac596100dadedde9b11bae2f0c37e05aa403de2899fde21355611b691dc0e110"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "c02c3b209f28e74e8901d7a250b258a5655454f93fc325fef696a7d24753fe66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c225dea40683d32d055cb5000f70762210dd103258bbf454fe8d94fcf9eb9c7f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "bbce0ade618d512f4fbad886f4355aa5491b78fe236f86b021bedb9353933fdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a5d75a93cc924cfbb8d8171c68c8aa5ad69c8d1651c4e338accde16a51594e67"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "5963e6398d7e1b5f9f299ca374d2d61ad7855010cb3161e821b0fcf3867120e3",
-                                "uncompressed-sha256": "490475710f041a61f16a6132dab6d37fa5ce3e7b2c5eaf74639bf028d6a80873"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cbc8e0cdb5a4f7ea9c1c4ef513248f96b20b35e8db7241298cadd822fe88c229",
+                                "uncompressed-sha256": "476ce2250e5d41e708f0f443d2dfba1373f1b66362f506065b74e4c0d7ddd71d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1e5da8ed10ae652352bd4fbf34f879eb12f870110943e409d2e02dbacc75407a",
-                                "uncompressed-sha256": "7b441dce8375c202bdfd5c48e2b7b0508b53844d7faad04b5f3b9f36ae4f8556"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "51f5c7a29c82382b5885e29827f50922fd30a1d7c66e02c6e7cc199df0560e37",
+                                "uncompressed-sha256": "f029a4ac9e5dfcfadad31eb8bb5f8f36a6ebfc435f2196612b92d892a2036f0c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/aarch64/fedora-coreos-39.20240128.2.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b230cf32d731c8f5131d3f04f3d22bf17216c05cf778a75cb90cc01a4a2d5b2c",
-                                "uncompressed-sha256": "dfcf90ee8a31a1acaf688e901ff0772b3f99f2ebeac86e2d7c140bdee1d034b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/aarch64/fedora-coreos-39.20240210.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "169aa981cafc787475c35333eebaadbdcb7fda780852f3347d05109ccc358e1c",
+                                "uncompressed-sha256": "a032a7676b3b3461e347f4a9716ea97d4fd4099956de71436db5244a4fdf4bb2"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-00c82ee543e76c11d"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0aed12ce94ed47be8"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0c1b0e9c7f1ec21cb"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0866ba31ae4fa8fe5"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0ee35ac389b5739d0"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-098afa7a5db289ad4"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-04beef8251429bf3f"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0300c9947cca527ed"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0d090b3db112a8940"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-066ee3f0de9daa2c2"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-024debf8acf528fb5"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0b340e2d732750420"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-053019c4b4feb1de3"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0c506c3a4facc2cd6"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0a98510e9e8f6fac2"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0ace1e62e2d4d4da9"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-044ac7f9cc71e282b"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-04b17f411fbc3f771"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-05fb6d934ab58a3cb"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-02f891ef63049903f"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-00677ae6c600634b4"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0f4df729296e42eca"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0dbefde27bcfffa02"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-02f17d78f40c754fb"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-07db56777eaab36c4"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-000ed4e2951e89896"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0ed72b520d8642579"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-04aaf63d7c04dbd25"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-08eeae36f4d603946"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0120945553fa268e0"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-034553f2e3ebe4cd6"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0a66cc0898f261db1"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0e2a8a2f197ad3169"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0bc1bce0a046cb471"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0c07a7894067c6562"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-066e2439f568c2b4b"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0f6162d814eb2d67d"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-09e95cee93851cf0b"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0b6fa53f3080f1430"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0b8a18b2760e8f010"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-044ee1cc8dd705f8e"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-066775ce13fca1137"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0079adc890c072a76"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-010fbb5a22cad08ef"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-02946ae12d55f62da"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-018d8d412b953f07b"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0a60449a566eb60f5"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0f7987903da73da12"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0388640549a4de87d"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0b0b0cb90ea80d6e1"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0b5f8b9b608260f33"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0874b27f4d194b34c"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-084a81d7ed50813f3"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0a332c94619310123"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0a469ff392c329aef"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-02db8de7eb6203045"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-016020b71f38f0441"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0ec0b0a5c988fac3d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240128-2-2-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240210-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c20225d33d0c2b4d17ad7a0446a137fbf4cabe9593179e0d6543c0eca013fd04",
-                                "uncompressed-sha256": "546190e845a36512f5e5bd73249fe90fe0720761fea0f465650a244fab262c72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6db2503dd4b7e2194a88ffcc372938b2bfcdf85063ee651cd977ee2d8e92c7d8",
+                                "uncompressed-sha256": "fe98e7c4d419c474f7840e17729c779a874a5204e30277e5a1ab08ed2c5b9127"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live.ppc64le.iso.sig",
-                                "sha256": "ff4a780bee7a3a9d6672876146ac1ff198af77ec7d96bf51de102c21320d6f05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live.ppc64le.iso.sig",
+                                "sha256": "ce1008131299e48a25392c288e8b2b975686bcfb9add04aa0c8b148916682fc6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-kernel-ppc64le.sig",
-                                "sha256": "c716b6290242f77765e2b82933e408c322d367eb89937a3f22b241c309e626b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "50aab873c1577431233890b4c36a4237b1f8b0f63a551d79031a1b6b4501d6b3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "803e0ca0c46e0790aa0436bca55e9fa4192ef345ce30af8e3421dc1bd9494de9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7069610b61edc84005ffe070312e08ac864d4c3818a0cabf88e5301159497470"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "badd68b39e99ef29f9c52a715f786de5d6da65a57fcf821314463a8d6990333d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "492234129dba1973a28f6e42cde8d4be44ced89d9d96bcf9dfd08cc74b1bf90c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "84493b93f499f9d4d3b901c23514de07ccadc60157088be056597bd0cb4d2dbd",
-                                "uncompressed-sha256": "c35d1816e715a59d48aef131612e0b31221e770e5a16a0f1eba57ae651f555f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "41f95b621ddb4ad7e07e20b6eda20e92df860ac8d6d7a479847f9bd4fb37edeb",
+                                "uncompressed-sha256": "2e94c4f558fc36a1ed90432107b0e78ff5f466d3f43380d83b732d9b2a1042f8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "82444afdf00c1b7a486a127a3be89a06b0c1adb29ed7f8421d6312a877d381fa",
-                                "uncompressed-sha256": "902a48daab5640b2c57c7a380f201d466612394adff7865736e2eadb36b3c28d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0fc660689f6ceada5feffd94862120254a2591c0e8c88e04b98866002c7d97a8",
+                                "uncompressed-sha256": "b654f4cccb77609d8b946ebb6ed8eb47ae695f459bd779cfa6369c1b234ad2a0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2c18b1bc6013215041f87875e99ea09afbeb084ec3a3651087bb41fa7e278c75",
-                                "uncompressed-sha256": "11945aa1110f4b15a74feac444bca7686e8216f1e05c541c476f7619f45f1f1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "66b5d76be723908d9d8e380f803905930c144b733c62088fdeca8350bfad3f69",
+                                "uncompressed-sha256": "d098bcb56a029b3755f5e5be4947bdccf6564a25fc429bcd367645714a20de32"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/ppc64le/fedora-coreos-39.20240128.2.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2b1fd298a1096532f84b13450b580e155a10306c9634e50a301ced0f1ed57191",
-                                "uncompressed-sha256": "9cfa2ad094f06cb2d6c29bc6365d34d78ddeffc875c2224ae1a25924d790349c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/ppc64le/fedora-coreos-39.20240210.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "34a16722061ba24a30123a20d6d6082c64592a9a341cd864331a2cfcd0049f7b",
+                                "uncompressed-sha256": "ffe7b6284fd3a5f4df5203593bc0bc85bc83e88ad44c33d476faf8341e8b2dde"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3811b5e572571c99dc66a49bb3eaf878d7d1c0eed21582ce9254dc11069678b5",
-                                "uncompressed-sha256": "f636a99a4475cb633b697b91faa817a86f39b6a03eca6dbb97f83187ef8cca79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "1c0f194cbd758edc517807f1978e0d8b54116965678032c8f87c680d0649d35c",
+                                "uncompressed-sha256": "fb0e371dbea5bdcc1abfe986e8af42fd36443e0d45394c18a619864caf56b381"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "95d84b3565e4e642c9d4f450e29f1b3d628dce025f4aa90ba5a244e8ccf97ef8",
-                                "uncompressed-sha256": "21d4a66b87a36f873b9b55108ea94346f3ba8d57e668a2c7794be14660d524ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fb841756781152e68b0f5f56b15d508215465d035c480552de2baa4dcb05c963",
+                                "uncompressed-sha256": "25b91b6d3ace00a30363a363161915fdd12ae604a12d831717d91e3ffa268c45"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live.s390x.iso.sig",
-                                "sha256": "3be8dca7473b00acc581ca744c6ac3f029f73af3b00a4c39b25ddd2b0114bedc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live.s390x.iso.sig",
+                                "sha256": "8509c64ef7dbe3df1fdaa1968b55386ee03fea23a5cc33101f9c2703a37dbe77"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-kernel-s390x.sig",
-                                "sha256": "c131717219f17e41b94ff2df9404a6251dc200144b7ecc093e1a525908389544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live-kernel-s390x.sig",
+                                "sha256": "14384c7a53470dc2a089425a7562f78bc6daedffeaf3ad24d6eb44d801284232"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-initramfs.s390x.img.sig",
-                                "sha256": "7d6106f22533cff575b5ea46821f5e0baad4edaa4f3765de7fe2c557dd8d0060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "0ccd5b5fe103ae1d1259bea21cf4f09454e117d539418dc8e7ae6189bc5eb86e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-live-rootfs.s390x.img.sig",
-                                "sha256": "3d17b71b9bae6dbab11834c64041542a89e3e9a3ff8af0a51d725f2134d68385"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "60d0c308978bebce5d0d627414f6fd57256bf233fd971d8591f70a249aeee28f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-metal.s390x.raw.xz.sig",
-                                "sha256": "c7f7aaaecc67195eafe1195bf7984e7c6828735159e50c984f696baa067135ac",
-                                "uncompressed-sha256": "b00a8fb2369e398d004a1d7301c968f9a23d69357dc6677533e307af3d973b55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7fc1398cc1e3b6278b5fdb05b1fe7caba567f3bed660e4023520276ac27dd812",
+                                "uncompressed-sha256": "a258fb7250cd8571d5afe8ead59d6449bd12f3c6d188a9ef9384c2a5b302840c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4b3ceabaf0a9c12c3f49e83fef6551ed771e347c21b33cf2017cac8f335e0d75",
-                                "uncompressed-sha256": "2577cf6130bbab3f63d07c654701d4f39059429ac1a7493f2fe097875c430a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9334ab871a4b5435c763b593e0440d96ffb82d584e66abbf560358419ca05676",
+                                "uncompressed-sha256": "5c8bbabed8b4e48e1395ec6183b8e57ef95ef62fb43ee35d2f3d71a2d0b056d1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/s390x/fedora-coreos-39.20240128.2.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "55dc7cd851e8b719086134dcb65204ee17b0cdae63418de33f81bcf27b0ed633",
-                                "uncompressed-sha256": "b598aba82ace3122ef1292cf78efa6e826c31a23f5667ce0f888be2a4fbf6dc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/s390x/fedora-coreos-39.20240210.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "70c3198115674327eb25b5b59dc522f579deea75adc54e5d8a0ebdffdf45ba36",
+                                "uncompressed-sha256": "56f9671c3b9a587436c7b8f6ccf413c4a9ec746bebd3feed34d761c4c0630495"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d092e6d54b02ffa3210979e6a240e4ce088022d42f99ab7606de1c7f1e39f75d",
-                                "uncompressed-sha256": "b213d682f63bd926777c6426855176882bfb50e297775576effb61f9f934684f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "78d41c78c731db7b2b3370bdb2527901b16d8f635a88a737e5fe20ba362bde2b",
+                                "uncompressed-sha256": "7e6a53626388c1d9262404d5429ef490c828c50444e0d2238087afd628a39dc8"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-applehv.x86_64.raw.gz.sig",
-                                "sha256": "07496201699decffb3213366905cf6319039cd0f11d820bfa7b41a3f0bdd097d",
-                                "uncompressed-sha256": "f1e5f98d02bf9b2b9e755f4b76ae8d7ee065ee753d7ce3b1c3457fb9437819a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ec901599129dbc955219387f1c261a70e4e5289cb82901b7c03de0f6677f4687",
+                                "uncompressed-sha256": "3ea27ab4a63dd41b221d4023c96d08c32dad495dd3d20a5d3c8a55c806261afb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "122f507a96df4090359ad400da44be6c52f6a8870145a0deddcd520e628fc9a2",
-                                "uncompressed-sha256": "0087a924da964fa3bb6609c3e3214d699369069946c4b3f5fe86062f84e31809"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "23d28a6307675b95dcd80ba041c6cb621e2f9c6554b7114cb2ed509ae876f25a",
+                                "uncompressed-sha256": "cabaece2c1b7c8ea7ca1164917370a4250638e29cd7f4b85e164396653b23161"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "48e911c6e40451d26f0d732c44eeb1dbb54aee307b53b50384b5b9c4039fbda8",
-                                "uncompressed-sha256": "45fbf3ed02e794a10eba15279b0842796ebc829de8a762ee9e4fae4c7bd24834"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a3b2ac09ea229efb0f4788e99df59eb455af020f2f62ca962dabe63c5fa64a69",
+                                "uncompressed-sha256": "45ad719d317a10e07a40483eb5cf83cf649848580e4187a5575294473e3b38c0"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "798249bf6afb8316b8bfdd766be4f619db5218bb835eb00d9492309c04e0a9e0",
-                                "uncompressed-sha256": "c86462ef669a2d81d1a440b58de25d6116780854bc322d460ad99d093cf19d69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ccf58582497b6b24f5bcdad786ff669865dd352d743a165b51b0b55bc6daabf3",
+                                "uncompressed-sha256": "5f902df1666f36cedfdc5d5e7180f05e5e7e93cfec0dfbbdcb76a1fcb13222d1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a75064509cf4b1039ff54f5c7934b5a128ee907c2f123fac612ac8d2ff6a0cb1",
-                                "uncompressed-sha256": "a10dc373a8c614f4e27cca8b8c0cb738d89a6521094cbccb889c304de281f833"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "435bb02f9e5c673f80dcf3ee8f54ccab4b9c4b48bc7a9e656e925cdd935a4b41",
+                                "uncompressed-sha256": "fbf17bc64d965c3ec30d9d69a47187734f76393b22125a5ef455b349da6897b3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "31b45428fd21e6389c2a63f25f6fa65bef96ea74e1a717348e82017852f50c90",
-                                "uncompressed-sha256": "e49d8b0ac15542a41898da415dcb4b42660e816eb63730bc7a8d458d64476948"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5901053733bdf7717109ecd7c706c6e753433508fb96d8d0d83ca2289b8f74fc",
+                                "uncompressed-sha256": "4df03b91b046b2752ca0c75e74cfab4e2b5e3a40bde35b7b8753289c56ea524a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7a00def6a308f7a2702551899b4023a1deb9d1be103c359b67553a44629379d2",
-                                "uncompressed-sha256": "670af9f323f51dfaa6e5de214471822971b4181287fbd5e1a31015de06e1d8b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "df9c78da1ddd42e2f9e07f20df4f7775c8b5e1ab51f2f6558e6a61df8c8e8923",
+                                "uncompressed-sha256": "62e305b5ecc6aaaa815afa23388f207415c98438e417b3f1bba2af8b1735146a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "34a092e7e8f437505413711626f6a35093969d98ec053a43a8f6801bcc7cdde3",
-                                "uncompressed-sha256": "8270a287136b9a6b85b9e1c611b3d213df122fa621cd8cff6c69a9d7533cef76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "881be94c8ac39ffabe09ffb84f2ecc0bdd8b9c936624635d9569cdc4cc6f132d",
+                                "uncompressed-sha256": "ea5f1470cd8477f306053b90de3b9efb0d89fbba379a7a4b8a983ca779b13acd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "da869b4a47cbf1fea5d73f0ce728459cea1e39d78603fe5360d9a785512c95f3",
-                                "uncompressed-sha256": "3929ddbcaf04091007a938dff8a23df86271bcae2c1c75ae626a4ce4e86f95cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "935d03952603f79db4fa96880bf2bbfddbff62d2ae628641891e335ee8ce6866",
+                                "uncompressed-sha256": "c908034715dddfeedce371c018d076c5e83f188d3319585a811d821dc9628272"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "9e6624d7ca86f7b44617f133a4bc740af1fdb8596d7c6f27f0b22256607b7f9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e44241669fb068fefa92beb82191b36c062d17b18a7d2c66eaa4d4be4e08d9bf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "576e571a752a4032cec277efb95099d6fec2e198978257a0acda491a9451b6c4",
-                                "uncompressed-sha256": "38c89373909f0521ef14ad263cba4e9f725ae7bc371c811d73693069f2a37b9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "55082a3c340b345e81a741066745d883eab8d67b0d09606021ac3004c69b3587",
+                                "uncompressed-sha256": "9e86364beea14b08dd8a329de1330d38da0475e8206d3dc6a357bc1228daa59a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live.x86_64.iso.sig",
-                                "sha256": "79e2e99624c1130b883448715e7b4aeef532573ac48e659f2574b5f318e0ed3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live.x86_64.iso.sig",
+                                "sha256": "4ec79c937d53f70666952394b5ad7dbe7d9fc976b813976a1458ccb450182997"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-kernel-x86_64.sig",
-                                "sha256": "b883c82c21d069540455be92b2b6ba1b6135bf48ecd3708b6517959e3fe0dcce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live-kernel-x86_64.sig",
+                                "sha256": "c835ffef4f5c8a3372c979271a27d3ceb63bb94fc09df1a610e0004667935ae7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "a8d26590c0f6e2e6a503b02f9a1fe1afa84ed2d3cb60483c29b042b190a0ccfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "85f4544f45174bd4b67f07b13240ff2ac0d9e1a91cdf1e04ea927127e2723d0d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "dc04122825cbd549a3c00006b1f705e4487d5937ad54043c36070b3f5f925b1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7005dc3ce65343b4c4fc182bc7162b456500f111eaed4d8e636b4df03d40b134"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "fe53fb32acb5d8d46c0af07eefab5ae4d99fd8c3d23d7ebb23dc98c691758e30",
-                                "uncompressed-sha256": "d65685380aa1d58e563caf04bc90349037683681dd14af0773b0d06b8dd80d21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3e360315cd87c79fbbb6cfcf2f492e142bf3ea4faa0f6df40c60815200ad193a",
+                                "uncompressed-sha256": "653f9ec4d2938ecbaff4d080bdf08f16dfc6756dd4ac990df4e4f25811eccf90"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "57a398bec7caf6f0d970a36b575a808f43346dde31949e6a4e5c2371f0ae2603"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0fa147d524140a70b1774432dc0e90cbca76dcf619d0056b2e5032f04be9af68"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "45fe67e328c6dacd0c004712603919328b5d69fcc7421e9f54c87d061e776e1d",
-                                "uncompressed-sha256": "bdb9b792a2d3c641004ed75962c5d1e9fcdb01121a5fc5d05ecf24698448743a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "18cde5092f125e47b8829af81a1a864fd83304f71f9705b5cfe2be6c2764836e",
+                                "uncompressed-sha256": "c322ba0bfc3e85d5f214cda4211af6fc1f128e0654a9bf76ce3f077f12c14034"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f3e06ea3e1c3c368ac228bbd9428d13bd85211e1ae4f5625c67ca5c446ef0768",
-                                "uncompressed-sha256": "f638fb37dddd094d917e58851b0b229caaef818b8cf7b32aa2f549ead602c98a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "64817d2334efd40d9b4db419dceb1e63c192dbcc4867b2f69d0b2d4e95baf1c0",
+                                "uncompressed-sha256": "0fac5bf0675652090c5a42d61dc6f1315bce4c48cffd0dd688ccad0a105a2be7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "735076710fe36a161ff7add140ab615ec1aae9b914dfd9de5006cf4d1f6ad1d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "16d73432c27c68dc3be255da0fd0ba2ea375270dc01766589501eac1670a8e7f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vmware.x86_64.ova.sig",
-                                "sha256": "9aff31d3fba3c59174c3216ed1e0b0a86b773a3beff2498c241380363cd989bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "d287bcd1361cda11e3e7accd8dc2a2b57c5b9539e8e4e8a3b6bc267cc2cd4c07"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240128.2.2/x86_64/fedora-coreos-39.20240128.2.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e46fae7abebc2073e2acae1bc2618b5cd55545413b5aade2de2f26afe2a1a8f3",
-                                "uncompressed-sha256": "8866ee35e3829c0c32ed4c8fe96687f2f53087b7436cb357e67c2cce413b4c1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240210.2.0/x86_64/fedora-coreos-39.20240210.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2813e6b6e5f8cb9874fa33455aa71af289ddcb28ff573af6d79814831b08c0c6",
+                                "uncompressed-sha256": "e77ec7a72c5fb4fba42f05736452cb3a3d9243f727b552a6e9d837b812a8af27"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0b4e743d88f94d7d0"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-05e8b74ded00f046f"
                         },
                         "ap-east-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0bc361c1e05ad4456"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-050ace7e76705cdcc"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0921742826c809d12"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-07765d7b615f1b70b"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0ecdd810f973887ad"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0637009daa769723b"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0db1d1500565165b4"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0fb67f8cbbb95c8b4"
                         },
                         "ap-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0c075d3c3bb4eba52"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0fcf2a122a5f7a3f4"
                         },
                         "ap-south-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0682fd49c714ce62a"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0113f8d4a65c0ce74"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0cf856ea450c6a7d3"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-044e7855f941ccc0f"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0c62d60edef67d1a7"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-02ad29c881f00f0a2"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-07a2a19ca47f7a5ca"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0d608cdf421a1864c"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0183491e47b69a243"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0b21be5fd8d80136f"
                         },
                         "ca-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-05d9aea491c662e6c"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0a7c80d9f3b8f7922"
                         },
                         "ca-west-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0a3eb9a52a4c78609"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0907bc7ed47719a48"
                         },
                         "eu-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0be6dcc68e17643ec"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-08fc659c2474085b1"
                         },
                         "eu-central-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0a9444ace0e689fbd"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-04b0e19e076d097be"
                         },
                         "eu-north-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-04d2bf4b3ba4c9bd8"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-00c032db497510376"
                         },
                         "eu-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0e96a17366e638df3"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-04ad80f0b51f2630d"
                         },
                         "eu-south-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0fded04366c51f6cf"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0dd57b823c790c32c"
                         },
                         "eu-west-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0408d90917a84c0fd"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-03c84a436fb33c065"
                         },
                         "eu-west-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-024cfc20e09220d68"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-005cdc91cfe24fd4e"
                         },
                         "eu-west-3": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0d693714d9512a09e"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0b2a0e4603563a09c"
                         },
                         "il-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-00dda5687cac89556"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0bee32778362d13bf"
                         },
                         "me-central-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0146110d6af817757"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0f6f1057166cb50c8"
                         },
                         "me-south-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0827470938d747f4b"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0a2d21b4e264fe587"
                         },
                         "sa-east-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0071d5aae317cfd31"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-05cd323f56af30a43"
                         },
                         "us-east-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-0d6c7d91285e70279"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0684504af76146506"
                         },
                         "us-east-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-097a2082699dc41d7"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-048e8bfab3057be27"
                         },
                         "us-west-1": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-03532b2d8a036351f"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0f819b7124384243c"
                         },
                         "us-west-2": {
-                            "release": "39.20240128.2.2",
-                            "image": "ami-057ec041095b9f979"
+                            "release": "39.20240210.2.0",
+                            "image": "ami-0f4d51951ae7497fa"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240128-2-2-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240210-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240128.2.2",
+                    "release": "39.20240210.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:41342a7a44599b10fe542302e046658bc5a9075ecd0e4f6a65d4b940792fb473"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9b90f68e256268c785fe412684a42e71e26b6b501e61650a2ab9b1b3c425f37f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-02-06T17:02:08Z"
+    "last-modified": "2024-02-13T10:25:34Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20240128.1.0",
+      "version": "39.20240128.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20240128.1.1",
+      "version": "39.20240210.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1707239400,
+          "start_epoch": 1707832800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-01-31T15:59:22Z"
+    "last-modified": "2024-02-13T10:25:32Z"
   },
   "releases": [
     {
@@ -87,9 +87,6 @@
     {
       "version": "39.20240104.3.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1637#issuecomment-1878186381"
         }
@@ -99,8 +96,16 @@
       "version": "39.20240112.3.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "39.20240128.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1706720400,
+          "start_epoch": 1707832800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-02-06T17:02:07Z"
+    "last-modified": "2024-02-13T10:25:33Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "39.20240128.2.0",
+      "version": "39.20240128.2.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "39.20240128.2.2",
+      "version": "39.20240210.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1707239400,
+          "start_epoch": 1707832800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).