### PR TITLE
Roll out stable 39.20240322.3.1, testing 39.20240407.2.0, next 40.20240408.1.0

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,9 @@
 releases:
+  40.20240408.1.0:
+      - text: "Fix rpm-ostree CVE-2024-2905 (world-readable /etc/[g]shadow[-])"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1705"
+      - text: "podman outgoing http connections are broken"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1704"
   40.20240331.1.0:
     issues: []
   40.20240322.1.0:

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,7 @@
 releases:
+  39.20240322.3.1:
+      - text: "Fix rpm-ostree CVE-2024-2905 (world-readable /etc/[g]shadow[-])"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1705"
   39.20240322.3.0:
       - text: "SELinux causes layered buildah network namespace failures"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1703"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,7 @@
 releases:
+  39.20240407.2.0:
+      - text: "Fix rpm-ostree CVE-2024-2905 (world-readable /etc/[g]shadow[-])"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1705"
   39.20240322.2.0:
       - text: "SELinux causes layered buildah network namespace failures"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1703"

--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-04-01T21:06:30Z",
+        "last-modified": "2024-04-10T03:09:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "92dad5c37c018f39334c5ea8d1719b9cf19e3dccdefeeb845468527741589848",
-                                "uncompressed-sha256": "65576523cf4e0c6cd058812dc52ce92ab30347bad941a7e0440c7242b67b70b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "bc9f6fae2d3397c87637a6781cc35a7390af8df6070c6f0a6c18c1ffb8b115af",
+                                "uncompressed-sha256": "7c6f74bd75a77d742e1385374dbcf00f0cded380c0faee3ba530288cce4cf803"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "bbed3563d0f3491f9128db9431028e2c4fa0076febecfcb9d475ee7270fd5dbc",
-                                "uncompressed-sha256": "a335955f2147c36aaf68cb58228053d9838935726945ef53c35b07bf4cf75302"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "592ea70013d4a0822081d2439e2de4040b638460b0635ee41f36978818518931",
+                                "uncompressed-sha256": "cbb570f8cd61c276a194744e5380f188cf3f211fb1afa29e3315000433caf5bf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "3492b403c8f55be710cc29c4e0a571e5983de9076dbf485f327caa7e5f554cfa",
-                                "uncompressed-sha256": "b90c40932c8a062f869777f6ebe3578912617526b83f5c03d438f034dadad63c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9a8592ed4d41a97ca9e1e02986c8724b64a51176038748e433fb447319137c64",
+                                "uncompressed-sha256": "453265931816c4996f99c9bcdf1cec15e443ab1172af4c43b1d68d9d04f01ffb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0fa1b83ed76c761302271e7922514f6ce40fc78c9755b909bb6827f353d600b9",
-                                "uncompressed-sha256": "73877d29c4535163eecf74fb13f3d48f1c286b857a36e553dc7a50eeb073ad31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "903070dd5166f40eae9981aaf2313c50162901dfa1d9b97ac01f40b64f8685fd",
+                                "uncompressed-sha256": "b44ad592637114c31d910dc0ea5b7d5c8cfaa46014fd078fe2d02442dcad092f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "bf4a5cfb210d7ca8abf5f08d73ee3a732ff2e50f1c14f9b8df35fe3c0203a279",
-                                "uncompressed-sha256": "25367db6be146c45dbec39a75aca553e68c59e29e04eae8429231a4d948ede17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "b33301de71698dc4591a409e3e5078fbf29f8bfa6b73f6e51ae2c7783e8c510b",
+                                "uncompressed-sha256": "b3cdd6757b09de412564447c5ec599d6d7c1f40452cafa7aab8781ef229659af"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b103cfe102351776945e1185d78cdc4b690e965ebd713e286d1a9138c2bf419f",
-                                "uncompressed-sha256": "10b5a246704ab0ba8b34d2963f0e81c3147b19bbe769eeffcf1bdcb39c034dfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "eb659744f3791894b2e17b185427c2370aecf26ebe239f0e270e9732eda9a7ae",
+                                "uncompressed-sha256": "04f69d28c10b28ce2d9ebf20d2bf97bd317d404963484b0661f2aaf7c4318fb9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live.aarch64.iso.sig",
-                                "sha256": "e41accb963f2655ee5c3194c4e91cd130fafe130e58cf6e7a7033256d3358760"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live.aarch64.iso.sig",
+                                "sha256": "c7c9934cf0c91ee85682ac556b3ee9596d72c3d5b5b58adef8de25cce954dc9b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live-kernel-aarch64.sig",
-                                "sha256": "a2d4af563d526e6b0f7e565b3f2694ca7fe063c49fbce6272d2a17d21cb5bfec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live-kernel-aarch64.sig",
+                                "sha256": "732dbadd77cb7bfd2c97740cc64d248dfcf0f11402fbef5ab73713bd49403f0a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e1790d821445b79efcc9472c040ab6c142739e4c76b609ed6300a90653fe78fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5a5bb43ee7315bb61a8900dcb9cf0b2595bbe044688493ac7de5c3df00568eb6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "aa1ae2088735f0634153f8424c873a4b0bbf8deb91f46dc487d30ef15315d289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4bf728c6967bd5dba1ee2bb7c47d020a515335c5a2d97c34f5b9c20433909abb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c5036ad016314a955df039f83101bbcd4ba1db3f0fe92e7220a4483b52786f82",
-                                "uncompressed-sha256": "36ff2f2d0610c63cf6a177a9d6d3385e406228e0fa10eb76e6fca861f76f1ad2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f294f10a15201c4a6756203e7c564fca9eb41193a97a820471da7f5c7112571c",
+                                "uncompressed-sha256": "79c452c84dca671d9fc94125da7578cd8ea220ae683efa92fcd2b8c02d3ea10c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5cd33d8c6ac19cdf42503eb3a2c853d1a66d551bd1a88d706a687c15f07735d5",
-                                "uncompressed-sha256": "b816ed6f044baea1bdf483af5712d4560cbbb5c6216ba173be9415f4da093281"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c8df6b51628780bb6460490f7ee17ff95c53d6083b4f132b2dae1b29ab4fb51c",
+                                "uncompressed-sha256": "afa8437d6fe95419827bfb588221e3410e08d503be3b55450f6d79147e401ed1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/aarch64/fedora-coreos-40.20240331.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c24b6a63071fbdf29da00b9b89fceeed6e147b7b0f7d1adbda8fb12973b327cd",
-                                "uncompressed-sha256": "a86186f990d17e3d23fecc8b0f3b4ef3464834d05ac48cac8d939be82605836b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/aarch64/fedora-coreos-40.20240408.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9190fe0965761cd620db69a64acf772e8b2bb6779fe25bd98e111a1e47a36ffa",
+                                "uncompressed-sha256": "dd2dd64627cee6f137963bfcd0ab6fcc166ea5b5fae303a862d304811a2f01bc"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0f4eac5643925ca11"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0a75d81da5d9f68ef"
                         },
                         "ap-east-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0fa3f2eb058921611"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-070a371d4e3b9132a"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-01e935b9f466f9ed7"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0ca1b4b496d837418"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-03be7f3add5cd0dde"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0963179af6a3b1eb1"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-030641db3f3f075c6"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0b50846935f5ec9dc"
                         },
                         "ap-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0aab2290ead070285"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-099c0b1994fed8fc2"
                         },
                         "ap-south-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-007758a82faa0cb8f"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-055c0f98e360a164d"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-02d20db09bf8e28c8"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-08c98e2fbc52b55e0"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0311d8c14d2a7035b"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0fb34f5db394d1304"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0fdc0cbd24019b061"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-05dd3d72d1f13773d"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0882f967562eed329"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-050dfcc7bb3a9c723"
                         },
                         "ca-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-05d40c4aba79d696a"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0754963a55f1403d6"
                         },
                         "ca-west-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-06b1e11ce57f98d61"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0b02bfb32ad5cc7f9"
                         },
                         "eu-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-03a0102e43619d36b"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0d57b7997fad00024"
                         },
                         "eu-central-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-07dca626a73d0e800"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-00543910d2d7dd993"
                         },
                         "eu-north-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-09e4f9084e0950377"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-033de6e39a89dd2d9"
                         },
                         "eu-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0f6b318d48df0c492"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-02d2107484bd82f72"
                         },
                         "eu-south-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-004b5dabb51009bbe"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0c8d494be5b26cb7b"
                         },
                         "eu-west-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-02cd531f57b79a7aa"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-08bcc0fd82c267e47"
                         },
                         "eu-west-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0eab39cbbd3b450b0"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-02cfb1fd4056e34f7"
                         },
                         "eu-west-3": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0ecfc4d55df8e9cc8"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0e5435380cbb17041"
                         },
                         "il-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-09f2d8254d55023e4"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0861d01450cbfec13"
                         },
                         "me-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0fe42511fa2671ada"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-069aedc272c95fd7e"
                         },
                         "me-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0cc6898527cd0cdb4"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0fac344cef0e19e44"
                         },
                         "sa-east-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0f527f9fbe07448f5"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-087df9274c4b4dde7"
                         },
                         "us-east-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-00f5623d1d8d863aa"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0c01735bae84eec3f"
                         },
                         "us-east-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0270bd5d45ef1ce2f"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0c23c4444084237d1"
                         },
                         "us-west-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0925bf6e49075aa8c"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-05ff0bd6065d57b52"
                         },
                         "us-west-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0e4711bf3d106e149"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-05f1605f71c7617f5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240331-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240408-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5b4d46321335a5768c45128477655d663faf00c507e56bb7f051c35f0f1ee699",
