### PR TITLE
Roll out stable 39.20240225.3.0, testing 39.20240309.2.0, next 39.20240309.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-02-27T13:15:53Z",
+        "last-modified": "2024-03-13T18:34:34Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "973dbf0744ffcf249673f1c2d8e2ecbeacf285e2975a2f502c8f7a786f9a8408",
-                                "uncompressed-sha256": "a860d75148f20551e27cd186f2e86aeb34840124e5239dd0fd14cd50f85a1610"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "9740603447c2ecec30d341f79675ae3a48661d23742543af584b9ca0e094d1a2",
+                                "uncompressed-sha256": "34ec7b1db545b7a1b6a11da3863ede5a4df49eca55da761622648c6f53d64425"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3ad97afe474d5ce15fc4d7fd4fd627239aff5b243020849091eeea014b24f1e8",
-                                "uncompressed-sha256": "6bc044421a584f23cf7e37461493f5823b0691b03eaa7203780f33368c7f8aba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "6fdd4bd9a65adc5e339a6e12420048ac3b4c45b53f31146f287a212afb6e3f2f",
+                                "uncompressed-sha256": "d1fd1e2dd6fee76ea3b8ac43eb92203ef11bdaa0c57a9e9466b253cf4f61f3b0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0703b11c78c5ee872708d64d5f70f1bb5d7a073336c7231b94f60419efb13117",
-                                "uncompressed-sha256": "7aec22c0edbe5f765f502f79dfffcfdf0d205771b20e7b1718094138a0f5646e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "80b87ebcb0fdd57e3478a68d10aa6ec9758e2d5733ababc64f155cfcbe129ffb",
+                                "uncompressed-sha256": "02050d9f9c426f5effc200720647d1179f99d5376639e4d721a42e511ad68918"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "701e2d9c213937eafa1206397e0126dcaa3af42f6651addae568788bce1f0e34",
-                                "uncompressed-sha256": "97087bb86c73c06bf7b4d3fd41e8a84b56c199b4c51dadf923ea2fda5390bc74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a09cd7a0145b06ba0e25e70b7925e0126be27d580430db6f54bf8b85c3c8dda3",
+                                "uncompressed-sha256": "8f41178f21ede435e08c1f968c15f9d696c3ff3d566a14ae2b192f556281e34d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "0306bc8740bb9d7e0029521d25176f10ee122615d131c89fee0a9c5d7e017d8d",
-                                "uncompressed-sha256": "3df06e93671b56e556ebb9b411641d9dbb6b371b8a875e80321335a7af345007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7d54a3b477241254e6d65cda9aa34ad9e8ee32c2607866a0af47922418a0acee",
+                                "uncompressed-sha256": "bc1820af60dd27d1b706e7b036658cef4e7ddfb700cc620e6b0696f140ea7673"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ac3bc1973d861695164d0fbb33cea4eb4ce09b62cb2da679d8d0327749c72d55",
-                                "uncompressed-sha256": "d3d70c5ba7e41a6d0042ae85c07193b3430dbcc87b19ff884a895a173be9fa92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a45a8b8a86506f1a78fc368b15a8853b7c47200f8617aafa50bb45ce2681fb2e",
+                                "uncompressed-sha256": "c0aa1118071584f4afdb2796e511a41c4c3f1077bfaf687989022699aa37b5f1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live.aarch64.iso.sig",
-                                "sha256": "5d37cde4a0f644e2b1589db9b6dd2b76ea53854a51cf44f58dbed57eaa498a68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live.aarch64.iso.sig",
+                                "sha256": "cc61c448a105ff5a5eda74195266e89ff552113054ecf0a56ad5b2238b91d0b7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live-kernel-aarch64.sig",
-                                "sha256": "3227da858d43988b80f31087cabf245d9355fc764f7f667a1b361cc99ed363ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-kernel-aarch64.sig",
+                                "sha256": "cc0c5db8f4d1d70162c90018eed4cbcf1a21f407f78dc2f9830020a62a43f37d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8d815a4360b35b074b6151d9e1cba280186a354606fc82eb5ebfefac30fc516f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5577ed7b5314c8a5758a289091912844a387658d08b021b7c6daca5f3e30bd23"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c13f9c3a3c87a9d02f6532d225ce51e200e6159b8ba38137b59c0a44d6b8cbf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1ca1de87f02bf852e37762391ad17f0e68fb3c57a6f6bcd3d0c44b2969804f43"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "93ca3b7a2ed9164170d5b59f2956f28ee4421767bc353cd8e5dfbdaca11fa092",
-                                "uncompressed-sha256": "04d7855aae6a898583b71070612b7197f0a8950bc3f8ac9bbb76de5f99c8318c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "abc0d4b584648d3dcf951158c26ae1c86ba9dd5ce5169eaf28f6ad6832482e52",
+                                "uncompressed-sha256": "c98001499b269fac56e95d1a43bcde22054b4dde33a2392b867ed36e26b573fe"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "41a897949ec3943330b0d1b904c8a4a8656497c13398f9d91f731b1d1b6e9e4c",
-                                "uncompressed-sha256": "f301a1f827fb8a7100111496f1963b2839571d5c62ab04c34e56e4fa41719b59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ba5529b02279fb4f81259562bd43dad22bf3516d6e6e73cb7557112c03a79337",
+                                "uncompressed-sha256": "76687c2bd68be8ec5324330e72c9860600675225f152c752ce46e6705ad7a209"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/aarch64/fedora-coreos-39.20240225.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2efb6ef7962b0f6bcc39d2ea8e9b01461817ce7744e682e04a1c3a80656a7ef0",
-                                "uncompressed-sha256": "ceedb71a205252d48d688554838f925b05b00b46c53dbfb5e10476d8ee184442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e6dcf64d8c6cc28a003a3fb1d646be98e51caea8d33cfd0285f341d61bc301dd",
+                                "uncompressed-sha256": "30bc39f5f42d386ed414bf98b1eeafb598c4e73c09c4ef5d412136decc0df5e4"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0c2fc900680016b6a"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-02f10e1da6f40bd4a"
                         },
                         "ap-east-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0f09780aaf0f794d4"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0d458ea018d679d84"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0eb08c90bd96a2db9"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-089a34c55485dc0fe"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-06be3a857c64fd04d"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0e43ba35783ab14c5"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0058573e820703b3e"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0d5f2a91ccf8069d4"
                         },
                         "ap-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0d283299167c0cb36"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-04ad48f4a4574f713"
                         },
                         "ap-south-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-07b763e21d41c7e1e"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0d50820b934d17403"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0170bf31f7fcd3044"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-063f572ec94a0b1c9"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0ebb64bf6e37f3ef2"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-044388e826b478e68"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-022dde0acfad81ccd"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-01a4e6860193d9e07"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0c5f04c628401b79d"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-086e749e2a412760d"
                         },
                         "ca-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0d9b21e6128b73ef6"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-05e7f9abc1b94e55d"
                         },
                         "ca-west-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0b0860ce7e160c29f"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0245bc6afe7b09e96"
                         },
                         "eu-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0d67bbba4d0b00642"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0d9da916a2248a075"
                         },
                         "eu-central-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-00c46a6527e3641ba"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0a3b886293ffb1dd3"
                         },
                         "eu-north-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0b6f3cbc8db5ceff0"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0971075b8629e25bd"
                         },
                         "eu-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0098aa96bb4db93d6"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-03994fcfaea3a5f2c"
                         },
                         "eu-south-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0e74904afc9344828"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0cf0d2e13652b2d1a"
                         },
                         "eu-west-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0c698c6939b7dbb08"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-009e15dc8c4dc8e2a"
                         },
                         "eu-west-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-06fb4e933d74e8f05"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0771104d0b396d35b"
                         },
                         "eu-west-3": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0ec3fd5851c675635"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0a0a92c65c3e62c74"
                         },
                         "il-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0f5f9480540e62800"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0c30bc13107db4c4e"
                         },
                         "me-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-08c6335927171f7a8"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-025590886ff03b2be"
                         },
                         "me-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-08e4543272a76a7ba"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0f2614bbf8a5f75c0"
                         },
                         "sa-east-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0a63251b5af9c2304"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-014b78d6e692a2850"
                         },
                         "us-east-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0fe04276371f5d93d"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-02643eac4a3f7d69e"
                         },
                         "us-east-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0bbf72421a40516f5"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0279b04db1c8c9545"
                         },
                         "us-west-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0b878a439b90b03fd"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0252410f655a382c6"
                         },
                         "us-west-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0d76912d2a06bb74f"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-09b94f18cedaed69e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20240225-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240309-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "34a204f178fc0a2c6710f4bfcbee356a233028655a9c340d77404b4fb48a91c9",
