### PR TITLE
Roll out stable 39.20240407.3.0, next 40.20240421.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-04-19T13:01:47Z",
+        "last-modified": "2024-04-23T10:39:56Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "e322201d68b34f36ab46c3e8525b24084bc1ce70df16d73313d7df525ed36d18",
-                                "uncompressed-sha256": "8adccc2298ded0f9fcb0d739e9d9c49a71d80b796d2a0ef91d0324f573b84030"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "dcfac22fd6be7fd233234de30db0682f857616b1d202930f769b1eab41ac5d0b",
+                                "uncompressed-sha256": "50f8b55e85e4c9fc578c19c14fe9866aade355b024829a222567a6a61bbc2b4e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0500b4ae152065b663609438e23270612ebd27f0695fd7bca7ee345bbcac8b10",
-                                "uncompressed-sha256": "a9ebd40d03c75c016a5158c813b954b8fceb4c7d2cad3b1960f6f4912b88af28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1729e56e664e50c064383baf4d94b8b73d633dff1343b6e3ec622a2ed25a091d",
+                                "uncompressed-sha256": "a33e9d540d294526b4ad1b310dfb0b75c4ff1f68d49dbe657d0c6b90cde12752"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2ba83d8da8db779489d74fc6e277842c6f6f2113672c7cea57da898344bd8b76",
-                                "uncompressed-sha256": "daa1aa69e7524c3c168db079724d1acb2d5b3ee8fd138765f0c8b2e39400498d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "64f91a39dc6bd65cadccb287769007042335eef07f3ca3cb8ce83a23a3d57c88",
+                                "uncompressed-sha256": "8bfa1b120a531e129a3e69f847f9582d4ff94a4ecab34a89680bb2e52d0c5e9e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "86f4be4901d11144d9b8c057bb68965663ed4e644b54e7af7d7235c55ea51f46",
-                                "uncompressed-sha256": "33d18372b96172b235229905066405d84bdee0fa530ba225241c7040887aaaf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d29e2ac1b05f70fe2b609daf128e19cead9205d5bb5c44bcf6e20b72d12e25e8",
+                                "uncompressed-sha256": "1a7ca7c84f1e69a0d40208f2674da59afcd90f6cb1e34ae22b51ed8d7e2bdc78"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "79a13bcd17871d58a99f33e4f169163c42a02ac870382c166e1bd6c414bff44c",
-                                "uncompressed-sha256": "b62769fce6d0bfbdfa041450d758e1ef7bc85ebabe7f7630957a7a52a335834b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "63e4faf34219421bd9c276ce15924aa76ceaf70ae63bcdafd1d32278067f3fb2",
+                                "uncompressed-sha256": "97dcf872feb2007f1fc7e9470e3949a0db1435be89b09634cccd347df6ec3585"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "cb49c36090a487a8015227d3373a747b0db8dac63c2e2577a978e907296933a2",
-                                "uncompressed-sha256": "1b1030b579611a86f41a5a4a84f269031a0958421ea811fbdd5aebd92e3a9b04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1f1b8aa4e704a958472c6bb9d24c17ac6855e64ce2e450cf6151102077703d94",
+                                "uncompressed-sha256": "62bc896ceb78f78f39ff4b6285d51709838181d6d8cafa3acd92b8fe1f1d01b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live.aarch64.iso.sig",
-                                "sha256": "4e9aef2fb18f60b33c55aa00cae444cc9d4e0abfb68fe6749d80c9f395b35ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live.aarch64.iso.sig",
+                                "sha256": "8052da3395864348b91edb6d092945b7637aad824f6f5c0eb4419e01533f8b07"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live-kernel-aarch64.sig",
-                                "sha256": "57185f8b19ee9b41fafd9e79e0c61902ae9dd25230341c6eef4286923138f5a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-kernel-aarch64.sig",
+                                "sha256": "e2cd50a7ac5a1f1f3f6a2e411e956635327fff9f6b60b9e48f9b81cfb669b0e5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "04d789af51c08c8f65301e22a2092026a34069e36620ba4b0e134d94007b061c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d34cd7c60c9b99398d7bf448ced97ec2f023c1e4c6f9f3001d7479937e93a406"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "cb2909fa274c047d2c4b81fc3974deb9512e73f790bc7ff80b06bd376fef3929"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "524159f1a0be096dbf89f2d6a6d1cd962fdc6cd0f98a1a94bdff9fe8b6a84d47"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "d70eb04b42935b66704303dbcbd5e33bc645a7c2d20995dc27e97be22191c018",
-                                "uncompressed-sha256": "e20baeaa9ae119df14ad517746ec23c126bfef12c56bc670013532dec3dcf279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a3f98e30f60fed8f361c3f401b28dafb367aee936a05ca9002e61ba5230f0102",
+                                "uncompressed-sha256": "7bd6a25a62f107ee26b627a2a171845a2ec2626360c528ce7ecc8c212f0af367"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2c77b2a95d9455a47ec621ecf53c7ae90c436a6053a8bcab95f97fae64923df4",
-                                "uncompressed-sha256": "3c714f944f3cb1b89c1400957b6aee44962c48c1040862f1ef1d15e503113d36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "780b71dd7f3b7628dc1a6b4b5725748ae98a15ec5b82742fecbadb8129c96d4a",
+                                "uncompressed-sha256": "7e1fcb4d9325cc8e3ab7a07006f6d8986fa13928bc9a463daab1ba1d7410121f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/aarch64/fedora-coreos-40.20240416.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a2a62f509faef0f00371ba85af71a60325b9e5c33fe2843cda191855590770b2",
-                                "uncompressed-sha256": "8d5bcdfb1f5d21d74ab8cf46636c6d93eda080580cc9c7e9d7139458e6ed76f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6bf19fb68c17e69b79cee886b9fb06f57d9c0ea5c3c24f622e891a768a51d5e5",
+                                "uncompressed-sha256": "18de6b192c5927a20c2700354266d7582509b5aac0724c5c3ccdf3e0fa60c687"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0444b0b2661ef60b6"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0d40ca073a43f317a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0d9ac2d5304733eb7"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-02e205c720f65cd7f"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0374c0c981357938f"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0cf6f8294550f5df1"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0fe9e1d46de5631db"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0c9a75125fb5e2cd6"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0bb5c319c5778acca"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-03e8a62195decfa3b"
                         },
                         "ap-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-014daf3a46d1cb7cf"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0458ce77272814648"
                         },
                         "ap-south-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0679770ca53a99b4e"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-07eae66f52ff4cf81"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-01cde89592cd45f34"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-083c3141e85ebc367"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0ee80a218e8598b7e"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0b3f9400107b27095"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-05f735cfba011367a"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-09eaef04aeb281a36"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0f520107a6a499e5c"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-08fc8ed7774fc971e"
                         },
                         "ca-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0864e4ed931dd4e6d"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0c8e829e71b2d5889"
                         },
                         "ca-west-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0b86658f6ab3eb194"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-00e9a6001680e9713"
                         },
                         "eu-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0ff8cc09d1dcac6ba"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-059830d45642e0c39"
                         },
                         "eu-central-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-04ce1011e9cb11cd0"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-08041c5d4aebdc3f8"
                         },
                         "eu-north-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0b31286dcadee84e3"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-01550db7761f295c4"
                         },
                         "eu-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-08bfee9254409123d"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-06e4b223ea376318a"
                         },
                         "eu-south-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0fb07faf6077f8b34"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0654784c1979fac70"
                         },
                         "eu-west-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0bd96fe6de92cf14d"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-06ca7ded4d70e01e7"
                         },
                         "eu-west-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-008c0674d34a2ffec"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-044c0955c0629f819"
                         },
                         "eu-west-3": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-034d694050aee3749"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0966aaea9a8c652b0"
                         },
                         "il-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0faaa8cafc6e6890c"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0c78155cc6bf6ea6c"
                         },
                         "me-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0271f818caf2e8143"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-05aeef5cafa1c77ce"
                         },
                         "me-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-015b30da8770962c7"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-02aef805d78b8a445"
                         },
                         "sa-east-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-095da04de195504c5"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0476cf3bf5c9f7f8a"
                         },
                         "us-east-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0d3a615fe00cff6c5"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0e81605d7c99294b5"
                         },
                         "us-east-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0950c1032d6538388"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-09517548ee7f6e38f"
                         },
                         "us-west-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0f0d6c94f72be7858"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-07d31fa309dc9703e"
                         },
                         "us-west-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-065899db1697aa47c"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-072eb658c02167040"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240416-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240421-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "d88a162296a10996566babe1eb8ca31cba0c946264adff542e7291ae94cf49e8",