-                                "uncompressed-sha256": "abcf66fdbb4e8c8b56e603fb1694b50841428b969fccfba39f2e1132053c12ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "65ed76044bcdc85fdf9e771f726fe2213e766d1b520bb21e3811d01ac831a396",
+                                "uncompressed-sha256": "daa23dcf91eaa7a576c6ede4f1302c1b8ec4327785c7b03b75dc229bcf291299"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live.ppc64le.iso.sig",
-                                "sha256": "72708f825eea78eb5dc8a80091623b31425487ed025aed2df609ecaa95e6d95e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live.ppc64le.iso.sig",
+                                "sha256": "a36ead34d9b27e7a317dee96ec6b0771103c14ca07c921e524a610286faed977"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "5531b0975f80776102e529cfd08ae5e43bef41c5c4bcd26d68202dd0bc3f007e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "7be3da1245a4de7bdc1820c5fc438da2de138e339186c312234e473905756a02"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "4197aba0bec836706e166030b050cfd01e2ba6571a53b7c501aed28d4791d99e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "704bb52bdc7f2b7c4ef8869082e1e84a1dacf7de830e0b2e57b64d03ff936b39"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b181853acf7c96c6aa51e4f4e6321080457b639407b2dd2ba526973022b7f3a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0b73791d56513d27c9d4ae989850fef8cf76a6ad983da4c09625f1bbb59f5f6a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "13945ba611a8703efd6c6a43033e228abab60f9ecd2d063f99b5f3e00d02859e",
-                                "uncompressed-sha256": "d178c1724de7fbf88ec7ad0cc2afabb9c412b6c6db371d4a1547474034dceb8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "af715f57df529dd0b53f1044a72fccd06ccf932e98db9f9be25a0d25a8b02928",
+                                "uncompressed-sha256": "bb2a445191781d50d8bd4a7c1db89a48c875996dbe6b99802c983461d15d73c9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "53dd11721b6581df4ca089dffc8f809a970a54f642264ba112840d7a2d305cee",
-                                "uncompressed-sha256": "8c40465d2ef42cd593746d523fec06946b4c7676b690aa06a5f1bef2556caf58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f11c54d7cd0b9da517f50818501d38a1abb9b9b011ef8328479463a719d829e9",
+                                "uncompressed-sha256": "c3a11872e2fb97ee1a7d6e2ac1c7bb6066389bc672e944ed709f1227751b3926"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0d24b3f6217c5fb1d78999f52a2e3d43f9252b79b779d5c507acc4220d62d302",
-                                "uncompressed-sha256": "a564e00d9541e9595b6983a7bcdb22444c1c6a53c8e1b1a01cb79e822cd5457c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5c223398152c099c8b4cd7553a6bc42c406dae22788e0468f35c8655f1b626cd",
+                                "uncompressed-sha256": "7387c4ab7081cbf956e7e4963b476d0c85f16ca8ad2a87bebd5ec5d61bdeb892"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/ppc64le/fedora-coreos-40.20240331.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "df1c331e8c41afebcde48cef839026672a1c546cf22c0881420bc3fc497fba0e",
-                                "uncompressed-sha256": "fb7bba7d1a42f61e5b49c17121a2a373bb84e01d417ef6be506c63b25cbaab8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/ppc64le/fedora-coreos-40.20240408.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "82d5deabf36d825c2955d10339804e8d1489249da680986b4b821fc86939cbaa",
+                                "uncompressed-sha256": "243574a6ace7c61bb0b3f1116c87039343b32ca662c0c5ce88c5fd0883ced626"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "722d58508ad609c4038f82b540af9f7f17e909d71607382e47cde8a05b728acd",
-                                "uncompressed-sha256": "d9a5131b9c4c4135e611f9242cd08f3af7df404c9c1d40c903b6ae7b85d06c15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "f269e7d25dc54fd74f11e2fbb74c03cc48dbc5c65f09a587add08d37bb52c9db",
+                                "uncompressed-sha256": "3157d0d148ecda10ef681d4755843d7409cb0f9e2a8cfefa8e2fed8cc25ea10f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3ab31588a665afa95bf9c8aa8f0c2ed702a14fc4fb45108ebc0cb302e5022fbe",
-                                "uncompressed-sha256": "06b923217c3bd36709bde93b254efdd5467a1c0b635cf4599d50513c7a09cf53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "9f97df8c04f68bd4f46903ad0b7b8b095e099f6363e23dbacf3b2de2a320ef15",
+                                "uncompressed-sha256": "0a150b252deb97986da9f72368c46eaeb770f85eb7be659d07ea7133f1c069ee"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live.s390x.iso.sig",
-                                "sha256": "85a3375de7b676cbd8cd08a4619c1e7fde8bd34742da659ec7c73bb2a6ddb626"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live.s390x.iso.sig",
+                                "sha256": "2eeaf0948a1dc4864b86d92a450fbc134b500303478b5fdf7af1d9d799895793"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live-kernel-s390x.sig",
-                                "sha256": "73161118c63c032cb7de8c789a6b6519dc88abb8b31ad4ec5296ceb7a6fdaf2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live-kernel-s390x.sig",
+                                "sha256": "8fd5ccf9974c5d2a100c5faa5e598d860d6f522cbbc9d5e487b341ffb8dfabeb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "467ca04883091c871f7f9763fd89ef6e209ca0d733c113b928f7fe1bf9853f97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "e98d755c581563c268b0a67641bc486a94f74bc55d6b348a6d0019112ecb8d5d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e6d3b99153297fce56f1df215e020202aa96830bc8ac94fb38752c2a53f48f12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6e09d1e0aa0ca8dbf9362b9514ed7c0a17ddbc667371fb6d9ba4f32645553a46"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "acaad31e1f4bac3445983477211a8a7afcf499d54007ce7b9785b0365b3fde20",
-                                "uncompressed-sha256": "6d38a2e767b753d48db5adf79cbde7d2aaec349a7ac236a34f58775068b88218"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7c13951999b49a752b4c7e558323d95a0e2262dfd53500d309c8bccec200f54a",
+                                "uncompressed-sha256": "5733e7fb66456103f1053dc4cb12980638b787d086f527f928fe4a4785840af7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d75c80d0c7bee873e78bc44d63d3154cf70729ef265439f05b6c52bb633b2757",
-                                "uncompressed-sha256": "35363270a0f6c66055b631dd1b5e1bc06ed10d8000d0a59c9c334f1c78794b09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c750f9473d2c85aa5e20f6fdc952f24b8a19e105923135078440359326072e8a",
+                                "uncompressed-sha256": "36677ed44cbcb2d65f4ad632cbacfa47327cc7a0750e7981f7d70bd571b59527"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/s390x/fedora-coreos-40.20240331.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "cec7cc1cb37f6aa1597588fddf293c5043d66e17d9a9fb8e1a98f4823b32828b",
-                                "uncompressed-sha256": "6435ddf7932f789a5b8bd8e06cfbd009f2316951c1631dd3e6ec5018271f6ee9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/s390x/fedora-coreos-40.20240408.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "1c338aa6b4753c4dc1942e426b1322706acd66ac638c962a3507ed5e22670023",
+                                "uncompressed-sha256": "48f2670db31ee6c4bee13f06bb6ffb7b52881f95d4aa3dfd4f1cfd35dc827bb0"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e9e3d562650b115c825a9246c957ee81fa98a5f71428412aacd4cdfafb6a98c8",
-                                "uncompressed-sha256": "8495298eb4515b7f1849781b3c9c28bf78c972dfba28a45cd344545b70b4290c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f8cfe1d1640946dd8b1429030bcc8c325dd438aade65dae113dad88c8cba35f0",
+                                "uncompressed-sha256": "d85e0790c7330a916d52301be576489af61e681b67fb1a10d254d1efe188efaa"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "9305d5343839ac2eb8fb4dc82b0e063b3a26f669f9aa47898febb94379392a9d",
-                                "uncompressed-sha256": "bc70c763570a38abfd94cba388f7297ff08af1e75cb5b5a0f5743a1545b333e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f359aeb4b2c4e2f7f6b4ceb0a231d9718779e8298bdb5ba755d185d87b10ca2c",
+                                "uncompressed-sha256": "3ca10d11567551db8e9008194eeabd7d3737f67372079260f08ddd8553db76dc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b9db7a3902d798b1ceb2e3699b54e5a92349f7651ba645f4e38936ad2010e9e3",
-                                "uncompressed-sha256": "967cc378a5d1ff3298a2d8399fd761857118d30e021b9633c7b3bf1eff5002ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "91b777649799d3a2de8bd42677774fa0490acdc25045a5c0a08f88e8bc90d4ac",
+                                "uncompressed-sha256": "4fd5f4d2b4a246aa083e518698057ee98931630fdc4891f7d0226f78a4443df8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "333bd74e329fadab70d6ccbfc3dc675b77897eb273240f2af4987a6e376dd6c2",
-                                "uncompressed-sha256": "12f8143cc360219703fcfaefa32d65eb5dcabd6d22b0d75f822e676c4ec1cb17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5a56c5c79f6baf8ac7847f2d22273ce147b3506c03d9394b2b211e46bb93ad4c",
+                                "uncompressed-sha256": "7a692a831fcf74eaa21eecab361aded001ed5edf0ddf3ce95c30330d959ba59c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1c02a9b5b8769c0d6b59df540a306c69ef8bd11ae8586570c1e82eb3053ca81d",
-                                "uncompressed-sha256": "a92094c17dcae66e6ea55a7a3064274c971f944d0d3138f102003c4454d3be22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f22baa877467e9dab2bcf0b96c770957d3358cd6e079ecc493fd0edbf7922875",
+                                "uncompressed-sha256": "ea22b029bc33d9f095edc9ac5119ae0ac223519c8d0ba29bf04c3d4649f51421"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e558dd2d513cfc5a49c7bcdbbf3897ea9dc71723c8f0090e9d40817ace4e0d9d",
-                                "uncompressed-sha256": "98abd91529446554dd127904254b7d64fc379770e9223b301d72db2ac8961994"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a7f96c502fcb01ed59e28c669ca94dc14fdef25f5a75b3cd0a9c088d99edd69c",
+                                "uncompressed-sha256": "30428e152c75f68e2dd9a86a11db71172a92844f48c4e7ccdb85f5661683aa27"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "446d2749824ab0d4f2bf822200a50c9acb3b72041bcc378371e9c96649903ee1",
-                                "uncompressed-sha256": "a40bffea69b7e34a8597f80a91eb2406e21c870020ecdd09a818811a57d616c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b9b57f8f689317302e99d34636c40dc7eb67ac92f4738672a8d1ee5f6464568f",
+                                "uncompressed-sha256": "ea3b20cb5217d8a72a0adf597eab9a1911de2fc1adc606261ba094e236a13dcd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1de3b9fc884aef4d0ee6ffd91885002b9e6e6cd8bf8ca9ef17aa81aa6a8bc22c",
-                                "uncompressed-sha256": "7a1d71a6aeaaefed6ceb6d25d353c29a9ca7a6a1f84bb0f0c445fc30e10ad53e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a15fd36021cbdd2236ee143a2aaab5fa422fdc1c29b4cb10a26e1055455628c0",
+                                "uncompressed-sha256": "d4fd0e0f8d56c24a00a75adf2dabbd59963ce4d0e3bd3042639b8485230a6a12"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "5c5de9789300a98d05cd6eb8c6e379e5a29d6de9bee6414c285fda955b51a913",
-                                "uncompressed-sha256": "c26c4080ec0b5089e7ef2181a15e1a072c2481c722788122b892350472f51e18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "1df120358d82ad72fa213c2c797b67a9faca61c5034ebf2bff1735755e7bb982",
+                                "uncompressed-sha256": "183c8361886a4abf377951c19a9148cccbcd246bfb267cc83024fc553aa4831e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "bbe7a153ae2548f0f833e03d58f7c678efd667a6cc971c6f4649d1af14476918",
-                                "uncompressed-sha256": "997e4194282de5c8faaec0b646786a1dd157c6f49dfe4af6e0499eaee9a8b35f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "57bb4609a8d8ff911daaae32da192083a54cc26ac89f406adbaf7e33341d09cb",
+                                "uncompressed-sha256": "964f47533c6287bce30712794d21944da31eda75caccb501686f8550f17a2424"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "405f124d131c76c3a4e468f93985c417d3ddc8f8604d2d29028d5c7b12f7041d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "8765227fca542906640ae43685f95e7aa6eb48fe52a8bd6bee878cf3e5afc413"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cd7060cd436143ee5b91be917f36b3607e8e351d28b89abe073215a43d41996c",
-                                "uncompressed-sha256": "9e3ad2f11f4196bba821dae8547848512f9bcf72be28b1f4cd766f8fa1f1645c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3a3edb03f901ad9786c525582690e5619df368dcacd43086ab90fefe83cf47c4",
+                                "uncompressed-sha256": "5c7ac91bedb6d7f6084e1e4a0a9c1ab6745f9e25143f38de8cf76588b3daf449"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live.x86_64.iso.sig",
-                                "sha256": "3dcfd1effba0be9b98861e6bf856fb665f88f443820481cff8f7f137ccbf4894"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live.x86_64.iso.sig",
+                                "sha256": "211510932f202eeb6961db4f5f0087bafb702a3f96ae62302a418d673b9eec51"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live-kernel-x86_64.sig",
-                                "sha256": "81184c63f437aeaa3622e1c8b376bb7f3d92dd2f0da7cb8e4a7ae8413339d919"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live-kernel-x86_64.sig",
+                                "sha256": "e291cfede0a9ab8287e8f6d65c0cacd85b5f234c6c2728c52a2cfaac0b775ae4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3c34f8ccea75e86f36497b9e344280240489fa41818768ccd23935becee55992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a677bda5d94299270b0d7abd68f63de211bd6a8cadb36053f7c92d9cc4b8e13f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "92feadf0834d8d37734f5c8eb264a9db8b5e8b9f7c0d71588e18474bf2f76ac2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "74b5334dab4e81e890bf719c31cfa97416bc24d1f0b599c02f0b720df4c596b9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4195d45caa77cc3faa2607104f20170eac2bc25d0437ed24b4cbe0bc612652c0",
-                                "uncompressed-sha256": "fa8dc6a42a760f16f01d126a2f6516bce04ff5500356f204824805a136321ab0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "31e10bd82e4bc43e2eadad9f17b0a80efd746c1ad5d6d98228b3cd92848dbb55",
+                                "uncompressed-sha256": "c1a1e3b682c366063479c59b7c35872de7ad80d0af442deb0c7bfd06f4ad70e0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "53cfdf3664f4b0b006aed267c95f3a373c09c3b869d0e94aad0b743b49454c8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "93275584c2dd8e26bc5af00f858bb6411cac7e2498f96c0990dd76ebd4d986b4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8966b57d60502309fb6a8dcdf18687ed8ef05fe997255d9ecba85480a9d030e7",
-                                "uncompressed-sha256": "0dd4e2f44b3b2d9db7db66da45f78f1e0ca1f8a2348434d8fce30fbbabc9a857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "518026f3d814fdf073b1074fa86268d4b227e384a85db2d54a7309d8b334371b",
+                                "uncompressed-sha256": "d6121d87f144042cd042534701042f7b35e5ce2e89a697bb9851e8f958be912d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "91471897a57a7b4e0d8e5d6a84c81e6ab435f51da47bc6e989b706c527f682ac",
-                                "uncompressed-sha256": "bdb4880923a472fba9367c672919f54ec1abf9beefaba0a80214f6445a15566a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3ed23f1ce79a76c032576913645d50679bb197b888c8c5e064c4045f24baddab",
+                                "uncompressed-sha256": "4b8fb01c8d41b91e063741a32a25946939367ba005277a6adf705bce5f9ed694"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f3ad28806644b187fdb120d070d442cf17bfe502da21b2a25cf28af37e342b41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "be7c4a94d42fde1a40e28ce2c481d3769f471f970d5163ec13d64f78b42a400c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "177340178f2043274eaad4a25bb99e3cae2ed45af9187ed8881fbb732aa87b20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "16442aae27968c2ced3492230d2ac3905e678bd01e952b26baf262fddb851c00"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240331.1.0/x86_64/fedora-coreos-40.20240331.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4c0e11cd5ccb210fbcb1e63b56ab51b7702ab3bc5f319c9814484b088977aaed",
-                                "uncompressed-sha256": "241e422506e43d3948f4f11fcba0bb801fbde2d96ddb76aa2fa9390d35d9996e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240408.1.0/x86_64/fedora-coreos-40.20240408.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "08753ad23b7e70f8308c5a6547c2eb2aaa2632690a3fd6cb4f3a190250114599",
+                                "uncompressed-sha256": "e718e58eddb1e213543f8a4ffd3b965919704b52ddf0991ecea9e97862896a76"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-07bc086117a22653f"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-091d468fcdc673d56"
                         },
                         "ap-east-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0d07e3fe584fda2cd"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0f0c846a68ecb752b"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0652e4768eb0787ad"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-02a5882afdd6fd606"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0c940943407a19b23"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0a9bf891d20bf94ce"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-03a66b5f7d1f45f05"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-03e39723680b025d9"
                         },
                         "ap-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0eb8390d2255b2c7f"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-05676105ffc760f62"
                         },
                         "ap-south-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0a52e5eed9f38ecf9"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0e92c85bb7c1513a6"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0b47f8ae2dc6d24f3"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-05c6fe97340b4f169"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-096b56b4de809cffe"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0812bc0c959d0a0a6"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-093913e7c343bcf77"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0fb5ade4a25771f54"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-021f7ef9222bd76dc"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0b8292c7b43924b7c"
                         },
                         "ca-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-04edae0331a2cb99a"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0f7456819aa61b8eb"
                         },
                         "ca-west-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-05ed8c63dce4195c9"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0c42f8dab46784883"
                         },
                         "eu-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-06a49229bdd5273d9"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0ca9419b7a64fe2c1"
                         },
                         "eu-central-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-04bf781e279dabcef"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-07646a730e094dfaa"
                         },
                         "eu-north-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0679e33db04e369fc"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0f4447f467af25bc7"
                         },
                         "eu-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0cbaa1a0ab3b0cedd"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-00c75c2e7cb34ed7f"
                         },
                         "eu-south-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0b7cbff6b9a0449c5"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-03051ec406324e94b"
                         },
                         "eu-west-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-037402d3e5225050f"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0114e265a96d83995"
                         },
                         "eu-west-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0de5e6511774e513c"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-05aeec7d8dde1f6fd"
                         },
                         "eu-west-3": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-099145a1f43770cd0"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-04031e2407e07fd0c"
                         },
                         "il-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0eed4f7691f973e23"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-09c8ea52f8eab9d22"
                         },
                         "me-central-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0a794b281fd1dd8db"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0c836ce305d4e9336"
                         },
                         "me-south-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0c9925c337fc81fe0"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0a5a11086e11c6a46"
                         },
                         "sa-east-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0a0a0f1c36cf8c3d7"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-046757ecf2e219582"
                         },
                         "us-east-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0d6b046b67f2ec40c"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0e20c9150f3748716"
                         },
                         "us-east-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-0da567111c7144af3"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-02ffe2b8f1244751c"
                         },
                         "us-west-1": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-03790d65f69cf2e00"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-03f995305a995952f"
                         },
                         "us-west-2": {
-                            "release": "40.20240331.1.0",
-                            "image": "ami-09b81f0f9f2acfcdf"
+                            "release": "40.20240408.1.0",
+                            "image": "ami-0f532f32c3c2597f7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240331-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240408-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240331.1.0",
+                    "release": "40.20240408.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cc445a4b9287be02060441a50389beef0b9d2f7dc017db256bcb0e0347112153"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:01fffac15bb5043d5cb2c2ef5b4835b88d3f6533715b756ff84caa2d9fbb0f84"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-04-08T13:44:09Z",
+        "last-modified": "2024-04-10T03:09:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "15f4f2ccdd0a204b34919d1011f5f92f698a802e12df7372b3032ec1671878cd",
-                                "uncompressed-sha256": "4f6fd38b1ad473bb82c6dace1bb3c25b726744fbb10148038f1c232d3d9a1dda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "47359bf5a7df0ac6f1db78f389cd8e0d51a9c9cb5e222b451a7cf09723f37741",
+                                "uncompressed-sha256": "17a49e2da207dad6d70a54bf7a1dd661a8e92e7e7125c83c88dc71d3d1f74128"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c9088b6abad7349ac7822a080280d44966fe84e56b061dda965d75f64c60010c",
-                                "uncompressed-sha256": "0c19c242cc95ddf9e6690ba07852425e782e61e761db83295742dd8c9df5cb4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d92aaf56ad09563c7d196c0977eb56bab5eacdb5f9b28655e9da05b81f89c3d1",
+                                "uncompressed-sha256": "7af9ea09ae8344c3231200fc1625150e02c3c7f0968339e5ae2ac53a4d3b6a88"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "aa6b4717aae755d8ef2dfdc46d784c7d8ca92da157236b79c1ab8adb54a70ee3",
-                                "uncompressed-sha256": "547109cb0751bcd99ea4d0a4c93aade95ec758d4784139bd2837a0ee9b55c314"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "6b0afea9fc1e9ee5515f42dd35b71bf4235d8ca1bafc13422f5026da397293f7",
+                                "uncompressed-sha256": "e7cf8fd2cf77f75d6c9b95ee7da90dc5f2907c0e0ec07847be9d07bdd8240105"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a5b69416e3ec7adebd6fe2a5641055ed7d16124084d6ea074c398775e7b1f596",
-                                "uncompressed-sha256": "f7a2297988a22a9f55ed1e80cbdb3e6b2acaf9415ff5b4a274e2ba9f6d7285ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "962250a78c8be436b77a4f5879ed0669a99d32782f38333d57652209e59e3cbb",
+                                "uncompressed-sha256": "fcfb54d04c89ce2beb89b38b453fda80ff17bca006000d4811b52a05610346ff"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d21544a9c4329f9b2555bdef87c9a5ed9be1dbb1005ff9ddd4d3f9eab3af82f9",
-                                "uncompressed-sha256": "2c3e35ccd6fdfb61e950fc17a368f67e9e0e2a4a14db27a1eb0ee5682e08f6f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "cee10de8ae56c9e400f8701454ec64dd12852d29d52caca2bc00bec7ee77784d",
+                                "uncompressed-sha256": "893a87a03733e47202092a22e9ed317015b69ff9fb2c8a7d1888b74bb34b7f0b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "67a43999b72b31dee4636709d4488d26fbd5e119fff62db9d2d54f0f73a54d0c",
-                                "uncompressed-sha256": "e5605f85bba734edd85d0d837cabe5df7f1974d0fcf2b1ca288a1790e3665c97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0b560879b785a5da8869635d3da939b1f0c0d02ff1d81600299fbf9e27ac642d",
+                                "uncompressed-sha256": "e23bce5966b70150f5e8a9ea2de412705aa2aad89ba3f8aa6a8e55699389b6d4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live.aarch64.iso.sig",
-                                "sha256": "3e68b68c7597684df8b6ebfa162945c162d77c2e37ad92f2e4c2f1a4cd2c7e46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live.aarch64.iso.sig",
+                                "sha256": "86b20ec7bb955bcd3f14c5ef320a95760ce4ac88600076d686aed5bccc5305bc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-kernel-aarch64.sig",
                                 "sha256": "4c32f6723eeaa9a00f53a0aebe674550099bce633c9a18255fbbf7550a611309"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "839de66325678ded487bd50cc99b3f6d08ce6030bc972a580a3251963764c101"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "633f21be091e667e09136717c62d2e0121776b3cd9a543df9ba870275b7ea7f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "24195b332f522b87dbb245df40faffeb605c4bc660b27725f408f4850ab90c98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "7f0a49112d98f8c1668510241c203ee1af826fc163a5bfb670a5ada6a8f4ffd2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5a1d51971d3dcdf9ffe1f8c84f1141492de2bc63eb03453cc14a5c41ac9a91cc",
-                                "uncompressed-sha256": "2edf8f440263d9f92ec5e213c161dd6bc7c8e424b8d40aacaac25a4a353b298f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "b5b8191012ef410f63e5afce453cb330f4887ecd486ab578664bbb0fe2587c35",
+                                "uncompressed-sha256": "4c8c682391cdf86fddb137253f06238c380e420b2b1fc84b561b6b74ecbc907e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0728e16d4d3a0253a06d77527728e9a86789ea363df554f1b7f9c8302a080035",
-                                "uncompressed-sha256": "32713beddda459c22b4f1ff7ba415d484b71ba3a1e1df43c38ab32e57eab2a66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e90f28dd3c5a4ae8d7a8f85028cc488539befdb505a055449601b2cac3184b58",
+                                "uncompressed-sha256": "866c718a12c7fd58f24211cc9e01dab49318ed98f856c13b353a2bf0d7ef9556"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/aarch64/fedora-coreos-39.20240322.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "fdca70628d385f23319ff6995eec4e378aff9b9906ac7d6b76edf095e87b559d",
-                                "uncompressed-sha256": "9e883fcd813aef15ae7351ea0f09a7987cbd0a1198e518a2d7f0fb8097cc871f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "98b1c696139a3a9fdd82e28d8da91134d0ca304debe28fe979fee575768cf8a1",
+                                "uncompressed-sha256": "0b6a5d0dc62a818c070229a95740393a66b28002223b3c9a74e0b2772d27ea54"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-05edcff0be768f852"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-009d3b4407c5ca5f5"
                         },
                         "ap-east-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-017e990da411a83b6"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-008927b5c40cc2b54"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-091b52bd0774d2fc4"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-05a799fcb8a54339f"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b7a8e23c533223ea"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-05276638850f006e8"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0fb3b93e029309b42"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0680824ff5521711e"
                         },
                         "ap-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0276619c08afcb7e9"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-09bdbea81ad0b5478"
                         },
                         "ap-south-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-09d263e67efe924f3"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-06cf2179c248f9486"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-069f010d27542bb8d"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0a60c5cb3f51479b2"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-08aa3f2bf5b24d41e"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-01c317b685d62a750"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0824bc69a282b6f40"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0bdc8bd09ed3439cb"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-06386b2dfb210bdb3"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-07e7ab714829512d9"
                         },
                         "ca-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0356a0ec744488bce"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-05f34c86b3c965ee4"
                         },
                         "ca-west-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-05f579346fd4ecc25"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-03243ffb289ecee6c"
                         },
                         "eu-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0dba57f62d7cf82fe"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0bca1b3ec69f2ad45"
                         },
                         "eu-central-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-069cd0790d1236aa7"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0945b84760ab503f5"
                         },
                         "eu-north-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b8aa9d8f111a620e"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-02d6581c97899ddd8"
                         },
                         "eu-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-09d494a96e8fddb14"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-035b6a1ac22c242c1"
                         },
                         "eu-south-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-004275f2590621598"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-00682d1a06fe8ce41"
                         },
                         "eu-west-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0dc1a1d7b40f5ebfe"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-00fdcbbe003855a8c"
                         },
                         "eu-west-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-038eab8beaba315c2"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-08b41f129a9325977"
                         },
                         "eu-west-3": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-07abb23a99d5dcd3c"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-08bb624150c16ac5c"
                         },
                         "il-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b0d5480c1bc7f402"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-09a40ad2c84e02285"
                         },
                         "me-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0f0979cbe71fef256"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0761f7054507a49df"
                         },
                         "me-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-094e939f2f280e046"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0cc0ffc487e7617ac"
                         },
                         "sa-east-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0e1afce45bca87143"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0ec705e3c5a6a3f92"
                         },
                         "us-east-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-023a091b3022ca2c5"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0aafce672e7c451bc"
                         },
                         "us-east-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0ca2c44beba46dbc8"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-022df84e2a2623b89"
                         },
                         "us-west-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b7e9f527683e3a94"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-047b1f82de51c1976"
                         },
                         "us-west-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-054ff717bf9b2db3a"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-017db7ff5f39db80f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240322-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240322-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "15fc0b2aba05111a43a45807e6701aba9c233d8eaad72435faff744c5b61fd51",