-                                "uncompressed-sha256": "c35b774aa300c55987ce4752c2fdba7b49763a0679a29666040e91719f704fc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6c745f3d257163af6d6a83332e7c30ae9d64e4d96e0e79a0f6aaaac9ff0f31a5",
+                                "uncompressed-sha256": "6e72c74114120f0ee636f62863856271294f0bc231c0cb7867ae63b8e71d6820"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live.ppc64le.iso.sig",
-                                "sha256": "197795ce28cea7e8df7d2f96419fddacc92864bdd854736046bac6b5a68c778a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live.ppc64le.iso.sig",
+                                "sha256": "66902578f72b581c2f02a6ca9faaac849d4ed5a51314650f34f7786c12357236"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "122485b01899266292cf32d81b9b26c45b63fe7d514e7ce5a9d0b0ce635dd925"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "c6e711430c00a439862574ffe2e68da456bfc0cf33306a207a33a6c70eac5cc3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "104e794965847fb7380da40eec3b64857125692c316dd87bb3d4bf2cf036d0fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b95bbd7130e213bf269bf4712ee24fe716c06dcc003f9854ed2b5dc3ebe61ba6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e3a7b7a6e209da0174bd8c8dc0221034259df772d0a66fdbf011272f49f59d98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0887c43f18d40f2c6859af986427f7cb3f03581b7bac1202c0f6b3bcd247ff9b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "73b31be0802a14e7dadef9b5e5c0e4f2b0270cd35f9300194a171b93ac970f53",
-                                "uncompressed-sha256": "494a2360e52afb33c8ff5bd79f99238cee4a84112ca6d001a79ffa9bc5ba3efa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "4c8c445d717a715e19a55dd4657501bdbc26e8f588346578ca187126ae1b6117",
+                                "uncompressed-sha256": "1697c1a03e19b48d691a89311a1471e41f3d14357b4a43d5ab57c30f1f128009"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "50d07b4e34eceb54869c381d38b10b02304d2bc01d8d806ebad1b86376946743",
-                                "uncompressed-sha256": "c33721bbfa270f6753f94064fc0da076782ba05ece0f450a7d6ec23f4fe63960"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6d2daa7de52aaeddd26fc228498e475ddad07e93c40a6618531dc7a82b502add",
+                                "uncompressed-sha256": "7d2adb2c48fb31dfb32e78e25bc02a6ab27eb0466a2f953b5eb48af1fb05e150"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d1c38c167daa5b38ba64d203d2757e40e4734213bf8314eb2b8f45dc4811619f",
-                                "uncompressed-sha256": "7f50eb486edce8952151b28a6aaad254d924e65289b0d9016843e99da31d4657"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1d502d3f9331243ca90c3323b69e46651254d1d04829471d0bffa59f713adc79",
+                                "uncompressed-sha256": "66375ce2a3218086e3cb7f23069d11daea061e8050f6ba96ea52bca0a8ef2d9f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/ppc64le/fedora-coreos-39.20240225.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b615bbfbe428167b26b2cf759ca47687e9cdda92135d5eb252fb96ce5c5fb790",
-                                "uncompressed-sha256": "b92883c58600e8a3a20ca109c92cd8edb2ed231eced6ab8f8d627c95a1c1974a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "8ae824d01ae116f112efd4f9efa99a5acafff58890648a83f6a04b435bbac4fc",
+                                "uncompressed-sha256": "823c7709379abda56efb3f7453a1747d3024460d8c42a7a7d6ea19d37b8c9809"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d3d59fd1da5147273e5caf19e45abf16224aaf05a9f7ff49bb7f5c4c56a43a59",
-                                "uncompressed-sha256": "383d697b96d0ed973ecbe86e1089ad7eaaa07fb3e9c58da2635e15152ae095e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cf828c6a96b561a8142e08db5282e9a278308f541daca8a3deea398bcbe210bd",
+                                "uncompressed-sha256": "0bf10a0c9789278e012133b076fd5b63904fdd52dfd04be75bd8fe6a661cb0e3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e8c34fb5e735e0d84ac024406d793da2cc63614467f38bd71cb210e04ea3d21e",
-                                "uncompressed-sha256": "f0d11018bf464b8cae1bca9c00b589d1a19305fb744738c8e20be045bddad0de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "98e92671ecce8d2c87d2792199670cd61cb10b90a912a840d0e67ceb705daac6",
+                                "uncompressed-sha256": "89bb4a84bbaa7b81407ad1bb305208aec9f6a91e410330236c0a0e9f6373fcbc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live.s390x.iso.sig",
-                                "sha256": "ab8797a96df57b65a09c7a84ab9cb4b28b7754fe491d254d79185e0883d98522"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live.s390x.iso.sig",
+                                "sha256": "104bc5905f8acd17af02212c2f48309c2f1aa79fde64f9672a3f7b35d5a08c9e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live-kernel-s390x.sig",
-                                "sha256": "ff066d94cde8640405ca9c7f7ffa871e1adefea8ade5cbaf60b15de9de98dfc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-kernel-s390x.sig",
+                                "sha256": "a1ea7d825271b9611f21f27b37dd91decca26c0a67391fff4dbeaa93ccf73259"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "899962b4ad240b0a9bd861e3518302e3472d9df305f5c9c82d3683b35d12b340"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "341381f28c8c5261b9279883fd9ed4dfc3ad5f50281c7787f9d211d9ec754e3c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c059b95b0346890ac85134bd1d72f0407c1a5baecabd0a7befff9faa1d3205a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "2f13996bcda29d0d7481305024f65b8cae8b80e0de712ef6e44876378b7dac73"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0a876648a00859881b6e0a3e76c2e5cc19a271a2182472f3ff8dc106a2a8c7a8",
-                                "uncompressed-sha256": "6de5927218f4085b4ed6f834ec278a89edd9b49de60f1510263df9316b280b18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "b58a86f456fe1c80efe504caf3a7e162124a2b8c15dc176c82dafbc30520da71",
+                                "uncompressed-sha256": "004e7cf1f451e53834244e90503c0c4d4a1f868123ee3e741142f549fde5fad1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "eb24098a9c2df93e1567ab0261cc755ad7bfd944a9e927a728faf878bfc611f6",
-                                "uncompressed-sha256": "7be0b2532972d7b8153a4e71ba15894f1eb02dc5ddd9a27e3ac4e2f20059b77e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0cc3e0c1d7bc8f5a60058b8059db268d9f1d144f1783dba27b29fc02964d6b2d",
+                                "uncompressed-sha256": "60934b2eab6f6bc3e67f39eb9e89f0333e769f6a2b4150f56ea09a9fe436a4ae"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/s390x/fedora-coreos-39.20240225.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ea57e2007115e7f8d36575738f1bc7212a155b4a75d718ad25f464d1c042dbc9",
-                                "uncompressed-sha256": "4a5fbb40352966926246fb113d200d7662e7525ff31c9cafef3dbb9a741a280f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "66548181f8c2d0b7b23c204f64ebe18b99f80d58f5a2bb8165f55202dabc0c67",
+                                "uncompressed-sha256": "aad95e63c28f4032b3f2db69bd92f863968febc5360288e6e970b513f5d7b67c"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b69f5305a6cfe43a01fd552e2a63a51a1cd9f0704ac8f79bf8cc1a5881fcb681",
-                                "uncompressed-sha256": "22d51ed782dc993c18a9b533a2f6409db81121b8ccaedc0e7536ac6ceddd1046"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a7a545245b0d54e5e2d7eddbb779e098d6b6ca7ebfda4e07adb39de8c40a7f95",
+                                "uncompressed-sha256": "31bec89ec199e3a9957c0b621bdf4d3591fb44e6be5f5f3fd82430b101dc71da"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "2c79717e47f201feae21890bd1f9be2881f07ac3e29e42d3aedd4b84dac1d460",
-                                "uncompressed-sha256": "92a988c9bb950de5defd76470becd77139d083fc6bc16ece18c910ce4b0d6357"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "15c4dd3a65464c07dce21f177d9f28cac2fd5bdb2d995e8f5a8f462b177c606f",
+                                "uncompressed-sha256": "cb0e8e6318fb85c0a529e76bdb0702f8d64a3aa44d56f304d7e8908c5d521b6c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9dfdbb047b271113d343257eabf6fc80781d2898dbadc71a163f9869e87492af",
-                                "uncompressed-sha256": "22d16132c18bb906ed0dc65511cc9aa7e2a7ffdfc06ff19ac84ab7ae4088f9b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9ecfa29fff6de01ffb350af1c162e99ab174852eaf62c3e9b83d20540668a4fa",
+                                "uncompressed-sha256": "e85ce44645a633f8be4fa8823baaa7b99d49548928b5d71f4e0a369941b4ecdf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "30c2d3ca860a2eb6227be34d1a082d892fa2ab5ec546481afc7ebb10784c593e",
-                                "uncompressed-sha256": "7c720cbda7d7073de26abc293a75e34efe40f2bc9e8923ea8cdf45d0856fc2b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3e5b22f3e96aff5e7bf7b8e65054b55bfc1391e9507c45d12bc59219c12af193",
+                                "uncompressed-sha256": "2a33c32438b89a751963382cf0f7d51e0c9df8919d4779df7ca63739f76647c8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "35534eb3a5289b127130b9f2989767a7a5562b91c7bebafff13adf60081accd8",
-                                "uncompressed-sha256": "27770bc8845dfe0ffeaa3b24ffaee56bfb5f340bcc461efb107d8216a228579c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8a126d403a992602fb3564a54bf36db8effabd70fca136160c703abee96b906b",
+                                "uncompressed-sha256": "aa64578e7e0b79c7bed7ad9176c9b51a506840fda74464214384fa965c2c18e2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "73613d96f471a198930b617d1daf57e48a0ea40946668b81f80ed0063cb27a2d",
-                                "uncompressed-sha256": "f2724137f133b074763e9b6f8b66986fc7066256565bc4545e109754aaba8e16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "faf666cf87f1d8889bd6a057839bc044035b3e8f325638fa8f2d10d1689a32ce",
+                                "uncompressed-sha256": "d31fa81bea25003fcb06c8582549c58c46ccb31e35387ec7b6f712ba162dd599"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c70d043f0c51dbb2ae73f6e710183cd155511a326a504eab539e24ee30e356c9",
-                                "uncompressed-sha256": "c574ee5142912c737005ca15eb942c65ef8606df271459f41f3463ce30b02060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "40ec4fa199def4520b11e17688c33bd2369609c7b2a86b47757f9f0597916daf",
+                                "uncompressed-sha256": "73e24d1a0de4953dae6602dc648b70161fd0b9ec5f274301bb735a108ae76a89"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "eb3cffa5d19896bb276d548b992ad86028301051383dc22889b27077e26e8be0",
-                                "uncompressed-sha256": "97d613786ede47df38c1e877066332a7273e5a610ecfe84f2b5d1d9cc9773b8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "fd9e6a0e0a998d1ad8fc06178ffb5806061341e426316438b388e17a6a31bec4",
+                                "uncompressed-sha256": "3fe63d3ab1f2017b404eedb533011f2f0cd9bacca8c6dfceda21319b5a1ba5b2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "a08280131a1b9b21a5fbf50dd57e82d8a07cce964517af0b9664364743dcb5a3",
-                                "uncompressed-sha256": "72587d5f799ccadca9614cefe14127308975880d9a84f34b6895ebb641740b55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "a9de36caa29e4a196890fe89b2ee8bc44b831457954c9ed67e7326282cdb9007",
+                                "uncompressed-sha256": "83c6a2a22d055e7c90f4a2253d55770086476ed9aa25ab64cdb83f73b6e2348d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "38faff8418dd9cbe45b6ed335847415ec9cb120def7612caed07c736311b37cf",
-                                "uncompressed-sha256": "ec7d0a029ecd3e7bf5bcde1b4c912a88582974655c064e09aa0fe89e20c2c351"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7eb50e9f53e609a95d46fea1fc2f28877a1054f659c40c2ff6940497a836c2cd",
+                                "uncompressed-sha256": "d8e437ae15f6a8e7548c7c803b18da6859054fec4a271bd7e6397f67e5c280c6"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6bed49d436015765c08772883ba7dc169a9e9e80928d5c97de2a7f78a01449d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "01fda0fedc5e9e2cbe79cba358d98b0f68fa43f83411febf446fb4014863f9d4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d1d843bd0261701d4f04de0e39fef5303d6c2fe922333d13396ec34e1d516ae7",
-                                "uncompressed-sha256": "664e827712f804d813a170e4fef2791a2917d4b2caa4e3727a28dfe1b3075652"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "154b13a705e0c2f8ad7515be6c5c1a0cd32ab175a6f1d808d16e52ae2c17be27",
+                                "uncompressed-sha256": "3387b3b33e77f066be1e10c6074d8e0d3e04f0f2d049146f2eaac08d8ec80cdc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live.x86_64.iso.sig",
-                                "sha256": "e07c71076be5b49c81789e1ac2c2275fe5494af7cc21413c462a7509bfd6d001"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live.x86_64.iso.sig",
+                                "sha256": "5aa5f331110d872e77f49ef71d8707029721e31240b24d6b7ca3e5fd6a1d5e7b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live-kernel-x86_64.sig",
-                                "sha256": "3c04d2fca66dbbb71e22305b203b6464e01a75df7a1b14e599f05311c4f89c09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-kernel-x86_64.sig",
+                                "sha256": "64ec45261821b16896a601b46d49304dd22a4084f1b1432c6dfe13990a0f8fcf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1a9182088c6dc2e16cfd8463f9d1d3474a68369dd5c3a089c24ea2c1683deccb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "349f79341ee636ca8afd969b8f53ac3bd669725bb7435979fb2b92dc21f2790b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fb7f2155c4298a228c0e68ac93be3d4be7e11db3b3e62b9a19ac45bf22f0fa31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ef6c2887cb45d32cf454ee341e8fa279c8a0380f78dc33397d539e19fc577729"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b3b237e7446aa44e8735f8a36c106a21c8a40ac2d0158eea580c62f5c63894a5",
-                                "uncompressed-sha256": "b9a6e60dbf6ef2b6340afe19960b4cf0b34e68b4fd46d27c96c54b751d651111"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "22073c0db807c1828eb484c55f6b44890e57b068c361f5841d6fe2bac2d05866",
+                                "uncompressed-sha256": "82e73a39c99a839ca412eabf4aa469b58da671bd37e419d3cbc7309582b508c2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0f4c6d2695454c7a808e983fa79093bec7e7bf2aa3e1745b9e2b24106faef926"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1a76bb1abc723d15b806169e570c1f49d0727d7dbb272ca7cde747dab2e2b36b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ff3f91f2287c829fc3e9e38212e718becada078c0f68d71ae1ac11e82a4e38fc",
-                                "uncompressed-sha256": "96f056f00899a75e039695996c61f3a348ddab3e057c89336613f83999ea2706"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3223809af97a3773ae41eb58d60a1f14dcc4a35cf65589b063cbbc6ddc0bd509",
+                                "uncompressed-sha256": "977047eb0c6c9d8131a45f87c6c8068ca83b874e2d10039df80e8ecf4cb4ffa9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b4c87f3c9a1dbda416dddbbf6bb9f246eacb3c049cb70f6a09f7393f0f5058bb",
-                                "uncompressed-sha256": "86fe07b6d950fd77317cedf9ee39d4aec205606da832038cc083074f7408f80c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8f298c450151c5805cbf74de85975876d3f4fc6a738c56786e35e761b5e9ae28",
+                                "uncompressed-sha256": "95798ea4d0b2d0ea711f9b02438e3e0da0335028657e062bb4b243fe34a00ed9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b5e881d198120f6a7ac37ccdb368e1b493f43c6683f548503578374fe8baf30e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5b4698801ee8b0f33194cd47df9f8a135a2ed52819dc0d1c71ae746d6580c894"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "990d121bbcabde51ab795ad7ecb37ee72736623f1dfb4181de5e4dea1a61fc32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "cc7c44e25ba965a87d17e1cb4c914ce55d6b893db80bd8e298a7159b9788344b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240225.1.0/x86_64/fedora-coreos-39.20240225.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "267d202bd681e787fe8a2a3013626dcb63f4d33de7263cf0b887f162cd5aed5f",
-                                "uncompressed-sha256": "cbf0855540b90f91f9eb6de33383f3cac0a5c2d86e2c5d4174f15383c11b2d76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9c778582cff59ef118d28092e7b52e9d7b48157738ab509812a952c3c04fbffb",
+                                "uncompressed-sha256": "dcb71fd0c970975eca4630e8c9ffd0f2ec7e1745bce79123c5f7f26cfa367a13"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-08e6d7e04f38d80b2"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0eea9950f0f74b27c"
                         },
                         "ap-east-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-05d2c3597285d788d"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-02e482c00d676ceb3"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0757b38053bcfa790"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-03b4f736aff955517"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0bb84ea6cf92b1d23"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-08ff81e6241608497"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-05a0552058f4b2316"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-011542b181651a68a"
                         },
                         "ap-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0c94aa1151c6da975"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0e269cc2253f4b33b"
                         },
                         "ap-south-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0d73b416fdef06249"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-04eacdcdbadeb90cb"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-051edd2c7d00e3467"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-08b1c6e1dea8b73f1"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0b2401c6e3d104b0d"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-054d01692c0bdcc12"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0a5be3fe86acdee42"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0eed852f682777ae5"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-07e9d78cd48988ffd"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-01324d3198676348c"
                         },
                         "ca-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0547a929d7285533c"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-04ef41f475f13562e"
                         },
                         "ca-west-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-03f5915394e74a808"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0b7addf4a52ac101c"
                         },
                         "eu-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0156747bea3c4ed32"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-08277cd037a794c3f"
                         },
                         "eu-central-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0ef0373e38d39e8be"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-025ca1b8d2134d5bd"
                         },
                         "eu-north-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-029f3c05340f655e9"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-09899e421708c374f"
                         },
                         "eu-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0ab4e70beebe095cc"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-078660f83363b4b69"
                         },
                         "eu-south-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-03f791f2e724c172a"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-06ea14169a818578b"
                         },
                         "eu-west-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0eb456a2071481162"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0fa10c65bb8c8765f"
                         },
                         "eu-west-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0e317f6a80dc5ecb6"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0a583fe9cc43f2973"
                         },
                         "eu-west-3": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0afffcb8718a89e9e"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0f997ce66fb9ac66d"
                         },
                         "il-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0ebd685973c0de635"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-088c1dab4183e1d5a"
                         },
                         "me-central-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0b77e3ed301b8b1d9"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-094d2e95248661374"
                         },
                         "me-south-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0af74ee2aeab9c385"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0a1d8bc2d226322fb"
                         },
                         "sa-east-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-07dd029e5e24068f3"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-00d987114a41dfb18"
                         },
                         "us-east-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-06e3dcd69ea041286"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-0f87d832349109851"
                         },
                         "us-east-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-0c380d3d409cf4dfd"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-015a1dccd04e15caf"
                         },
                         "us-west-1": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-01a7d5b8b202336fa"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-025821526249d14f4"
                         },
                         "us-west-2": {
-                            "release": "39.20240225.1.0",
-                            "image": "ami-01f9caf7bee329695"
+                            "release": "39.20240309.1.0",
+                            "image": "ami-08dcf7f53cd8b6c7e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20240225-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240309-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240225.1.0",
+                    "release": "39.20240309.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0f78f46425fe6487f0fa117c5f6a7cebb587a6f9769f6df767278715459a32df"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:af33397206febabf4aa9b83b31ad830c6a5580e0b7c65ed07049972ac901d326"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-02-27T13:15:49Z",
+        "last-modified": "2024-03-13T18:34:32Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a5852964cfbf711530fefe176c596b9540b042ef09184ef4dbc36f0849ac2a67",
-                                "uncompressed-sha256": "6ba058b84da4083ed0133a5153a947ff8cafc22327d31cbcf8c81dea4589533a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "fc147b36c8ceb7e5b989145dbb02e35cace6dbe07307b3066f7222015e2712e5",
+                                "uncompressed-sha256": "ad4616073913e13a2e3e15aed29f68864739b492d6210bae0564a0679c2f6611"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5000d212e4609790dc380c24e3b2e55b7bf10260cbb4307678c8d8e918bd2f8d",
-                                "uncompressed-sha256": "9809efd62ce882e8bee514c6d70a9faeb6e3ab40190130062985e68fc47d167e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "95dbd596c1ab1f5d0e79243caeb4510f525da9420bddac9285277ae7be05618f",
+                                "uncompressed-sha256": "527295379ba4c7c866f4df677d10739e7009b3dc5e3736edd221dbca7bbf3f44"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "21c75a5d0090989366ba43d5edeefb02774fc59d990e987350347830679950fe",
-                                "uncompressed-sha256": "dcb96739f6cbe17e981ed23674fbc27b66d13ba7b2834ddf29fb6e799342dd42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "722a0aacc72c1c46cc3b2f425b7ea1a0f9ee1f4fc8d4544e6a00aaf85e3116d4",
+                                "uncompressed-sha256": "331de64a4fe2c3f62b0596b743d108771fe3f83543a92460006ff01e658c642c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "b2dc117c50b9c2b90235a5cbc96e1514f89b200219c183817b14a57a49740a9e",
-                                "uncompressed-sha256": "821363da38e2a8ef44a3cae76a43c677aa1beb839f68fbac62621c261934fad1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3b97d24630d3e719c54a686c5e9bec5034b50606c2a030e8040be7f742e0a247",
+                                "uncompressed-sha256": "26db6f4bd0d5a77f7c723f046c40621b6e6aed641bfe0ba6c56aee76c5d6a526"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "2f6cde126f77f8aacd3fb311b0c58a8a54567af4fb160d60a7af78d45a4105f7",
-                                "uncompressed-sha256": "31f2c83ad0039fec1702910e3f4acda5472ce1004b160d50ff79db5d2e9b390b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "be9ff74f5a792e0f05cbe764e393840ce410d429643f7c37a4003f1ed3edcbde",
+                                "uncompressed-sha256": "f8c20db33d2c0f0b67b7ee9e8670a631585c0416eb7cdabd93fe3d5536e2682c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7dd1b2495c0310a088dc1ea95979230bf719230ead6ddfd34a7767e359102ea1",
-                                "uncompressed-sha256": "cd807418299f8b90b863c3e47b769022201dec31ce3f3de688219063ccbe3bf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ef6aafe1bd69bd0d42d499a482382930f30ce60a790139a6db208e8b2e50d96e",
+                                "uncompressed-sha256": "59c65258cd92a42e2b5bc489754f64920accbac69684ec244b4affe9363409d1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live.aarch64.iso.sig",
-                                "sha256": "72042dd898739c619808f87be7f6e0a6ff9be4a381ba8640f38781eccf2e5e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live.aarch64.iso.sig",
+                                "sha256": "0682f3fef774147c3c16480bcb259534331431922cf60f81146b858b032f4439"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live-kernel-aarch64.sig",
-                                "sha256": "ac596100dadedde9b11bae2f0c37e05aa403de2899fde21355611b691dc0e110"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-kernel-aarch64.sig",
+                                "sha256": "3227da858d43988b80f31087cabf245d9355fc764f7f667a1b361cc99ed363ed"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3f19d85510a13a09946fee2afd55d6aab6efc0c46843901c21bd9308b14d0f50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "91b249564f17ad216b02dff6272bf1abf2f0fdea1dd3ef8714e6e540ee83c912"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1805b5cc44ea8683f79942f33002104248ca5619d0442e4127f80fcec462a2bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "605f3883a808435023024c70eb2e8ae8072097996b4c889df476934ea057ac23"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7fdeef09740267c50f6d23e71d5c03d83709a4f5d5a19b2368736de0ace8c469",
-                                "uncompressed-sha256": "de0b310cea564d5bc305731bb8b115de9d1e7cf1745194a89940de8bb28bed25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "028c0562396dcea0099267a425f7795ae638525f52c82e5e3a81e68cafce86ee",
+                                "uncompressed-sha256": "c0d5b8598785c8e4bc7681612df3ea95383e533df88cd6bc3d762273d7335ade"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "506704d09e7cff89e5b12ee949ee43fcd44d9ffc40c1cce1bd78b8b04bf14146",
-                                "uncompressed-sha256": "e81d7f01027b68dc50454c50fa6378f09397b58332bca74fe1e8dd624bf5f33c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2a2fcd9ef67598de81503d7b0ad65da780098afc6e0103c24ff997d36252e356",
+                                "uncompressed-sha256": "695b7f5cf8186730501c0b8345b8a20a6f780051c377af9f58724d459e06575e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/aarch64/fedora-coreos-39.20240210.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f71ac1832ae29aae59fed2cfeb159d41eebec2c3bfe5e19b972cbe1ada38b8cc",
-                                "uncompressed-sha256": "cb4cf6d321df087b87dce69f1bf499ea5c22c7409dd83d2549e09acc376a2ad0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d009131608db3fb7b5100217f245f641d101eb411450b27519a10662c1479ae7",
+                                "uncompressed-sha256": "bbfdbf318aadb358e372efab3d28d2f8e7677c82d8020cbf8a33839a7f25dd30"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0bfcb49a452f2f0e7"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0450ef14924d761d8"
                         },
                         "ap-east-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-010d0a0b8537c82e1"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0ba718c15a8c2f7cf"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-05cffc30e7f1d794e"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-011f32ece0b6fa094"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0ea75df90854b9316"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-06e266e3beb320583"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0469a083ac84525f5"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-06466e4d5b19ca655"
                         },
                         "ap-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-09e8de530085dd468"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-01117ed9fede92c2d"
                         },
                         "ap-south-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0e45f1ad7b094efd6"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0ef5ec3189f8df2b5"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0282f6e3a26f94d44"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-03d38caaa100071ba"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0b9769aa5341ee545"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0b08229b424b40f49"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0cf5ef835b41cc44f"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-00c2c626ff1df3b20"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-012cd001d5be1c294"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-062b52642984abe2a"
                         },
                         "ca-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-047e2fe2237a70589"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0410261666d16c90f"
                         },
                         "ca-west-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0a8d76da9edb5c0d0"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0daa761eb4f6927e3"
                         },
                         "eu-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-09963fe5db695d4bd"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0830961058b670e65"
                         },
                         "eu-central-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-005df127887b714e8"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0b37f3b5bc1034cd8"
                         },
                         "eu-north-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0b6a671d61c73292b"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-030020e7f0b4101be"
                         },
                         "eu-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-05d3aebc4fbf8e229"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-057d3d16e285decbd"
                         },
                         "eu-south-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0c5cd3eeefffdbfc2"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-06d56bd3acf7fc27a"
                         },
                         "eu-west-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0a48f06810fc06978"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-019d4dfd2306c8e83"
                         },
                         "eu-west-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0d97683c02afa5d8b"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-00d63f593b727161f"
                         },
                         "eu-west-3": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-081408c8e0f9ae22c"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0f65f712296f64de8"
                         },
                         "il-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0779595e90210d761"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-012dfe209929ac359"
                         },
                         "me-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-08844ace18a4427d8"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-00de206996fe04c02"
                         },
                         "me-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-00a2ec82c1bcaf6d3"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0ab7f675eafbb0715"
                         },
                         "sa-east-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0f09323dae7e88103"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-071aae83887dbda4b"
                         },
                         "us-east-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0ea13877b869f6290"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-00c3b61190f39235f"
                         },
                         "us-east-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0f48f7b14cd61d28a"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-02addfb382a67a6ff"
                         },
                         "us-west-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0a55095048ebfe908"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-00164a98d09e41eab"
                         },
                         "us-west-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-09f00bc1f350c79dd"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-026f3e36c4b6c925f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240210-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240225-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "cae8d05c99aac4cce04d9c2e7ad2efb08a4267e93490a7a661f00ef96ab9eb34",
