### PR TITLE
Roll out stable 39.20240309.3.0, testing 39.20240322.2.0, next 40.20240322.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-03-13T18:34:34Z",
+        "last-modified": "2024-03-25T14:13:45Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "9740603447c2ecec30d341f79675ae3a48661d23742543af584b9ca0e094d1a2",
-                                "uncompressed-sha256": "34ec7b1db545b7a1b6a11da3863ede5a4df49eca55da761622648c6f53d64425"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d5f22ee6476ba10f3d31c5b62b97d677a70a6d7cae0ced3ef55e4b443ea1d229",
+                                "uncompressed-sha256": "3fb11e29023c8d550f13722f9a86fa27dfe5078d0b50c3df9ddd3fd87246afd1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "6fdd4bd9a65adc5e339a6e12420048ac3b4c45b53f31146f287a212afb6e3f2f",
-                                "uncompressed-sha256": "d1fd1e2dd6fee76ea3b8ac43eb92203ef11bdaa0c57a9e9466b253cf4f61f3b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "835b42a5a5a58e2f2afc21c466465ff914ea2afa01762f48555679991253dbcf",
+                                "uncompressed-sha256": "83b7a72f54973e5e35f751af65ede582d2c628d5799f7db013d7940ded5974a8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "80b87ebcb0fdd57e3478a68d10aa6ec9758e2d5733ababc64f155cfcbe129ffb",
-                                "uncompressed-sha256": "02050d9f9c426f5effc200720647d1179f99d5376639e4d721a42e511ad68918"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9d22fe1b335170bccf88ec9a88a72bd10e56e475dc2cf52b7ab75fc94551dfd8",
+                                "uncompressed-sha256": "5eefe5fe2b505fc5c29522319379a2eb53a30861b1c0ab547176c38a61ee5a31"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a09cd7a0145b06ba0e25e70b7925e0126be27d580430db6f54bf8b85c3c8dda3",
-                                "uncompressed-sha256": "8f41178f21ede435e08c1f968c15f9d696c3ff3d566a14ae2b192f556281e34d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "7cfc7e259d775c92b0c47f626db24e58fa0ba09c9b792e0fdbb9949543789442",
+                                "uncompressed-sha256": "548674d54dcabe2c61f79a273ff19535e31a30a90add62bc65ed50c167e6bc6e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7d54a3b477241254e6d65cda9aa34ad9e8ee32c2607866a0af47922418a0acee",
-                                "uncompressed-sha256": "bc1820af60dd27d1b706e7b036658cef4e7ddfb700cc620e6b0696f140ea7673"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ba5f4c7d2a6179e730e44de6b3726ea51860c1cc5c364b41210b25ea0fdd7327",
+                                "uncompressed-sha256": "41c5bf9c5a03e9e73a7650694360f96bb84358c6432b193bd5f073909c0a5436"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a45a8b8a86506f1a78fc368b15a8853b7c47200f8617aafa50bb45ce2681fb2e",
-                                "uncompressed-sha256": "c0aa1118071584f4afdb2796e511a41c4c3f1077bfaf687989022699aa37b5f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "04475ef69dd748766a73f340f1cd52c0e58cc3b6aa1465e26ff5e61b0f00bed5",
+                                "uncompressed-sha256": "31def11fef1c301b56d877fcc6a1af8d57fc5e4b2ffd658525c30a36e27c9307"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live.aarch64.iso.sig",
-                                "sha256": "cc61c448a105ff5a5eda74195266e89ff552113054ecf0a56ad5b2238b91d0b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live.aarch64.iso.sig",
+                                "sha256": "278b6f3ccfd237d9e2d91c4781a9e6b7890cd1a75dbec335085c5a28eb13aef4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-kernel-aarch64.sig",
-                                "sha256": "cc0c5db8f4d1d70162c90018eed4cbcf1a21f407f78dc2f9830020a62a43f37d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live-kernel-aarch64.sig",
+                                "sha256": "5d7c2774ef88f40df2c7f4d5bfeab192852db96a4012dd9a33cc1e64399d4b9e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5577ed7b5314c8a5758a289091912844a387658d08b021b7c6daca5f3e30bd23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "631ba341a2b2d17b010788cca6732c5275cb198a9d74d9d30620e1fee2d92b71"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1ca1de87f02bf852e37762391ad17f0e68fb3c57a6f6bcd3d0c44b2969804f43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5e5b520780c28102975f5810641d851dceaa5fd3fc2f0cff0769d804d568fea7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "abc0d4b584648d3dcf951158c26ae1c86ba9dd5ce5169eaf28f6ad6832482e52",
-                                "uncompressed-sha256": "c98001499b269fac56e95d1a43bcde22054b4dde33a2392b867ed36e26b573fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "96f4a486ae9fd60be1ec0810c4d5d1c0db1541f3a803b941d5ac2b433f3bfb1a",
+                                "uncompressed-sha256": "588d3d5cca8380da91f240b5e9746f3265207cf921a617eef0d3b45308814d4d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ba5529b02279fb4f81259562bd43dad22bf3516d6e6e73cb7557112c03a79337",
-                                "uncompressed-sha256": "76687c2bd68be8ec5324330e72c9860600675225f152c752ce46e6705ad7a209"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "937424de6e043c04b120d2d45c391bf49a189a6d7d8589cbcf27ef7bdef17dbe",
+                                "uncompressed-sha256": "9e21a1990bc072ab05dbded8ecbada4e8f4723706cf023b3f74d5d30d2ca745e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/aarch64/fedora-coreos-39.20240309.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e6dcf64d8c6cc28a003a3fb1d646be98e51caea8d33cfd0285f341d61bc301dd",
-                                "uncompressed-sha256": "30bc39f5f42d386ed414bf98b1eeafb598c4e73c09c4ef5d412136decc0df5e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/aarch64/fedora-coreos-40.20240322.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "57f818db78dd8369fc8c5897baacd65b7a9252f6f5cd92168e42f0c494a2a882",
+                                "uncompressed-sha256": "91ce83d87fe225fcf3beb0fae826e8ab09e06cc0492e6af0ce9500c419d9624a"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-02f10e1da6f40bd4a"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0a9de9334207fd5c7"
                         },
                         "ap-east-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0d458ea018d679d84"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-02e7f5efcf8a40b24"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-089a34c55485dc0fe"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-07985f9c157129ea0"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0e43ba35783ab14c5"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f72fa95a5627219c"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0d5f2a91ccf8069d4"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-07aacab1f5abdd8b3"
                         },
                         "ap-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-04ad48f4a4574f713"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-01689038fc71b2eea"
                         },
                         "ap-south-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0d50820b934d17403"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0ea256a6d32cd39ff"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-063f572ec94a0b1c9"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-099f1a5215d5f2dc8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-044388e826b478e68"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-07f8919c20fb07188"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-01a4e6860193d9e07"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-04d5fcffe4cc851cd"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-086e749e2a412760d"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-00cd14d85bdcf4b3c"
                         },
                         "ca-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-05e7f9abc1b94e55d"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-014a6a31d450a789d"
                         },
                         "ca-west-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0245bc6afe7b09e96"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-017e9318c946e5fa7"
                         },
                         "eu-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0d9da916a2248a075"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0305680376dfdfef1"
                         },
                         "eu-central-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0a3b886293ffb1dd3"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0e4d0250ee1f8a134"
                         },
                         "eu-north-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0971075b8629e25bd"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0a757cf1541aea74c"
                         },
                         "eu-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-03994fcfaea3a5f2c"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0113855ff3ed3957e"
                         },
                         "eu-south-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0cf0d2e13652b2d1a"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-03accb1a93b5f3cca"
                         },
                         "eu-west-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-009e15dc8c4dc8e2a"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0ddbb57c1948f9617"
                         },
                         "eu-west-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0771104d0b396d35b"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0611bf71b3000f798"
                         },
                         "eu-west-3": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0a0a92c65c3e62c74"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0736fe0f261e4e80b"
                         },
                         "il-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0c30bc13107db4c4e"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f23d3e8f48a90ab0"
                         },
                         "me-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-025590886ff03b2be"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0b0930800091d90df"
                         },
                         "me-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0f2614bbf8a5f75c0"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0e7c58a70941d2e8a"
                         },
                         "sa-east-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-014b78d6e692a2850"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-06dd93d719ba7d559"
                         },
                         "us-east-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-02643eac4a3f7d69e"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-08edfe5fa61aa14eb"
                         },
                         "us-east-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0279b04db1c8c9545"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0339e461a339816f8"
                         },
                         "us-west-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0252410f655a382c6"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-03bb21714a38732b9"
                         },
                         "us-west-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-09b94f18cedaed69e"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-08f6e38ddc635ab2e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-39-20240309-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240322-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6c745f3d257163af6d6a83332e7c30ae9d64e4d96e0e79a0f6aaaac9ff0f31a5",