-                                "uncompressed-sha256": "2ea22fdb40ae48e34b9893cb2a8cb24795e2b7713b48fc394e1b577bdd6399ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "4672d5091b71130c06541ff98fda75a1c8b87d4a317d4aebc010985b201a69f7",
+                                "uncompressed-sha256": "c523e6328d106671c11459631a99311669e5c491a98ac3b5433ddbd164295ae9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live.ppc64le.iso.sig",
-                                "sha256": "83bb533fa92243c5e60d70ad7f3a4641d8543f1eccab0fcb5da9a1d279532d14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live.ppc64le.iso.sig",
+                                "sha256": "8374d34a5cfab632fd72484dc73a0e941b79a4917bcbaa647fde3cb1dcca35e8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-kernel-ppc64le.sig",
                                 "sha256": "def369c309a15c02788023689658dffda971eda68161320ff683fb5183181689"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "0f7b3d3ccc347945ae6c7132ac83133df983fea26a82c0eab501ac68a9a84a42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "afd560efd0d2ef069feaa8bd575bf8364fe565d73c757f26a45090d548ffa200"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c91d88ca23633fba88d3c897e94091869e5a5597136b997addd49b458375ca61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1ce45839d0a3ae80be9d4657fa29d6e291def52fc9989829b39df38cab35e915"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e2852d3eee0672592f3c890d1389a7dffe874411351108204abe6a7fefe4e025",