-                                "uncompressed-sha256": "13acf6c2e759698c3651a70017420a62ab9e0c937872a924719da0469ef14deb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "695aaf7503b69a0d6830768e058bbc7190d63e300bf9a46baf96151b8c3eca21",
+                                "uncompressed-sha256": "ce3c5f7385aa05c7ee52e6a5d91afe0a0dd533110f9102486d9626f3aee9c693"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live.ppc64le.iso.sig",
-                                "sha256": "9a2d48d76bbe636c4995131a5abc363f100417ec93c46f872f9026d8d05d38c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live.ppc64le.iso.sig",
+                                "sha256": "f6c13697b6fc4957086e36fa0f5d88645c124fee3ab391f92498bf628f42c02a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "50aab873c1577431233890b4c36a4237b1f8b0f63a551d79031a1b6b4501d6b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "122485b01899266292cf32d81b9b26c45b63fe7d514e7ce5a9d0b0ce635dd925"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ad7028ad0c05119e2e24e715a82056fe235e9bbc38b9cb1cccaad8bf5400189e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ed4d05ba5a7a32e83af00ae791c9680761cc1766083a9c2839c78da0d5469733"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1400e95e2a49158124873c6d1a15daf1bd2a5ef11dd34427d439235b8f178603"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "3d4801fd9ddfb7e9de187e772f44828e525282cc71551b524bd06d7862f307b9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e8c2432957d412355a1be70189cef0d826b1cecb239a9f89f0b7435b0c9c1307",
-                                "uncompressed-sha256": "728c4d7ce834c3de1353d7bd98cc6494780ee94ae42360f58487c194fe59be21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "ce627a7de81b930a891b6184772a81ab377790983e76d1ce642ce03b0427e1fe",
+                                "uncompressed-sha256": "6209ec2d7ca332f00a6e772ddafda35d910dd704f534861b51d3b349ed4567f4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1a15938ee4fb76b19919924761aa07cc81d50f00fdcf2e73a11731e98b962232",
-                                "uncompressed-sha256": "05f62cb3523c3a8326de2e0cb3b01cec9db78c842e824007ea073d31fae00a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "60abd35c578a8a74e1f8bb669db74a78157f68ab47d0ab8082b471f6adbf5e11",
+                                "uncompressed-sha256": "1bb76ef50c201b55bf386382f40109ebae8411ee7f7fe72d0091df95b826fcc1"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "621db60049bb4b9515adae1641344143b9ceb5714684dc0c307b95bd57ec1d54",
-                                "uncompressed-sha256": "fab8992a409c774bee63a758e8daafc0fc6ef448408491713ba960b8a3415c22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ce3b722a1102f25d07ed6aae2942003dd5e4d17bf8b6e3b4b1fc5d66cd2d9fdc",
+                                "uncompressed-sha256": "090f5b9179d0bb675b1ad6523c5fb7bd3268ce9d55b5ca3d1d62ade06d383870"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/ppc64le/fedora-coreos-39.20240210.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2f0e0f969572eb37141d3e77dc18db1fef48da4d6957b5cfac00de2219342d13",
-                                "uncompressed-sha256": "308a3576ddcdf36802da0ee667f8412cce75ff39b3610a4caa362ac9fefad22f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5e9096c73feb259c66897a459c6284e0a7d0ebb5d52a71886017a65c0200d9f5",
+                                "uncompressed-sha256": "fa55fbc49065488a21a1c44f9bebd76f3ee50e1b594488b2dd586df4091a31c1"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "22dd2b32b4b78ca4d4b8d5fd56dd12e287d7508c99df1a013b4d3dc86f048a38",
-                                "uncompressed-sha256": "a9b87fd178e006aa2080031683825b97225815a50ec4280a510228846d3dc748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7a7990e3126e7066290f47325f142eec4fdb3efca6eae5169ad49116f3c99571",
+                                "uncompressed-sha256": "363dddc8b0b40b2a827da31c5dfcb3a246d6c6eec23e33f0ecc5b914761e9169"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "94f4d4157c4fad393d5d436a6bc613d1dc0a510d83bb32a9edc7972f9aa072cc",
-                                "uncompressed-sha256": "ef1b9f2c7eedbe67785e37093b8b234616ea65588f040a92300a0d67185f8108"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b40cd6d0eb476c44411032e38ffe062e128be100359738bfe02488f81a5b1075",
+                                "uncompressed-sha256": "2cf93d68ac2ba46565e9161df8a8ff3f68743fbe6ef76e7c14793b8aeb3ef569"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live.s390x.iso.sig",
-                                "sha256": "5fd1f3a44af6be785f9360b969e62b8638efd2cd904953e9d5964a9b1449b667"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live.s390x.iso.sig",
+                                "sha256": "6a19c3a6d3f88a3673f6b64894ef7829868c140de833799c8b3ba528de3fdb24"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live-kernel-s390x.sig",
-                                "sha256": "14384c7a53470dc2a089425a7562f78bc6daedffeaf3ad24d6eb44d801284232"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-kernel-s390x.sig",
+                                "sha256": "ff066d94cde8640405ca9c7f7ffa871e1adefea8ade5cbaf60b15de9de98dfc2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c7682b7484f5021e6661ed2cd95d0038319ad8f3ee827655ab6c6599960dbd5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d321d2d0046a7e1af3a1f39b179e2f0ff12cfcfe1e38f976429b52419264fc85"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "df58d7756daaea99b62e79cd2f3af5c8c2dbf0cf149f5793e5dea16518b8edb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "286e7ef1c63703d4d351a89ba362a1c037d2290249ced868fca77cad7702c513"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "3604e27788635f4270faba6fea5b2c218cfa105fae73c22567e01f48dfc2ac27",
-                                "uncompressed-sha256": "8b9931928c2b1868191e4580c3fef54ad7f4d9913b3eefda89a03fcb03bc0507"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "b49813a834385eda19508f6249e11f94b70e2626966b5a1ee04a7cc8edbe3482",
+                                "uncompressed-sha256": "ee45d5059e02944d6ff746f6716ac2e8008d108b8adc4888c2c9cf2c8135abba"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4243109188373f7f57d224b2721104b16134323031de081faafa0df89df92ed7",
-                                "uncompressed-sha256": "66e891775aaf1c6d8018b6532c0b2b215f0a5ba22a53dececcb20b1999816d62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5e037ae1ecc65476fd80ec854e46f2924256388bdc4dffdff00984ca74ce1cbb",
+                                "uncompressed-sha256": "6fc37ecfe8c48fb59ced108988b6d86e2006ea388f2a49029470e6bd21c6f2cc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/s390x/fedora-coreos-39.20240210.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3c2d4c3c5e3a963773fc96f2ffc98fed666cf56f1988f63628568459964ac33e",
-                                "uncompressed-sha256": "bb48d9e5e6e64122fb5aa29a45b9cdaef5c6a82c027a6ed5f5dc5b2ba14dd17b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "0e6fb107305a375a0998ce0de5564afd653b7caa636b9f9a0c75a1e5fc345f34",
+                                "uncompressed-sha256": "7aec8687aefb13122d20d35b97efb0f1dacabdeca45b1941337e4cbecbdeae76"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "10c82fa9dfee44f263ad7ee77b5a6fc1fee9af00c7ff81b061533d121174e368",
-                                "uncompressed-sha256": "45ba13a91ecdb45d4bf965954d412173d5049051dc2b078cbe14644affebcff6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3586fa4e876c43f9699134182caab874d99840fd5a50f368000924e9944ba16b",
+                                "uncompressed-sha256": "1f2b2b0953aab177a3376aa1b4547f0843171602958e0a70e9a5ae12b446f75c"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5301a4fbe66c531edc2e2fdf7a9e251719a06b74eede6d22e554f9eee7ed9b83",
-                                "uncompressed-sha256": "0f00b68c7b6225e154e408f64bf4670816e74bc68b70d55b48f430a0f3670c2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "d060cc8781f3a7e434da4af9b11bc9d9f49bca05bfa581ac6833cf2c6de877bd",
+                                "uncompressed-sha256": "753218ec7888961e7e0b9419a5649e8aa5c83fa6fc3c5fc156ee936157e11028"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9c06dee7541fcebc446117780da6e6b00e15b280aa77c1daf93586c27920ddef",
-                                "uncompressed-sha256": "a1ff9b6f125a92777eb28a64630ae8e02c6fb8e08a9364857bdc274fe653b4bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2b01aed6c93be81223b94161495362c80f3c966dc624484519a4903c450952e2",
+                                "uncompressed-sha256": "e8ec7e669f37a6824e25cbd4bdfd048a6e0e9108255e06c551c5db525cb213b3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2f42c5ebe31e1e9e7ebb4e455b3b4a728df81a5622b1532175a668fd964440f5",
-                                "uncompressed-sha256": "1b277b63f8de1dc96e48e22f53362579fe07c10b50d716d4c3565a6559e78c2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e802d4f6a0505d5eb5700f8ca5a3e3057a2838cd165346793526e2aa5bb6b0ed",
+                                "uncompressed-sha256": "6b6645b386f1e856fb5ee61159343ec58dd34d75d2111aab50c654be5298f32b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4d29f6cba83c67dd0c8d322ace8570334d6f00e90ddd770254c2cdfc7ecdad61",
-                                "uncompressed-sha256": "ff1a7154f269d6f5b947caf578237f12208c55505f0e09cd3d2b94d40e8ee7e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "22d02da2b21d255ef397628e52ac11a9df0a0afc8544b32ec47366b00345936b",
+                                "uncompressed-sha256": "7ea24290da99da31921b468a484aec1201a1824a1aba5c4dea4b4e4d92ce607d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7cf7d78965e9150fa6a82019191bb718800aece634d0a3055936a112adfb0644",
-                                "uncompressed-sha256": "19c4eb58f76191e995343687abad83d93cd9854628a02ccad358373d0688f739"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1aab2fb6bf7f0861a82e9a31553b6c8b5694089800761b1f51c9f86fdf057ea6",
+                                "uncompressed-sha256": "cc12ab0a20737e230e8d2d22e15f4e380427d4a5e8bb1fdb98065acac67b2d09"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ebf3e23410834e94d0a98f2cbb3de792391709a0550716e2e0169daf93a1d529",
-                                "uncompressed-sha256": "289a2e66744402aaa1357a21f05b54124e619b96d710b5627e9e8d3c7f30cad0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6f83729187983dc5b2a73d007eedaadfa90e6d261713880d483df9c33bfb3be8",
+                                "uncompressed-sha256": "294d2aa674061c6503de31f579db2ce14a191c3a250e9a58701e440e7242fcc0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fcdaf75efdeca20d4e21a9ca371bbfb61cf89e7590d4980e65bc5acd0a3dc017",
-                                "uncompressed-sha256": "c4d67557fe649ec517e1bfd3990da08147da71c495c490eb4d7dc46b62d6c857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9630d788125b3045544413b5976cbd30871a68efd904ac58c4c093da3d4ac397",
+                                "uncompressed-sha256": "72bf61a5b1bcb86db79f134b71087e16bb5923d5d533d10e07a4ca1259c07b68"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7f1b5f07e5337ad9ad6cba0c5ea29109d3cc5aef1efa919773cccbaab94f0526",
-                                "uncompressed-sha256": "e45df126d74b2df41aafc8bec7b6521fe1da60c20ae5ac55c51d51bb0dc4b6bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c1b97a8333ce40e6781f442d63ff7890c56c603ecaaba090e164d1e7cff24109",
+                                "uncompressed-sha256": "a0c7ddd2cebb955522dd295d9a4beb4e64f7db656d810b2790a8b048e82844c6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3e2b4df4e9b5fb88d38d26cfb4143abc24e330b996fd2b4475315a17f9090864",
-                                "uncompressed-sha256": "8d75a0770b591e2240bff77ff23fc2c46d6924a6d2dccaa2f8ae3fc9aacb77a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "124835f15fee0b879618d3a2a39fc47cc03a354eaa57c8a090f281a0b8d79dae",
+                                "uncompressed-sha256": "74af32c8023462c19dd34c1a00b119194d8e0103828db82fe4b780bc570ce2b6"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7759a91d3cb87bb661e1b9b65b8ebf9ecece925e93895e1f4daa28d353ea542e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d825f7feb1bbae761706d22c2aabbc2dc006b09f7525b42ff0771264566b59eb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "aa53a696744092e3141f5fa9e8c61ece476370b0579b2efaffdf44ff619f32da",
-                                "uncompressed-sha256": "76490b4453b2d7fac53b053bd3b45605e80bbf8a2bf48a39f6e863c703203ffd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1493bcb799bba0f0e44e85e52505ea03f5a25750e8dfb7dca5684e0b29247821",
+                                "uncompressed-sha256": "030ecaa8643c782871220b1c41b7e0c07602a5a942c36dbf7c4e069e1da9c250"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live.x86_64.iso.sig",
-                                "sha256": "909dd47ec6f2b96a2d1fc7035f57b80f14593291e623f0e2de918185771b7260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live.x86_64.iso.sig",
+                                "sha256": "864473da38e2c2235eac3eec60255309e599d67bcb8f7757cd655086815c9077"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live-kernel-x86_64.sig",
-                                "sha256": "c835ffef4f5c8a3372c979271a27d3ceb63bb94fc09df1a610e0004667935ae7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-kernel-x86_64.sig",
+                                "sha256": "3c04d2fca66dbbb71e22305b203b6464e01a75df7a1b14e599f05311c4f89c09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ddb2cc98905a576b90119a68fd08a4c8d9c0c04b736e25aaadf72cf716674976"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "4c9793723993a7ade1782c6211089efc467b9c7d0aab313f21a99a4c4cc19710"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6ad62a3ad8cc9bd65e7d1520c7086f2a18f5932a4b73ef09ee7cfa27e5f9efbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "9013b8a7d66554c44ba752df686b9c38d9d0191f3644f9ff834bbff0d212dd80"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d257655b12071284d0f0a8be470b8a9b4a4b9f5c68c4766ce6a7fd7406a04044",
-                                "uncompressed-sha256": "50817c5cb6af75971331e512173f2f65649fc9e07dc4738c1218a9698a7a6c36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e54a27daf300cdbf9d723807f159646ae5c7f842381424511b4a340917e98d24",
+                                "uncompressed-sha256": "c0a5b07a94b50a8270ebc6d5ea454356c0fe0876eac1ad8fbbb7fd8089f2c0b0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "97d063e4cea5196e7bcced58652057cd340a1a8adb181e7c61b324f23ef3ec11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1db1fa552547a15e0146913d37ecedc1429ba26eb7235ff7fcabbd8dd1d32faf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9d8bc3850e4fcf9a6482af041c577b6330552243e9a26317e0e38f008fb69cda",
-                                "uncompressed-sha256": "652de5277c75e3003fd00079acbe8cd90a96dd280066c81cdec7e15a0d7b3728"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "94712249144ff59ee57dd4527ceabaf3e844ad68ce53a934d1f7939d1fd961b1",
+                                "uncompressed-sha256": "51dd39ff3fa9bb07858150ef86b903933b9fd69bec8b1fe35a2b6386a3a7076b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cfd857b900d3bcb3403ea7cd699a4e818f260b9b8042b48f1f0ba1498d467d8c",
-                                "uncompressed-sha256": "fce97a5a5a00b7ed8a8e24e396aed4836bf77be2e29e7e9fc956988a9c8e7e78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c6cf49830a37d749a4cfbbaaf8ea1996fd64359daa8c2be289e5d89bc62116b8",
+                                "uncompressed-sha256": "8647aa29d93b08dd88737207df4f331494ed01615021a6463e1343a6631d29af"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "dcf5ae7edde95b1ef89fc29e9fee7aad0c79f6c613a4d2802ef10aabc3ea3ab7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d4b38ad2c1e71975b56babcb231541e591fb303970033951ada37246f7d26ceb"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "1327246c66a66431e88ac52520eac6ed0fb2ae65d2091088c53cbd93c7ee0a3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "d0725756637077b572863963a98cc8ac481211d820f818b9139fcb71da34c701"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240210.3.0/x86_64/fedora-coreos-39.20240210.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1b06bc47a44c0392fac07556bd3e74fd13f1d432c17ff0c8a4e906c5b2960856",
-                                "uncompressed-sha256": "8dc0e8336334bd33bd506ebeba0beea5050dc5914f57d3eca0e46f1527931c33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bebb3af55a12de11c30e0d39822fcf6eed461e303f48c5f1731ddf7f2bcf576b",
+                                "uncompressed-sha256": "72b3a0c6cf1ddc2f5d9a1005be264d2f20d5550f696c2b266df2a402552b92dd"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0ae3eef990353a52d"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-097f4b22f495bdbef"
                         },
                         "ap-east-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-086842fda6e94d3c3"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0d63c98a574825181"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-04b1b27df6f81fbbf"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0faa7e87f883f4d0d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-00069fb48abd584fc"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0fd2a360c30b6f5f4"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-030405ad9a02a1371"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-085724a0a90d0b119"
                         },
                         "ap-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-07354490bd1c8b20e"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0277c781bd28317fe"
                         },
                         "ap-south-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-023c9e8d226f312c0"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-06a52b10bf02418ef"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-062723593849f137b"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-02cf9999d08f251cf"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-09ebb46d2d2d813c8"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0229ca27b789af570"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0f2e9b279f1b5bac8"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0a54edded4ad9831b"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-05e3afa35f2818944"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-05f143aea963d5cd5"
                         },
                         "ca-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0a081b9d87420169b"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-019d3be7133973ac1"
                         },
                         "ca-west-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-08ddcb47e2fab0d00"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-08e757c7d625f0f97"
                         },
                         "eu-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-043177626b1b1a2dc"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-057875a8895315232"
                         },
                         "eu-central-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0c045afa70c0f545b"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0328cad82e8587cd5"
                         },
                         "eu-north-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0e7d32a0f3e7a807a"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-099d68a4e2ea1c260"
                         },
                         "eu-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0a13b9814cc9b0850"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0fcb3c9b403e130c4"
                         },
                         "eu-south-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0c83245929f1796ab"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0c2a16ca6a49a03d2"
                         },
                         "eu-west-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0473f6aa395e960e3"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-06d291c7b158e1d4d"
                         },
                         "eu-west-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-054108fa066f9e524"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0692ae63ceac2ac59"
                         },
                         "eu-west-3": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0137e847aa1b22fe4"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-048e8ccd010fa0815"
                         },
                         "il-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-04cd1b3c386b03704"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-08631113856279701"
                         },
                         "me-central-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0ae932a9a19ccd1cf"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0672a9b44d99d270c"
                         },
                         "me-south-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-061ea927fbebd8624"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0a2d063e056853f99"
                         },
                         "sa-east-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0e94478f0340555dc"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-047361a5451d22062"
                         },
                         "us-east-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-00e2a96da3cd0de4c"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-097758d62ef002f2b"
                         },
                         "us-east-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-0c27fbac559f7d96f"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0ad6f4985f9d75263"
                         },
                         "us-west-1": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-09ac56eb55c2aac4d"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0d8f15321e783b7a1"
                         },
                         "us-west-2": {
-                            "release": "39.20240210.3.0",
-                            "image": "ami-02155510af5e5922c"
+                            "release": "39.20240225.3.0",
+                            "image": "ami-0645759dd2430f25d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240210-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240225-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240210.3.0",
+                    "release": "39.20240225.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2e46fdedd6cc9ebeb44b3bad5c4b67ed414840ca6f3ccbcc34866f227eaf8f95"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b6c3599f7b84db56280c90900248643727cf69f9edde1ae710883530df626a9f"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-02-27T13:15:51Z",
+        "last-modified": "2024-03-13T18:34:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "46b981000abef252bd274390ef16ee065a9d7f466cc9678153c566dfdb57f291",
-                                "uncompressed-sha256": "1c05e1c3716130617110c46858a887ff9c60e201cadcd862b49824afae9dbb61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f043050b39282b19031edcfe5b29030c7f895b9edfe960f5f023a14c493264a3",
+                                "uncompressed-sha256": "1ca7261272852189d2e16063407e712f0dcda1ef05ca5c9d56909a4d961422b9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8a6986931066c2da9acdd1ef55cdd6d2a59073a4a05b91a3d61b68b26104b126",
-                                "uncompressed-sha256": "69f03ed21f446b2dff6e7e33cc4d85d16519a97256bb1ebd47e8406bcab9c1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4e1cd2c3713357d97a668959ad23a06127167df5f2e6499f13ab5e6b28122596",
+                                "uncompressed-sha256": "edb38ce040f6b07559228ff47b37db3caca259de6d84938dd8abf5efbac4b0e3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "6b2ce890ce0c419221fd24c0274692787697f63698399568c968b27196c7ce28",
-                                "uncompressed-sha256": "6b1e5f0ebc4d57ff9af3cf0fd3cb096ac0e998faf8376d53a2458441cbb36c3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0c74e940bda4134c6350172e488ce4b93b43d7c4ce2bafad30af872bd30fb88c",
+                                "uncompressed-sha256": "0e25982d5e1449b1e6d7b74cfd08637b10f60a5d9f28e0c44d9e8347648e4f31"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5a70d5ad33ef5f2cbb508407b71c9d2ac7b5b2d0c6b4ed0a890a6f8bc96f3811",
-                                "uncompressed-sha256": "3c6d4f457acde0a2e49771112e4471f0dc4e89c130c91a7639c9074b1e36ce0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "53beac067fe16674486de044d6effe26a42a58a8aa8b288c11129cc082096652",
+                                "uncompressed-sha256": "9da141ee699ffd9d3334d000bf5c4ff38ef9d64960cc7db465a7e02f60e4d8d7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "14f1cdbca9cedff6a64911ad3170c0abb2ea7209814e8f987fd7408054112530",
-                                "uncompressed-sha256": "972f48686a0c58cd1906ca86eee75e3d6504a8475574bfed6df8826986a03b77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "8e5493875510b51fc5a2dc4e90cf84bf8e563bad242e02a6c223427ef8be8785",
+                                "uncompressed-sha256": "ee8b9893d855f025cbf7f19840763742020f2a6a5e68cc1b1118406f060d66fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "60e9bddd02c2f81f821614d3b2a39195744b84263979b30590c952bc668b9f6b",
-                                "uncompressed-sha256": "0858445b0d5147f69bc4a391a94c66e51612c67f12426c4923d331528e7704d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6d8b0b086e628afbd7bfa0038335a7deddfdbd41289774dbc4432a80991d5a7d",
+                                "uncompressed-sha256": "e24969fade519782303de6457b9cdedf9f864652faefc31750f2ef185f6a0b68"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live.aarch64.iso.sig",
-                                "sha256": "f4cf0257b73880218c636fb0b3fec99dc64b59f2876380d160771d4440e20ef5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live.aarch64.iso.sig",
+                                "sha256": "89a19250f2f516b74c372f04b83bfa3ebe3aa287c68026c3de6dd59d147c2be7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live-kernel-aarch64.sig",
-                                "sha256": "3227da858d43988b80f31087cabf245d9355fc764f7f667a1b361cc99ed363ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-kernel-aarch64.sig",
+                                "sha256": "cc0c5db8f4d1d70162c90018eed4cbcf1a21f407f78dc2f9830020a62a43f37d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1c32d13224f4e204ab9953e1dc7cb31be6378134974b59d4f9e09b5aa02fe95d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d0bfe91b4b2fb0297ba83c4bccd7c9bd9ae817ee0cc5caf084bed0b480758598"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "387e1614e1b4ccf35fe9edfe140c55bc497b8c224c55aa4294e6ee8aa1dc21dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4e147c5875c9c5fdb14bf358053a2158eedf70d7b7358e5eda9bbd60ba425ad5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4be04042cd155a49ece463d6fa64dd17d74129013ec57d19a1a3ff9b1a040e7f",
-                                "uncompressed-sha256": "f9fe9b720ed20b320952a80184aa697d77f508e34b3478c8c33dcb7a7734e2cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0c03f4d76dad80ec8a7d1b78ca84ea73d6a35a51052b4e9e2242aef712c89526",
+                                "uncompressed-sha256": "c27c5b394fa524caa8ad34c0dab438d48b33e3c7c3a21efdf594480a704751ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "46d4e57eb2376bae556c0a0dac98df325f913009885af7004d722f3d864711d3",
-                                "uncompressed-sha256": "47d6f489f70d666a8fba8365d722ad74fd3eafc3d3ba1a544210d001187a4706"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "48a4ede9a8b50fca2f5cc331b163a5e4e6efe4f493a8c03864a6a5cb8667ac8a",
+                                "uncompressed-sha256": "056a0c952d3ddc8eb2c1895188358d9c22f313a1f1dad5c0d73d12d6ed428049"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/aarch64/fedora-coreos-39.20240225.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8cba76f57bb433ae925925ed00abfb33f0f6ac570b6657fc4652763d32ccae84",
-                                "uncompressed-sha256": "2e5746b13d73ac8319ef434bf4cd974c12dde9cba41d6bb1b30502f3567f1d8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f7a4c9c7514021572a37e193753f59f43d14c0142d43d77cd56c42fdbd026154",
+                                "uncompressed-sha256": "61a7fa0df242663044e7135ab8c9790392c852ac0f96ca798c19ea4abc348cca"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-001ecaaec1ca78c07"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0707f3147e421a1b5"
                         },
                         "ap-east-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0fc53b0d811a12c30"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-09d1cd2200ad7d5eb"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0bf58b9f71846696a"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-07a664c4dab617bd1"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0d23bf092e9e599c4"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0766f7eed591686e9"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-033614b0788fb354f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-00b28019a77aa9355"
                         },
                         "ap-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-08e29a6f4e09552b7"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-051b985748dab484d"
                         },
                         "ap-south-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0fdfa2a31194cee09"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-027c616efdc64f6c3"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0a73581963fe90bf0"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-01ac4130f2f9da685"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0c4e0916b8ce9fd9f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0a26d26fb7ddc87d7"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-02fde1bce7ba1a68b"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0fe23f6c55977e76c"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-02b6a700cebdc0959"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0059ff16aae5ca0d4"
                         },
                         "ca-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0130a66745160d920"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0da3b6b78f3fee898"
                         },
                         "ca-west-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0ba19b763e5f3355f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-05e8e5da75c30b0a8"
                         },
                         "eu-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-09e45450ba3b89bc7"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0cff5ed565ecd1fc1"
                         },
                         "eu-central-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0218e1b4a794454c0"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-061be3760818dfaf7"
                         },
                         "eu-north-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-074553959926a3cae"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0efbb14fece6802ef"
                         },
                         "eu-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0685af401e7e5c0dd"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-03629af95870ca381"
                         },
                         "eu-south-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-02b097bab0f591e34"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0cb855936e5da06b1"
                         },
                         "eu-west-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-09e6d05ac3d469bab"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0e47ffb174ef3c552"
                         },
                         "eu-west-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-056db9a5e1fda6d7a"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-003d59f94b40ce7f9"
                         },
                         "eu-west-3": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-00c67280eb26ed326"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-092e2690d7042cbbe"
                         },
                         "il-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-07573994f321fda5b"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-017862bf0a5154ed1"
                         },
                         "me-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-060bd64d372345168"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-060f163ce853e6e36"
                         },
                         "me-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-01c74ee027710230f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0c855858ee09f2bf9"
                         },
                         "sa-east-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0d6dc080c0a6b2b3d"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0d1d17b0cfe523c33"
                         },
                         "us-east-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0ffe07cf8e35ad81d"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0354659a9ad5c5876"
                         },
                         "us-east-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0ca47227c7ccffd0f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0883ba74d29985639"
                         },
                         "us-west-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0a3c044b08b3da6b8"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-03a8e93dbbc330ea9"
                         },
                         "us-west-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-02aa5130e38ca545b"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0a31bccefa8d53fcd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240225-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240309-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b3403aa2ec48a819e6f842f52ca7f448a5087119dfe7e86726ba198ea918c5d9",