-                                "uncompressed-sha256": "b4fc3d349dd4bc9fef79357ce3e7cd464a7070ef72441edbaec82a2e9d30b034"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "32c30f1c1f33fbb75d905d9f6d3977db1e614ffdb0ed6b3eda0f82f6af20b7cb",
+                                "uncompressed-sha256": "a8aaa66aff3620f0f603e145ed9d0a2cdecd9ca9efb5cf3bbfd811edd1e1b120"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live.ppc64le.iso.sig",
-                                "sha256": "12b149ff83a93d2ea0e3ff520893987a208c8ec6b6fecb17e2da15283aeb816f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live.ppc64le.iso.sig",
+                                "sha256": "83c977e42826ab278ce076b8fcbb7838e29a69f6528e55dbff59545e491f2023"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "d829058051aac9a552d3f694854e8f8f5ce3a13d5f61d98a092c90ac4f5fc5ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "84d65f838f462b47fe4b95bd90b0162b1ed021646652e633078648bf94e17d22"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2d57285282d5b086edbb6cded96a3029a72917fb3382b1dacdbf9fa06fe240cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0d8b2eda3ffe9524953ccfbf26538813e3c7f2653711184b9c67276464116117"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b300aa08a7db4cb6c2bd8452d991c4d7570d24481ab25c739677436c92a44ec7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a5d2c8e1825b7f864dc2b0f49451e38e728c128a3e911b0522ea2eb8dfaa1af0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "729a5bcaceb28d9cf716e3df8f1373ac76d9a48a6616a4b453f8f6c07fb528f6",
-                                "uncompressed-sha256": "95aa1e2bbdb0c4641cce9bf8a0620c0d6269751d0ec50ffcbb49e5c1e869275f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "241b8c0c1f862ba4fe75e501b4f1bc427aa4de2798649727e9273f485d99724c",
+                                "uncompressed-sha256": "79b94750a32f8492208aa6e5a03ebbffc7aa2311936c9a2953a6652828e6e8a3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d63f06c1d6bfb41c2260cb49f7827f0b0c356d15a205fd5a3508fa2e4bba16a8",
-                                "uncompressed-sha256": "428b20c3e1e52de63c438ed761959df99714db934635d71fe6fc3b689e10e395"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "7cc9d1b6c09b95d2f75842a3c571ab1972a3800fbe143243218eb2a152072a34",
+                                "uncompressed-sha256": "08c67defe41a6270b07577ef4488135c5f282bb2e0527ca4e4aaa4007c39ffea"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "8cd78576f3f9503f7e76f8fe11d804cd300c31326b742b0181d2991529ab946d",
-                                "uncompressed-sha256": "79be54a410ce379316309535538af24aaebba944dd00de59e00f3491ad503f75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "6676d05aa26dc292eb8ce27b69f331e96fcf1d78c039f9e41540f7e99d9ee8b5",
+                                "uncompressed-sha256": "e24ce7cdad6bf6b093c09d40ff77b3825af2cf5db285640fbd4c7e24793652dd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/ppc64le/fedora-coreos-40.20240416.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "26b73c14048da3523eeac58e24dc7f712869218f896e12b9f761207010272a5b",
-                                "uncompressed-sha256": "305e18de7c46dfcb43b0feebfb4430c06f177c9a489780ad5d1d3ab74b2d28da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7a14ab8b9fffa6e3813b0340e5f569dc161a42441b0704c8b069caae768d031d",
+                                "uncompressed-sha256": "0cb3077cad0ef813966d62090a6ac8d4a431f0a97de1ab6f4f8296d238cc4b87"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "95b3ec6daba916df81e458fbb4d64f7474e6deeec7de961186aeacd4883754d7",
-                                "uncompressed-sha256": "d4b2bfec9de7cbd7a72958e10072e5e459c325f9f208adc23398f0d858d5202e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "287e60649e8e1fc200e64e248092e9e4dc33435f73386dfa11aadc08cd4dcebe",
+                                "uncompressed-sha256": "49235e0d647d69a4e1e3ed6ed2d6168e7b1f09cb4426d0462d7b7700bdf233ac"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c806e376cd1d94f779038d182fc5b84efd1656280fdc8312feb206ce81949a51",
-                                "uncompressed-sha256": "5888f393360a5a3bfc84a3822e0aed4848784953c5ef1f0e110f598cd0771c1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b20e04e1de24373fe282403b1236932be7586166f0f0e5c04303d553b98008ea",
+                                "uncompressed-sha256": "37d452acb8597101b09e8805db20f0e9e10ace2fdad9f3ead12b1731e969d20a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live.s390x.iso.sig",
-                                "sha256": "ab930f17143c7101f652a5370330cb58aed4da3a74c137b063fe344b5ca6b88e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live.s390x.iso.sig",
+                                "sha256": "7e0870d5db2e69f472d2032787e86e1282d5d4129e9d6aee58e65c7629860a92"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live-kernel-s390x.sig",
-                                "sha256": "f8e229d00405633e55de979cdaec9df069baa6d715005cdf003728c6c0ed0a01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-kernel-s390x.sig",
+                                "sha256": "9d4da609877d88cfccdafc5a58502c7396875001c74ff9d1dc60b92f17d7ea94"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "1098127b8a776a172b49e808bc6dcac026b2f8249f9ab9c37a2668de4e355be5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4601d32b189956918ed96cd607ae0c802ae2830939de0a0b9b81c7b664834590"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "6aa08f04fb0d8723712634e547d45d3db05e7ba9f19bed74a37c847030680369"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "fbd0e7865ee85c40107b7a5f081104b7233e3e6c41950420395d2d5a11fe283c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "62ef4cd46215973b52b6ffb31325e5358a5b9a4040040e7691743a9ac60e7a06",
-                                "uncompressed-sha256": "e858bfa232f094d2655812b2e1290af9dc1bb64590c07634a2177e877b09e2e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "61281e7a5b58c640ccb1d00354825764d1ae5b74446a340a32870cd55ac8e8a2",
+                                "uncompressed-sha256": "cc4530abd7577af954a7681bd4abb01b19abef637effe23b2a3a13264e8c95e7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "72371f4e3904f35553bc139aece5539f9de8a7fb0c476bd92b52fef317b9fde1",
-                                "uncompressed-sha256": "8dfcfbf28cbc67085925fcdf5edae9095cc7e535d17dcf75bd5b948c716abf4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "35012bf6926a77be957ba3a989d9e09b3efd40ed284136ae1ade7993a52bb13c",
+                                "uncompressed-sha256": "8f4d14a428692aa07ee8619a41e00f571701243889087c9f18da3ef775d824a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/s390x/fedora-coreos-40.20240416.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5d61b17abc754189598160b5cb64423eb28561dc0194f6d41704a49378c72605",
-                                "uncompressed-sha256": "65763b88d4390902f97eb4e56e5b9afe86a3f67915dbd52b0e0fd7ffb5bb226b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5be79903ec9b3ff5a64e907f747b761579c5aac5f338e49fe587b93065418f1f",
+                                "uncompressed-sha256": "cb27786d6eecc369f4b55193beaf31ad5012e9e4282183b708998c38e6342cb1"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "dbd7cb6e9f36f2b26141befc5ea15445df6701a26863a713c2727bd8cf6435a9",
-                                "uncompressed-sha256": "18c9785574892dcfed9a3e8f5a214db23669aee739aa1c28a0fcd234e6d006e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5a3f9ceba4484c94cb94787789b1864eebf2ed7398bcdc857155be00053e73aa",
+                                "uncompressed-sha256": "759a6cf17660ba5b99510738fe21a5eed914c2432b02e62f3c5273a450fc9a5c"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1e63a182bbe6489c0982e21e916ccddb469613bd5790ebe8571a426a52dcf0f9",
-                                "uncompressed-sha256": "e646d8c373e0d91b182cda4900586372935efc82fa52e9bad2ffccfea573c7e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "b0794077422daab691e1f800066a24f00c34e03e4d786c56f2d8c195453b8d22",
+                                "uncompressed-sha256": "e4274b02c25bed66e2802f00da279780b76342950c953f400e012c7db447bbc5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "580a380a75271b8ca1dabc0c0b7ce0d491895d826824ae5fb62631729b6aac38",
-                                "uncompressed-sha256": "61b7b2633fb6c5789274b5bc006f959c1d36c176213d30ee5cf1d920d46fde70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "46f0492029b095dbddb45bb9710155bce7c3f0645171dbd907dbf1ab54b1deff",
+                                "uncompressed-sha256": "97a53c0471c410dac4336befd44667f3a90ec75592b242975e538a9df094b658"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f079580412e867e383a669a7e033c747f90bbddfa276250f84c4a4db3cfed954",
-                                "uncompressed-sha256": "ba61441ed7de2cc82ef7b42f8bc72bd0b26c21a075d828f20254a04db8a563fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2c1c19b2b24475d6296117944f735d6b8dc98c737da8e9d36cb0982584906a7c",
+                                "uncompressed-sha256": "bacd940103160c03c83fd305708c2dc789b0513686b340b0fcac19f278a9ce39"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0eeb99045507cdba9d30bd8ba7226b66241ff84c086f7f6edce9b5d1de4a94c0",
-                                "uncompressed-sha256": "9fcf9ad58b78e8b20101c8625e523697096dcd349c5938e7fcaf932ddf6feb7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4b1b07af53b0bd7f204533009cd3e42c2f45e95c8487c9ab65b873f1d34b7b0b",
+                                "uncompressed-sha256": "3fe8d5641fc644cdbddded9a8bc98e12c2925e00090d96f4078555a22f0a2297"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "6a18c1c6f34267e7dd85faa4c20d62be6017bda7ae436c483c487c285d33c16e",
-                                "uncompressed-sha256": "217a75b21d0f422c2cc21ce1b5e3ff80f8c28e4c962af7ea8557576388c5fbd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8e0bc06b09c469d7d6b8cdb408589457087ea7a468c2e203c79bd2ec40a3c99b",
+                                "uncompressed-sha256": "8026e2fe2c2bcb26f3e708b4380f0ca76270a4791de2d1078029e515aa253d04"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "250e32b763aefdc46be7e4876b457f70208fafac66769759762ed5c28c861716",
-                                "uncompressed-sha256": "468e414be69190df07321d05684ab3ed9be79c20ec1c59c65d5ae48a61e676a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "46cb3aa42269cf849862dfa9977614c028887facee16cb510d74c393b6638386",
+                                "uncompressed-sha256": "5c153a38ad3a979577d1e4b6956d4ac2c211ebccca9848d0908e1415a3f66df7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fee88807c15de231384f570a31077a2d1e657cc4a7ab7b3b0b54a67ea22c92a6",
-                                "uncompressed-sha256": "acb72c32af16aaba28e45e46a9a4b05ba054aa01d8fab9ebd98aad3b3600c1fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "19612d1c3594c90751bf64e9a9ba4b0cf85b9cd466eb877a7ee336940eaef388",
+                                "uncompressed-sha256": "a3c744831990c0057aa6f070944f2b1ffeb0f00bc7ea52892ccaab2a626fdc44"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "b4ee2872d7b053845d6ec98ec300b06f762bdde8c11d62e5878f7c30b66c2f33",
-                                "uncompressed-sha256": "752196ff1cad01a72133085e5c8735021e5e3298353efa0c0cf0384b92ff4169"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "9d6baa4bf1145b99b88744e501914e42f149b05c32074bcca9482fc3703c2ca8",
+                                "uncompressed-sha256": "af1b4f9b63276fe436d598beff287d3fd0cbd34199a416f98e82cd7d08189261"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2027b6e50917a77a0c6917d8417bba48c82f683ea1457632a27413c02694fc71",
-                                "uncompressed-sha256": "be215faec4b7b92583d5f77cf6074c78415a95b99d18496a217c4d99c39750d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a86a05f46f65e1f5b89351f421e980f6367f8e80861297731be531d42b96f3ff",
+                                "uncompressed-sha256": "a23003f665a28387bcb3c50ed5a76f587c64f32e759e4fa485daf5f6cc36d20c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "3de68be814c7f6bab70b9e63363589d6bc458c62621fc19033f9f0397b33a6d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bfb0f94d5c6ec52876d3f2eae42595827dfb932e942648309c2c81ffa693774e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ce052838c9defd76afe17d4bde0055ec9c5bfb8f40c6df82a4eb51230dceac53",
-                                "uncompressed-sha256": "7da50de83fd763edfacc1f43c9adfa7f5564cab066c8f46dfde4aae9943f7365"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f4469d47faa3c3563505942028f99a43d045274c85d90080ccf9110d55257938",
+                                "uncompressed-sha256": "d8566bf02bbc363cd178a3aa0c6482e3905b7b4e1d8104bbf8c6ccb7cea73403"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live.x86_64.iso.sig",
-                                "sha256": "552a5f98fd07c9ad6154b28ca8a90d65c97698e71dc4a9e438358c0bbde44cd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live.x86_64.iso.sig",
+                                "sha256": "f6c97c90f82648f33fa65bc56fba1c95adf4643ce2ccb57161a32c385022077a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live-kernel-x86_64.sig",
-                                "sha256": "09cf5df01619676e91e998fac6c456d67ec3cac25ee9244898b59699c588bb86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-kernel-x86_64.sig",
+                                "sha256": "ffc26b51409af5ad0694ed5740467918685083d77b0819230ccd8758bfca389c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "132c9099668737dd02665bf33d35751defb4f78ef3f06c09010f4285373eab39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "f189ec900af0683a29c317be84da017664e88a53a387bb6440638922520d8581"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "c9c1d5380c95a170c55e46b8330c64f9544d675b4b6c53611ee4cf6deaf3dfea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "fb489b4743c465c2bb8c24f7cabc841bb35376c494289d5c66936683857193b6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "659d78410d67576894636b243cae50f1108294a75e96546b40ff99a30b14aca7",
-                                "uncompressed-sha256": "600df50a3ff4806baa74f06f03d201a5a337b1229853f6cf79a81cd2c6f335e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e6fe56af6792e25aa295477f064bf7aecc184eb904d51fb630568f13981a01e0",
+                                "uncompressed-sha256": "5f8113cac0da6d9d5d5593feb391562af9376379d88287e4270629699a65c5fe"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e360fa49bac7d8ece7219b9e85ae3ba70db90e083d03e8d799fa8bfdb634e63c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "860467fd46526930c0bc9cab71f555d5e8eaa56b79681aec23f8eb05a2a7180f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d3a6fc838a423ad979081792c4b955720eb94b779c36537c1068ccd48b14a289",
-                                "uncompressed-sha256": "f992e73e7127537e6c857dd4d07147fdc1ea890a9ca19366bc0ac0c2f6cc74ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6f6ae63f6917367fb08f9e26788218f3e3a3f1b7a1c037e07da1a74df6cce2da",
+                                "uncompressed-sha256": "83c72aa416b9069b20f82b972834c8540bc2708e5266b47ae217113d813cfc24"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "233c2fae5c5f9dbd18bae3623f93e884b6d45093091817330ffcab24c1c20c8f",
-                                "uncompressed-sha256": "af52a11312c08488d10fd631d94a7f7e1e085e01d84ec0102b4b99ac5c136d76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "75a33f1e958f68183b37b5f4e16fee719a310068ff5bab8258eca39705d1346f",
+                                "uncompressed-sha256": "1df105ce68cfd5dfc3745ce1b3368a563d20c010942e404bc396663eaac9cefb"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "2150a54f96ea98dbfbe632faca6ff04a155290fd9089be3b9e19f9019b95b1b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "61b97778666984887a20bb76f2bc05ce2074a6ddf70ce30ed9b2937e24fa9bf0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "0df00db541ecdaef5f44c11ba56259fc1163573bdd5d875d2344476ecd66387a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "56a38fe01d5c962e21fc999d02fc958131405bc3f898bd15a358c58febd6fc0c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240416.1.1/x86_64/fedora-coreos-40.20240416.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "65352af815cac29bcef5959ba154ab67bc37c99145aafa884675f1b6bca25ee2",
-                                "uncompressed-sha256": "32710847399d75ef5bd8b6ac07130c692c1e630f8094fcd7521f29d48ec3e52c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4222cbaef313b67926f6881116bb0046b5d63d2bcdcbd6e071b52d9e730dbb94",
+                                "uncompressed-sha256": "7cfbbcf77c342d31879714a28d98c4543d4aa75278314c812860ebf97c1511cd"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0355dfa2402c02387"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-03b21becef98d67e3"
                         },
                         "ap-east-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-01540c07027e69675"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0f4b6b19417572480"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-073ce2f9a4fd39e8b"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0a98ae314b855049a"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0cff7b30e029959d9"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-02c89d5e235c0abe9"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0e480040abd1b876b"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-02ce817d5fc4e13d4"
                         },
                         "ap-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-01d6c207f1d9978b6"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0decb1f3a587bf069"
                         },
                         "ap-south-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-010d2fa2bb2a10dc5"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-07eea361962df2fba"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-068542747c7e73401"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0294eeb8c99a6d6ee"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-026ce13d78d88a282"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-079b324487a158385"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0c629a69c060b2cf0"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0e0420fece31d902e"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0958ba2a999cdc0ea"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-00347fd2bf636e449"
                         },
                         "ca-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-000d7ff5492196e99"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-098b6055d1a98d3ec"
                         },
                         "ca-west-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0d61e6972426d1f21"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0f58fb8c1e1740e08"
                         },
                         "eu-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0b49de81a02af649f"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-02dad9d7f19117f93"
                         },
                         "eu-central-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0115e9f0e2060f363"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0ba5d627818bdf8d9"
                         },
                         "eu-north-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0023db0d0295ac4d1"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-07e715cf94eb1f5de"
                         },
                         "eu-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-090e07997691f61f1"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-099aed6d56f4f38ee"
                         },
                         "eu-south-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0a0ebfd8d5fd5f711"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0ddc7b269932ca442"
                         },
                         "eu-west-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0a27d549c701a3a3b"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0554a21afa707df31"
                         },
                         "eu-west-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0b9a1e39f1076e365"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0a8eacda2a2ee95ab"
                         },
                         "eu-west-3": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0ff9c8eee630fa170"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-02f1c07bd86b86be2"
                         },
                         "il-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0b2798969022ebcc6"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-04a40cfbd8c164b21"
                         },
                         "me-central-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-01240db49a7a83f66"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0117296433ad4d1b7"
                         },
                         "me-south-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0afc05cc1c06a1c3f"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-073b4bff524c64f0c"
                         },
                         "sa-east-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0d870fa141c8fc1c0"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0cfa3a3c692ed79a6"
                         },
                         "us-east-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0df5bfaf7e256a0ab"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-00a08b183f3800606"
                         },
                         "us-east-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0593caba1ff79dd50"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-0d6729deb02db1699"
                         },
                         "us-west-1": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-00a577acff05dda3b"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-06ecf9585f781db34"
                         },
                         "us-west-2": {
-                            "release": "40.20240416.1.1",
-                            "image": "ami-0faed29239fe2cb8f"
+                            "release": "40.20240421.1.0",
+                            "image": "ami-092e5880e6e85b15e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240416-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240421-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240416.1.1",
+                    "release": "40.20240421.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:949e97c444b67bfaeb787cfad3e3b3172fddf60a339cec4192b103954b9b51be"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:18aac9610a3eb21ac15139a1972fb0664dd9ab6f30a5c29fc68307b70fd17bd5"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-04-10T03:09:12Z",
+        "last-modified": "2024-04-23T10:39:54Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "47359bf5a7df0ac6f1db78f389cd8e0d51a9c9cb5e222b451a7cf09723f37741",
-                                "uncompressed-sha256": "17a49e2da207dad6d70a54bf7a1dd661a8e92e7e7125c83c88dc71d3d1f74128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "3c5d9386723a283ce096fe4967f21acb369a9066fa14bcc032327f5f156805e9",
+                                "uncompressed-sha256": "51dedd856eab4411537f58800185034b53387479655f0f87959001a30d5b840c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d92aaf56ad09563c7d196c0977eb56bab5eacdb5f9b28655e9da05b81f89c3d1",
-                                "uncompressed-sha256": "7af9ea09ae8344c3231200fc1625150e02c3c7f0968339e5ae2ac53a4d3b6a88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c746715bee4ba1ce40b83ed7407bb692043dd1eb24d7b073d3cd71b5096aeb5d",
+                                "uncompressed-sha256": "0758c450f258a0c2d2603567db8d8b8ef3cd4611dfb9f902c1039ee354606fc9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "6b0afea9fc1e9ee5515f42dd35b71bf4235d8ca1bafc13422f5026da397293f7",
-                                "uncompressed-sha256": "e7cf8fd2cf77f75d6c9b95ee7da90dc5f2907c0e0ec07847be9d07bdd8240105"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "bc7761c8258fec8c6ca193337c8b04754c6d66e0e97880c28379861e11167ff4",
+                                "uncompressed-sha256": "5e68ba9507c3de1b9ccba7ca171b809aedac6383075d6f57bce35b175e234a49"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "962250a78c8be436b77a4f5879ed0669a99d32782f38333d57652209e59e3cbb",
-                                "uncompressed-sha256": "fcfb54d04c89ce2beb89b38b453fda80ff17bca006000d4811b52a05610346ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c540e42046ea7bafac80d51baa4d2092aa32f3663688550e4f68ec38fee213d5",
+                                "uncompressed-sha256": "57b7c7708cb9f15708593f5ae18f6ee44061713ec2e3f489323ded504e38b5ea"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "cee10de8ae56c9e400f8701454ec64dd12852d29d52caca2bc00bec7ee77784d",
-                                "uncompressed-sha256": "893a87a03733e47202092a22e9ed317015b69ff9fb2c8a7d1888b74bb34b7f0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "3d7254741bec80ccb901c3052a27ffd5254015e56b4683e31454e1abd9a46d68",
+                                "uncompressed-sha256": "7743a3340b4db9fd92f81a9a433cb7a2954cee7fa3ab731675b951f807f7ebdb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0b560879b785a5da8869635d3da939b1f0c0d02ff1d81600299fbf9e27ac642d",
-                                "uncompressed-sha256": "e23bce5966b70150f5e8a9ea2de412705aa2aad89ba3f8aa6a8e55699389b6d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "217ff7ec3b5430ebf7e7bb483f384f7e02f7c1743625b9b4e730d9096909a0b7",
+                                "uncompressed-sha256": "f4f6aeee17a8047697c043f17c7ca0022e01dc224794b6f1877d0e3b8dba0f38"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live.aarch64.iso.sig",
-                                "sha256": "86b20ec7bb955bcd3f14c5ef320a95760ce4ac88600076d686aed5bccc5305bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live.aarch64.iso.sig",
+                                "sha256": "3bb72410bb0b307e6d3525fb254b3fdd2f55c0cd5b4f56cffaa71658868b19ef"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-kernel-aarch64.sig",
-                                "sha256": "4c32f6723eeaa9a00f53a0aebe674550099bce633c9a18255fbbf7550a611309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-kernel-aarch64.sig",
+                                "sha256": "d1fb3ceede533eab6a44af4f2506be05d6f226b996abb0053370066c1c192627"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "633f21be091e667e09136717c62d2e0121776b3cd9a543df9ba870275b7ea7f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "715be266dd057badb7d72e99f838755e15a3cd04371ed95c557ed01b5d47f6dc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "7f0a49112d98f8c1668510241c203ee1af826fc163a5bfb670a5ada6a8f4ffd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c9eedccfb95961cc31e350f9bfb4d7de53ae09a2e91e5a6e8ef23192a1f491d3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "b5b8191012ef410f63e5afce453cb330f4887ecd486ab578664bbb0fe2587c35",
-                                "uncompressed-sha256": "4c8c682391cdf86fddb137253f06238c380e420b2b1fc84b561b6b74ecbc907e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ff35636449db42ffc73c93f74c86a4cf927d6166d69d350b450c639645f9d180",
+                                "uncompressed-sha256": "34dd0725357bd9755df121977250b6d7055c378ffa5998f0dd6d885d8104ecf1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e90f28dd3c5a4ae8d7a8f85028cc488539befdb505a055449601b2cac3184b58",
-                                "uncompressed-sha256": "866c718a12c7fd58f24211cc9e01dab49318ed98f856c13b353a2bf0d7ef9556"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7ed5f5c682344d1ff6102bb4abb70f11adb7f2546d2cdad6f0ff7bb496abfa7c",
+                                "uncompressed-sha256": "9469ebb36a4f4468e85f7716d5da3ea531f7cf46b68e6bd183e8e17bf22329d1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/aarch64/fedora-coreos-39.20240322.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "98b1c696139a3a9fdd82e28d8da91134d0ca304debe28fe979fee575768cf8a1",
-                                "uncompressed-sha256": "0b6a5d0dc62a818c070229a95740393a66b28002223b3c9a74e0b2772d27ea54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "149e0f320c1cb2866500ad2908033d733333781215cd5038b11558548b5fdce3",
+                                "uncompressed-sha256": "a758606d7bf5dba665485633a130d78566fe1ed34ab6be46c4cdb170d52eab74"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-009d3b4407c5ca5f5"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-013b28ef3b61bf89c"
                         },
                         "ap-east-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-008927b5c40cc2b54"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0d44c66a7b06018b1"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-05a799fcb8a54339f"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-012f1b2fc74b87426"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-05276638850f006e8"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-00a943a004c821bac"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0680824ff5521711e"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-06d5211146bbab5ca"
                         },
                         "ap-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-09bdbea81ad0b5478"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-03a221d4d47b7aaab"
                         },
                         "ap-south-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-06cf2179c248f9486"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-07c78993ecd991217"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0a60c5cb3f51479b2"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-03c4b27fbb1b997fb"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-01c317b685d62a750"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0b52e22a3b6c3b3a4"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0bdc8bd09ed3439cb"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0848ebf462778a036"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-07e7ab714829512d9"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0911c8a8a3bc1f700"
                         },
                         "ca-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-05f34c86b3c965ee4"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0474ba563ac95a86c"
                         },
                         "ca-west-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-03243ffb289ecee6c"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0068f2d0de0434956"
                         },
                         "eu-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0bca1b3ec69f2ad45"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0591320b746a6f116"
                         },
                         "eu-central-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0945b84760ab503f5"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0441e3086b6e2867f"
                         },
                         "eu-north-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-02d6581c97899ddd8"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0114e6089fea70868"
                         },
                         "eu-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-035b6a1ac22c242c1"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-041789593b05849b1"
                         },
                         "eu-south-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-00682d1a06fe8ce41"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0313db5b425b7210e"
                         },
                         "eu-west-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-00fdcbbe003855a8c"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0257913d26295dfcd"
                         },
                         "eu-west-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-08b41f129a9325977"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0920ecefed5327fad"
                         },
                         "eu-west-3": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-08bb624150c16ac5c"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0528ce952d25dd3af"
                         },
                         "il-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-09a40ad2c84e02285"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-044d1734013867482"
                         },
                         "me-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0761f7054507a49df"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0a71e7ca5a185f5df"
                         },
                         "me-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0cc0ffc487e7617ac"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-020a55bb0473d9857"
                         },
                         "sa-east-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0ec705e3c5a6a3f92"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-095acd62ba26109e3"
                         },
                         "us-east-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0aafce672e7c451bc"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-021a0efb55804dfdf"
                         },
                         "us-east-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-022df84e2a2623b89"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-06d172161f21c0c97"
                         },
                         "us-west-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-047b1f82de51c1976"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0171f62d013b3f8c6"
                         },
                         "us-west-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-017db7ff5f39db80f"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0fdff140b1f434097"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240322-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-39-20240407-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "4672d5091b71130c06541ff98fda75a1c8b87d4a317d4aebc010985b201a69f7",