-                                "uncompressed-sha256": "bcaa9cf6877b9a802e019fbd031d405033172a92c4f2dc57d8749dc02f470f6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "760694370a4c12060ce99193a208c3710c6f8b0cbf7bd7da696b5e417adad4ee",
+                                "uncompressed-sha256": "9446e359cb9c5fb755e2c26a69054336efa60758ef0afd6b80b47d29b5145c87"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b5f7c8ebef85a3dc4b2c1f0f47c6657d341c659186e8ee15238850e7023eacb5",
-                                "uncompressed-sha256": "4133c1a3f822cf5ca6bd0182c17048072bab73b6c3c191f29f990aefdd016387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6412f0d238c95457b67c5fd69ebb286c1f1d3f92818d80851f9b9acdf9cb76df",
+                                "uncompressed-sha256": "8938c4d12c771c36b179c48e5423542f01195115fd1129d42fc00650471eae19"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "78f96428535c0681677a2c4decb67bbf9688d8cccc623c46422d5bf2612a94e4",
-                                "uncompressed-sha256": "091c5f29ae82f60424697f7ecc33d7c552da2578881570777e67e434a6b5e827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b711771bf55549fea9ce0ca60d2073268f50f4c15670a27af8e32438fb515caf",
+                                "uncompressed-sha256": "89869dc9866360c23d85aa77b7366bd78db97dbd83b3af05d28b5760a438ae75"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/ppc64le/fedora-coreos-39.20240322.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b679aef7adbd91a1cd9d6acfd24c04c91f27da530dd96b59f48812b855c60a6f",
-                                "uncompressed-sha256": "e59e91204e56166b80712f78b3555dba80dc2d8ec1019aa73f2dc6789b019bac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f8d3e0694e5f1b1666326a015fe452bffa6621bd2b37def61db4fe5a0331bc36",
+                                "uncompressed-sha256": "dbca260fc93833bd1d97a747cc5bfce1ec97eb66d0082cda88c6fd00d8cc1104"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "48f95b0fe366245155c880e9341eea22515e7bb646bab3fcfaba91ff57a20e74",
-                                "uncompressed-sha256": "db341efa79c4e8e1c8b415d93be9b20b469d0f3a4e66f783b34b2924801dfade"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4944f0d891240a0944e1c954bcc45ca427535bc3d5f8c02809099f0504dbe3eb",
+                                "uncompressed-sha256": "e110d557df400adb4bfe3aa8302f3f4418b6f89c9c1dd9944214d694fa3c4373"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ba585f46f2d902269df178e072780aefb3b97858b1a558d6f0ade3b30847f873",
-                                "uncompressed-sha256": "d4366d68e16ad38763e1b3019ccdce8d188106432b38b273d3e85359439c79cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "75fd70860a4b840200d52d1d2a06fc30723ae65d3c3d9c70490ed9db0596e2e1",
+                                "uncompressed-sha256": "2511a62347b67c548c669bfb1aa2c8e145bc6b3304260f5f96afb560d020372f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live.s390x.iso.sig",
-                                "sha256": "deaa2a9d58488402a655167829634b53241a87a9cfc242a6bdd9add0147e5ace"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live.s390x.iso.sig",
+                                "sha256": "171459a9378319faba036b8efa155aec875a35a871224757b5ec7f0221a8bcfd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-kernel-s390x.sig",
                                 "sha256": "e753d389d4f2432b7c213a0c8c8b30db77cce8d0bcbdb1420be1b328163051ba"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "6c5f60c0602792a4616af1d5ca9e1c812b07babfcdea3d49179b373f3b4070fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "60ea4d8bc1ca6807cc2d060b616f22ad35fabcd0a9dce83ea549feb9b5920ea2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "1878c1591cb5b0819d127daa008e6fc134607f39acbf2bd294eae5f14995a8cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "bb74a7328d58a304f2bfa90bb61554af471f7b9906823c169d9fb9b0a7ee886c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "38c3f5fe8432f1f45d0183056c4196750eb8914821929cbc5008ff6087f18d53",