-                                "uncompressed-sha256": "4ccbb24024e84d21c29a1dfcc40868d0e3940f78d598a57be1776a61e876cc3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b66023ac5b9387a911d61eecd46076c904dfc298b6486de034005bc1b5dae8cf",
+                                "uncompressed-sha256": "8f2894d39e36ea752c9e2ef704d518864c926707ee740340c3eaeb1f1f03cab0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live.ppc64le.iso.sig",
-                                "sha256": "b162db79f2d4a7ebdad89e5f4454c7911ba8fc74a9fc0315fca3c882a67d55cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live.ppc64le.iso.sig",
+                                "sha256": "191007dabaa6ceab9eddef60d447ce8d953a9b0821d8c3a7204289318ad96ad3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "122485b01899266292cf32d81b9b26c45b63fe7d514e7ce5a9d0b0ce635dd925"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "c6e711430c00a439862574ffe2e68da456bfc0cf33306a207a33a6c70eac5cc3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "41987824b4715d3e65af49af6cd954e6ab35e6192e1bac34963304fabf97a62e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "90d4be1ca920462b08321f714750241e1f343f0d1f8d7d2912c414f181ad90c8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "59dc2af90796c50de94ad1116b2a54fd93dbd72ab7693db5f5cb1122c9726de1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "8df60762c711e0cb9b6b859178befef1de9fbae958bb79f8f0a1960b7b3f78f1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "263d8aa9f39f8d9887ae51a92d22a231615041df5702bdb10a1fcd4ffa89e896",
-                                "uncompressed-sha256": "36ac36733395cf5b3ef0a8a7a2ec368ce403c699ea304267e47573f2e12af322"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "672d468700ecd9991692279d8d49235ebda19e0672b6c28e219a2d48f2605fb8",
+                                "uncompressed-sha256": "16bb98f273e8ea4652df8e2659726dceb9cd00cdbbfede2aebc15122749bbd28"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "69d9495be4c8c25d75be301d8f143acdc42f6b49e54fd918ef26eb33e702451b",
-                                "uncompressed-sha256": "74eca0059a68279c50308333c8d6ae71c757f6c95424ab3e3b5809484233d0b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "778bcc5d992d7e54cdbd2306acb2b40819acf16715c0722b2ff1b6902b6fb535",
+                                "uncompressed-sha256": "c58957be854d76388c2396d3f5b42f415e59317d0a656f4f28867bb9669d4a4a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5952a6137078a6662000539d1287318de3b2155d6f894bd57452594ff96e1e26",
-                                "uncompressed-sha256": "fcb0ccb458da9e0da0852adf22b4b0606a608e34edeb57005af57b9576e51ea5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "eb4e6de268e736610b203609054c226bb0aa8a7d8bd0bf772db4de89c5704371",
+                                "uncompressed-sha256": "eb1263b51069edbf106c57f7cb6d48769b904ad9cf8907de14dead3f09b2e9b2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/ppc64le/fedora-coreos-39.20240225.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "0d7c4551c946d77df849c99d9c73f3161ad56ab74cb6e01ed8d8bf2ec6a7ab66",
-                                "uncompressed-sha256": "3ac4355d7aa85a5cb573d2ea6b7df8af86b17c4a086145c8ae0887116f0c2076"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "365453260c8ddaf0159d451770e56192cb80e6d674a5b997d5ffeb06fe69bc64",
+                                "uncompressed-sha256": "7a3ebfd1a5b7a770dda87556c0116e66941ec91bafdab328ec9a1b30f853d013"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "553daf184152fc97b11c7816f0fafaf59ebcc99a534ad0d7b4454dbf5f85a650",
-                                "uncompressed-sha256": "106a8b7746472babdfe6347e60e591bd8f0bac13860791ba9d7ec23c24eb38da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "29e45053c8a65fffee626ee6fbe7013a3daebcdaa4ca8cd600b16b855af0379e",
+                                "uncompressed-sha256": "de2a84c001c3dbad4b63a6a1fa4df181187a7aa1f3137761dd7ff376a6f91bac"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b14c21f194c1eff4e9a9f4f501ab87d073dd9526ef5ea70b6940344d837f2dc7",
-                                "uncompressed-sha256": "7fb9ace23ff8bbeae84f699de1c620dc26b7f4783d64ee393f9101f6a9221dc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "625c0e917b787e7fceab71f05131eefd6c58617d05f723cf6b2bd51f1d5b54c4",
+                                "uncompressed-sha256": "bd821a27196238dec49761df2740c60b8ebf885fd092107bcc11cc73ef7d21e8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live.s390x.iso.sig",
-                                "sha256": "dd5d263fb3580f36ecd32308127b30d932731d1263e024b3e6cc4c6b84ba820b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live.s390x.iso.sig",
+                                "sha256": "60af68212ffaa1bf462bb057d305a29d3b42002a531fc89fd6b70cb76fb4336e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live-kernel-s390x.sig",
-                                "sha256": "ff066d94cde8640405ca9c7f7ffa871e1adefea8ade5cbaf60b15de9de98dfc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-kernel-s390x.sig",
+                                "sha256": "a1ea7d825271b9611f21f27b37dd91decca26c0a67391fff4dbeaa93ccf73259"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f5ac4ca6e3f1612a95ce25a127ee6dd746bac609695163d299d3ba6642559be7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a012cddd178668e226f0984da06e58a8b1bc185719ff32a7cd2eb7daa0113903"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "8b2243d8ae9dede621882943b2ff732fffe4be468b21e7b57e18362461e54daa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4b7f9be4a64f7bad78197018992b144290d34f07107a20c31d4394f10d67157e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f78f3af7ecd6213b4f664f860cabbc5bba5bdf32d359ef7dc4685a84ef4307e6",
-                                "uncompressed-sha256": "07b2376291701103bf325127641a43c1e21256004262f65994fbf589a5e7549e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4a25ed572dda7d2daebbc036753a0517a463d2dd85138f12488a23d8ab5b6419",
+                                "uncompressed-sha256": "f467f5e05ba7356abd5d61259fd36522c71824d53bf04f2e3d15dc203e74a327"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c5ab1cfece588adcb2c9245d79550ba225ef9d40d1cbcbbdad79230c095933f5",
-                                "uncompressed-sha256": "0039eed447b843bd7d82d2786a1c30c97d4221f23434147ef4ee3d27e89dd85e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "16551d329fbd391ad4d7dccfb59cd129b91284be7fe03bef8b37c80b8b050e1c",
+                                "uncompressed-sha256": "5dfac70a6b1f65e297bd77872204cee6f92439ae845ff056dd323afa0d6306a8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/s390x/fedora-coreos-39.20240225.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d9a2f8e5d60e07b177d0c3d69e78fe589f9210c3ed45516717fd60bbaeba8667",
-                                "uncompressed-sha256": "78969c007cd94d82ac211376b2d9accc785da211d4da88254771705ab2951f7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "48f9bb88e9ebff9208ad089a0d020a979f478150eefe37db63ea81f9a0798c66",
+                                "uncompressed-sha256": "477194eea316674fdeefdda6fde7de36b3498ede58c0800e3b9a1044b8663e7b"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cba6156ce6ccf6da139067e5bd5cce248a166c748564760a00e9ddf5283136ac",
-                                "uncompressed-sha256": "0c9135a3a7deb84a94f4f371abea9ee04e011759d05be51b56b6035bd6f80c8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8b480714943a6549034f0c64def2a8d4f298d19656371df12650e7ae066535a3",
+                                "uncompressed-sha256": "c403729351f521768510cd97495a4acde51039c2a02f9bb2b2751ec45dc46377"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "c4ad8914feddb253c56ee2798e117f2ecbe0e02021f9e99f59ab6577a25e37c0",
-                                "uncompressed-sha256": "2e0dadc87f631b955777f4a9479b08336d7c72999bb32992b13cf5669ffb415f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "767bd11682e33c231fe6e8902eab71f078cde49dbe381472169f41995bb6d8b2",
+                                "uncompressed-sha256": "3023080939ae6efbc18a550c275f23074b34201d054e38fc06f029ad115568bc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "772770a17e0607c6109f1fa12214b033682a531ec4a56aa5e20dea6a5db16156",
-                                "uncompressed-sha256": "fd2f86b80ca730bce7045bf23e0d598a52da38820cb776214cd031f2c276d64d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8c864ec74cb4dad1268f58795a1ae377bf6ce030513ce38e30197fe628a14e75",
+                                "uncompressed-sha256": "e554e2c62f084230aa54c09f5cfe4de1fa489284abe02accc6d454d0dea45f44"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ae690791724d5890d69ae27aba644746c9e0c7c423d2c68189a26bd88a41da19",
-                                "uncompressed-sha256": "1af79a6e355c07de016711e4fbc29db6a4cf137f080be749b183e69f9016b8ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f8523905d6f95a84027269f89822f6722e0521b5a1e4c6ce615d16f0d9f31f24",
+                                "uncompressed-sha256": "c6442130dbb1038d891729f38af4903d37c900209e43fa40327cf1efe91a7aa3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9d72c4d02df050ea498473511c3815d374180a104af54d851729f5a1eab13abf",
-                                "uncompressed-sha256": "fc03259210b85542c089d09c2961fdcf4e8520dbe2ef6cf3419b7ca00f8a7c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7349da81a3763f109d0e459562d17935f9271f362881df6fa2209b1dc7599580",
+                                "uncompressed-sha256": "815f3643ad7c8d3bba43afa4e3c401dcc72b33ef3ddb06cbd06cf89b646dbcff"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "27405c7ccc305b89b083d22194368c39e2944b74de271b3d6fec0cd0b42beb52",
-                                "uncompressed-sha256": "264d3f90d35e290e6a827d5a1b7877be760f688dc247a1b80ccbfa402fa6ac96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f5ae236829d994e0eecfe56c5e21ee2c811c8ddaf86dc5e43947edf80bccc7d1",
+                                "uncompressed-sha256": "99a7024f39d2df3d7698c20308b5bd59675b7d363934ee9d62347f62250347ba"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "aec947b17bcd35268f33c6e91eec92fd2d4e22247d65990103801b9a70556d80",
-                                "uncompressed-sha256": "8811d368b5b11c083f9db44713c44b7a2c921f96e41b59d66d139be902196e7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3d6152b981b9ec932db0c8442934106ff970c2a65e61afdf3adfce98316998f1",
+                                "uncompressed-sha256": "46d9abab0f182995a0022e4d4ce181c92ada448cdc48950967ccd63df8f0d6e7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "99ef4566add981a1822bdad80b360c77b8b9adab9454f792a31b6b98eeb096a2",
-                                "uncompressed-sha256": "5cfc1473e9cf949b3ef64ae92e09f1724510ad54f165027f3b0f391abf8f6868"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d15dc2f7ee93298b1458e1ade4e6e8c83ddca1c3bbcf500a012356141fc58676",
+                                "uncompressed-sha256": "49cfc3c85678de67e74ed8d8085f28b29fd50118241dd4c56f6156c0a8a90ff1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "341c4146139296e794de79c020236f05ed2644bd4cdba38b5fd947404704381e",
-                                "uncompressed-sha256": "54b80dae0bbd99810132a52c585932ac3d26f5d020d264520c9e661f2f31b007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "453530f0f4a6d69528b8c9801eba0639d0ccb7ee88ef1a77254f092bc73e7a56",
+                                "uncompressed-sha256": "3556feab3b89eef2c02153debeefaaa00778f624405aef283f4730e0d15d8722"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "32d81db637d0bc22fe05ea95460171eda19d7fe949555e775aed90d80d346937",
-                                "uncompressed-sha256": "be1c766ee795a2284c0f7723c77f40783584f7a2515bb15a590a4e60d14603c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "72056f778a539f7f8cbf33eba20f7e906cfb3b867c817fd138f5966b27f66a34",
+                                "uncompressed-sha256": "86aa8df82784283c74c4c15c49df7944eac7e7094cfb73a3cd07b39ed53f8272"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "0012057cc16b208b6029bc9db2af213ac1d567122fa0a9cb02ac24288fe256d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b93c82c89a5314f71ccedb52be3fced2fcdb27542291396c2bb3490481fc1544"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "114b829a7e7d85ffa39506b44156e4092a29f38ed476db2d02b5999ea468b991",
-                                "uncompressed-sha256": "d87e9eff40fb2f30ec8e08d643cb2b31e7994571fef56e2071dbde905869987c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1511162ecd0a1c33fa0f56df5b74ee5a090a55ea068a26660a3aeb1925730920",
+                                "uncompressed-sha256": "2a142a6be34c7347f138c31b3fc8f77f9509bd0afb1ca2b07baf119687a6e626"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live.x86_64.iso.sig",
-                                "sha256": "c6c098eb2419f9ac8cb607cca7708f0696c16022e1b326d711f20c5debfc57b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live.x86_64.iso.sig",
+                                "sha256": "41f9e9309dd778c1dd6f21eed214b727be2d9355f79dabee33707b2adb4e1db2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live-kernel-x86_64.sig",
-                                "sha256": "3c04d2fca66dbbb71e22305b203b6464e01a75df7a1b14e599f05311c4f89c09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-kernel-x86_64.sig",
+                                "sha256": "64ec45261821b16896a601b46d49304dd22a4084f1b1432c6dfe13990a0f8fcf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ee8c81e65e5a2326249ef8e26fe3c7daac8c0e42c8fa872cefc0fd3582670444"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0feff7f1b5f10cae99356ace395548f96c38b753825b021af4f2d40c36787d72"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "116df26286f084e94e2d0312aa98020bbd64843dcf078ab07664d5694efb7ecb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "722459ad118d9db4faf83f09549c4e92a4456494ce0748117cf93fa11a6aae9b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a00000e669760df8108f3d9b8dee0e80e4424d23f9807a10fec380286b30ba21",
-                                "uncompressed-sha256": "a3a19ebf3f4d622b7770549f69066d258b181d493d2215b0ef9f8002c9958f08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "11ceb623c001db90158ad3b14b320a8d5c551df79c620c1e46f1ce9c3958df7e",
+                                "uncompressed-sha256": "91cf71c3e576653f9604a9de8ac55eb84630bed56026f900e0368bbf3bdb707b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1cb180437426e9733592da6ca8b401e0fc9115b60289456683f833d8c8719d2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "67622a4b676487cd207eedb50ed62b184c3befc2f283cc0b3fd12a233bc27d18"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a02aba9ac70b5b4f97f1d8735d01214ad68bcbcb2cecf4725c67a5f557678b83",
-                                "uncompressed-sha256": "e54611d1e76fd96b36a93c21f1df039cca813e12ab3cc70d763fdd710ae9f6f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "eb64ee31b82227131820dbc00126be684f673d60f4d679ed4c205451b64518dc",
+                                "uncompressed-sha256": "d1491a359eff40c02d4dcf137c15b496b4925788760ce93f911408493492639b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ad8a3cdd9e609bbe961ef1a34e26afe3011cb60d423d3dd80e947cee2b08455d",
-                                "uncompressed-sha256": "85568bb2cb50aafd701aeb398ce6fbc42874b61d4d003ef363fa781e276b800a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e089b9e924ff8297c4f8beedbe05e631d44dfcdfb1b976e2ad817f4c8fa8a72a",
+                                "uncompressed-sha256": "1a1a044817e3b5bc0f3657b78ecbbde6f9b50b493e55e4e78cf1ec4f2a196bcf"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f1b0ec9952c4cc4550beddf6dd3e322e75736f7fb7b9e62679ef550b50612fff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "cce0dbf56db5a6a6ac3b7e640939b53ede5bbafa6bb19ec59a57f595e517432b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "cb2f4ba1efb0720b2304d1f76425237d0cc43746653e360187f55eee0ad67560"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "1c1e37b2454ea4cb6208b715d99436590672439105fbc9c06530983bc5b9178e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240225.2.0/x86_64/fedora-coreos-39.20240225.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "60bbaaa64b8a6c7bf86d56fd216122d2648135670170a12a36518060c374d013",
-                                "uncompressed-sha256": "71094054ffb123bc83d338e770137116389c28b709a0c32fe2b6ef12c75de1c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "591abb6b2dadbaf44153679dcb3ded858d139893073eed674446a967add998f1",
+                                "uncompressed-sha256": "90fb9d1683ef156c31cb428de13f5e146be85006abd8aabd1461e97b10778aea"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0f93d6b6149a17c1d"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0b7b9329e4fd75933"
                         },
                         "ap-east-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-01d23d8776cb2922c"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0ad2dab4e9a878f7e"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0331b158ae11756ed"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0ff80636cd1165cfb"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-079cba3e57922c2b1"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-07c204e8e10d2fa02"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0efb5783cd6239ea4"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0e867cda01f0a04be"
                         },
                         "ap-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-01c9747b34b64c245"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-069a63c5d4f93a907"
                         },
                         "ap-south-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0ed466530ed3ab13e"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-01ab7a6550d2dff98"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0fed76d4dbf6f9ed1"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0ae12a3dde0ebeaf8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-07f78a5898cb1fec3"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-033d660fbb0765479"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0da5774f816b731f6"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0b8b0d61ffebc02bf"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0a343479052d95ccd"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-08a9c29edc22e8307"
                         },
                         "ca-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-00fe99aec7cc59b70"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0ec84e1986bdbc060"
                         },
                         "ca-west-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-04232f15645280bbc"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-04bb28e79cd10827b"
                         },
                         "eu-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-085e364901b30bd0e"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0235afdc58fcbd344"
                         },
                         "eu-central-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-006ad357a225aa50f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0759892d7c0b39bdc"
                         },
                         "eu-north-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0e8772862b1a08b1e"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0e1691dc457cef7a6"
                         },
                         "eu-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-01803a83134bb663f"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-07f59e926faccaf11"
                         },
                         "eu-south-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-07e8d7c381c344bc2"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-090d8c459135e40a9"
                         },
                         "eu-west-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-060bf684996103a6e"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0296206ede4f4cb49"
                         },
                         "eu-west-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0fddf109d510e6c00"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0816f749a15a2568f"
                         },
                         "eu-west-3": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-07213122b1995ad14"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0b1f7f0a48654da45"
                         },
                         "il-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0473cc4d67efd2775"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-09c59e517cafba745"
                         },
                         "me-central-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0303ce09b42667107"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0b165c85742289c32"
                         },
                         "me-south-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0c3c1db58df331eb9"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0a55fd733daf87159"
                         },
                         "sa-east-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0243e95e8dedb5edb"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-03fd0b2c5084a3a9e"
                         },
                         "us-east-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0e9c6112aa0265be3"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0df8579426636a572"
                         },
                         "us-east-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0a81fcb0ccff29bf6"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-0bd272c49a311d1bd"
                         },
                         "us-west-1": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-0bba98b5d66f8b7be"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-05c6c1b5c255d1471"
                         },
                         "us-west-2": {
-                            "release": "39.20240225.2.0",
-                            "image": "ami-054827f7e43950ef0"
+                            "release": "39.20240309.2.0",
+                            "image": "ami-015daa66b85fcb8d4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240225-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240309-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240225.2.0",
+                    "release": "39.20240309.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:47399c94b592f1a33d31651e1ca0155c735e3be2e2b5cbd4f2f63dcf094bcf15"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d340ced6f988da1206831b6168815f57202f90f88f8ef7edecf534437170b895"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-02-27T13:15:54Z"
+    "last-modified": "2024-03-13T18:34:35Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20240210.1.0",
+      "version": "39.20240225.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20240225.1.0",
+      "version": "39.20240309.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1709042400,
+          "start_epoch": 1710358200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-02-27T13:15:50Z"
+    "last-modified": "2024-03-13T18:34:33Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20240128.3.0",
+      "version": "39.20240210.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20240210.3.0",
+      "version": "39.20240225.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1709042400,
+          "start_epoch": 1710358200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-02-27T13:15:52Z"
+    "last-modified": "2024-03-13T18:34:34Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "39.20240210.2.0",
+      "version": "39.20240225.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "39.20240225.2.0",
+      "version": "39.20240309.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1709042400,
+          "start_epoch": 1710358200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).