-                                "uncompressed-sha256": "c523e6328d106671c11459631a99311669e5c491a98ac3b5433ddbd164295ae9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c767cc32b26684064c076dc7107dde0329b49675cc70ad4184427789a83116f5",
+                                "uncompressed-sha256": "2a3458aef824cdc26239552b3cc4a7314e90bca61bcc739c2082447db43b35ef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live.ppc64le.iso.sig",
-                                "sha256": "8374d34a5cfab632fd72484dc73a0e941b79a4917bcbaa647fde3cb1dcca35e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live.ppc64le.iso.sig",
+                                "sha256": "e38b1a833f0e4b96bc371c5680c24e695b314b3506a8ebfa009ca521e58d71ec"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-kernel-ppc64le.sig",
-                                "sha256": "def369c309a15c02788023689658dffda971eda68161320ff683fb5183181689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "ae53d03ab28dcd102fa5dc7dd7b7e1a64d3f6f7ce4b7610ef11856c8c206f4d2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "afd560efd0d2ef069feaa8bd575bf8364fe565d73c757f26a45090d548ffa200"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5ca09bdd832dca38566d477a1d2f9fa8f058f70fd50af20de96898e78167b4d2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1ce45839d0a3ae80be9d4657fa29d6e291def52fc9989829b39df38cab35e915"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "20441cfe63c189238571f4852966bf2a4273dfc37e7dc9b8cc11617740ce8660"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "760694370a4c12060ce99193a208c3710c6f8b0cbf7bd7da696b5e417adad4ee",
-                                "uncompressed-sha256": "9446e359cb9c5fb755e2c26a69054336efa60758ef0afd6b80b47d29b5145c87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "cfbdf0d03912d6f171ea76706f1fcfcbedc0084b2bc8a926462f7c7185483223",
+                                "uncompressed-sha256": "b71a369154452537aa2defa8c2e59eff8958132029cf9b1350cdb130a4e0300a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6412f0d238c95457b67c5fd69ebb286c1f1d3f92818d80851f9b9acdf9cb76df",
-                                "uncompressed-sha256": "8938c4d12c771c36b179c48e5423542f01195115fd1129d42fc00650471eae19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "90a6d4fc7d04542bdbaaff80d9bb833916c5656ba60ae89f38ab71acef7bbfb5",
+                                "uncompressed-sha256": "3ee3562bd4e129fa97d7d1bd014b9464ba76c9fdbb4ef0a2689528bb5fd83cc3"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b711771bf55549fea9ce0ca60d2073268f50f4c15670a27af8e32438fb515caf",
-                                "uncompressed-sha256": "89869dc9866360c23d85aa77b7366bd78db97dbd83b3af05d28b5760a438ae75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "54f1b9a7766f861f74a9046e8b8ac3d5dfdcf5f6ffaf7340f4397b8ed797ba59",
+                                "uncompressed-sha256": "fe2f773c679cc4786955f2f88a9921b40ca7343c296e314420fd234451fc23c0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/ppc64le/fedora-coreos-39.20240322.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f8d3e0694e5f1b1666326a015fe452bffa6621bd2b37def61db4fe5a0331bc36",
-                                "uncompressed-sha256": "dbca260fc93833bd1d97a747cc5bfce1ec97eb66d0082cda88c6fd00d8cc1104"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "da50b58619c0ea3dbc7f229ba668a92ae70066728ea11006387ffcbbdb3bea20",
+                                "uncompressed-sha256": "27b88e4ff92f0cc8f7a6015d8e766c537651cc1921f3621e678c15bad7ac5f60"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4944f0d891240a0944e1c954bcc45ca427535bc3d5f8c02809099f0504dbe3eb",
-                                "uncompressed-sha256": "e110d557df400adb4bfe3aa8302f3f4418b6f89c9c1dd9944214d694fa3c4373"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "72acfa94356b9df70ebc8b6c5bfd5512ecfd9773de7eb2550c9e44546158fc22",
+                                "uncompressed-sha256": "a99105138821174b22cf7d63b246fd15e5f69962dc64458782d9e3e21225f70f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "75fd70860a4b840200d52d1d2a06fc30723ae65d3c3d9c70490ed9db0596e2e1",
-                                "uncompressed-sha256": "2511a62347b67c548c669bfb1aa2c8e145bc6b3304260f5f96afb560d020372f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8cfd7fb659f9499ef9a6c306d60a1bcdff1492173e2d618865f8ccc7fb473eee",
+                                "uncompressed-sha256": "7dd8804bb8dd9236bd399da16f845d3ff8c5b201697acaeefe620ef2ed1ab9fa"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live.s390x.iso.sig",
-                                "sha256": "171459a9378319faba036b8efa155aec875a35a871224757b5ec7f0221a8bcfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live.s390x.iso.sig",
+                                "sha256": "da79ec749c0eb7bacbc5607c8396e312c2280395390570e6537e2ecb8c7bf1c2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-kernel-s390x.sig",
-                                "sha256": "e753d389d4f2432b7c213a0c8c8b30db77cce8d0bcbdb1420be1b328163051ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-kernel-s390x.sig",
+                                "sha256": "2ca011ae1580244de18d048b10b0092614a64d8786e3c182764977c036b81dc3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "60ea4d8bc1ca6807cc2d060b616f22ad35fabcd0a9dce83ea549feb9b5920ea2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3f52f236c55c383006c3092c2ee98723391cf27cf0aaa8aa81ae5a09b694fcb4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "bb74a7328d58a304f2bfa90bb61554af471f7b9906823c169d9fb9b0a7ee886c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "d8de4f6b5dfcc49168e9e1d629c6cc6955afa652eed184f54fb08c56fef42472"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "03b76038b99664f4c6158de6e9c13ed90a5359c00326aa0b19ab15ff496b9730",
-                                "uncompressed-sha256": "60548cb8c902809f3c9ba31f3f4d5af9ef001349f5cb6521bde7e78010cd4075"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4e6153fac54e02b235c23cb4710e154d127643857935806ea3eecb53401599b2",
+                                "uncompressed-sha256": "e5431ebb97c64c154867aeda6600986d1ba00f98cdb532d968f9598b99a023be"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b68d24e1d16d9ce708ee4cc0b447bfe1667dd11d64f8c07613c31fa87be4c6ff",
-                                "uncompressed-sha256": "074f4eb51b4bfc546640371c433cb367bb4c389037f35742821ab482344f0124"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "dd65bba61d4b53b241eaae4625c34a2bf9c38731dc38c537e10932cec3f6abc7",
+                                "uncompressed-sha256": "82200f5e1635fdb12ff5ec9835656737aaa600902d7119fac1d70f83d15ebe0d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/s390x/fedora-coreos-39.20240322.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "24de7e7024047a014fe0367965f1d2b37294d07e0ffc63964c5632a996abbf86",
-                                "uncompressed-sha256": "687875fc838a8b5ef0a120897c69b5572cec414451ac1a2d3340a7d999b13b7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "795f69d323d198d132e259d85f6b1f8b64bde3d894478ea37e2191a38ea5595b",
+                                "uncompressed-sha256": "39f9817f9757aa75b18259738f072bbcb749258d64f4bb45cbe5cf0091ea1758"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6669191f3ecc0a311d4c45cc56083309238bc071aae342215a5bb4c22a1b7b49",
-                                "uncompressed-sha256": "bf65502c6dcc40afda1c8e8017b05f4ebc81c693da134a297b8dd42a48acd0c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9fbe615e53e7f05edffc34088d0c2c71348cbce374b5e406af92e34efd83ea13",
+                                "uncompressed-sha256": "38d447b97264f097cb864df6e32c62e35cc032c012b6040837065339e4a32bd9"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "38d25d71c3cd5072c7f206d6dd728f0d03468bd387dac5a9e856cd933b62962d",
-                                "uncompressed-sha256": "af4716040fe2351c47238cd16977172a133efad617ed4f7f29cde7f87290f83f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "7232d7866e3f6d1e678778cdb7243e745a11102d8372a0a72294acef311ef4c5",
+                                "uncompressed-sha256": "73398ed027345e144a10a36c96ef1bd3f1ac07a96915170d0a2274f0f5109be0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "bab994220088e217e4e57ab67bb3b7d3cbfbaca4ccef1f030cb4a5f23a17651e",
-                                "uncompressed-sha256": "7415cb8f6b548b0fe545cd1874efd8ea6d04a629ffa3c9df79bc7af1f2ddb9d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "87212c874a5329752a4532fc47b8eeb5cb8ec252f105445150176b83504916a6",
+                                "uncompressed-sha256": "cf189e79dee6cc8dd0c8211dac7687f3e1dfacbcd7c306da1e1f4492c9edfc67"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ee9438ff9ba343dcb106168b08db39890ff6ecd4a17081b9d4d592946d99bb43",
-                                "uncompressed-sha256": "640431cc772a3bcb4f5f5637939cf9fd4f14b14804e102dd0792df015b1e5985"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f7e2b6102f2f65a2c1e4808920da4a55b2c0f104dd9bf4dd4b71b9a0b3673cce",
+                                "uncompressed-sha256": "392595841c4351962572031ba29455409bdbc17fbcf83b29c573be7c95b999a8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "73c89e07194e567f6b945005a094f491f1d95fd74a917657ae50ffb5efb4f2b5",
-                                "uncompressed-sha256": "c8a13748dc5613a01a58cb83c54c7be08d7a6b8ddb7cc605b5091ac5ddc68c2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "895011629e8f63239a24233deb2b15b1c30fa4f05588b2c2538a9177e8efe3b4",
+                                "uncompressed-sha256": "129c4d95a1f34075db9e88e0909cfd56fb25174f4059f45f9abbc2cf5a7e3f1f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2a7f3bd8788c00bedc79a63a82b71281350e3bac7d0ebdb837be26990c4aeb3d",
-                                "uncompressed-sha256": "98ddcc878e333d5a32045583bc72fc6a91e7f5e710eefa1968b2702556cecfab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9c908e9666a650844a5ca6944763218a88efa99d46636d15dc093277e4b29f89",
+                                "uncompressed-sha256": "9cf6ea31f06a0afa9b644ec42239632deb998cc7a476f5f47e8b0ad130d71da9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1c7bced30a36c1a3b06c22dc2a2f3acbea9e6f7d8fed1d9e31d5c0d3ad78ac20",
-                                "uncompressed-sha256": "b491ddd50d275a505bf0f4da48b2aa0a5de45f8ce87cd6991cf4d0c027945533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b4b7c0a938ba10f20d97ef0d0fc2f510aa8e5dcc83ed03339d7ed8195f02c65c",
+                                "uncompressed-sha256": "bb951fb98bf153181b3a81668569cd5dd5ecaa660db09118e2b82a57c99b6008"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9f8825df8f985f7f3481783a2e6368a815f60aa10ffc09ad6131ede1ef4007f0",
-                                "uncompressed-sha256": "fa7dfe1c02da41f7fcf3a087ef4ef4f76bb3af8f86dfb1db9a889153358ee6d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "19bcf8336bdfbf9240c9e3d7edcf841cce4d851e6084738d76aa927422ebd23d",
+                                "uncompressed-sha256": "8ae4a76fc12b8aaa1ea3d6f3139efc326a2fe8f69b06172b2eb224835aaecebc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2c71a19a8ef79c04549228d942c216afe0720043e7eb7b4fd9faba11abe978eb",
-                                "uncompressed-sha256": "394a1f46d0a2a467408c928ff9708addfa0d6edebc39331d2572f6dfa539b547"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "545deb671e3945de77520298a761e3a4e26c2ee7476f4edaf1f8067070598cdd",
+                                "uncompressed-sha256": "73f4fd4b6ec2597000b775659ab58427dbac497f18439f6ebbf8cbf2ea7a906d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "cc68100d7c584c8695c99f143ad523998005fd0b56385edcfe8867015ffda163",
-                                "uncompressed-sha256": "7a3fa13f7a67020c0c311cd74fb24b9782586d314b89402617408e1f6c701b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "304dc64b9f1f75b6b2fdf64bbe1100a9462b5a77d8ed02d5a51a990719dc40ca",
+                                "uncompressed-sha256": "778de7b202d3f198e7c6f1e185e022b3041228e0b32f17902842a98a9cb43ba0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b02c7f3fb91b06c9369ead406e65c3f00ac42072db11021f105c4cc1136d8b80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e70a650645e632f81ce3cd764276cb09fb5c137cedabcc0e4a91d1b1fa59b051"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "929f9cfb73651e184b1547216751f483177f609610be46a72dfefda0d1bdd24b",
-                                "uncompressed-sha256": "2bde6ad2b106f4505510eb38de62f1a5a8b208c0a4809f78f180c0de1963ad65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "47464ab4fe5a876568c91ca642b73a96383a174ac857dd4eb31a9a5d902ab7a7",
+                                "uncompressed-sha256": "434508eed304cd73ec02c6255271d4f1a74b198a9e4ed8be20826267ed2a3cb4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live.x86_64.iso.sig",
-                                "sha256": "efc1417331c7af28e8dce16183c824820cd587a4b9f786e2d3f5790f0d7d3e9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live.x86_64.iso.sig",
+                                "sha256": "c49ac47800dbd0c5d53e5156565f093d5b7ec791094987bc4ca5bae2d7b061b4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-kernel-x86_64.sig",
-                                "sha256": "7f32bf7a5d73623734939c5db8fadc3c43da33768ff4b60414300daf9d843bf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-kernel-x86_64.sig",
+                                "sha256": "c1a86e0cdd001817105aab0ecff410f58dfa371d31533b186a28872b4b305190"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "dfc9237f7a027826324576961161b6f62c1b4a8a32462a7cec1161b9c54423e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1d50bd16acad866a473877dd0ef1bdd8bdca6822144ae09990edbbf4000c7832"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "d2b97f15382c9ec3d4e3fbd9cebd9ffd0666adf668ca416cca612182efaeca0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f49a7f0f8a9b593439bda39b8ede403773e2b890c4b4b1f24773f40ecc59928e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "de22c179f992125ced49a73eb76dcee5152be7ef6ce3651b9a30d0d6b6aef94d",
-                                "uncompressed-sha256": "a962e4bc28e102f0c2f8ae9d34d6a141ca0d80139e56cecd86bac4d24230bc22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3afe4898d644fdc7dc869c89454d8b7eb192cd6b545c51024de70e9fc38ea871",
+                                "uncompressed-sha256": "e7e5021e93b5e8ff4714af3538a23bee7a3db69d6dd70bfdfba38a9350416b12"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "afea7f3e16dc3d993e0a0db98a5e24cdd983b20527bb21a8c9b3c59e83039759"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "88035965a7ca35ba0adeb44ba16fd1424fb86855ec2f69d06f4fe3737927a071"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f2bb1688222690c8a8725ffab2c4b45242e41ca5d3f48a5ef373bff97652623a",
-                                "uncompressed-sha256": "897cae492e24877f1d0b28db3c6f0514e70a258870be3891ff099898d3b5451f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7b1f2f5c55b841277e56107d6b8ce5613de66b0d6dd5ae117f658537a610aaf0",
+                                "uncompressed-sha256": "b1a0041efa06a2e912cd519210e36f20552ad1bf4fbc93e1b26568a93a57e312"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "86083b3f391ebb516736180abcedd8c6a5c76335ac965ead2add09619118bb13",
-                                "uncompressed-sha256": "96c1b02bcd272824b02935d6be909450c158c7f3459c7d29553fc27d072a2f6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d153a2e1cca1ce0797ddfed2b469d7d00ecd4b3b84f7aa079739b089cb1093c8",
+                                "uncompressed-sha256": "f38ceb37cbb4b7c7af87b49c5fde82a2b00344721936a818d041f7eba26846c1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "8d91bbb9f48a222749d20fc050124bfecc4be7cdfe303b1a58615ea3eda2bdaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a0e4e243c3f2a33ad4ffeec9b16bc955cf630e5b627725fd6eeedb14e2221bbe"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "317b92b43589a26b36e9b8c3463a7d59b6ae94fd74dc11ede50835ce38635442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "be5d2284a3875aad14a4c3adc5c67f9e094636cf231386d749dbd411ad45fccb"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c3650a14c29f54d00c39ec89184e6727ef828fb8b1c8f16d17597b1aa2d03528",
-                                "uncompressed-sha256": "cec8d68f90988d4e87e9f2711e9b6baf668b8d048daffa75afa0604790057179"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "71514ad50550532233f05ef4443185034fc286fe212f30720dc01056faba5f2a",
+                                "uncompressed-sha256": "5d0d56051c4c72611ed753beaf686d67b46a9f17f6a1d26d26435d9f3049366e"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-087523d908fb2be54"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-03b792b52ab4e8c53"
                         },
                         "ap-east-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-08138f2212dc41d79"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-03d09109912bac5cb"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0d854b6ef795d3ccc"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-09e91c5d0f1e3a564"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-07d0dc39f428c8b8f"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-08052baafe5b05bf8"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0485fd3e194cf7287"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0ddebb49b0821d70f"
                         },
                         "ap-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0b4066c437b77d488"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-08160ae66cb742afc"
                         },
                         "ap-south-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0dad98f00e2020007"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0e0d87b280bcfd764"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0fc4e3d69fc849cfd"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0dff9d974b0a8c311"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-03753916a5948b95c"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-01cc2131baa8c87aa"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-013a6149da6539029"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0d407c99cdb8c0683"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-09ecb3ac27dfeecbf"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0daa58be6ed96e154"
                         },
                         "ca-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-038738d64e55a1ec8"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0d610ea9e88ab40d8"
                         },
                         "ca-west-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0ad32b6783569a9bd"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0bd43320538e5b8e1"
                         },
                         "eu-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0c2f63fd255bd8041"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0d497b7d3de3e3818"
                         },
                         "eu-central-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0a7ce10e431d07c77"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-07cdac746c7020ec0"
                         },
                         "eu-north-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0793d8793ca987475"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-09f7c3700ed84def4"
                         },
                         "eu-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0e65d7718f9d33776"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-029e3fdbf7aac823a"
                         },
                         "eu-south-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0cd8283cc4fd47586"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-00d164f7444a7e38d"
                         },
                         "eu-west-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0b6f196bf2342972c"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0525172c6650d9504"
                         },
                         "eu-west-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0ec09fb131e92f009"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-00981bc893691e490"
                         },
                         "eu-west-3": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0262df73dce63d2f2"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-000db03f3ba156d36"
                         },
                         "il-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-03e8a6d83b2972d98"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-026f32c46b75137d8"
                         },
                         "me-central-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0fe09dec31194432c"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-038bbb04d3ad61b63"
                         },
                         "me-south-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-05b42fad6a04da7f2"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0ae28312c96379cad"
                         },
                         "sa-east-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0d4d86d0287cc85c6"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-08a0d9a15723519dd"
                         },
                         "us-east-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-04003e644492ae5e8"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-094f5093032075d8b"
                         },
                         "us-east-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-0f792dd7f469043aa"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-0c7514b647922ce4b"
                         },
                         "us-west-1": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-050d8c3a0f4053839"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-007f8fe367b0c8e14"
                         },
                         "us-west-2": {
-                            "release": "39.20240322.3.1",
-                            "image": "ami-03252df1a16747813"
+                            "release": "39.20240407.3.0",
+                            "image": "ami-08904be33085ad1aa"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240322-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-39-20240407-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240322.3.1",
+                    "release": "39.20240407.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e0b9bcfdf88cae6a193ff3c3bfc5ea4541aa5629ebf436942fd2f808dc70b954"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5007e62310dce431902dd8e7766551bfcf49634fd94a59b14f6f4e8a72f36476"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-04-19T13:01:48Z"
+    "last-modified": "2024-04-23T10:39:57Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240416.1.0",
+      "version": "40.20240416.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240416.1.1",
+      "version": "40.20240421.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1713533400,
+          "start_epoch": 1713880800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-04-10T03:09:12Z"
+    "last-modified": "2024-04-23T10:39:55Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20240309.3.0",
+      "version": "39.20240322.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,21 +101,11 @@
       }
     },
     {
-      "version": "39.20240322.3.0",
+      "version": "39.20240407.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1712584800,
-          "start_percentage": 0.0
-        }
-      }
-    },
-    {
-      "version": "39.20240322.3.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1712757600,
+          "start_epoch": 1713880800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).