-                                "uncompressed-sha256": "985e73e55a20844c712da2020e0b071fee97bc809c2a7115c15eba548a014ed7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "03b76038b99664f4c6158de6e9c13ed90a5359c00326aa0b19ab15ff496b9730",
+                                "uncompressed-sha256": "60548cb8c902809f3c9ba31f3f4d5af9ef001349f5cb6521bde7e78010cd4075"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d8b941163be17987429ee0cae9b66190cd8f73abd34f0d9d420dacd900b637d6",
-                                "uncompressed-sha256": "d52ba7c9e8ded9de42db758ddf5cdfa60fd9bcf84f747d1c67914c453231c38a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b68d24e1d16d9ce708ee4cc0b447bfe1667dd11d64f8c07613c31fa87be4c6ff",
+                                "uncompressed-sha256": "074f4eb51b4bfc546640371c433cb367bb4c389037f35742821ab482344f0124"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/s390x/fedora-coreos-39.20240322.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "58b557424e0786510c81cf6134bf5c46a8023ba2f95db6b0b0265046086ee7c9",
-                                "uncompressed-sha256": "67a4e8aea3f235e0a044f4f5fd0fc03b3497e7ba9de069d90f25c710dfe03aae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "24de7e7024047a014fe0367965f1d2b37294d07e0ffc63964c5632a996abbf86",
+                                "uncompressed-sha256": "687875fc838a8b5ef0a120897c69b5572cec414451ac1a2d3340a7d999b13b7e"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7ee854ea1002a8bcf21a2d1d79475700a47948e380e227efd645497562fd7762",
-                                "uncompressed-sha256": "9cdfc5ab5cfb99e37fe57bcefd5bb50487f7a78ad2cec9dda568baa653060102"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6669191f3ecc0a311d4c45cc56083309238bc071aae342215a5bb4c22a1b7b49",
+                                "uncompressed-sha256": "bf65502c6dcc40afda1c8e8017b05f4ebc81c693da134a297b8dd42a48acd0c9"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "bc7437b988381ecd584963b36cbb6b4918cc19ff54d5fca3af343eae6b3de1b2",
-                                "uncompressed-sha256": "d720015cbfe2697ef5eec5d5a76c1d159fe30f3821ab40135669a8e51e410c21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "38d25d71c3cd5072c7f206d6dd728f0d03468bd387dac5a9e856cd933b62962d",
+                                "uncompressed-sha256": "af4716040fe2351c47238cd16977172a133efad617ed4f7f29cde7f87290f83f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "71ca02c03f4f10ec61d4620b196b32b1020915f134e2db33cc78522c092af3be",
-                                "uncompressed-sha256": "1e0c25674dc1860981980c6c7e668dea399c2041b85e8d03cd598636657161ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "bab994220088e217e4e57ab67bb3b7d3cbfbaca4ccef1f030cb4a5f23a17651e",
+                                "uncompressed-sha256": "7415cb8f6b548b0fe545cd1874efd8ea6d04a629ffa3c9df79bc7af1f2ddb9d5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "37758f52319b40db8cb7e884d89a4e589c6cbdbba42f12adff70e7f5123cd661",
-                                "uncompressed-sha256": "ee1c6ad4be92fd8670860138b740a7a702fb8ed6bb82a7086ac699f9da86b56e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ee9438ff9ba343dcb106168b08db39890ff6ecd4a17081b9d4d592946d99bb43",
+                                "uncompressed-sha256": "640431cc772a3bcb4f5f5637939cf9fd4f14b14804e102dd0792df015b1e5985"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fb7f68d1904e0a05c10e1e0038678d41e0bcd9dbcb88407d251256d85e9c769f",
-                                "uncompressed-sha256": "1a382cf064210f7c0ded3e529d091b87eae1e4f66f485e819492cd739b4e1ac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "73c89e07194e567f6b945005a094f491f1d95fd74a917657ae50ffb5efb4f2b5",
+                                "uncompressed-sha256": "c8a13748dc5613a01a58cb83c54c7be08d7a6b8ddb7cc605b5091ac5ddc68c2b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "16bb57785d82b4f39465df7c512bf120396b958efa74661af53ec25b808ce06b",
-                                "uncompressed-sha256": "30b2cd451c68fe562d0c1d84a1e4d70484bbb03f85e96b8c259b17026e15db72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2a7f3bd8788c00bedc79a63a82b71281350e3bac7d0ebdb837be26990c4aeb3d",
+                                "uncompressed-sha256": "98ddcc878e333d5a32045583bc72fc6a91e7f5e710eefa1968b2702556cecfab"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b0c6d6eff4b3305ae6fc1e1e3df640a94debf3db2e4a9fb9a16940f3a30151c7",
-                                "uncompressed-sha256": "015e8b700d6c023c32ffecdc20ba087e39998c6920750dd3e5beec1d4a5ac19f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1c7bced30a36c1a3b06c22dc2a2f3acbea9e6f7d8fed1d9e31d5c0d3ad78ac20",
+                                "uncompressed-sha256": "b491ddd50d275a505bf0f4da48b2aa0a5de45f8ce87cd6991cf4d0c027945533"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5f9d7e9531c67147c458e663e8718c5df3d08ed0b234b5bc160d6eb763d290b5",
-                                "uncompressed-sha256": "12f9f9bcc5f4cc04f1c36f691abaa98d3761bfbfcca8b6e471b865ea2d6f6642"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9f8825df8f985f7f3481783a2e6368a815f60aa10ffc09ad6131ede1ef4007f0",
+                                "uncompressed-sha256": "fa7dfe1c02da41f7fcf3a087ef4ef4f76bb3af8f86dfb1db9a889153358ee6d0"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "11734e7c7b23b49a97dfbe448bc66625dac7033924ec767a2c72311824725eb4",
-                                "uncompressed-sha256": "bf4695ddb46112745a7384c7ff7e90f81866f7b46f7d37a95447e69eb7390e29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2c71a19a8ef79c04549228d942c216afe0720043e7eb7b4fd9faba11abe978eb",
+                                "uncompressed-sha256": "394a1f46d0a2a467408c928ff9708addfa0d6edebc39331d2572f6dfa539b547"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "dea0270f961b31f2ea1e8a6a1be82d8bfa761923c50859719ee3286592722d6e",
-                                "uncompressed-sha256": "7e85eefc198dddc6c58903628615f4cfa36abd6f76bdd2ca249f26bf5395421f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cc68100d7c584c8695c99f143ad523998005fd0b56385edcfe8867015ffda163",
+                                "uncompressed-sha256": "7a3fa13f7a67020c0c311cd74fb24b9782586d314b89402617408e1f6c701b8b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "eabb74b7f45ae0b3145f26400ece60f49d5aca09f55d186ede0bf10c74415046"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b02c7f3fb91b06c9369ead406e65c3f00ac42072db11021f105c4cc1136d8b80"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d0998a80795c7952e6c51c3073991e7f882772b450751687be982ac2f77f640e",
-                                "uncompressed-sha256": "ec72118439a2665063103d7c24fd153f763a32de81f700d5427a2ca148302895"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "929f9cfb73651e184b1547216751f483177f609610be46a72dfefda0d1bdd24b",
+                                "uncompressed-sha256": "2bde6ad2b106f4505510eb38de62f1a5a8b208c0a4809f78f180c0de1963ad65"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live.x86_64.iso.sig",
-                                "sha256": "37aeef740cdb3b47a2bfa3e6ffba10edaec2e70817a387e56223802bd7c82768"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live.x86_64.iso.sig",
+                                "sha256": "efc1417331c7af28e8dce16183c824820cd587a4b9f786e2d3f5790f0d7d3e9b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-kernel-x86_64.sig",
                                 "sha256": "7f32bf7a5d73623734939c5db8fadc3c43da33768ff4b60414300daf9d843bf2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0b19841edd6019287ea89ef63e0846a7d7107fdccf586fd11d18e5e3f789df1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "dfc9237f7a027826324576961161b6f62c1b4a8a32462a7cec1161b9c54423e5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ff7d0a98f0ae0e1125950533cec66f200e6e35e84783485cd2087199a9bfb618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "d2b97f15382c9ec3d4e3fbd9cebd9ffd0666adf668ca416cca612182efaeca0a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "9abc1bf718c4cb4aa49f5802ab302501ae94c845fc1575b53453abf872c27d51",