-                                "uncompressed-sha256": "6e72c74114120f0ee636f62863856271294f0bc231c0cb7867ae63b8e71d6820"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "afe253cb7f47d723ada8a25a7dbcce43fb0dff6c47ddf456e4d3f969e8f3b1d2",
+                                "uncompressed-sha256": "8f16418c17c25fb53ef4584d5a53d174c055f5c81d71066215a5b8e722bd6721"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live.ppc64le.iso.sig",
-                                "sha256": "66902578f72b581c2f02a6ca9faaac849d4ed5a51314650f34f7786c12357236"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live.ppc64le.iso.sig",
+                                "sha256": "df149f26e1d5f9f8775ae7389f46685e5083ef859d97296e232282be6a3721f2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "c6e711430c00a439862574ffe2e68da456bfc0cf33306a207a33a6c70eac5cc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "49167b4ec6d77eb81bb8816191cc339b6cd569752feec9bf0c063baa21771edf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b95bbd7130e213bf269bf4712ee24fe716c06dcc003f9854ed2b5dc3ebe61ba6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b90189e7d22bf4d865b898e4dc3f3f339f09317a25b73b67489faf64ff0c0d46"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0887c43f18d40f2c6859af986427f7cb3f03581b7bac1202c0f6b3bcd247ff9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b385dff8c3bded761ec5f84ee165fd0b3c659798b7aaa7b70d6fcfeb78bb9504"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "4c8c445d717a715e19a55dd4657501bdbc26e8f588346578ca187126ae1b6117",
-                                "uncompressed-sha256": "1697c1a03e19b48d691a89311a1471e41f3d14357b4a43d5ab57c30f1f128009"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6b9405d543827ef0db93448066a6398b0a2d0167d2619956caac09b269d19524",
+                                "uncompressed-sha256": "5c12179626ae8b4e7b7ebd1d34708a53ca68851299fbdc22f4ed27354b48e891"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6d2daa7de52aaeddd26fc228498e475ddad07e93c40a6618531dc7a82b502add",
-                                "uncompressed-sha256": "7d2adb2c48fb31dfb32e78e25bc02a6ab27eb0466a2f953b5eb48af1fb05e150"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f242b8bd3f019af8fe7234cf6f15525a7a31316a8885143a14843042b35d0484",
+                                "uncompressed-sha256": "dbe6e0fcd3adb4f172e26d2fcc25f57042ec15bcced11882bdea62973a4a7a87"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "1d502d3f9331243ca90c3323b69e46651254d1d04829471d0bffa59f713adc79",
-                                "uncompressed-sha256": "66375ce2a3218086e3cb7f23069d11daea061e8050f6ba96ea52bca0a8ef2d9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9d0c68a9fa15d6ef36972d12683434931cd167921e61e17761e2c5bd935cd18f",
+                                "uncompressed-sha256": "874a331066749700db8ea1955af277b79203e9a4c7b3bad8551cb6a5d864c7c6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/ppc64le/fedora-coreos-39.20240309.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "8ae824d01ae116f112efd4f9efa99a5acafff58890648a83f6a04b435bbac4fc",
-                                "uncompressed-sha256": "823c7709379abda56efb3f7453a1747d3024460d8c42a7a7d6ea19d37b8c9809"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/ppc64le/fedora-coreos-40.20240322.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "318312ee6d9f13f56faebf7bd1643fba053ff913c45069210747478bb6ff228a",
+                                "uncompressed-sha256": "38a636d882372bc794744818a8c83ac8aa232226fac7e342ca08fa4f87247c39"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cf828c6a96b561a8142e08db5282e9a278308f541daca8a3deea398bcbe210bd",
-                                "uncompressed-sha256": "0bf10a0c9789278e012133b076fd5b63904fdd52dfd04be75bd8fe6a661cb0e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5877c478d646f5f5db6a1fde06e640dd9e1004abbe4b8b4990af18f9f74f798f",
+                                "uncompressed-sha256": "5d55cb65dac89ade683140668411753b160e6260bb80e8f1ca23ed6dbc79dc91"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "98e92671ecce8d2c87d2792199670cd61cb10b90a912a840d0e67ceb705daac6",
-                                "uncompressed-sha256": "89bb4a84bbaa7b81407ad1bb305208aec9f6a91e410330236c0a0e9f6373fcbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1cbaa5f0ea20e607edc5d8b998e41f5fc5405d6dda54d10b664b114ef3069872",
+                                "uncompressed-sha256": "e8b84819cb6bc3d37137e84829fc9dc9e9e2a9ae2d6b621eec4b456b0d13e04e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live.s390x.iso.sig",
-                                "sha256": "104bc5905f8acd17af02212c2f48309c2f1aa79fde64f9672a3f7b35d5a08c9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live.s390x.iso.sig",
+                                "sha256": "568c5656ad2f69a1492d403ec1238506023a3077ad6e5257c4d7bdee2a68d646"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-kernel-s390x.sig",
-                                "sha256": "a1ea7d825271b9611f21f27b37dd91decca26c0a67391fff4dbeaa93ccf73259"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live-kernel-s390x.sig",
+                                "sha256": "1e40c2331cca4e1e8df14a212ca4888faf9d178ecdf23940aa7b90aad409707d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "341381f28c8c5261b9279883fd9ed4dfc3ad5f50281c7787f9d211d9ec754e3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a84801d5300eedecbabac9c304cc08e0a5ea466151a335da7d6478cc86a4b41a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "2f13996bcda29d0d7481305024f65b8cae8b80e0de712ef6e44876378b7dac73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "8f5da5a97df5b0e631076c2653bfe3a0c7648e5e1ec9ba47ffb59078be3ac1ab"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "b58a86f456fe1c80efe504caf3a7e162124a2b8c15dc176c82dafbc30520da71",
-                                "uncompressed-sha256": "004e7cf1f451e53834244e90503c0c4d4a1f868123ee3e741142f549fde5fad1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "172902aaa682703e7e48c6f6382d5462dc8eef789483775167036dd03125019d",
+                                "uncompressed-sha256": "e0911f8f0bd8e6d6b5c441ff463b8027745b53e17396e3ed1dd03b533efa1fcc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0cc3e0c1d7bc8f5a60058b8059db268d9f1d144f1783dba27b29fc02964d6b2d",
-                                "uncompressed-sha256": "60934b2eab6f6bc3e67f39eb9e89f0333e769f6a2b4150f56ea09a9fe436a4ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9f3db02c3899034983cd3d0aad3b79f31ebecd20a85cd2e5d003b1ec832beb8d",
+                                "uncompressed-sha256": "0e77ec2902b4dcf2b0a4e73c127a93a42466514be94860acfae1e8d79aac38c3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/s390x/fedora-coreos-39.20240309.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "66548181f8c2d0b7b23c204f64ebe18b99f80d58f5a2bb8165f55202dabc0c67",
-                                "uncompressed-sha256": "aad95e63c28f4032b3f2db69bd92f863968febc5360288e6e970b513f5d7b67c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/s390x/fedora-coreos-40.20240322.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3f011b3a39886cf836428f3c3f6f592812097d65f0fc754f7df89780c1bb80d6",
+                                "uncompressed-sha256": "0c730b06bdac4de4ac96934b2967ffa52dd851cb84c5395eeb7c47706fa7a7e4"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a7a545245b0d54e5e2d7eddbb779e098d6b6ca7ebfda4e07adb39de8c40a7f95",
-                                "uncompressed-sha256": "31bec89ec199e3a9957c0b621bdf4d3591fb44e6be5f5f3fd82430b101dc71da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "525b85ecef01dbab9a116537a82d6aefa45c8c001422a099ec3266567e066e07",
+                                "uncompressed-sha256": "02f57dc834ad4c422b22ab5946aac526d253726fc36d71803e42c8919748535b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "15c4dd3a65464c07dce21f177d9f28cac2fd5bdb2d995e8f5a8f462b177c606f",
-                                "uncompressed-sha256": "cb0e8e6318fb85c0a529e76bdb0702f8d64a3aa44d56f304d7e8908c5d521b6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "772e8427c347839103fd02517fb8ec33e314f55273b64b4684c50fffe7192462",
+                                "uncompressed-sha256": "320422ef9221c6506965c421f975b0b7a9ff892ad225b0794f0dfe75733d5914"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9ecfa29fff6de01ffb350af1c162e99ab174852eaf62c3e9b83d20540668a4fa",
-                                "uncompressed-sha256": "e85ce44645a633f8be4fa8823baaa7b99d49548928b5d71f4e0a369941b4ecdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1822c902e4e4532b8eb379efa3a05d74efd05c796ddd29cdd4302325bec438ec",
+                                "uncompressed-sha256": "e0934f1eb048187e024ba09de9d07142ed9dc310bb2513f0921665b14ba994ff"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3e5b22f3e96aff5e7bf7b8e65054b55bfc1391e9507c45d12bc59219c12af193",
-                                "uncompressed-sha256": "2a33c32438b89a751963382cf0f7d51e0c9df8919d4779df7ca63739f76647c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "77977c40a9a90359219c02dadb445abe453ead27e18fbc7f1235113999369e17",
+                                "uncompressed-sha256": "a89fd05f39ff9091ce28831e1616a5e4dae4066e1aae7aaa51eb74bc48c19fac"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8a126d403a992602fb3564a54bf36db8effabd70fca136160c703abee96b906b",
-                                "uncompressed-sha256": "aa64578e7e0b79c7bed7ad9176c9b51a506840fda74464214384fa965c2c18e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8b8052987b9b5e74dbb75feccc0f8db223d843a351d2154a24b85c5fd4f1a306",
+                                "uncompressed-sha256": "9c364f8b2c7760155d3e86450b83add1dc4a50716c13d1fd77de1f2cdb2cf282"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "faf666cf87f1d8889bd6a057839bc044035b3e8f325638fa8f2d10d1689a32ce",
-                                "uncompressed-sha256": "d31fa81bea25003fcb06c8582549c58c46ccb31e35387ec7b6f712ba162dd599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "758ca77baee4e9bd088346873a9ba00ef3e388a59df41cdd6adc2cdfed01129d",
+                                "uncompressed-sha256": "949bf9be5ac421bd4add1a82e8c39962e882d19ba0a7c8b1f88083fa7b506b83"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "40ec4fa199def4520b11e17688c33bd2369609c7b2a86b47757f9f0597916daf",
-                                "uncompressed-sha256": "73e24d1a0de4953dae6602dc648b70161fd0b9ec5f274301bb735a108ae76a89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4b0f839b82c37aabea8ddbd73332f6954bf04f1f2d024be4759afd51c41f981d",
+                                "uncompressed-sha256": "18bbfd34daaa480e68a8495c948aa279e2c243b5574555bbd59343f3f05aac5f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fd9e6a0e0a998d1ad8fc06178ffb5806061341e426316438b388e17a6a31bec4",
-                                "uncompressed-sha256": "3fe63d3ab1f2017b404eedb533011f2f0cd9bacca8c6dfceda21319b5a1ba5b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "732e7cab2f6004e5f3bba0fb1760b04ff00428db1179b8e746b29391fa566bf3",
+                                "uncompressed-sha256": "dcc6b683bc1579a203abed910acf372d2bed8eb542a6f3051b3fa22e124a2958"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "a9de36caa29e4a196890fe89b2ee8bc44b831457954c9ed67e7326282cdb9007",
-                                "uncompressed-sha256": "83c6a2a22d055e7c90f4a2253d55770086476ed9aa25ab64cdb83f73b6e2348d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "3295f133032d6e34f3e9441b2b4c992a4e95ea5201460cc6575d04ac10eb9aff",
+                                "uncompressed-sha256": "a517a8f2358718d649f265f8f31e80a75d0747934fca92019691de70f6931e55"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7eb50e9f53e609a95d46fea1fc2f28877a1054f659c40c2ff6940497a836c2cd",
-                                "uncompressed-sha256": "d8e437ae15f6a8e7548c7c803b18da6859054fec4a271bd7e6397f67e5c280c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e6a6e8b3bb5f640166572b931d8dce920070f142d214740995fa40ce1eb9773b",
+                                "uncompressed-sha256": "f32c779f54874810b8b187f73c14fe285697a2ee752069758259171191aa9dd5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "01fda0fedc5e9e2cbe79cba358d98b0f68fa43f83411febf446fb4014863f9d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "98d30dcab517ccfac156bbf511a2cde5ccb81b99588174c4ae2655f0feebdd6b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "154b13a705e0c2f8ad7515be6c5c1a0cd32ab175a6f1d808d16e52ae2c17be27",
-                                "uncompressed-sha256": "3387b3b33e77f066be1e10c6074d8e0d3e04f0f2d049146f2eaac08d8ec80cdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "552c990217d69151cb42ef347b2120573a18f9afb7e710deccddbfcba13be3cb",
+                                "uncompressed-sha256": "5e929415b690d27dfb04306ceba7e8e3a82a9187be43a6ba0e566b2d9435c7f3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live.x86_64.iso.sig",
-                                "sha256": "5aa5f331110d872e77f49ef71d8707029721e31240b24d6b7ca3e5fd6a1d5e7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live.x86_64.iso.sig",
+                                "sha256": "476359ee3848eeeaecc860fab4e06036a6abdcab478f2eae165750950617d4a7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-kernel-x86_64.sig",
-                                "sha256": "64ec45261821b16896a601b46d49304dd22a4084f1b1432c6dfe13990a0f8fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d3d9cd8fc1828c11a160212f948fb1d47f8553bed9248009db8aff334af9476f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "349f79341ee636ca8afd969b8f53ac3bd669725bb7435979fb2b92dc21f2790b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8e85784f28d6cfeb95117ce8a48fa3d07943b11130f6363b60bab6c4799e0966"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ef6c2887cb45d32cf454ee341e8fa279c8a0380f78dc33397d539e19fc577729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "67c4f32841c17696be133dc78e5ad0bb2a6df2eabab6584953221b7ed382ebd7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "22073c0db807c1828eb484c55f6b44890e57b068c361f5841d6fe2bac2d05866",
-                                "uncompressed-sha256": "82e73a39c99a839ca412eabf4aa469b58da671bd37e419d3cbc7309582b508c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6bfc1939edf5b351ff9f875f9d85d35e035acd8ea49ec9724976aac484d34969",
+                                "uncompressed-sha256": "0469d973e766b443ffbf4a07a74284a9a503cd7332c4e27356991b794283ff8b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1a76bb1abc723d15b806169e570c1f49d0727d7dbb272ca7cde747dab2e2b36b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1b091068e60a3f7b8a562578c258212c8cb071a572e9031655fbf9369d50f7e6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3223809af97a3773ae41eb58d60a1f14dcc4a35cf65589b063cbbc6ddc0bd509",
-                                "uncompressed-sha256": "977047eb0c6c9d8131a45f87c6c8068ca83b874e2d10039df80e8ecf4cb4ffa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2cd4f213e19ab341f54910dc85f62bad99d66ba7bc8cbea5e8f99e1e219a6104",
+                                "uncompressed-sha256": "beb6b5b10af286b45d6bb25c035877603ac2ff4330b094a91e9e575d22f41254"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8f298c450151c5805cbf74de85975876d3f4fc6a738c56786e35e761b5e9ae28",
-                                "uncompressed-sha256": "95798ea4d0b2d0ea711f9b02438e3e0da0335028657e062bb4b243fe34a00ed9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d10e51ab862c3d66d21ef4d315d8ba7fd42217c0498118d91cbb99c184a032eb",
+                                "uncompressed-sha256": "f2ba9f45415e9be625e78d1df3049f0b426e25e48e569230ff9c237dff82a3ca"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5b4698801ee8b0f33194cd47df9f8a135a2ed52819dc0d1c71ae746d6580c894"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "ae59f7f99f04a3954e1a5f0648dbe1efda139b9a7a2e6cec357cc190258f76d7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "cc7c44e25ba965a87d17e1cb4c914ce55d6b893db80bd8e298a7159b9788344b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "4ac286bf3679d29063a4581313dc8b11f84ec2895558e668db9122206574ba1e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/39.20240309.1.0/x86_64/fedora-coreos-39.20240309.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9c778582cff59ef118d28092e7b52e9d7b48157738ab509812a952c3c04fbffb",
-                                "uncompressed-sha256": "dcb71fd0c970975eca4630e8c9ffd0f2ec7e1745bce79123c5f7f26cfa367a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240322.1.0/x86_64/fedora-coreos-40.20240322.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ae0d0e2ec645653da2ab73c71be5addd791952746e38402fe692342becbabd6b",
+                                "uncompressed-sha256": "586e3a5e67cdc0c59e4d51bd043684cc4f4c08b247f58ae4b6d8503c9ac60c20"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0eea9950f0f74b27c"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-01acf26ece453c25b"
                         },
                         "ap-east-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-02e482c00d676ceb3"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0c0ad1759e0576a4d"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-03b4f736aff955517"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-09e79a0dd2aec75e5"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-08ff81e6241608497"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-035216414a9ef7b72"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-011542b181651a68a"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0a10f88f4a2207d0b"
                         },
                         "ap-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0e269cc2253f4b33b"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0ae40f2ac668c20e5"
                         },
                         "ap-south-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-04eacdcdbadeb90cb"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0e60c67768c409ea9"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-08b1c6e1dea8b73f1"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-048726aafbf5f9ebb"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-054d01692c0bdcc12"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f761ebe0472520cd"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0eed852f682777ae5"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-06629f35688366feb"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-01324d3198676348c"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f8edd753f9efe023"
                         },
                         "ca-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-04ef41f475f13562e"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-04fd224c4585bd745"
                         },
                         "ca-west-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0b7addf4a52ac101c"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-08685322c3978a323"
                         },
                         "eu-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-08277cd037a794c3f"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0738495a4a945cc5f"
                         },
                         "eu-central-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-025ca1b8d2134d5bd"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-02b3c6e149952276b"
                         },
                         "eu-north-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-09899e421708c374f"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f654204e5b26bc13"
                         },
                         "eu-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-078660f83363b4b69"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-064f3b13cf42ec730"
                         },
                         "eu-south-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-06ea14169a818578b"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0220d9897b410562c"
                         },
                         "eu-west-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0fa10c65bb8c8765f"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0ac38c1e222e4d0ca"
                         },
                         "eu-west-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0a583fe9cc43f2973"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-009deec907449e706"
                         },
                         "eu-west-3": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0f997ce66fb9ac66d"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0392ea79744229f71"
                         },
                         "il-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-088c1dab4183e1d5a"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-08277ea0f8fd04e42"
                         },
                         "me-central-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-094d2e95248661374"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0249f4b42aa15353d"
                         },
                         "me-south-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0a1d8bc2d226322fb"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f33daa72323e0977"
                         },
                         "sa-east-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-00d987114a41dfb18"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0537a3839a7b15a6c"
                         },
                         "us-east-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-0f87d832349109851"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-04c198e0ebb947484"
                         },
                         "us-east-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-015a1dccd04e15caf"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-037d369ae5c0cf2c0"
                         },
                         "us-west-1": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-025821526249d14f4"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-0f8428c34af86752c"
                         },
                         "us-west-2": {
-                            "release": "39.20240309.1.0",
-                            "image": "ami-08dcf7f53cd8b6c7e"
+                            "release": "40.20240322.1.0",
+                            "image": "ami-06d1146a6c4110311"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-39-20240309-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240322-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240309.1.0",
+                    "release": "40.20240322.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:af33397206febabf4aa9b83b31ad830c6a5580e0b7c65ed07049972ac901d326"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:540f8fff2784a0c0df5e529d3fd1ebca9d2103968321ed97c4ebf9ac959496ba"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-03-13T18:34:32Z",
+        "last-modified": "2024-03-25T14:13:43Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "fc147b36c8ceb7e5b989145dbb02e35cace6dbe07307b3066f7222015e2712e5",
-                                "uncompressed-sha256": "ad4616073913e13a2e3e15aed29f68864739b492d6210bae0564a0679c2f6611"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "930ec48509e51f4c8ce7331ad98752ead36a1cfdd58636e1d2f17751c815a903",
+                                "uncompressed-sha256": "bb5ba61beaa956caba3d9f129e37ae2205c695016a2085f27c5bbc6fed0f2d92"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "95dbd596c1ab1f5d0e79243caeb4510f525da9420bddac9285277ae7be05618f",
-                                "uncompressed-sha256": "527295379ba4c7c866f4df677d10739e7009b3dc5e3736edd221dbca7bbf3f44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ae7249c87cb0b9d30e6b2a2a302601e190c3cb02927caf2284e45b70c8767798",
+                                "uncompressed-sha256": "1bb38fce6a07b2a4111ccda8d800e81dbef9c1361aeffe31f093451daedf8e02"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "722a0aacc72c1c46cc3b2f425b7ea1a0f9ee1f4fc8d4544e6a00aaf85e3116d4",
-                                "uncompressed-sha256": "331de64a4fe2c3f62b0596b743d108771fe3f83543a92460006ff01e658c642c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5b611242d3c949efca32df415ce41a144a0b453d1890efc6348dc9ec6cd8cdf8",
+                                "uncompressed-sha256": "b45b798cdf16312714327efb12700ff7c6b1b25f79be04806c92e267e9f8b6a2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3b97d24630d3e719c54a686c5e9bec5034b50606c2a030e8040be7f742e0a247",
-                                "uncompressed-sha256": "26db6f4bd0d5a77f7c723f046c40621b6e6aed641bfe0ba6c56aee76c5d6a526"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "9acbc9eedfa4dd087f5d1decbf92034e3165b657e3674331b7988a4f89e11d93",
+                                "uncompressed-sha256": "794da16258350f5387291e1741efcd83b415d1891a0096de950957dc5db52c8e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "be9ff74f5a792e0f05cbe764e393840ce410d429643f7c37a4003f1ed3edcbde",
-                                "uncompressed-sha256": "f8c20db33d2c0f0b67b7ee9e8670a631585c0416eb7cdabd93fe3d5536e2682c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0977d21f18195a69f43cd7928ac68bdc43653170643ed10e4981e00f553e69a9",
+                                "uncompressed-sha256": "fe8f9cd91ca0d796316e540885489d8d2959d707c41a8c76e44eaeaef0ce0f2e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ef6aafe1bd69bd0d42d499a482382930f30ce60a790139a6db208e8b2e50d96e",
-                                "uncompressed-sha256": "59c65258cd92a42e2b5bc489754f64920accbac69684ec244b4affe9363409d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "834d5bb3e2c1f43becbcfd6fe3f85b8f96c5c43c9f26cc61a7f88d5376a5439d",
+                                "uncompressed-sha256": "fc22ab20945afc528e0de1236d90e54e6586abc97f923f6bd09f8d32f3f97c4f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live.aarch64.iso.sig",
-                                "sha256": "0682f3fef774147c3c16480bcb259534331431922cf60f81146b858b032f4439"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live.aarch64.iso.sig",
+                                "sha256": "2456e8835e144b0bce4f546e65d4e6c10e5f742c7ea0a47e7e80c4aae505f8b5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-kernel-aarch64.sig",
-                                "sha256": "3227da858d43988b80f31087cabf245d9355fc764f7f667a1b361cc99ed363ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live-kernel-aarch64.sig",
+                                "sha256": "cc0c5db8f4d1d70162c90018eed4cbcf1a21f407f78dc2f9830020a62a43f37d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "91b249564f17ad216b02dff6272bf1abf2f0fdea1dd3ef8714e6e540ee83c912"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "483dbbf87b3045ee794123dbf90419cad497b82ab3b734c16936227bc9d49e42"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "605f3883a808435023024c70eb2e8ae8072097996b4c889df476934ea057ac23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7b65c085f70f143f83f3dece5ac3948a0d13a71415a28dc151eda404c998027d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "028c0562396dcea0099267a425f7795ae638525f52c82e5e3a81e68cafce86ee",
-                                "uncompressed-sha256": "c0d5b8598785c8e4bc7681612df3ea95383e533df88cd6bc3d762273d7335ade"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "548299ba4b0b3b0cc94a4aaae1e8d79b757f3d87a68032652c7951d018dc7f8a",
+                                "uncompressed-sha256": "a5b84d78302df0f17d84c16fc9e8ea6d5196250b54bc5c5fcef682610240ce3a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2a2fcd9ef67598de81503d7b0ad65da780098afc6e0103c24ff997d36252e356",
-                                "uncompressed-sha256": "695b7f5cf8186730501c0b8345b8a20a6f780051c377af9f58724d459e06575e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d259c81900fbc4b5e98c3b446739d606c9157e4fedceef1e66391b21d5539b0a",
+                                "uncompressed-sha256": "9dba5e90a15f997289b320ff58f0ac3e584fcc0d9e0fda925bd0fc2b90cac1b3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/aarch64/fedora-coreos-39.20240225.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d009131608db3fb7b5100217f245f641d101eb411450b27519a10662c1479ae7",
-                                "uncompressed-sha256": "bbfdbf318aadb358e372efab3d28d2f8e7677c82d8020cbf8a33839a7f25dd30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/aarch64/fedora-coreos-39.20240309.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "bc2a9b30e39412d9713b82c38d522254e29be5ca26ac0684aaf6c370fb47092f",
+                                "uncompressed-sha256": "5d7a1f7137a4d60e516bfab2743bb5778035d9f7721125761f7e9c8931a95cd1"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0450ef14924d761d8"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0182a08096cfefa9f"
                         },
                         "ap-east-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0ba718c15a8c2f7cf"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0fe863ba8c16aed0f"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-011f32ece0b6fa094"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-00d4e3c15d5118e40"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-06e266e3beb320583"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0827c53158c088817"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-06466e4d5b19ca655"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0ee07ac79bba7c7b3"
                         },
                         "ap-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-01117ed9fede92c2d"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-01a7c4a8bb5ff7fc4"
                         },
                         "ap-south-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0ef5ec3189f8df2b5"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-04baa6e1fb6f8d14b"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-03d38caaa100071ba"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0aeaaa629ec49bba8"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0b08229b424b40f49"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0f470bbe35e3f6e0b"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-00c2c626ff1df3b20"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0d93ebe7c7f1ca6d2"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-062b52642984abe2a"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-01141a5ec696f9abd"
                         },
                         "ca-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0410261666d16c90f"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0da2973054ddeb827"
                         },
                         "ca-west-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0daa761eb4f6927e3"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0d4877f2ffdd6960b"
                         },
                         "eu-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0830961058b670e65"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0f6685798dcb0d105"
                         },
                         "eu-central-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0b37f3b5bc1034cd8"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0084e419a1b4bd83c"
                         },
                         "eu-north-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-030020e7f0b4101be"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0690a93280e56dbc0"
                         },
                         "eu-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-057d3d16e285decbd"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0b17362f6755c8a63"
                         },
                         "eu-south-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-06d56bd3acf7fc27a"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0dba42b4730f0db9e"
                         },
                         "eu-west-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-019d4dfd2306c8e83"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-045129382531cddea"
                         },
                         "eu-west-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-00d63f593b727161f"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-00a294763097d9b42"
                         },
                         "eu-west-3": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0f65f712296f64de8"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-036d1164aa785209b"
                         },
                         "il-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-012dfe209929ac359"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0d9fce1a408dc1c1f"
                         },
                         "me-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-00de206996fe04c02"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-032ec91b3d9741301"
                         },
                         "me-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0ab7f675eafbb0715"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-007db7c9f7e7a1be3"
                         },
                         "sa-east-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-071aae83887dbda4b"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0afe2afd17e37aa75"
                         },
                         "us-east-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-00c3b61190f39235f"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-078f716ad3a9335e4"
                         },
                         "us-east-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-02addfb382a67a6ff"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0202c21399e0c6470"
                         },
                         "us-west-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-00164a98d09e41eab"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0111636c375a0c254"
                         },
                         "us-west-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-026f3e36c4b6c925f"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0b91842b38b9f2924"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240225-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240309-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "695aaf7503b69a0d6830768e058bbc7190d63e300bf9a46baf96151b8c3eca21",