-                                "uncompressed-sha256": "5f6ec35b9050535ae63dc184ce6a3b1e1dedf65dc530202bbdc6209e5c03542d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "de22c179f992125ced49a73eb76dcee5152be7ef6ce3651b9a30d0d6b6aef94d",
+                                "uncompressed-sha256": "a962e4bc28e102f0c2f8ae9d34d6a141ca0d80139e56cecd86bac4d24230bc22"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "77370becce3620d786ac7c800ade7d21b3bc1054fe29c21bfa43250b03805943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "afea7f3e16dc3d993e0a0db98a5e24cdd983b20527bb21a8c9b3c59e83039759"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "931985eba2fa9c74469944248633f8519072e05dc2347a1a673d31e00d15757c",
-                                "uncompressed-sha256": "8a3f60e9dd88bf8e79741bbf328e72595d12db18ba773aca57de10cc05a2fb84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f2bb1688222690c8a8725ffab2c4b45242e41ca5d3f48a5ef373bff97652623a",
+                                "uncompressed-sha256": "897cae492e24877f1d0b28db3c6f0514e70a258870be3891ff099898d3b5451f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0f9c99e9f85f9ecf036f72ed10f6563bce60d25fd984e570a5f61e3eaec5b3e8",
-                                "uncompressed-sha256": "4ab1039ed4e8a06ece79093aaf09f3ebb05e3be20c5221d1191515596a9bd5ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "86083b3f391ebb516736180abcedd8c6a5c76335ac965ead2add09619118bb13",
+                                "uncompressed-sha256": "96c1b02bcd272824b02935d6be909450c158c7f3459c7d29553fc27d072a2f6a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "197aa24b1603bda2cc7db83512a4cbc187feec13716da755d89472040ef7a42b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "8d91bbb9f48a222749d20fc050124bfecc4be7cdfe303b1a58615ea3eda2bdaf"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "c711949fdffaf8ea5dafec518461d90a13ce7a3121c3d53aaf0b549d1ab4a56a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "317b92b43589a26b36e9b8c3463a7d59b6ae94fd74dc11ede50835ce38635442"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.0/x86_64/fedora-coreos-39.20240322.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c7bc925258be44c13eeeea025a246a22487c2196a5b0c44ea7b91d25f6d5a851",
-                                "uncompressed-sha256": "734dc051925d40408ce0defaa80444c31b73ea0b97e42d14178702b9ca56224f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c3650a14c29f54d00c39ec89184e6727ef828fb8b1c8f16d17597b1aa2d03528",
+                                "uncompressed-sha256": "cec8d68f90988d4e87e9f2711e9b6baf668b8d048daffa75afa0604790057179"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-047923788f236fcdd"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-087523d908fb2be54"
                         },
                         "ap-east-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-06438b7b7dbab83a8"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-08138f2212dc41d79"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-02412f69b83c7e860"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0d854b6ef795d3ccc"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-01490d20f6f9d0313"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-07d0dc39f428c8b8f"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-065a71eec7362f63c"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0485fd3e194cf7287"
                         },
                         "ap-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0c499cd766e3f4f2b"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0b4066c437b77d488"
                         },
                         "ap-south-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-01d0786f0e301044e"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0dad98f00e2020007"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b53a7ce477de1824"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0fc4e3d69fc849cfd"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-08b989c74a1d2147a"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-03753916a5948b95c"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0657c6a234cea66c9"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-013a6149da6539029"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-06b6754accc507f0e"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-09ecb3ac27dfeecbf"
                         },
                         "ca-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-07978f7f5b76334ec"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-038738d64e55a1ec8"
                         },
                         "ca-west-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b11ab77eea3ee5fb"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0ad32b6783569a9bd"
                         },
                         "eu-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0ec2b71eb2b92d80a"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0c2f63fd255bd8041"
                         },
                         "eu-central-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b2a60e363b71d4e3"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0a7ce10e431d07c77"
                         },
                         "eu-north-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-02c5ff04ba1eb10ad"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0793d8793ca987475"
                         },
                         "eu-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0b62cc222dcc5ff3d"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0e65d7718f9d33776"
                         },
                         "eu-south-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0ed2ca5e38b2bd382"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0cd8283cc4fd47586"
                         },
                         "eu-west-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-09f33bf474cd3da37"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0b6f196bf2342972c"
                         },
                         "eu-west-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0ba051a2f1d7b78f6"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0ec09fb131e92f009"
                         },
                         "eu-west-3": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-00bdb1e49ea081d10"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0262df73dce63d2f2"
                         },
                         "il-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0ce165bd2dca8bb94"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-03e8a6d83b2972d98"
                         },
                         "me-central-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0d0dfda1248fa17a1"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0fe09dec31194432c"
                         },
                         "me-south-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0a5adb71a5bb27c38"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-05b42fad6a04da7f2"
                         },
                         "sa-east-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-057de57e970bb2fc5"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0d4d86d0287cc85c6"
                         },
                         "us-east-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-094d14917a37a2c5e"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-04003e644492ae5e8"
                         },
                         "us-east-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0a87dfc14c7559a72"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-0f792dd7f469043aa"
                         },
                         "us-west-1": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-0041dacc318a5972a"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-050d8c3a0f4053839"
                         },
                         "us-west-2": {
-                            "release": "39.20240322.3.0",
-                            "image": "ami-02d0b308a50e3848f"
+                            "release": "39.20240322.3.1",
+                            "image": "ami-03252df1a16747813"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240322-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240322-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240322.3.0",
+                    "release": "39.20240322.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a5ba52e28cc38bdadade5962c6a32a780c23deca0ef8a767579d16a579036aad"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e0b9bcfdf88cae6a193ff3c3bfc5ea4541aa5629ebf436942fd2f808dc70b954"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-03-25T14:13:44Z",
+        "last-modified": "2024-04-10T03:09:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "22ddb364143b0187e4c134721d8f074de48ec2c0c5958c8d3d386783d3b91c7e",
-                                "uncompressed-sha256": "33d7cdd28cfc840a77afa9219b9efa57dfb9ee09ebdf0bb1623868b477aab259"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "52fd0c927dc02c92fd833fe84004e128dd371bfd331cddce87fbe29abb5db849",
+                                "uncompressed-sha256": "fb751ce1f5920803494798809fa6a01e162b5d26955ffc3769b8541cf81fa973"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5919ec39400d1b2331a089df9c89a39ffc480f8121f75473901eb6ea5038fa10",
-                                "uncompressed-sha256": "b08dcd7e60dd032b7df8c1b7e6e540ca4d37472d63df318d534f2328d992d4c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d4730c88c0432d7b09a0f17fea3fdd3206f6efd47934ef21f0f894f639411482",
+                                "uncompressed-sha256": "900a62e5d99de54ecb4bbf17e4dfd8e09e016783c9ac8b4ef5c8d6f242adb929"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "09abdb537c8f7a57236c5407064ffe1b573a31b34966ea8eb3b8bb3a7e5feed2",
-                                "uncompressed-sha256": "31c7b848305b7ef3614d3b27a2b3e4a0f0d90f5407092e7892ccedefe042ba63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7c8b992cf2efd1667400ea9d8889ea3d7050331a2039544c6ae076bc6c1a0d67",
+                                "uncompressed-sha256": "7132214a1ac7cd761ec83b0c6ef0318d1c8c64bbccf2d03cca5df7bd4281ffe9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "136e703d2d172cd0f87cc50c9c5bb39f541416f6e73d587edf6ffead28db69e9",
-                                "uncompressed-sha256": "d41a060f63d0e7bc2c8cd892276383dcb16a97a420514a07b28d465137271a2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "7eecc3dc887a73ebe3064cc495925936e393a327bba522685f85b3a4c356cc4a",
+                                "uncompressed-sha256": "50b02abb35d1ecf755c355db934bca1c21b16f58b6be917d6a9ee576da4b526e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "971d88f03d900d379a9b0ce563a258f5d08fab036ea6ce65f0e40f764e80cc86",
-                                "uncompressed-sha256": "83acf347c9635f790b628953b67abbe897060cabe54ffa73c0f3242182313814"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6e700fa7a85064068611d0f502e9ab5f6e3afa355b019ff67138f576b6193ba8",
+                                "uncompressed-sha256": "2a450390277bd8ac840a27716bd26b1945a5d8a67c8cfdc5ea5a4ba66612e65f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e26e094272bc9d627eb2084e23677511b7e427825052db7e06e56b136cb25519",
-                                "uncompressed-sha256": "a3fec8ea5412656a41348d9591c2ba1d699816a554025f5c8ea5d40804d6f91f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e293d7fcfcc33d4c168147b99821ed0aaab7dffae6c5ed2e9fb8f5463542f6e1",
+                                "uncompressed-sha256": "f7074404551e674f640f8faba00b7921569ea0dbe7bb775993fb55497c0a5cda"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live.aarch64.iso.sig",
-                                "sha256": "a8fa22ab649e1807aeb7ece4585620eae4441927f179399703454c596982a73f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live.aarch64.iso.sig",
+                                "sha256": "9f9189ae727d62c4069b8d8ba2056df9dd476027aa1da5d4cae1c25237179eb0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-kernel-aarch64.sig",
-                                "sha256": "4c32f6723eeaa9a00f53a0aebe674550099bce633c9a18255fbbf7550a611309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live-kernel-aarch64.sig",
+                                "sha256": "d1fb3ceede533eab6a44af4f2506be05d6f226b996abb0053370066c1c192627"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "dc743ab0fdc10c3e7afa81a0f687ab60f27a7e74be832281bbb402036c417c82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2bfe463e4bd29093200b655be0b53101ccc247b1fc28ac008c6296ede8f268f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6e90b4db06bb44353f212307347820548f0a059b398a72a3d9ff5c7306f1c217"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "122b78b32095394ce0889aa90d51aa767bbe6311cd8380dcba9e3260fc973646"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "d0a04c2518423298651c3e8ce6cfbc55a631f8899a64cadb0469ab8b8f01917e",
-                                "uncompressed-sha256": "6eb823a767891e26d9cc3bfb2e031454b6ffb0b4ce875656efb69e4d851423f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "be3fa6b5ea44712786923cc0636cf28cb94208b7adfcb4181fd5da43f87657cd",
+                                "uncompressed-sha256": "025def3fe4e6714fd2f364878da4cf4a878638bc4a4779d0bf69ebc19946a096"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6a48340b434c9fd883a07cd4db7dcd68c77387c49968da2cae89d0714df578c9",
-                                "uncompressed-sha256": "bacb713c19957519b507cac047b19ceac28043c99431afc88f35fc89fd593b04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0efe9db9c6da06303cc7639c59ac5f933ecfd05bbb54692392c8994632bcbae3",
+                                "uncompressed-sha256": "636e693a52ea3178ed174599bbc91b1cf5f270ebbb9d69644f2f86eefda1b824"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/aarch64/fedora-coreos-39.20240322.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ec782bd732b57d270aab3679d61fee30dc081f1f4d655eb647ef50ae94530dda",
-                                "uncompressed-sha256": "7d9ed18012445f9f742963f8acd6a558a19153af2a2c23c0b3258c138a32e315"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/aarch64/fedora-coreos-39.20240407.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0c8e11b45d55517ca5aca5fe8dae4a35c265b3a6562c60ebb341358d29a225ed",
+                                "uncompressed-sha256": "9f4d93045578682302d108b48411cf030db21d3a04149f72bc14ccaa02d06df0"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0cf396b8e7292701c"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0d7e0d72cd0511426"
                         },
                         "ap-east-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0670f14d972741406"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0bbd35f83667432a1"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0685bb7dd9f9271b4"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0547c4828be2981ee"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0708831cc258a5dc0"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0da84d3a3f4689f7a"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0377ac15e115eb323"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0c841fa563ab0de48"
                         },
                         "ap-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-07f6f3f87ad9f8fce"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0aa01edc0b9416ba0"
                         },
                         "ap-south-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0455057288ad1f060"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-05e7f08b25d2873da"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0d9927a9f9d84c096"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0a45b77db17dc000f"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-06a34f9fe6371cdf2"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-00da13db2361b80a8"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-024d9483e5252bd67"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-04a0074db37b1b09b"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0c27ce1f18dc6b67e"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0801ddc36e7dbf6c1"
                         },
                         "ca-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-01b14df11c2063b4b"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0c6eb0bf5795e80a9"
                         },
                         "ca-west-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-03a149703e82d111e"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-09e4b8ed244454158"
                         },
                         "eu-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0522a17465f728102"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-092cc7c5707c872c9"
                         },
                         "eu-central-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0b091bb8c7a4f498c"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-01f153b02864daadb"
                         },
                         "eu-north-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-01c0359f0ee2dbd1c"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0c14c46aa5fe0e562"
                         },
                         "eu-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0589b591b8991609b"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0345bfae4498c71aa"
                         },
                         "eu-south-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0aa0159dcd682d0eb"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-04d707a8890900286"
                         },
                         "eu-west-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0de0e7454c6960a6b"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-02280c3c3d313851b"
                         },
                         "eu-west-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-07c2fc1eb866cb92d"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-09f7da8c02b04ee97"
                         },
                         "eu-west-3": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0a6e29bcd2b234d08"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-07e1ccf11f261aa7e"
                         },
                         "il-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-025ce3bf3215e2aee"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-06fbc26b37026f5bc"
                         },
                         "me-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0649c76b21de7362c"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0684fe06819cd2319"
                         },
                         "me-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-063c6fd7ebf6208db"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-07ac7413beb34fcf7"
                         },
                         "sa-east-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0c886f46caff8ad39"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0cab665ac33249164"
                         },
                         "us-east-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-08c333442cd34e26f"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0949478816ef5b3c2"
                         },
                         "us-east-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-062641163abb38628"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0c04115cbc64ded1a"
                         },
                         "us-west-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-069981f0eaea3083a"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-00fd7550ea3c0c7df"
                         },
                         "us-west-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-01d32880bbc5d08ae"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0f5de984bdb6815ed"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-39-20240322-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240407-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5cb4fa0dcd0d9ff3a2a5ee43c20169ca560cc60aaa35a5057b71a354a7fb8a3b",
-                                "uncompressed-sha256": "cb8349201e39ed94adb7f0a655976a7b774cc565a0d4aa672e52547f4146bac7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "aa78568f8ad1d82a48fadc67d24ad3e60148b425e6f2a1cccc2f4f769050491b",
+                                "uncompressed-sha256": "4b9cd416b0e6aa85f816731d654b0fa537d109016e0b9631fe859f636dd41814"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live.ppc64le.iso.sig",
-                                "sha256": "dba72a8a42f771284b2beef4dae4ed46ded4e70a71b8f866fdb282d1fe2a73d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live.ppc64le.iso.sig",
+                                "sha256": "25839a0d8ef212e4d0d8963e73f16b1ef5551d240610e46b9f05c521555b41f7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "def369c309a15c02788023689658dffda971eda68161320ff683fb5183181689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "ae53d03ab28dcd102fa5dc7dd7b7e1a64d3f6f7ce4b7610ef11856c8c206f4d2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "16b52ccce1619ade6e98879820cc4004a79c048470e318339c130047d21ac986"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9bfd3da264dc1da68d314cc6280480470de9e900618e36574bbfa42d9b7345bd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "66e3c6935eccc98fe7457bc6195657df6494a4ac8e5e1313f227c08d454c4d16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "659e0f1c4f7ec094108494f9a839586eef21083ee4bc2b89a8f8e25e0f460cb2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "4f29a61cb427fb558217391bd7bcbf1908442066852ead2e084608d2af5bb2a0",
-                                "uncompressed-sha256": "2880803a74315c97d758b5916f2539a04de595afaad5b0c0378526b6839588c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "594f022e17d3a4a0b0f21d999dd0a408f7bbfe5ee7757d6e694243013a36645b",
+                                "uncompressed-sha256": "6e4e88ce06be6b4cbcdc94c96e9c454c2bc03443d33c67ec6fe4f0c42ab7f300"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "30dca040efbb8069e55caae75824acc5bb96bf76abe213e48cbc83ad50a1c7ba",
-                                "uncompressed-sha256": "37a279c1c6dd192d1adf3ad649e1c191ad0b7b2ea3eb9f7bb21ad8e032745828"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f78bab35f4e617b4ee4a89b1576896586e1f6dea01523d7e368c932c5ab343e1",
+                                "uncompressed-sha256": "5ec3d4e610154163b9c9bfdf106e9b422a8807f0f35f107e1c80f3d9f4b4ac0d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "8896b23c074199527199129ae6f5d6862244c688dcbdaf64e0a327f57b54b3fc",
-                                "uncompressed-sha256": "e2fbdb2a1fd1a17ece78ed99c4516fbd239b56cdb232ab4a5e881776b7c6ec95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5dc1a2d52c88ad5dcae0a10d5073f8c7cdcc1dc26c1e4b93f7267716d8061bd8",
+                                "uncompressed-sha256": "73620ee2a339e0247df9fc53e59359c5f0e2b5708226dc2f20abbb97d4d19b9b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/ppc64le/fedora-coreos-39.20240322.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5458da5e8090da4080839633e81a2de0556482a1260c1bb3ab0405ccae406392",
-                                "uncompressed-sha256": "85a8b3c508b7f240989a8a7400b7d6065b44148856cc3be8aae11c3bfe89f24f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/ppc64le/fedora-coreos-39.20240407.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9971f120a569321882dbb3921f019d3f8ab95471069f9756b1c66123d3021721",
+                                "uncompressed-sha256": "b50cffb8f3301579d685f0b17fa412aac3ae38d595621b08a1806e63ade8833d"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "f954e009903a83f64b93ba59e897daad71f5916916cb4d9ae127083c79f845a5",
-                                "uncompressed-sha256": "d99462b0566ca876550b3053e2ba80b1f54fb0e36580fb36424f9435970191a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8189d0c388abf9e956b6d473310d32f5c489da2018d53d66a9fcb02e3b904156",
+                                "uncompressed-sha256": "0ec518b6f7fce7a3b51960b991b97f502f52b2bd9533265e5e3723d56a76834c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "0d183ef6fc1b7670614993c7c02b8c9b57393024f7e6eb167722954f50bf803c",
-                                "uncompressed-sha256": "abb56df266ad7a494f59a38846fa8c59024cbcbf0ec6747f03be0c7aef8d1547"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "84173fc896ede155c82688a6e09ce3f567e1af1594fafdb25f7e43fa361d9857",
+                                "uncompressed-sha256": "4e7a7d2100f63fe439a4aa103e95a0b016ddfc02e0ed2bce3a2e02022ada2092"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live.s390x.iso.sig",
-                                "sha256": "f425760b02fe9a99add891c652c1f3a82cda9c35ab182fe702b87ccdad021c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live.s390x.iso.sig",
+                                "sha256": "40e91176cec51b59568934c16720a4e9742069a0e81b300e2440ca2db49630b0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-kernel-s390x.sig",
-                                "sha256": "e753d389d4f2432b7c213a0c8c8b30db77cce8d0bcbdb1420be1b328163051ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live-kernel-s390x.sig",
+                                "sha256": "2ca011ae1580244de18d048b10b0092614a64d8786e3c182764977c036b81dc3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7e98e626a01709d04a440665440f73b2a5fa680b81df1a61c2f5d9c686ff93e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "90c31f5f4300ecbcacf0ed31530194dc8588e236338c8f5786aeccf72794883c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4a290bb79d0714654c5441a590dfed692a3c8a82218dbb4b240432204a838641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b5ec17aa2c53b8ae4d553d367cf360b8ea145cafcac7b39bba332c2c0ee5c992"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6a15160c6450ab4b7db7cc28bf6095824af29a7a336337ea4226b56e3bf3e6cd",
-                                "uncompressed-sha256": "0fc46218be3da1619504243eee801c6766c7a54ef7df8076d333951654bf73d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "68710d5533cdb5bec2c6f1efda2bb90eafcb36b0848ee9a9e0e9f0e304c37b0b",
+                                "uncompressed-sha256": "0cda59fdcef9326cd13bede82c54d1592e28cdcbf01cd5ecb17cca865c48fe10"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c04c0cb187f77c41468fa0b96a4695abca5f7850afb725bd1ea78b2cdb57648a",
-                                "uncompressed-sha256": "0ae1409437bb71309550511e7573d4fcce2d7109ce91dbfcf8c49b66acb9c117"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e974705720d90882336e89537e12bf305f355b71fe4e17e5a9ead409f5b5d3b5",
+                                "uncompressed-sha256": "006238253d967dd7264c2b6c9e9938eb0bf97bc117a5b69dfb2384b1ff404c8b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/s390x/fedora-coreos-39.20240322.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c24eaf634a6ca1c00615e32093d91d71b1a84663bb995fe0e54659efd3273fb3",
-                                "uncompressed-sha256": "b4c82c73de85ef07ae50f6576b6d558bf8aa2d30c1ad446053dca626dc05b164"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/s390x/fedora-coreos-39.20240407.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7ba3db7eb729b9aaa361216aef95d9cfdd0c29ee89245c9c04c8da207fe41c0e",
+                                "uncompressed-sha256": "b6434bc4a9ca3f182408e1e5878abe46eb55c873dbe17c24389c4ff686456748"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fc74010f7d405e6a7484972e7202ef60d929b5da4a45c19937d13809b56c3583",
-                                "uncompressed-sha256": "39e535208b6da30a950ff4a309a4f319af06bce0835ae61ea21e5fa7c8a970d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "eddbc8f898b0586a646c0764b504a7bb21c13ac96a7594b1d8b4570ca4d7f56e",
+                                "uncompressed-sha256": "19e91138153216ab174461c8100c6ddf1129515d0167072596c6288426147f35"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f5850011816138e2dfc3d306897e5c00090148ac6e19f87ae5dc7f51b02e37ec",
-                                "uncompressed-sha256": "b75c6f0d9c29b1b0aa666828e33f2cd3d65293a99c55dbc4a72013f981845520"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ae5a252669da0125406bf50ad4618f4e452ea1122ad294ab45472744dcf3443a",
+                                "uncompressed-sha256": "b0e07b3b19d599a422b18c5c020cccb9b418c09493ddc0a28ecc30c50f1d7bc1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "fe0c03677d3b74af64ce0f5b50d8ad1fa3c1f4eb4ffbc80ea15b22f6a0708e71",
-                                "uncompressed-sha256": "97d6b432e0398f415590a43ece73a0c1be878387ce036e162e3b89361ebccab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "6a834aefa1be18b0647c46f8d6790e83432991a0b83056e71b4ce9b9fbe61b92",
+                                "uncompressed-sha256": "66d081cfa1b4ee5e1a6b025d0793d0d2fd57d2ea42a9fd29210c6e6d6b81a97d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "05ce4979484cff7eae22fed79c87a884cc66689197eee4cd1657a15c80dd7889",
-                                "uncompressed-sha256": "fc07178f7db79520c162806e3f11765e0d1a6d09c20d41aa4cddf3679701c727"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "afc2eac262d466bc4562dcdea0cd8c9f222a4df3c4d202ca8934c46103c32b17",
+                                "uncompressed-sha256": "e357677dd1af24d64f195b7bbd34584deac42ecab4a19502d9f1738a88dd5c67"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2b39f52b3aa4d545ef2355e0d9507444796d80cb2b2892cae53142041987b724",
-                                "uncompressed-sha256": "b85e86ce2253a34314a109e5bc0892cca29fbdf766b85dbb155f9f34fcee6517"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a69e1c645e87eb7368280fbf06b17d93b87c8d878f22872e50e91dc0ae155511",
+                                "uncompressed-sha256": "7af9633afe670c0da0a43a5f85dcb02a99f8c4cb6524e1716cdd93d358438913"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d3ab21543b732c47d9b2d3a0f05bf3a4828b6663026c65718cd53a546fd71c5f",
-                                "uncompressed-sha256": "72332375e120493ada77b63ef05aceba229bff0907e50c0cb23e248eeafb41bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "5e543dd643321083cd6006685af8c9de2c607c45519b130e83e871b8805e5bf4",
+                                "uncompressed-sha256": "d5ced18d2cc6be1f1f6c6292a4814c92155e56a53f27fd61de227c62a0e04024"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4ce51dc623c4e4b3c5cc6579b69b1f8a9dbce1fb74f36d3444391fee9d3a5165",
-                                "uncompressed-sha256": "79cea052069fda28465e975ac6419186aade55862080cb3e773e573ed943d7d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5a8c5c43325f49349c55d6ebeb7c64916b55f150d11646b486b213c95d35f736",
+                                "uncompressed-sha256": "4d1012121574418c219b7f6394accdafc9b28eb4111cde0365cac7692d047df5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "421314482b361be14ad1312f2e19152fcc16837e8733592225befc263d3595cc",
-                                "uncompressed-sha256": "38e85cb8316746e9ff8e758046d908c6e0fb4bfc0a5179ada0cbe7355e09df8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f21385258bf84bbf54109c601de725b0fd97c44db97cf430873401bdf603a714",
+                                "uncompressed-sha256": "470116f69096bb81d7cf8fd8e0365355c4e134020afc85c7e48a56e0434dd9c5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "cd19b9d835fef8de20000fd6e5acc8e7452487767c5501cfceb3d5bd7d31740a",
-                                "uncompressed-sha256": "c75bb4bb6e65eb290d26db4a70fa9d3d821433f8e356a5a70a7f5ea0f8c37e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "dce7e83f60d418b8663a4c0ffb9faca16ad7d317e7f4d38d3cbef7452c7db070",
+                                "uncompressed-sha256": "dc732a4840ae64f0d0b7cb01f737a459a90c318967908a71bb8e96ec2413d4bf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f214e44fbc2c4569240af7d795f3e00d82dfa8480e26937df9746850de262299",
-                                "uncompressed-sha256": "bd7c73bb6b5f74b7c9681350eea4bdd73188e6b3690746d803c63f5c65ed0cf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0b725b53a6ea1a0881b055b73dff014147cc122eb2e02bbf663d4a4dbcf93548",
+                                "uncompressed-sha256": "d35c3830f0a395b820fab55dbd0111c7b55d0cff16e5aab45dc00d79e603a755"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2086cb6923cb064e9a6322c2b74ef0a047e90cd57654ab3cf9985f6eec06476e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c80aede652499d19f50c0ddeea78a6a792a588728ea6b973c1a19b6caa06a8f9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "70bab1e35553ba21c0d52ade8439fcc884553bd71c1c731b2154b2bf31a9edce",
-                                "uncompressed-sha256": "73a9cb8698be47c908b85af947bece356e3836473017c586f6674f939226c37b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "58c4a4da24d6583e33c42158fd63d9938ead55a164449cd09fe39b358c3d5bfd",
+                                "uncompressed-sha256": "5e8c1e1cbbb8672fa5b9e1af8b4044ce90a737a24ab277c78ab19e5ed90b89c6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live.x86_64.iso.sig",
-                                "sha256": "fe4a9838d482f8336b757d898ad757398d1ffe0fdb15da5480b10e3ce5b8bed7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live.x86_64.iso.sig",
+                                "sha256": "51deea902c6e2d4f98484d7a7ace319f4463406e9e9d8aae7264cf5615d1686b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-kernel-x86_64.sig",
-                                "sha256": "7f32bf7a5d73623734939c5db8fadc3c43da33768ff4b60414300daf9d843bf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live-kernel-x86_64.sig",
+                                "sha256": "c1a86e0cdd001817105aab0ecff410f58dfa371d31533b186a28872b4b305190"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7ceda922891cd76a216ba280b4c8d716a0bd58c9a837f614e28362575225b2fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1d3449358698eddd12e71f9d68ba199e156c74b82e6e0cfe8e0938e2f0ac4063"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ad6377afd1edc98118d4dbe2e2d743523ebe28451dcdaac43de8919094087902"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1b85b2f5e6084cb0bb0ff616e94bbce7e47422c8ed648c0ef9e5fb6b67b8903d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a6a01d5109c395e93f01c3c1c8290fbdb1cdc831c3edc1e0c81a9443e48f742a",
-                                "uncompressed-sha256": "4e3ee550ce4df8f0b8498775e37683db3251fd24e7a1f3fc7e4f59776fcf8d3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "27ae16e98f68ebbc54fb9a5baa3ab5c8e061d168643c6ba8d97c61a44b2ff6ec",
+                                "uncompressed-sha256": "7588ef3fa3d8684521c68ed869c2ee6d1724294434290edbccca689789e00f4f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "67ebdf991bddbbab8f38fd72eb61ee3317ee7914ce7b6ae2e1a2a4b8ea2167c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9bf3d8c5e3ea15b8229a7c144362147ccadbd660f937095a63949103394e80ba"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3510d428d21c841e0c55a0f06035827ba98ee218d31819b5adbb04f2dccdde42",
-                                "uncompressed-sha256": "80e8f7555b4792aca56696c52c46f48577b609c435342a29d9faf806f7e2e55c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f3aabb6b5b9f3f0e1c657685e8f048a8c57297bf68d04a0162287c37ad5a98a5",
+                                "uncompressed-sha256": "3c1b9ee4e1c17d8dad90708370e9061264ad0c8627d1fe9a40d7dd6fa829ff41"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e4506b7a1df988c68b30d9919328331d1f9977e1ad9e9bbb2ce99ed494291c7b",
-                                "uncompressed-sha256": "1d7579b3c0e14f3ac4e338c505fd20939a8224b6cde35770673a276e4b8c7910"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "cdf9131ed2d1d440bfeb84abbb2c8a0727e81d48a188a379819643d21b80d096",
+                                "uncompressed-sha256": "f2534c604246e44c1d875e05784f7572c43aa3c3192e31cfe7b42167e0c616ae"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ae241c220feccbfc39a8320e92ad981b135c91f278fa299daa4d98bdcd11eb16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a0d8fa3438298a888abb4082aa44f9f61384cb873ee6797e0ebb2b9b64bafb25"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "0a2e15a9190e83ae179fd3eec41964d1e6bf9b8bc95c914048bd4a005b3eb156"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "360a4915ddee8bffcf200e215a3b64a07e7a78eb6d2f2f796d6ffd16836397e9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240322.2.0/x86_64/fedora-coreos-39.20240322.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "83c46263517214e6c9dd90653643fce9fae6d4f67695d66b4ac01f0977425043",
-                                "uncompressed-sha256": "5ddd6e87b051abef3ef6687e01f685e206320945862222af0f7c82eba8efb473"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/39.20240407.2.0/x86_64/fedora-coreos-39.20240407.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d0fed86db2b1c77b14efbb3ee7b509d4dfa7105b01e7343d320fada6dee43a99",
+                                "uncompressed-sha256": "86776a97b24388ead8d0b5bbe6bf0dfc451ef535f4fcea532d4d30ca2b112f7b"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0dd14c3b484158922"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0d5854b9b33f0fd15"
                         },
                         "ap-east-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-082838fdcd920b426"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-040023ac5bafb3d1b"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0de3ea0131bc12a9c"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0b9f954c7803036ac"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-07e7056ae7a5b6f63"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0eb4e701d28b5cd2e"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0412912c4948ef81f"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-074d68e107ae1c6f5"
                         },
                         "ap-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0425f4ca1a22b40f2"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-01c2eef5049be2620"
                         },
                         "ap-south-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-09b3a722c3e355da4"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-02ca988c94e1a1775"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0308185d33c5c0017"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-00cbb403ef5aaeab5"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-023eb32eedc34774f"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-039b49f588ffab643"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-095e20f37acb19dd5"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0a575f3ab7ead4736"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-06c188c094641a1d3"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0141315210b22272f"
                         },
                         "ca-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0d766f14a9e0263a0"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-01ede810e2ce9c0ea"
                         },
                         "ca-west-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0125fa3877d617811"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-092397ae0ff4eaa90"
                         },
                         "eu-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0f6e0629709d9361b"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0f2cc045f988b4088"
                         },
                         "eu-central-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-050790b222f50d8ef"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-07a6e2f8068bb7d9d"
                         },
                         "eu-north-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0cf8223214a13a617"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0ff50a620b6f5a011"
                         },
                         "eu-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-023a6d669dbf23485"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-033aed1a385a50001"
                         },
                         "eu-south-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0a0cf221f5f3cea44"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0a8db694ac864d7e9"
                         },
                         "eu-west-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0f818f05b8f8f3352"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0d32d0f71f40d7a75"
                         },
                         "eu-west-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-02969f3fb186e7a30"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0282a990b7ab24c42"
                         },
                         "eu-west-3": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0ec68bffab6ab5458"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0feabe0cbeac37e9f"
                         },
                         "il-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-071c8fd8e1b208076"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0f0de3451ffaaa1d2"
                         },
                         "me-central-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0475a1976c782f9e9"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-05cbd4aee03068970"
                         },
                         "me-south-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0b75a463041ee8803"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-09c302d865176705f"
                         },
                         "sa-east-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-06bc826f5f93cc87b"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-066b9eb07a4005dfb"
                         },
                         "us-east-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-04eb433d85ce7712b"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0471908decc2e3a8b"
                         },
                         "us-east-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0b4e11e2543441f6f"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-0c16645ea75d9e9b8"
                         },
                         "us-west-1": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-08b52ac7f519a6ffe"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-041b193d43253a988"
                         },
                         "us-west-2": {
-                            "release": "39.20240322.2.0",
-                            "image": "ami-0955ccc92631c893a"
+                            "release": "39.20240407.2.0",
+                            "image": "ami-00b782f556ff12df7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-39-20240322-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240407-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240322.2.0",
+                    "release": "39.20240407.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dfc5c7cf10571d153c4f65ef1e90a3d4ce1fd0dd7bf6c5156fdbc39dd1408441"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fc33fd482670ac9f3a8a64f53b7c11641646cdb3c82002f071e47aecbf7bbdcf"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-04-01T21:06:31Z"
+    "last-modified": "2024-04-10T03:09:14Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240322.1.0",
+      "version": "40.20240331.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240331.1.0",
+      "version": "40.20240408.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1712059200,
+          "start_epoch": 1712757600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-04-08T13:44:09Z"
+    "last-modified": "2024-04-10T03:09:12Z"
   },
   "releases": [
     {
@@ -106,6 +106,16 @@
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1712584800,
+          "start_percentage": 0.0
+        }
+      }
+    },
+    {
+      "version": "39.20240322.3.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1712757600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-03-25T14:13:44Z"
+    "last-modified": "2024-04-10T03:09:13Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "39.20240309.2.0",
+      "version": "39.20240322.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "39.20240322.2.0",
+      "version": "39.20240407.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1711461600,
+          "start_epoch": 1712757600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).