-                                "uncompressed-sha256": "ce3c5f7385aa05c7ee52e6a5d91afe0a0dd533110f9102486d9626f3aee9c693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "36521723dbae207ad415d611f9bf61d9a6581b6073affed21adf6102c74c3363",
+                                "uncompressed-sha256": "d88260162f2fc90a729546a07b6faabc708121bea3da9b605080c0cedc45662b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live.ppc64le.iso.sig",
-                                "sha256": "f6c13697b6fc4957086e36fa0f5d88645c124fee3ab391f92498bf628f42c02a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live.ppc64le.iso.sig",
+                                "sha256": "dbd107df7dc8d155f1fc689f44e5c98c9fe3cd0f92d07f8d8798e065cd4953f5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "122485b01899266292cf32d81b9b26c45b63fe7d514e7ce5a9d0b0ce635dd925"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "c6e711430c00a439862574ffe2e68da456bfc0cf33306a207a33a6c70eac5cc3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ed4d05ba5a7a32e83af00ae791c9680761cc1766083a9c2839c78da0d5469733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0f2bff6078d39c48803a043a4d96c841d54a3c90061f201b58d500e1f42c614c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3d4801fd9ddfb7e9de187e772f44828e525282cc71551b524bd06d7862f307b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "2fd0458a1cdfea0dbd94320c7db3343ca01137d63f9557988f34c653cd228b5c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ce627a7de81b930a891b6184772a81ab377790983e76d1ce642ce03b0427e1fe",
-                                "uncompressed-sha256": "6209ec2d7ca332f00a6e772ddafda35d910dd704f534861b51d3b349ed4567f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "33750ce3f2f8d866640c417000a98c2677e99ccd04ab96c18bfed5951b47c008",
+                                "uncompressed-sha256": "599413f7cbbcd46bcc73d2e83c2b7a9f9449e4af09f50cc6bf845fd7ac88101b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "60abd35c578a8a74e1f8bb669db74a78157f68ab47d0ab8082b471f6adbf5e11",
-                                "uncompressed-sha256": "1bb76ef50c201b55bf386382f40109ebae8411ee7f7fe72d0091df95b826fcc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "deb78a325f9eb72d93976b3c2b1983619f9701633f82aedadbedefc8560f84c5",
+                                "uncompressed-sha256": "8515300de9efa62bd76363581ecafe81fae025d1e1aa9df4c9b039307194a1c3"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ce3b722a1102f25d07ed6aae2942003dd5e4d17bf8b6e3b4b1fc5d66cd2d9fdc",
-                                "uncompressed-sha256": "090f5b9179d0bb675b1ad6523c5fb7bd3268ce9d55b5ca3d1d62ade06d383870"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "d48b90dc7133e7cd3d403dcef96b11e233580f884f6d997c379a2a68808b1df2",
+                                "uncompressed-sha256": "81867611c859a976f5b226e6d24be68af71bd1b315c97f6f6a5d5867ce782f8d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/ppc64le/fedora-coreos-39.20240225.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5e9096c73feb259c66897a459c6284e0a7d0ebb5d52a71886017a65c0200d9f5",
-                                "uncompressed-sha256": "fa55fbc49065488a21a1c44f9bebd76f3ee50e1b594488b2dd586df4091a31c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/ppc64le/fedora-coreos-39.20240309.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "67156ad5461fc6c3ae450df1a15324e459e540582c14f78aad16634a5681d398",
+                                "uncompressed-sha256": "2836028559226c766e90c8cb6ac49279c59f42ce740ef84017a4ab34f56b629c"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7a7990e3126e7066290f47325f142eec4fdb3efca6eae5169ad49116f3c99571",
-                                "uncompressed-sha256": "363dddc8b0b40b2a827da31c5dfcb3a246d6c6eec23e33f0ecc5b914761e9169"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "15feb1889efc593e9155cad651eed3e9c67f1e99c5e13ccdf4ebbc1aaaeabcc6",
+                                "uncompressed-sha256": "992e3cbbe3bd2197e5262b25b449ccefb5b6e2fc926fe4f752fe9142395f1e60"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b40cd6d0eb476c44411032e38ffe062e128be100359738bfe02488f81a5b1075",
-                                "uncompressed-sha256": "2cf93d68ac2ba46565e9161df8a8ff3f68743fbe6ef76e7c14793b8aeb3ef569"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e04988372ff45656949c592decafd5e94aff0b2bd32b3b78971fedd9aff4d174",
+                                "uncompressed-sha256": "21e218ec2bdb2d070440838c614c29833810aacfbe5d56dff192152122b4d415"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live.s390x.iso.sig",
-                                "sha256": "6a19c3a6d3f88a3673f6b64894ef7829868c140de833799c8b3ba528de3fdb24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live.s390x.iso.sig",
+                                "sha256": "c68130d95525ef69521df38c3911b4a3c2caca13161629d82a78867823c1e8df"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-kernel-s390x.sig",
-                                "sha256": "ff066d94cde8640405ca9c7f7ffa871e1adefea8ade5cbaf60b15de9de98dfc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live-kernel-s390x.sig",
+                                "sha256": "a1ea7d825271b9611f21f27b37dd91decca26c0a67391fff4dbeaa93ccf73259"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "d321d2d0046a7e1af3a1f39b179e2f0ff12cfcfe1e38f976429b52419264fc85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5fe4047c165fd62e37ee906e9055e39f19e73a243b33995b5393fcf45a47c681"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "286e7ef1c63703d4d351a89ba362a1c037d2290249ced868fca77cad7702c513"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "8773edca7386d70296a3d104954f537b5c0c3deabab8872aa2c0e638e5761dc8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "b49813a834385eda19508f6249e11f94b70e2626966b5a1ee04a7cc8edbe3482",
-                                "uncompressed-sha256": "ee45d5059e02944d6ff746f6716ac2e8008d108b8adc4888c2c9cf2c8135abba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d27e95407779a89a73341bf471e12f022737b10073ae67cf9e22b33494b3919d",
+                                "uncompressed-sha256": "cc9e6de7d429e5c9c6a353cf8c093f7c1c37214d58a894e129ef2259cc09b6c7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5e037ae1ecc65476fd80ec854e46f2924256388bdc4dffdff00984ca74ce1cbb",
-                                "uncompressed-sha256": "6fc37ecfe8c48fb59ced108988b6d86e2006ea388f2a49029470e6bd21c6f2cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "58ebd70946c04490840c130ae92d4052e78e7dcfa7ec8d01ca40ff2073307979",
+                                "uncompressed-sha256": "31fae5c112850f5616b7e23785486de4a292d94d66f994365078b8794821d23b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/s390x/fedora-coreos-39.20240225.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "0e6fb107305a375a0998ce0de5564afd653b7caa636b9f9a0c75a1e5fc345f34",
-                                "uncompressed-sha256": "7aec8687aefb13122d20d35b97efb0f1dacabdeca45b1941337e4cbecbdeae76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/s390x/fedora-coreos-39.20240309.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "04c75e10d3658acde4264c3cc70e0669d07131680b9272cbfe0f410f2554f087",
+                                "uncompressed-sha256": "3e19bd982faad544dd465ee59378d6ac79ba82bfc880ea5833af636d4b0647ec"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3586fa4e876c43f9699134182caab874d99840fd5a50f368000924e9944ba16b",
-                                "uncompressed-sha256": "1f2b2b0953aab177a3376aa1b4547f0843171602958e0a70e9a5ae12b446f75c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5af7c412d0d0adad1061f6f180b14653fa166631ca42e6f246602018adc1f258",
+                                "uncompressed-sha256": "41270995350b43a13c989512a18ed45d6a8f5ebae014d92b4eefc247979f61f7"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "d060cc8781f3a7e434da4af9b11bc9d9f49bca05bfa581ac6833cf2c6de877bd",
-                                "uncompressed-sha256": "753218ec7888961e7e0b9419a5649e8aa5c83fa6fc3c5fc156ee936157e11028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "b73f8e77c036988e84abe921c843045db5b13135f6de6e899f67cb4a92590a26",
+                                "uncompressed-sha256": "54cc3e05d2b997e7df02145f6d6b83493554aa6a21d3c31dba91e4b8b91e8d10"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2b01aed6c93be81223b94161495362c80f3c966dc624484519a4903c450952e2",
-                                "uncompressed-sha256": "e8ec7e669f37a6824e25cbd4bdfd048a6e0e9108255e06c551c5db525cb213b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a15e09d4dbf5917d597267a2175e56260caef569dc69b2e1213e9217f953f6bc",
+                                "uncompressed-sha256": "deddb74861fbbad62c3557ba1de27d836aa865c9d2cf15d4d7ee7fb8e3e75ba4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e802d4f6a0505d5eb5700f8ca5a3e3057a2838cd165346793526e2aa5bb6b0ed",
-                                "uncompressed-sha256": "6b6645b386f1e856fb5ee61159343ec58dd34d75d2111aab50c654be5298f32b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "38aad3a0fa8fc0024d02ee094ff114b65c21677cdbd702af6e51c1b75ae768eb",
+                                "uncompressed-sha256": "c0f1b00189120a129217319f527a541c4403681a261f49b164a9eb4b884bddaf"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "22d02da2b21d255ef397628e52ac11a9df0a0afc8544b32ec47366b00345936b",
-                                "uncompressed-sha256": "7ea24290da99da31921b468a484aec1201a1824a1aba5c4dea4b4e4d92ce607d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3acfd99a73898b40b2116ed418133105d34d6ea865734d9addd8fa20a58b4e4f",
+                                "uncompressed-sha256": "d56f13bb51274f5241c5dff76ac86d1108bb702663cee75ed4be581ef87ad1fe"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1aab2fb6bf7f0861a82e9a31553b6c8b5694089800761b1f51c9f86fdf057ea6",
-                                "uncompressed-sha256": "cc12ab0a20737e230e8d2d22e15f4e380427d4a5e8bb1fdb98065acac67b2d09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cd9c3922ef27eec52bc8f31b498ee64f8e1b4929b0f0fdc0f7dee84c5ca521ad",
+                                "uncompressed-sha256": "07092f9b836c79874120cac34db5ee8bb51703ef51ff23182d8cf45a34a81cca"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6f83729187983dc5b2a73d007eedaadfa90e6d261713880d483df9c33bfb3be8",
-                                "uncompressed-sha256": "294d2aa674061c6503de31f579db2ce14a191c3a250e9a58701e440e7242fcc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "aa0f9f7238d7ce889e5d799e5d3f6d49258d91bdd4571d0c10912265d453b68a",
+                                "uncompressed-sha256": "7d22ab6f239aa83bf74f78bc94609482d0037e9ebb0457aaca5fc99bc51bbad7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9630d788125b3045544413b5976cbd30871a68efd904ac58c4c093da3d4ac397",
-                                "uncompressed-sha256": "72bf61a5b1bcb86db79f134b71087e16bb5923d5d533d10e07a4ca1259c07b68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f174e1401310b42a78b13845c77de858aef6f8cbd03c2434c5d74832647dfe6f",
+                                "uncompressed-sha256": "785d3c37794f606c231a4e131e356756485f9ab8a0bc0c5e428964a0f29349d2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "c1b97a8333ce40e6781f442d63ff7890c56c603ecaaba090e164d1e7cff24109",
-                                "uncompressed-sha256": "a0c7ddd2cebb955522dd295d9a4beb4e64f7db656d810b2790a8b048e82844c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4ea5edfb15783ae4da284087f82e9f0c6cf2e2a86912602da6bc636242cf3a0f",
+                                "uncompressed-sha256": "58cec780b32d1ae541e704d429fa0b9ffc2f9e8eb04b09c3f6de6471d3b459a6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "124835f15fee0b879618d3a2a39fc47cc03a354eaa57c8a090f281a0b8d79dae",
-                                "uncompressed-sha256": "74af32c8023462c19dd34c1a00b119194d8e0103828db82fe4b780bc570ce2b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4c3748b37e11e640fe7f3d405556717ff3791ca22b0208e6db801225f41915d2",
+                                "uncompressed-sha256": "fd6da00da3d753da7a4caa70aa6506d03497ace94c45865b8cd39a5e00649bbf"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d825f7feb1bbae761706d22c2aabbc2dc006b09f7525b42ff0771264566b59eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "da2a50de82953f0f488010319a37f116fc1c131b3ea4cb7bee5432934a1f4b15"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1493bcb799bba0f0e44e85e52505ea03f5a25750e8dfb7dca5684e0b29247821",
-                                "uncompressed-sha256": "030ecaa8643c782871220b1c41b7e0c07602a5a942c36dbf7c4e069e1da9c250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "318fb9856586f02ddd8ac6d2d96abc9b1fd7833a5f4acf313d505ec45377c3e7",
+                                "uncompressed-sha256": "47ee9e550f6af5c98f6b7f58fc62fb3679de007be560d75dd768b54a9afd29ef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live.x86_64.iso.sig",
-                                "sha256": "864473da38e2c2235eac3eec60255309e599d67bcb8f7757cd655086815c9077"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live.x86_64.iso.sig",
+                                "sha256": "e5e55a77717b92cb9c85df03fc5e75521f3cde64a157f92568de7f70db27ec82"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-kernel-x86_64.sig",
-                                "sha256": "3c04d2fca66dbbb71e22305b203b6464e01a75df7a1b14e599f05311c4f89c09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live-kernel-x86_64.sig",
+                                "sha256": "64ec45261821b16896a601b46d49304dd22a4084f1b1432c6dfe13990a0f8fcf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4c9793723993a7ade1782c6211089efc467b9c7d0aab313f21a99a4c4cc19710"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "03df8e56e674bb907db179ce993741694e1c473834442c61205cb7897b786f99"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "9013b8a7d66554c44ba752df686b9c38d9d0191f3644f9ff834bbff0d212dd80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0de02da08ac8c96f9a5ddfa130cfc1ad37417cd8b0df52c4c5a937c75fca4850"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e54a27daf300cdbf9d723807f159646ae5c7f842381424511b4a340917e98d24",
-                                "uncompressed-sha256": "c0a5b07a94b50a8270ebc6d5ea454356c0fe0876eac1ad8fbbb7fd8089f2c0b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "587dc8ab839b2936346332848b7691f5614d8cce0791a0c25b2244d97bf3d559",
+                                "uncompressed-sha256": "f594ebff166b86fd431aa9d89429dc1105ec533b487ae7d50c328b8d8860922e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1db1fa552547a15e0146913d37ecedc1429ba26eb7235ff7fcabbd8dd1d32faf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "20c900c537ae858a9e8e54e73163fe0fcc4e3efd5a5876e0bc5518beffdbf771"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "94712249144ff59ee57dd4527ceabaf3e844ad68ce53a934d1f7939d1fd961b1",
-                                "uncompressed-sha256": "51dd39ff3fa9bb07858150ef86b903933b9fd69bec8b1fe35a2b6386a3a7076b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a82a31ee0db84d7c82a34706a51323c1445f408689ea6f5e04ac48a1e3e51621",
+                                "uncompressed-sha256": "bf8dbe52517851caef13818efc69504519647734df6dfbe6ce5074abb17a8bae"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c6cf49830a37d749a4cfbbaaf8ea1996fd64359daa8c2be289e5d89bc62116b8",
-                                "uncompressed-sha256": "8647aa29d93b08dd88737207df4f331494ed01615021a6463e1343a6631d29af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "be4213dad35e18ba1cd95484d51965d759c437fff407d5412c007985d16f81d4",
+                                "uncompressed-sha256": "97944564ad07db6a4c74ec442d28610029edd04b1dd87df7749be64acac1b9cb"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d4b38ad2c1e71975b56babcb231541e591fb303970033951ada37246f7d26ceb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "adc3ae346ef658e12eb4a8301ba91212012e8376021d9ab8016e446d344bf0ff"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "d0725756637077b572863963a98cc8ac481211d820f818b9139fcb71da34c701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "efe17ec12be721286a9da4b4d92e4a4ccdfae5991729eb94a496b4b3b4139c1d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240225.3.0/x86_64/fedora-coreos-39.20240225.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bebb3af55a12de11c30e0d39822fcf6eed461e303f48c5f1731ddf7f2bcf576b",
-                                "uncompressed-sha256": "72b3a0c6cf1ddc2f5d9a1005be264d2f20d5550f696c2b266df2a402552b92dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240309.3.0/x86_64/fedora-coreos-39.20240309.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "cb710113e0225d78b0ce0fae3c96958f470664f81280fa66c1b3b8cfcd4ded91",
+                                "uncompressed-sha256": "49490e1aa689736cbf6fb2de12fb754cc5de93ef05d372289d95b3cebe355ab0"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-097f4b22f495bdbef"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-05ea316ed07ca16ce"
                         },
                         "ap-east-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0d63c98a574825181"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-018de721e1b2102f2"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0faa7e87f883f4d0d"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-01d5719b9eb8903f8"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0fd2a360c30b6f5f4"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-00e61cc211124cb7f"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-085724a0a90d0b119"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-04c1b9fa7482b4a37"
                         },
                         "ap-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0277c781bd28317fe"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0841b4e4ed7894ad2"
                         },
                         "ap-south-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-06a52b10bf02418ef"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-078c4604a621a7aa4"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-02cf9999d08f251cf"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-05f5cbc5e3c21d5fd"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0229ca27b789af570"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-041a85283cafc5b10"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0a54edded4ad9831b"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0d912ac3e912237a5"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-05f143aea963d5cd5"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0532f8f3a1651db6f"
                         },
                         "ca-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-019d3be7133973ac1"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0ef3e79f2dd40b1c2"
                         },
                         "ca-west-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-08e757c7d625f0f97"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0c0126bc89987d383"
                         },
                         "eu-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-057875a8895315232"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0473cd3f19c92106c"
                         },
                         "eu-central-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0328cad82e8587cd5"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-02c9fa60fb7223f14"
                         },
                         "eu-north-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-099d68a4e2ea1c260"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0c8c90b1021226a5e"
                         },
                         "eu-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0fcb3c9b403e130c4"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-08ecd9619e1176c4c"
                         },
                         "eu-south-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0c2a16ca6a49a03d2"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-02c64b8f1731b2de8"
                         },
                         "eu-west-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-06d291c7b158e1d4d"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-042154f5c2402a802"
                         },
                         "eu-west-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0692ae63ceac2ac59"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-013f42d9de8ea6064"
                         },
                         "eu-west-3": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-048e8ccd010fa0815"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-02b839fc9d538ca7b"
                         },
                         "il-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-08631113856279701"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-072eedd89831a2d5c"
                         },
                         "me-central-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0672a9b44d99d270c"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-07b8ecc90002cd6b7"
                         },
                         "me-south-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0a2d063e056853f99"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0530f02bb123e5bb4"
                         },
                         "sa-east-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-047361a5451d22062"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-007682765983c8113"
                         },
                         "us-east-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-097758d62ef002f2b"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-089abecde41ce4142"
                         },
                         "us-east-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0ad6f4985f9d75263"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-06f3f6892d5fe3fe9"
                         },
                         "us-west-1": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0d8f15321e783b7a1"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-0562e93921509e590"
                         },
                         "us-west-2": {
-                            "release": "39.20240225.3.0",
-                            "image": "ami-0645759dd2430f25d"
+                            "release": "39.20240309.3.0",
+                            "image": "ami-00397faa7cc284a28"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240225-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240309-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240225.3.0",
+                    "release": "39.20240309.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b6c3599f7b84db56280c90900248643727cf69f9edde1ae710883530df626a9f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f166be9250a134ce613d124f79bdc91c0130a8b030f67c5f7c29059eafc5bc84"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-03-13T18:34:33Z",
+        "last-modified": "2024-03-25T14:13:44Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f043050b39282b19031edcfe5b29030c7f895b9edfe960f5f023a14c493264a3",
-                                "uncompressed-sha256": "1ca7261272852189d2e16063407e712f0dcda1ef05ca5c9d56909a4d961422b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "22ddb364143b0187e4c134721d8f074de48ec2c0c5958c8d3d386783d3b91c7e",
+                                "uncompressed-sha256": "33d7cdd28cfc840a77afa9219b9efa57dfb9ee09ebdf0bb1623868b477aab259"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4e1cd2c3713357d97a668959ad23a06127167df5f2e6499f13ab5e6b28122596",
-                                "uncompressed-sha256": "edb38ce040f6b07559228ff47b37db3caca259de6d84938dd8abf5efbac4b0e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5919ec39400d1b2331a089df9c89a39ffc480f8121f75473901eb6ea5038fa10",
+                                "uncompressed-sha256": "b08dcd7e60dd032b7df8c1b7e6e540ca4d37472d63df318d534f2328d992d4c6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0c74e940bda4134c6350172e488ce4b93b43d7c4ce2bafad30af872bd30fb88c",
-                                "uncompressed-sha256": "0e25982d5e1449b1e6d7b74cfd08637b10f60a5d9f28e0c44d9e8347648e4f31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "09abdb537c8f7a57236c5407064ffe1b573a31b34966ea8eb3b8bb3a7e5feed2",
+                                "uncompressed-sha256": "31c7b848305b7ef3614d3b27a2b3e4a0f0d90f5407092e7892ccedefe042ba63"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "53beac067fe16674486de044d6effe26a42a58a8aa8b288c11129cc082096652",
-                                "uncompressed-sha256": "9da141ee699ffd9d3334d000bf5c4ff38ef9d64960cc7db465a7e02f60e4d8d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "136e703d2d172cd0f87cc50c9c5bb39f541416f6e73d587edf6ffead28db69e9",
+                                "uncompressed-sha256": "d41a060f63d0e7bc2c8cd892276383dcb16a97a420514a07b28d465137271a2f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "8e5493875510b51fc5a2dc4e90cf84bf8e563bad242e02a6c223427ef8be8785",
-                                "uncompressed-sha256": "ee8b9893d855f025cbf7f19840763742020f2a6a5e68cc1b1118406f060d66fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "971d88f03d900d379a9b0ce563a258f5d08fab036ea6ce65f0e40f764e80cc86",
+                                "uncompressed-sha256": "83acf347c9635f790b628953b67abbe897060cabe54ffa73c0f3242182313814"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6d8b0b086e628afbd7bfa0038335a7deddfdbd41289774dbc4432a80991d5a7d",
-                                "uncompressed-sha256": "e24969fade519782303de6457b9cdedf9f864652faefc31750f2ef185f6a0b68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e26e094272bc9d627eb2084e23677511b7e427825052db7e06e56b136cb25519",
+                                "uncompressed-sha256": "a3fec8ea5412656a41348d9591c2ba1d699816a554025f5c8ea5d40804d6f91f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live.aarch64.iso.sig",
-                                "sha256": "89a19250f2f516b74c372f04b83bfa3ebe3aa287c68026c3de6dd59d147c2be7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live.aarch64.iso.sig",
+                                "sha256": "a8fa22ab649e1807aeb7ece4585620eae4441927f179399703454c596982a73f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-kernel-aarch64.sig",
-                                "sha256": "cc0c5db8f4d1d70162c90018eed4cbcf1a21f407f78dc2f9830020a62a43f37d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-kernel-aarch64.sig",
+                                "sha256": "4c32f6723eeaa9a00f53a0aebe674550099bce633c9a18255fbbf7550a611309"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d0bfe91b4b2fb0297ba83c4bccd7c9bd9ae817ee0cc5caf084bed0b480758598"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "dc743ab0fdc10c3e7afa81a0f687ab60f27a7e74be832281bbb402036c417c82"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "4e147c5875c9c5fdb14bf358053a2158eedf70d7b7358e5eda9bbd60ba425ad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6e90b4db06bb44353f212307347820548f0a059b398a72a3d9ff5c7306f1c217"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0c03f4d76dad80ec8a7d1b78ca84ea73d6a35a51052b4e9e2242aef712c89526",
-                                "uncompressed-sha256": "c27c5b394fa524caa8ad34c0dab438d48b33e3c7c3a21efdf594480a704751ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "d0a04c2518423298651c3e8ce6cfbc55a631f8899a64cadb0469ab8b8f01917e",
+                                "uncompressed-sha256": "6eb823a767891e26d9cc3bfb2e031454b6ffb0b4ce875656efb69e4d851423f3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "48a4ede9a8b50fca2f5cc331b163a5e4e6efe4f493a8c03864a6a5cb8667ac8a",
-                                "uncompressed-sha256": "056a0c952d3ddc8eb2c1895188358d9c22f313a1f1dad5c0d73d12d6ed428049"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6a48340b434c9fd883a07cd4db7dcd68c77387c49968da2cae89d0714df578c9",
+                                "uncompressed-sha256": "bacb713c19957519b507cac047b19ceac28043c99431afc88f35fc89fd593b04"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/aarch64/fedora-coreos-39.20240309.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f7a4c9c7514021572a37e193753f59f43d14c0142d43d77cd56c42fdbd026154",
-                                "uncompressed-sha256": "61a7fa0df242663044e7135ab8c9790392c852ac0f96ca798c19ea4abc348cca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ec782bd732b57d270aab3679d61fee30dc081f1f4d655eb647ef50ae94530dda",
+                                "uncompressed-sha256": "7d9ed18012445f9f742963f8acd6a558a19153af2a2c23c0b3258c138a32e315"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0707f3147e421a1b5"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0cf396b8e7292701c"
                         },
                         "ap-east-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-09d1cd2200ad7d5eb"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0670f14d972741406"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-07a664c4dab617bd1"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0685bb7dd9f9271b4"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0766f7eed591686e9"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0708831cc258a5dc0"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-00b28019a77aa9355"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0377ac15e115eb323"
                         },
                         "ap-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-051b985748dab484d"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-07f6f3f87ad9f8fce"
                         },
                         "ap-south-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-027c616efdc64f6c3"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0455057288ad1f060"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-01ac4130f2f9da685"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0d9927a9f9d84c096"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0a26d26fb7ddc87d7"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-06a34f9fe6371cdf2"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0fe23f6c55977e76c"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-024d9483e5252bd67"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0059ff16aae5ca0d4"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0c27ce1f18dc6b67e"
                         },
                         "ca-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0da3b6b78f3fee898"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-01b14df11c2063b4b"
                         },
                         "ca-west-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-05e8e5da75c30b0a8"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-03a149703e82d111e"
                         },
                         "eu-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0cff5ed565ecd1fc1"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0522a17465f728102"
                         },
                         "eu-central-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-061be3760818dfaf7"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0b091bb8c7a4f498c"
                         },
                         "eu-north-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0efbb14fece6802ef"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-01c0359f0ee2dbd1c"
                         },
                         "eu-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-03629af95870ca381"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0589b591b8991609b"
                         },
                         "eu-south-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0cb855936e5da06b1"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0aa0159dcd682d0eb"
                         },
                         "eu-west-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0e47ffb174ef3c552"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0de0e7454c6960a6b"
                         },
                         "eu-west-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-003d59f94b40ce7f9"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-07c2fc1eb866cb92d"
                         },
                         "eu-west-3": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-092e2690d7042cbbe"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0a6e29bcd2b234d08"
                         },
                         "il-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-017862bf0a5154ed1"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-025ce3bf3215e2aee"
                         },
                         "me-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-060f163ce853e6e36"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0649c76b21de7362c"
                         },
                         "me-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0c855858ee09f2bf9"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-063c6fd7ebf6208db"
                         },
                         "sa-east-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0d1d17b0cfe523c33"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0c886f46caff8ad39"
                         },
                         "us-east-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0354659a9ad5c5876"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-08c333442cd34e26f"
                         },
                         "us-east-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0883ba74d29985639"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-062641163abb38628"
                         },
                         "us-west-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-03a8e93dbbc330ea9"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-069981f0eaea3083a"
                         },
                         "us-west-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0a31bccefa8d53fcd"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-01d32880bbc5d08ae"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240309-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240322-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b66023ac5b9387a911d61eecd46076c904dfc298b6486de034005bc1b5dae8cf",
-                                "uncompressed-sha256": "8f2894d39e36ea752c9e2ef704d518864c926707ee740340c3eaeb1f1f03cab0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "5cb4fa0dcd0d9ff3a2a5ee43c20169ca560cc60aaa35a5057b71a354a7fb8a3b",
+                                "uncompressed-sha256": "cb8349201e39ed94adb7f0a655976a7b774cc565a0d4aa672e52547f4146bac7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live.ppc64le.iso.sig",
-                                "sha256": "191007dabaa6ceab9eddef60d447ce8d953a9b0821d8c3a7204289318ad96ad3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live.ppc64le.iso.sig",
+                                "sha256": "dba72a8a42f771284b2beef4dae4ed46ded4e70a71b8f866fdb282d1fe2a73d0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "c6e711430c00a439862574ffe2e68da456bfc0cf33306a207a33a6c70eac5cc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "def369c309a15c02788023689658dffda971eda68161320ff683fb5183181689"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "90d4be1ca920462b08321f714750241e1f343f0d1f8d7d2912c414f181ad90c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "16b52ccce1619ade6e98879820cc4004a79c048470e318339c130047d21ac986"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "8df60762c711e0cb9b6b859178befef1de9fbae958bb79f8f0a1960b7b3f78f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "66e3c6935eccc98fe7457bc6195657df6494a4ac8e5e1313f227c08d454c4d16"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "672d468700ecd9991692279d8d49235ebda19e0672b6c28e219a2d48f2605fb8",
-                                "uncompressed-sha256": "16bb98f273e8ea4652df8e2659726dceb9cd00cdbbfede2aebc15122749bbd28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "4f29a61cb427fb558217391bd7bcbf1908442066852ead2e084608d2af5bb2a0",
+                                "uncompressed-sha256": "2880803a74315c97d758b5916f2539a04de595afaad5b0c0378526b6839588c8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "778bcc5d992d7e54cdbd2306acb2b40819acf16715c0722b2ff1b6902b6fb535",
-                                "uncompressed-sha256": "c58957be854d76388c2396d3f5b42f415e59317d0a656f4f28867bb9669d4a4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "30dca040efbb8069e55caae75824acc5bb96bf76abe213e48cbc83ad50a1c7ba",
+                                "uncompressed-sha256": "37a279c1c6dd192d1adf3ad649e1c191ad0b7b2ea3eb9f7bb21ad8e032745828"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "eb4e6de268e736610b203609054c226bb0aa8a7d8bd0bf772db4de89c5704371",
-                                "uncompressed-sha256": "eb1263b51069edbf106c57f7cb6d48769b904ad9cf8907de14dead3f09b2e9b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "8896b23c074199527199129ae6f5d6862244c688dcbdaf64e0a327f57b54b3fc",
+                                "uncompressed-sha256": "e2fbdb2a1fd1a17ece78ed99c4516fbd239b56cdb232ab4a5e881776b7c6ec95"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/ppc64le/fedora-coreos-39.20240309.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "365453260c8ddaf0159d451770e56192cb80e6d674a5b997d5ffeb06fe69bc64",
-                                "uncompressed-sha256": "7a3ebfd1a5b7a770dda87556c0116e66941ec91bafdab328ec9a1b30f853d013"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5458da5e8090da4080839633e81a2de0556482a1260c1bb3ab0405ccae406392",
+                                "uncompressed-sha256": "85a8b3c508b7f240989a8a7400b7d6065b44148856cc3be8aae11c3bfe89f24f"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "29e45053c8a65fffee626ee6fbe7013a3daebcdaa4ca8cd600b16b855af0379e",
-                                "uncompressed-sha256": "de2a84c001c3dbad4b63a6a1fa4df181187a7aa1f3137761dd7ff376a6f91bac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "f954e009903a83f64b93ba59e897daad71f5916916cb4d9ae127083c79f845a5",
+                                "uncompressed-sha256": "d99462b0566ca876550b3053e2ba80b1f54fb0e36580fb36424f9435970191a5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "625c0e917b787e7fceab71f05131eefd6c58617d05f723cf6b2bd51f1d5b54c4",
-                                "uncompressed-sha256": "bd821a27196238dec49761df2740c60b8ebf885fd092107bcc11cc73ef7d21e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "0d183ef6fc1b7670614993c7c02b8c9b57393024f7e6eb167722954f50bf803c",
+                                "uncompressed-sha256": "abb56df266ad7a494f59a38846fa8c59024cbcbf0ec6747f03be0c7aef8d1547"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live.s390x.iso.sig",
-                                "sha256": "60af68212ffaa1bf462bb057d305a29d3b42002a531fc89fd6b70cb76fb4336e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live.s390x.iso.sig",
+                                "sha256": "f425760b02fe9a99add891c652c1f3a82cda9c35ab182fe702b87ccdad021c3c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-kernel-s390x.sig",
-                                "sha256": "a1ea7d825271b9611f21f27b37dd91decca26c0a67391fff4dbeaa93ccf73259"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-kernel-s390x.sig",
+                                "sha256": "e753d389d4f2432b7c213a0c8c8b30db77cce8d0bcbdb1420be1b328163051ba"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a012cddd178668e226f0984da06e58a8b1bc185719ff32a7cd2eb7daa0113903"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7e98e626a01709d04a440665440f73b2a5fa680b81df1a61c2f5d9c686ff93e8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4b7f9be4a64f7bad78197018992b144290d34f07107a20c31d4394f10d67157e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4a290bb79d0714654c5441a590dfed692a3c8a82218dbb4b240432204a838641"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4a25ed572dda7d2daebbc036753a0517a463d2dd85138f12488a23d8ab5b6419",
-                                "uncompressed-sha256": "f467f5e05ba7356abd5d61259fd36522c71824d53bf04f2e3d15dc203e74a327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6a15160c6450ab4b7db7cc28bf6095824af29a7a336337ea4226b56e3bf3e6cd",
+                                "uncompressed-sha256": "0fc46218be3da1619504243eee801c6766c7a54ef7df8076d333951654bf73d0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "16551d329fbd391ad4d7dccfb59cd129b91284be7fe03bef8b37c80b8b050e1c",
-                                "uncompressed-sha256": "5dfac70a6b1f65e297bd77872204cee6f92439ae845ff056dd323afa0d6306a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c04c0cb187f77c41468fa0b96a4695abca5f7850afb725bd1ea78b2cdb57648a",
+                                "uncompressed-sha256": "0ae1409437bb71309550511e7573d4fcce2d7109ce91dbfcf8c49b66acb9c117"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/s390x/fedora-coreos-39.20240309.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "48f9bb88e9ebff9208ad089a0d020a979f478150eefe37db63ea81f9a0798c66",
-                                "uncompressed-sha256": "477194eea316674fdeefdda6fde7de36b3498ede58c0800e3b9a1044b8663e7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c24eaf634a6ca1c00615e32093d91d71b1a84663bb995fe0e54659efd3273fb3",
+                                "uncompressed-sha256": "b4c82c73de85ef07ae50f6576b6d558bf8aa2d30c1ad446053dca626dc05b164"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8b480714943a6549034f0c64def2a8d4f298d19656371df12650e7ae066535a3",
-                                "uncompressed-sha256": "c403729351f521768510cd97495a4acde51039c2a02f9bb2b2751ec45dc46377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "fc74010f7d405e6a7484972e7202ef60d929b5da4a45c19937d13809b56c3583",
+                                "uncompressed-sha256": "39e535208b6da30a950ff4a309a4f319af06bce0835ae61ea21e5fa7c8a970d7"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "767bd11682e33c231fe6e8902eab71f078cde49dbe381472169f41995bb6d8b2",
-                                "uncompressed-sha256": "3023080939ae6efbc18a550c275f23074b34201d054e38fc06f029ad115568bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f5850011816138e2dfc3d306897e5c00090148ac6e19f87ae5dc7f51b02e37ec",
+                                "uncompressed-sha256": "b75c6f0d9c29b1b0aa666828e33f2cd3d65293a99c55dbc4a72013f981845520"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8c864ec74cb4dad1268f58795a1ae377bf6ce030513ce38e30197fe628a14e75",
-                                "uncompressed-sha256": "e554e2c62f084230aa54c09f5cfe4de1fa489284abe02accc6d454d0dea45f44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "fe0c03677d3b74af64ce0f5b50d8ad1fa3c1f4eb4ffbc80ea15b22f6a0708e71",
+                                "uncompressed-sha256": "97d6b432e0398f415590a43ece73a0c1be878387ce036e162e3b89361ebccab2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f8523905d6f95a84027269f89822f6722e0521b5a1e4c6ce615d16f0d9f31f24",
-                                "uncompressed-sha256": "c6442130dbb1038d891729f38af4903d37c900209e43fa40327cf1efe91a7aa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "05ce4979484cff7eae22fed79c87a884cc66689197eee4cd1657a15c80dd7889",
+                                "uncompressed-sha256": "fc07178f7db79520c162806e3f11765e0d1a6d09c20d41aa4cddf3679701c727"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7349da81a3763f109d0e459562d17935f9271f362881df6fa2209b1dc7599580",
-                                "uncompressed-sha256": "815f3643ad7c8d3bba43afa4e3c401dcc72b33ef3ddb06cbd06cf89b646dbcff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2b39f52b3aa4d545ef2355e0d9507444796d80cb2b2892cae53142041987b724",
+                                "uncompressed-sha256": "b85e86ce2253a34314a109e5bc0892cca29fbdf766b85dbb155f9f34fcee6517"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f5ae236829d994e0eecfe56c5e21ee2c811c8ddaf86dc5e43947edf80bccc7d1",
-                                "uncompressed-sha256": "99a7024f39d2df3d7698c20308b5bd59675b7d363934ee9d62347f62250347ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d3ab21543b732c47d9b2d3a0f05bf3a4828b6663026c65718cd53a546fd71c5f",
+                                "uncompressed-sha256": "72332375e120493ada77b63ef05aceba229bff0907e50c0cb23e248eeafb41bc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3d6152b981b9ec932db0c8442934106ff970c2a65e61afdf3adfce98316998f1",
-                                "uncompressed-sha256": "46d9abab0f182995a0022e4d4ce181c92ada448cdc48950967ccd63df8f0d6e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4ce51dc623c4e4b3c5cc6579b69b1f8a9dbce1fb74f36d3444391fee9d3a5165",
+                                "uncompressed-sha256": "79cea052069fda28465e975ac6419186aade55862080cb3e773e573ed943d7d2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d15dc2f7ee93298b1458e1ade4e6e8c83ddca1c3bbcf500a012356141fc58676",
-                                "uncompressed-sha256": "49cfc3c85678de67e74ed8d8085f28b29fd50118241dd4c56f6156c0a8a90ff1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "421314482b361be14ad1312f2e19152fcc16837e8733592225befc263d3595cc",
+                                "uncompressed-sha256": "38e85cb8316746e9ff8e758046d908c6e0fb4bfc0a5179ada0cbe7355e09df8d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "453530f0f4a6d69528b8c9801eba0639d0ccb7ee88ef1a77254f092bc73e7a56",
-                                "uncompressed-sha256": "3556feab3b89eef2c02153debeefaaa00778f624405aef283f4730e0d15d8722"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "cd19b9d835fef8de20000fd6e5acc8e7452487767c5501cfceb3d5bd7d31740a",
+                                "uncompressed-sha256": "c75bb4bb6e65eb290d26db4a70fa9d3d821433f8e356a5a70a7f5ea0f8c37e9e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "72056f778a539f7f8cbf33eba20f7e906cfb3b867c817fd138f5966b27f66a34",
-                                "uncompressed-sha256": "86aa8df82784283c74c4c15c49df7944eac7e7094cfb73a3cd07b39ed53f8272"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f214e44fbc2c4569240af7d795f3e00d82dfa8480e26937df9746850de262299",
+                                "uncompressed-sha256": "bd7c73bb6b5f74b7c9681350eea4bdd73188e6b3690746d803c63f5c65ed0cf0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b93c82c89a5314f71ccedb52be3fced2fcdb27542291396c2bb3490481fc1544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2086cb6923cb064e9a6322c2b74ef0a047e90cd57654ab3cf9985f6eec06476e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1511162ecd0a1c33fa0f56df5b74ee5a090a55ea068a26660a3aeb1925730920",
-                                "uncompressed-sha256": "2a142a6be34c7347f138c31b3fc8f77f9509bd0afb1ca2b07baf119687a6e626"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "70bab1e35553ba21c0d52ade8439fcc884553bd71c1c731b2154b2bf31a9edce",
+                                "uncompressed-sha256": "73a9cb8698be47c908b85af947bece356e3836473017c586f6674f939226c37b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live.x86_64.iso.sig",
-                                "sha256": "41f9e9309dd778c1dd6f21eed214b727be2d9355f79dabee33707b2adb4e1db2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live.x86_64.iso.sig",
+                                "sha256": "fe4a9838d482f8336b757d898ad757398d1ffe0fdb15da5480b10e3ce5b8bed7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-kernel-x86_64.sig",
-                                "sha256": "64ec45261821b16896a601b46d49304dd22a4084f1b1432c6dfe13990a0f8fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-kernel-x86_64.sig",
+                                "sha256": "7f32bf7a5d73623734939c5db8fadc3c43da33768ff4b60414300daf9d843bf2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0feff7f1b5f10cae99356ace395548f96c38b753825b021af4f2d40c36787d72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7ceda922891cd76a216ba280b4c8d716a0bd58c9a837f614e28362575225b2fe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "722459ad118d9db4faf83f09549c4e92a4456494ce0748117cf93fa11a6aae9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ad6377afd1edc98118d4dbe2e2d743523ebe28451dcdaac43de8919094087902"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "11ceb623c001db90158ad3b14b320a8d5c551df79c620c1e46f1ce9c3958df7e",
-                                "uncompressed-sha256": "91cf71c3e576653f9604a9de8ac55eb84630bed56026f900e0368bbf3bdb707b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a6a01d5109c395e93f01c3c1c8290fbdb1cdc831c3edc1e0c81a9443e48f742a",
+                                "uncompressed-sha256": "4e3ee550ce4df8f0b8498775e37683db3251fd24e7a1f3fc7e4f59776fcf8d3c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "67622a4b676487cd207eedb50ed62b184c3befc2f283cc0b3fd12a233bc27d18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "67ebdf991bddbbab8f38fd72eb61ee3317ee7914ce7b6ae2e1a2a4b8ea2167c3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "eb64ee31b82227131820dbc00126be684f673d60f4d679ed4c205451b64518dc",
-                                "uncompressed-sha256": "d1491a359eff40c02d4dcf137c15b496b4925788760ce93f911408493492639b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3510d428d21c841e0c55a0f06035827ba98ee218d31819b5adbb04f2dccdde42",
+                                "uncompressed-sha256": "80e8f7555b4792aca56696c52c46f48577b609c435342a29d9faf806f7e2e55c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e089b9e924ff8297c4f8beedbe05e631d44dfcdfb1b976e2ad817f4c8fa8a72a",
-                                "uncompressed-sha256": "1a1a044817e3b5bc0f3657b78ecbbde6f9b50b493e55e4e78cf1ec4f2a196bcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e4506b7a1df988c68b30d9919328331d1f9977e1ad9e9bbb2ce99ed494291c7b",
+                                "uncompressed-sha256": "1d7579b3c0e14f3ac4e338c505fd20939a8224b6cde35770673a276e4b8c7910"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "cce0dbf56db5a6a6ac3b7e640939b53ede5bbafa6bb19ec59a57f595e517432b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "ae241c220feccbfc39a8320e92ad981b135c91f278fa299daa4d98bdcd11eb16"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "1c1e37b2454ea4cb6208b715d99436590672439105fbc9c06530983bc5b9178e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "0a2e15a9190e83ae179fd3eec41964d1e6bf9b8bc95c914048bd4a005b3eb156"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240309.2.0/x86_64/fedora-coreos-39.20240309.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "591abb6b2dadbaf44153679dcb3ded858d139893073eed674446a967add998f1",
-                                "uncompressed-sha256": "90fb9d1683ef156c31cb428de13f5e146be85006abd8aabd1461e97b10778aea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "83c46263517214e6c9dd90653643fce9fae6d4f67695d66b4ac01f0977425043",
+                                "uncompressed-sha256": "5ddd6e87b051abef3ef6687e01f685e206320945862222af0f7c82eba8efb473"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0b7b9329e4fd75933"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0dd14c3b484158922"
                         },
                         "ap-east-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0ad2dab4e9a878f7e"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-082838fdcd920b426"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0ff80636cd1165cfb"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0de3ea0131bc12a9c"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-07c204e8e10d2fa02"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-07e7056ae7a5b6f63"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0e867cda01f0a04be"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0412912c4948ef81f"
                         },
                         "ap-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-069a63c5d4f93a907"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0425f4ca1a22b40f2"
                         },
                         "ap-south-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-01ab7a6550d2dff98"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-09b3a722c3e355da4"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0ae12a3dde0ebeaf8"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0308185d33c5c0017"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-033d660fbb0765479"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-023eb32eedc34774f"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0b8b0d61ffebc02bf"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-095e20f37acb19dd5"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-08a9c29edc22e8307"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-06c188c094641a1d3"
                         },
                         "ca-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0ec84e1986bdbc060"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0d766f14a9e0263a0"
                         },
                         "ca-west-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-04bb28e79cd10827b"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0125fa3877d617811"
                         },
                         "eu-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0235afdc58fcbd344"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0f6e0629709d9361b"
                         },
                         "eu-central-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0759892d7c0b39bdc"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-050790b222f50d8ef"
                         },
                         "eu-north-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0e1691dc457cef7a6"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0cf8223214a13a617"
                         },
                         "eu-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-07f59e926faccaf11"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-023a6d669dbf23485"
                         },
                         "eu-south-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-090d8c459135e40a9"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0a0cf221f5f3cea44"
                         },
                         "eu-west-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0296206ede4f4cb49"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0f818f05b8f8f3352"
                         },
                         "eu-west-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0816f749a15a2568f"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-02969f3fb186e7a30"
                         },
                         "eu-west-3": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0b1f7f0a48654da45"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0ec68bffab6ab5458"
                         },
                         "il-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-09c59e517cafba745"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-071c8fd8e1b208076"
                         },
                         "me-central-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0b165c85742289c32"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0475a1976c782f9e9"
                         },
                         "me-south-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0a55fd733daf87159"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0b75a463041ee8803"
                         },
                         "sa-east-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-03fd0b2c5084a3a9e"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-06bc826f5f93cc87b"
                         },
                         "us-east-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0df8579426636a572"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-04eb433d85ce7712b"
                         },
                         "us-east-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-0bd272c49a311d1bd"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0b4e11e2543441f6f"
                         },
                         "us-west-1": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-05c6c1b5c255d1471"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-08b52ac7f519a6ffe"
                         },
                         "us-west-2": {
-                            "release": "39.20240309.2.0",
-                            "image": "ami-015daa66b85fcb8d4"
+                            "release": "39.20240322.2.0",
+                            "image": "ami-0955ccc92631c893a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240309-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240322-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240309.2.0",
+                    "release": "39.20240322.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d340ced6f988da1206831b6168815f57202f90f88f8ef7edecf534437170b895"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dfc5c7cf10571d153c4f65ef1e90a3d4ce1fd0dd7bf6c5156fdbc39dd1408441"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-03-13T18:34:35Z"
+    "last-modified": "2024-03-25T14:13:45Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "39.20240225.1.0",
+      "version": "39.20240309.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "39.20240309.1.0",
+      "version": "40.20240322.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1710358200,
+          "start_epoch": 1711461600,
           "start_percentage": 0.0
         }
       }

--- a/updates/next.json
+++ b/updates/next.json
@@ -103,6 +103,9 @@
     {
       "version": "39.20240309.1.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "start_percentage": 1.0
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-03-13T18:34:33Z"
+    "last-modified": "2024-03-25T14:13:44Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20240210.3.0",
+      "version": "39.20240225.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20240225.3.0",
+      "version": "39.20240309.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1710358200,
+          "start_epoch": 1711461600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-03-13T18:34:34Z"
+    "last-modified": "2024-03-25T14:13:44Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "39.20240225.2.0",
+      "version": "39.20240309.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "39.20240309.2.0",
+      "version": "39.20240322.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1710358200,
+          "start_epoch": 1711461600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).