### PR TITLE
Roll out stable 40.20240416.3.1, testing 40.20240504.2.0, next 40.20240504.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-04-23T10:39:56Z",
+        "last-modified": "2024-05-07T19:56:48Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "dcfac22fd6be7fd233234de30db0682f857616b1d202930f769b1eab41ac5d0b",
-                                "uncompressed-sha256": "50f8b55e85e4c9fc578c19c14fe9866aade355b024829a222567a6a61bbc2b4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1cb41902491815f8a796d435f4b4326bef9029b3860b449ba5b320a5cb23d164",
+                                "uncompressed-sha256": "ff4e66e84517070d69d25cf4a6d8b68c5b9e7bb1dc99d8fa21493198d0b7e406"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1729e56e664e50c064383baf4d94b8b73d633dff1343b6e3ec622a2ed25a091d",
-                                "uncompressed-sha256": "a33e9d540d294526b4ad1b310dfb0b75c4ff1f68d49dbe657d0c6b90cde12752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f283dfeb477411a5b142f60aefadc1156d97b2796aaf7f3d7dd5054256e8f4a9",
+                                "uncompressed-sha256": "e65642d9f8432aa61da7028c19fc6e1328f3f99b9c828ac235421749240fb570"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "64f91a39dc6bd65cadccb287769007042335eef07f3ca3cb8ce83a23a3d57c88",
-                                "uncompressed-sha256": "8bfa1b120a531e129a3e69f847f9582d4ff94a4ecab34a89680bb2e52d0c5e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a73cb8d328ad397bdeef3b228bb82903b329b277f1ca969179b6f36868fbcde6",
+                                "uncompressed-sha256": "5bf2fde65bb8a6dd9e8d8461fe297364f4a43b8be777de2390b5ed1b244b3998"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d29e2ac1b05f70fe2b609daf128e19cead9205d5bb5c44bcf6e20b72d12e25e8",
-                                "uncompressed-sha256": "1a7ca7c84f1e69a0d40208f2674da59afcd90f6cb1e34ae22b51ed8d7e2bdc78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "6d35e8e2906ebfc21a6d4286677723e1550fb5570948d8c8785a38851745befd",
+                                "uncompressed-sha256": "80f196f762ea0263ab09f4a27d89aa435e100c77c52c6a4174c5ad842488e8a0"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "63e4faf34219421bd9c276ce15924aa76ceaf70ae63bcdafd1d32278067f3fb2",
-                                "uncompressed-sha256": "97dcf872feb2007f1fc7e9470e3949a0db1435be89b09634cccd347df6ec3585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ea7bf5e243e4e779f4cef7bbb9014ffd40f682b7d91e35516cc2087d790af53c",
+                                "uncompressed-sha256": "2a2e9c01ea5b8b257bb21f997a6947a17dfdf6464f704d4a01c661799da17fa1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1f1b8aa4e704a958472c6bb9d24c17ac6855e64ce2e450cf6151102077703d94",
-                                "uncompressed-sha256": "62bc896ceb78f78f39ff4b6285d51709838181d6d8cafa3acd92b8fe1f1d01b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "28257b12361659fca85777fbeefb746b583d2d762a87624e2b2f19b207feeccf",
+                                "uncompressed-sha256": "07962ffc73a62e5532c6e6303419ba5950035ae8d99e764e8c60b016405fab37"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live.aarch64.iso.sig",
-                                "sha256": "8052da3395864348b91edb6d092945b7637aad824f6f5c0eb4419e01533f8b07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live.aarch64.iso.sig",
+                                "sha256": "9963cc577299bc9078321ee1ad96436c22a3824ff60d264c679740229f9ae952"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-kernel-aarch64.sig",
-                                "sha256": "e2cd50a7ac5a1f1f3f6a2e411e956635327fff9f6b60b9e48f9b81cfb669b0e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live-kernel-aarch64.sig",
+                                "sha256": "22a76059b7d6d8be5caf551b38648d15e410f1e92e46b5508e164e8bec7d54ae"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d34cd7c60c9b99398d7bf448ced97ec2f023c1e4c6f9f3001d7479937e93a406"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "9b79af85b6c91d47db3be246dfd5b4d33c29fdb23a24099ef05254eeee123008"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "524159f1a0be096dbf89f2d6a6d1cd962fdc6cd0f98a1a94bdff9fe8b6a84d47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "325bb050f47c5f986e14b1691ab5477cac22b3d5471bdd3ecb88ee14e39c514d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a3f98e30f60fed8f361c3f401b28dafb367aee936a05ca9002e61ba5230f0102",
-                                "uncompressed-sha256": "7bd6a25a62f107ee26b627a2a171845a2ec2626360c528ce7ecc8c212f0af367"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3846e985f2dfb24ec796150bc06f859e21121a9f9f82fa84826c9d68033aa295",
+                                "uncompressed-sha256": "f0956eb1fd2721e31f328085444121f513ead821f109e1a3350da966e8e0ac46"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "780b71dd7f3b7628dc1a6b4b5725748ae98a15ec5b82742fecbadb8129c96d4a",
-                                "uncompressed-sha256": "7e1fcb4d9325cc8e3ab7a07006f6d8986fa13928bc9a463daab1ba1d7410121f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "565226945cecec599bcb75eb5738e66e45fbab542c984235b027a28a3b4a2eaf",
+                                "uncompressed-sha256": "14db4f2f8f84c5eb1ba8e9bd466231e43f0f0b214fd8418d1bbf030abe0adf35"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/aarch64/fedora-coreos-40.20240421.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6bf19fb68c17e69b79cee886b9fb06f57d9c0ea5c3c24f622e891a768a51d5e5",
-                                "uncompressed-sha256": "18de6b192c5927a20c2700354266d7582509b5aac0724c5c3ccdf3e0fa60c687"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/aarch64/fedora-coreos-40.20240504.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "54426b2575af6b6753e363176060f19a22c13d0c39d792558d5c0239a5f0e53e",
+                                "uncompressed-sha256": "870558d242a18ed918cbe4cbfa050ebf5c22593852cbfe90c18cff06ab278147"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0d40ca073a43f317a"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-04984f5f0e769fc98"
                         },
                         "ap-east-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-02e205c720f65cd7f"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-05555fd75f7baceed"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0cf6f8294550f5df1"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-00aa53ba9eecd290f"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0c9a75125fb5e2cd6"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0462e489db423d168"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-03e8a62195decfa3b"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0d12955d2dd7cd85c"
                         },
                         "ap-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0458ce77272814648"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-097c881d03c5fac95"
                         },
                         "ap-south-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-07eae66f52ff4cf81"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-06e5c46cd29ff1cf2"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-083c3141e85ebc367"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0710be3373af4d2a2"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0b3f9400107b27095"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0d23bea1f5d2b5956"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-09eaef04aeb281a36"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0cae01dae04ea7946"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-08fc8ed7774fc971e"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-098f09e8c8f202a52"
                         },
                         "ca-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0c8e829e71b2d5889"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0a4c0d1ac7ed821ca"
                         },
                         "ca-west-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-00e9a6001680e9713"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-02d46796500135f7a"
                         },
                         "eu-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-059830d45642e0c39"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-04ddcac23a536aa09"
                         },
                         "eu-central-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-08041c5d4aebdc3f8"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0fa4f617906aa67b9"
                         },
                         "eu-north-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-01550db7761f295c4"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0a48338b374442623"
                         },
                         "eu-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-06e4b223ea376318a"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0145dcda9e40ad08f"
                         },
                         "eu-south-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0654784c1979fac70"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0057d639eea9affd1"
                         },
                         "eu-west-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-06ca7ded4d70e01e7"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0a2426a10cd114489"
                         },
                         "eu-west-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-044c0955c0629f819"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0e24dd54575c61cbb"
                         },
                         "eu-west-3": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0966aaea9a8c652b0"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-08fee291d5515dcf2"
                         },
                         "il-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0c78155cc6bf6ea6c"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0fb1015ae2605c895"
                         },
                         "me-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-05aeef5cafa1c77ce"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-002943a6e86e53467"
                         },
                         "me-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-02aef805d78b8a445"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-094bd70fc21f23569"
                         },
                         "sa-east-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0476cf3bf5c9f7f8a"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-08529761680c11fb2"
                         },
                         "us-east-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0e81605d7c99294b5"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0355c1016083ff780"
                         },
                         "us-east-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-09517548ee7f6e38f"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0ac57ce979d6b22df"
                         },
                         "us-west-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-07d31fa309dc9703e"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0b949084ec18943db"
                         },
                         "us-west-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-072eb658c02167040"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-05124ce1a8e13902d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240421-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240504-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "32c30f1c1f33fbb75d905d9f6d3977db1e614ffdb0ed6b3eda0f82f6af20b7cb",
-                                "uncompressed-sha256": "a8aaa66aff3620f0f603e145ed9d0a2cdecd9ca9efb5cf3bbfd811edd1e1b120"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b6c84e32ce356daeb6dd9d88ba622f8764d4eb94fe85468524e5d2a5b4ab0fcf",
+                                "uncompressed-sha256": "18b718d1c1870e28f3c171a4d290209d8824d9c6a63cd82d28bd1c8cc4c98b5d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live.ppc64le.iso.sig",
-                                "sha256": "83c977e42826ab278ce076b8fcbb7838e29a69f6528e55dbff59545e491f2023"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live.ppc64le.iso.sig",
+                                "sha256": "37764bb04387ab3e9c57acd4113d959763249402c8bd0261c9c3ebe80f8bc04c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "84d65f838f462b47fe4b95bd90b0162b1ed021646652e633078648bf94e17d22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "ef98875e9d1bfde2b08ad5a7e18119c64ce4746699fe5940b03b07251b8f451b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "0d8b2eda3ffe9524953ccfbf26538813e3c7f2653711184b9c67276464116117"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "df42803ae0ca71276d71c4f3f272c56d379db1956bda1a4626c3486c5d402de2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a5d2c8e1825b7f864dc2b0f49451e38e728c128a3e911b0522ea2eb8dfaa1af0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "02399c8e3d7253576c65e78b1263d30fb96e10e7438f7694909057b667acac47"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "241b8c0c1f862ba4fe75e501b4f1bc427aa4de2798649727e9273f485d99724c",
-                                "uncompressed-sha256": "79b94750a32f8492208aa6e5a03ebbffc7aa2311936c9a2953a6652828e6e8a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "00c018ec8fb96829f8e1a053da05eb666ddc730f90bd78c229825a93ab25f11f",
+                                "uncompressed-sha256": "cfd34ae3082a9a90da6c399480d55be1e56822f489bb5866ca35a3e5954c917e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "7cc9d1b6c09b95d2f75842a3c571ab1972a3800fbe143243218eb2a152072a34",
-                                "uncompressed-sha256": "08c67defe41a6270b07577ef4488135c5f282bb2e0527ca4e4aaa4007c39ffea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "62ae9ec26fe92a441efffb6faac8fb84bd2df44f88a914b2a132a0d82ee4b424",
+                                "uncompressed-sha256": "5096c4f5ffac1b9f8f62054e5828f1312c2983250c5c12a8dd9a80f9ee68f374"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "6676d05aa26dc292eb8ce27b69f331e96fcf1d78c039f9e41540f7e99d9ee8b5",
-                                "uncompressed-sha256": "e24ce7cdad6bf6b093c09d40ff77b3825af2cf5db285640fbd4c7e24793652dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f55bf0a4de379c7e91274761ef74464db5fc6caa79c16995efc03d0772a49861",
+                                "uncompressed-sha256": "5bb1b70900a3a5d6a0bf6a2472fdd96824170718091ca7de8d9d1ba540161f99"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/ppc64le/fedora-coreos-40.20240421.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7a14ab8b9fffa6e3813b0340e5f569dc161a42441b0704c8b069caae768d031d",
-                                "uncompressed-sha256": "0cb3077cad0ef813966d62090a6ac8d4a431f0a97de1ab6f4f8296d238cc4b87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/ppc64le/fedora-coreos-40.20240504.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "24aeabf394fdf39f639b199dede7b303f6a12695605b802f458074c2199a370b",
+                                "uncompressed-sha256": "7604d3c49d5feddeb83f5e253be16175e3923f846e94558e2b74868a0b2ab3f1"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "287e60649e8e1fc200e64e248092e9e4dc33435f73386dfa11aadc08cd4dcebe",
-                                "uncompressed-sha256": "49235e0d647d69a4e1e3ed6ed2d6168e7b1f09cb4426d0462d7b7700bdf233ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4040a040aa991c5cfb5579b46f1c03d0b13f095aebae4d9c8643a3a1f051b6d6",
+                                "uncompressed-sha256": "99cb3d5cf36dd6ec2d2b529516b52b04c263c6fd24102cc5f5e3c44b8b2f5225"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b20e04e1de24373fe282403b1236932be7586166f0f0e5c04303d553b98008ea",
-                                "uncompressed-sha256": "37d452acb8597101b09e8805db20f0e9e10ace2fdad9f3ead12b1731e969d20a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6245d03d116fbb7c6d3d5d9451dd74d3b88df191a043f64f44b5ad7d2c83000c",
+                                "uncompressed-sha256": "51e964f7db655aa3e312a441ed6130c58b37b83a5de42f1a50e1e1cf5a530a5f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live.s390x.iso.sig",
-                                "sha256": "7e0870d5db2e69f472d2032787e86e1282d5d4129e9d6aee58e65c7629860a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live.s390x.iso.sig",
+                                "sha256": "387c53ecb35cd09e476865b36cf614587502a618a21768e52828fed21f657acc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-kernel-s390x.sig",
-                                "sha256": "9d4da609877d88cfccdafc5a58502c7396875001c74ff9d1dc60b92f17d7ea94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live-kernel-s390x.sig",
+                                "sha256": "d093ef3f5a434b806892b5709b1ea1c2aa58b5064e0469632ac7e04454b2e410"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4601d32b189956918ed96cd607ae0c802ae2830939de0a0b9b81c7b664834590"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "452b8761bacdf62b250861c1b642d42439034bdd20b012c34f61accfca5acede"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "fbd0e7865ee85c40107b7a5f081104b7233e3e6c41950420395d2d5a11fe283c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "eeb8daa50e3a04fe90c02c14575df8ef17ea2aaa79b8b42a5157b4a725974b6d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "61281e7a5b58c640ccb1d00354825764d1ae5b74446a340a32870cd55ac8e8a2",
-                                "uncompressed-sha256": "cc4530abd7577af954a7681bd4abb01b19abef637effe23b2a3a13264e8c95e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c3c8755cf67993a8553e3a857143b4cb7d15b23f97ab0f1d07a8a7060f84b685",
+                                "uncompressed-sha256": "8289e442d226b7fc285224d454eff3388f0b26d32dee97bea1ae068c923a5a17"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "35012bf6926a77be957ba3a989d9e09b3efd40ed284136ae1ade7993a52bb13c",
-                                "uncompressed-sha256": "8f4d14a428692aa07ee8619a41e00f571701243889087c9f18da3ef775d824a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2b99852aba31ece6ec3492e866fd08fb0dff0f17f972cc0c782ec2b8c8fa511d",
+                                "uncompressed-sha256": "49f1213f5b09966dc380aba856e7726ad1515987bb0c6302e01565797a5af027"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/s390x/fedora-coreos-40.20240421.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5be79903ec9b3ff5a64e907f747b761579c5aac5f338e49fe587b93065418f1f",
-                                "uncompressed-sha256": "cb27786d6eecc369f4b55193beaf31ad5012e9e4282183b708998c38e6342cb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/s390x/fedora-coreos-40.20240504.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "689f286dd3967bb394e19bd8ee9036ed4df5b015e9c55bc87df47c91bb0466d8",
+                                "uncompressed-sha256": "0d16bfcefb7870de1318c3fa9e7a720dd5f1c5ba7bd5d3e584a4e253fa4e7320"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5a3f9ceba4484c94cb94787789b1864eebf2ed7398bcdc857155be00053e73aa",
-                                "uncompressed-sha256": "759a6cf17660ba5b99510738fe21a5eed914c2432b02e62f3c5273a450fc9a5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5ea092ae9df28830163ff16e91d5e9f815adecc9a38a84bfc6ee1bc75655694d",
+                                "uncompressed-sha256": "78661ddeb5faa730059c21becb5cc6d235bdc9a1ebd710b339ccda7e3411a74f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "b0794077422daab691e1f800066a24f00c34e03e4d786c56f2d8c195453b8d22",
-                                "uncompressed-sha256": "e4274b02c25bed66e2802f00da279780b76342950c953f400e012c7db447bbc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ddd653b4791198c70b7f636ef4290be992758f79c46f0cefd9e852e114d064ef",
+                                "uncompressed-sha256": "1cfdb694cd563d87a06a9ec5f2746d983a8cbddb17acc1c94b2a614740dde960"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "46f0492029b095dbddb45bb9710155bce7c3f0645171dbd907dbf1ab54b1deff",
-                                "uncompressed-sha256": "97a53c0471c410dac4336befd44667f3a90ec75592b242975e538a9df094b658"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f89d7f5bc6ed0b5977960b976565a37f719ea83464c43e97004ea57ff7723846",
+                                "uncompressed-sha256": "c532252beb63b49e8b0dbd9ff15ff0ad161991b8e6394daaa36ad7d682d9d686"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2c1c19b2b24475d6296117944f735d6b8dc98c737da8e9d36cb0982584906a7c",
-                                "uncompressed-sha256": "bacd940103160c03c83fd305708c2dc789b0513686b340b0fcac19f278a9ce39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8d74ccb69f626dea61d9e1b84c06ae9aa23719d9ffa3f72212268e685c12632a",
+                                "uncompressed-sha256": "f09a142c853a0c5acd3b7ef8ada4eea50517e32bb48a62b3b73c69cff5aa5417"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4b1b07af53b0bd7f204533009cd3e42c2f45e95c8487c9ab65b873f1d34b7b0b",
-                                "uncompressed-sha256": "3fe8d5641fc644cdbddded9a8bc98e12c2925e00090d96f4078555a22f0a2297"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "49e9a02eabbfe3ac1a92156e79c8893903f5e267ff68e3cf03e2040f44f949dd",
+                                "uncompressed-sha256": "bdb6b25e7cfe239ff4d9bc5b778705cd417069f195721af160121f962bc1c88b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8e0bc06b09c469d7d6b8cdb408589457087ea7a468c2e203c79bd2ec40a3c99b",
-                                "uncompressed-sha256": "8026e2fe2c2bcb26f3e708b4380f0ca76270a4791de2d1078029e515aa253d04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8653b78454a6d0e29daf8fce5c28dfdc3bea6007f8c6697c915f85b9600dde38",
+                                "uncompressed-sha256": "74f97b7546de41df84a6b3daff1b4a401e4b069fa7e95871d217a4b351ada334"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "46cb3aa42269cf849862dfa9977614c028887facee16cb510d74c393b6638386",
-                                "uncompressed-sha256": "5c153a38ad3a979577d1e4b6956d4ac2c211ebccca9848d0908e1415a3f66df7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e85a0e010dce1654ea03f6e1ebbfab7ffbe4e8347a1c0b188749accf9db96c78",
+                                "uncompressed-sha256": "1f2d8551c72b0abeb94f298e81a58cf40733b06f858410af373722f8023f638e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "19612d1c3594c90751bf64e9a9ba4b0cf85b9cd466eb877a7ee336940eaef388",
-                                "uncompressed-sha256": "a3c744831990c0057aa6f070944f2b1ffeb0f00bc7ea52892ccaab2a626fdc44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d4695f8bfaf5688ab400cd4deaf30b8cab5db6fda9b66f34ecb482c9bb2dd34c",
+                                "uncompressed-sha256": "96ee1b118dee171f0fd1b9f30971027a07ec36e65ef66824e95dfb9bd9655305"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9d6baa4bf1145b99b88744e501914e42f149b05c32074bcca9482fc3703c2ca8",
-                                "uncompressed-sha256": "af1b4f9b63276fe436d598beff287d3fd0cbd34199a416f98e82cd7d08189261"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "98cd2524209696cd3f4d36dcf62caf1db7d35231bd860392dbd1fb93a0560621",
+                                "uncompressed-sha256": "48276d89774e0a0955ab1d4dfdd37dffc64d8c44a8940dd5b16cf4720108a4ac"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a86a05f46f65e1f5b89351f421e980f6367f8e80861297731be531d42b96f3ff",
-                                "uncompressed-sha256": "a23003f665a28387bcb3c50ed5a76f587c64f32e759e4fa485daf5f6cc36d20c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d687fedb408b661c68776a0cf3d176169ad9240e0afc5330a1766af26c011bb6",
+                                "uncompressed-sha256": "facbb0a0b6fd9f7ca898187eb78c0c99ed68dfe34785c626b27a4508f119c5b5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bfb0f94d5c6ec52876d3f2eae42595827dfb932e942648309c2c81ffa693774e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f2c8c5eb666092a20dbc035390926b69fa4d087ea1743ad245276b1ebff24a07"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f4469d47faa3c3563505942028f99a43d045274c85d90080ccf9110d55257938",
-                                "uncompressed-sha256": "d8566bf02bbc363cd178a3aa0c6482e3905b7b4e1d8104bbf8c6ccb7cea73403"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a6647beb37d0cc9c6f960f18498d4993626dc65cbf9e028a691f43685a6bc278",
+                                "uncompressed-sha256": "b480501b98071fa226665ddff7a7ed53e52977a0eda57ca6a27015db021ac4b5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live.x86_64.iso.sig",
-                                "sha256": "f6c97c90f82648f33fa65bc56fba1c95adf4643ce2ccb57161a32c385022077a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live.x86_64.iso.sig",
+                                "sha256": "d7a67440a4f9d68cb4f635a74bd2d191ce9dda8936c8d0c84353bc30cab5efc2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-kernel-x86_64.sig",
-                                "sha256": "ffc26b51409af5ad0694ed5740467918685083d77b0819230ccd8758bfca389c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live-kernel-x86_64.sig",
+                                "sha256": "56978c9bb331df1467947db3d4fdeb69fbda7f277fc090f2e647ac551363be4c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "f189ec900af0683a29c317be84da017664e88a53a387bb6440638922520d8581"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "bc27ab28655bc9e51b3f88d18d37e73bf6aa0d84863375daa61c66fd4769b060"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fb489b4743c465c2bb8c24f7cabc841bb35376c494289d5c66936683857193b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c6361b825a348de9adf35f1f6de330464d246b47c9ad8a02c0aab7948575379b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e6fe56af6792e25aa295477f064bf7aecc184eb904d51fb630568f13981a01e0",
-                                "uncompressed-sha256": "5f8113cac0da6d9d5d5593feb391562af9376379d88287e4270629699a65c5fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8632aa8a69bd8e01ca002e20be74996f08d5a2b83902a4514fbc5d30201e1cee",
+                                "uncompressed-sha256": "638f297c540e0c0acec35dac4d3571e66086090f3974b914b141ce5a0f816bc8"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "860467fd46526930c0bc9cab71f555d5e8eaa56b79681aec23f8eb05a2a7180f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "56e66cd7e87b1818defc0e9a5ecbc5b7401dfe227e4aca6f0170c808d0e65182"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6f6ae63f6917367fb08f9e26788218f3e3a3f1b7a1c037e07da1a74df6cce2da",
-                                "uncompressed-sha256": "83c72aa416b9069b20f82b972834c8540bc2708e5266b47ae217113d813cfc24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "64f7a63b42d1b586182cf48b51f0d8eaf85b6e7c90ddc8e6a670566b1856f588",
+                                "uncompressed-sha256": "2483beec87049a7ccd31d241d3949912c17da394b6a0c32a5b86ab00920d5607"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "75a33f1e958f68183b37b5f4e16fee719a310068ff5bab8258eca39705d1346f",
-                                "uncompressed-sha256": "1df105ce68cfd5dfc3745ce1b3368a563d20c010942e404bc396663eaac9cefb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2f0127bec5adebf77705daa920bdbb286e9d99679632ba7f9da7ae4041c35619",
+                                "uncompressed-sha256": "8bcf4713f68117c5855b5f3c8b27e67fdbe2d9f982f3bd11b419d180e7c29f86"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "61b97778666984887a20bb76f2bc05ce2074a6ddf70ce30ed9b2937e24fa9bf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "e94285ef99b9d687bc29095441c96d5471f9d9887536ee6684341a962aacc0e2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "56a38fe01d5c962e21fc999d02fc958131405bc3f898bd15a358c58febd6fc0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "2961da0fe15f6844729af1d8bb0948033e7f86d507464b46dbc10cdd40a35413"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240421.1.0/x86_64/fedora-coreos-40.20240421.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4222cbaef313b67926f6881116bb0046b5d63d2bcdcbd6e071b52d9e730dbb94",
-                                "uncompressed-sha256": "7cfbbcf77c342d31879714a28d98c4543d4aa75278314c812860ebf97c1511cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240504.1.0/x86_64/fedora-coreos-40.20240504.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "353dc1453988f6307c75a1843a29c7ab00f73fef2955008faa717ade2f082ef3",
+                                "uncompressed-sha256": "79e1987dfed117c3feca5f83e579e9cbd7b29784fc45b938628215c79b89ee88"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-03b21becef98d67e3"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-06dade0b63e4f00c1"
                         },
                         "ap-east-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0f4b6b19417572480"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0ca8eb804c2d794e3"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0a98ae314b855049a"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0175a3af1b0af7399"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-02c89d5e235c0abe9"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0ed291f8cd0b42e8a"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-02ce817d5fc4e13d4"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0bfb59c7d59edc60a"
                         },
                         "ap-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0decb1f3a587bf069"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-06d0be727d196ee28"
                         },
                         "ap-south-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-07eea361962df2fba"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0c38cb7e4c8d97eb1"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0294eeb8c99a6d6ee"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-088561945eda8ea6f"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-079b324487a158385"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0b766eb5f9557e933"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0e0420fece31d902e"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-053ce13e9d30f91cc"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-00347fd2bf636e449"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0967e92b055551ec4"
                         },
                         "ca-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-098b6055d1a98d3ec"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0f6c24537cd09ba40"
                         },
                         "ca-west-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0f58fb8c1e1740e08"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-04029808139d41354"
                         },
                         "eu-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-02dad9d7f19117f93"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-05b5194d32f30a0f5"
                         },
                         "eu-central-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0ba5d627818bdf8d9"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-02f5bf6da6cbbe838"
                         },
                         "eu-north-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-07e715cf94eb1f5de"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0f04c66310cb67d96"
                         },
                         "eu-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-099aed6d56f4f38ee"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-022c56d868502ab9f"
                         },
                         "eu-south-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0ddc7b269932ca442"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-05fd92f80bd4d4841"
                         },
                         "eu-west-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0554a21afa707df31"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0df5d4431f0d40736"
                         },
                         "eu-west-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0a8eacda2a2ee95ab"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-07a10ff5c6c9a2563"
                         },
                         "eu-west-3": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-02f1c07bd86b86be2"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-01294132332758765"
                         },
                         "il-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-04a40cfbd8c164b21"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0cc3c2bf70e3c8f25"
                         },
                         "me-central-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0117296433ad4d1b7"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0e1db8c24ba9c7ed3"
                         },
                         "me-south-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-073b4bff524c64f0c"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-06861034811769c28"
                         },
                         "sa-east-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0cfa3a3c692ed79a6"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-061bb02c8be092bf3"
                         },
                         "us-east-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-00a08b183f3800606"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-0761c610c8c69f175"
                         },
                         "us-east-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-0d6729deb02db1699"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-02163e00809fb7768"
                         },
                         "us-west-1": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-06ecf9585f781db34"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-02d60231ee38c58ca"
                         },
                         "us-west-2": {
-                            "release": "40.20240421.1.0",
-                            "image": "ami-092e5880e6e85b15e"
+                            "release": "40.20240504.1.0",
+                            "image": "ami-061743d3b181fdd61"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240421-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240504-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240421.1.0",
+                    "release": "40.20240504.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:18aac9610a3eb21ac15139a1972fb0664dd9ab6f30a5c29fc68307b70fd17bd5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7e25ada2188b722c448c7a64e5be1332a73430fdde4f978c30e765828cc5a446"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-04-23T10:39:54Z",
+        "last-modified": "2024-05-07T19:56:46Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "3c5d9386723a283ce096fe4967f21acb369a9066fa14bcc032327f5f156805e9",
-                                "uncompressed-sha256": "51dedd856eab4411537f58800185034b53387479655f0f87959001a30d5b840c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "2ba130732776673132bfc1aa005b4d6d40e13d8f14b204ceae4504a02aa1c812",
+                                "uncompressed-sha256": "54f13dbd6a208c1fae4dbae883f802fdf2175f4d63a987da38268db207f423c0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c746715bee4ba1ce40b83ed7407bb692043dd1eb24d7b073d3cd71b5096aeb5d",
-                                "uncompressed-sha256": "0758c450f258a0c2d2603567db8d8b8ef3cd4611dfb9f902c1039ee354606fc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3a995c6172e27371703d3e71838201fe1e2a49c51f5254f709af6f74630625be",
+                                "uncompressed-sha256": "8ed5b8230e5118136572ea0c263d3f77dd0962657a13808f02dd0557578a6cb8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "bc7761c8258fec8c6ca193337c8b04754c6d66e0e97880c28379861e11167ff4",
-                                "uncompressed-sha256": "5e68ba9507c3de1b9ccba7ca171b809aedac6383075d6f57bce35b175e234a49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "10d5db0dfbfda3f3cb8c0bc23d1d75ac3b596db933fd5dcbb01fe076ccb26eb7",
+                                "uncompressed-sha256": "4c1aa249c14600384de033bf58c2f72885daf3c8b621bacc6afe712c1378fbc9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "c540e42046ea7bafac80d51baa4d2092aa32f3663688550e4f68ec38fee213d5",
-                                "uncompressed-sha256": "57b7c7708cb9f15708593f5ae18f6ee44061713ec2e3f489323ded504e38b5ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "b270bffa6aa9ff354ab7c233c3ba9dffe1e6e51fb0adbf998719f03d52291ad8",
+                                "uncompressed-sha256": "b775dbe2f099f3eddf5c154ad9278fc7d04d7bd7daa33ba78b1f712c6f73b1a8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "3d7254741bec80ccb901c3052a27ffd5254015e56b4683e31454e1abd9a46d68",
-                                "uncompressed-sha256": "7743a3340b4db9fd92f81a9a433cb7a2954cee7fa3ab731675b951f807f7ebdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "83f2d7a4cfd8e21d2d6ed6542349b82c7253b9ed081b5ac14356d0d2560df003",
+                                "uncompressed-sha256": "5e26d8d5d0acce631e168a7fae051447f50849b6920c148a41b01319f9dbb317"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "217ff7ec3b5430ebf7e7bb483f384f7e02f7c1743625b9b4e730d9096909a0b7",
-                                "uncompressed-sha256": "f4f6aeee17a8047697c043f17c7ca0022e01dc224794b6f1877d0e3b8dba0f38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8b794e42893309c144bc429cda7da0141a336caff9fb9f23117b3cfccf4a1b40",
+                                "uncompressed-sha256": "3736176b25f10813443e22895cc5379161512f357f7002d8af7dceb2fa4fe843"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live.aarch64.iso.sig",
-                                "sha256": "3bb72410bb0b307e6d3525fb254b3fdd2f55c0cd5b4f56cffaa71658868b19ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live.aarch64.iso.sig",
+                                "sha256": "0d734e940ac111e38332666ad3488c2b8c990e4da9f1674f9cd9e1276844785a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-kernel-aarch64.sig",
-                                "sha256": "d1fb3ceede533eab6a44af4f2506be05d6f226b996abb0053370066c1c192627"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live-kernel-aarch64.sig",
+                                "sha256": "57185f8b19ee9b41fafd9e79e0c61902ae9dd25230341c6eef4286923138f5a5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "715be266dd057badb7d72e99f838755e15a3cd04371ed95c557ed01b5d47f6dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "f39e2e140d3313f430b2d43f2194ae5209af9ff19504ea8ab91b38f49b046051"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c9eedccfb95961cc31e350f9bfb4d7de53ae09a2e91e5a6e8ef23192a1f491d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "810fe11a4b88a5118207ba5e5fb7febb349cff849cde92da69a641c4d108e6cc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ff35636449db42ffc73c93f74c86a4cf927d6166d69d350b450c639645f9d180",
-                                "uncompressed-sha256": "34dd0725357bd9755df121977250b6d7055c378ffa5998f0dd6d885d8104ecf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "a4022472f6b82fcf7688b6e16d4b2a14e8e64b0959a41e4ee9e04db85583a827",
+                                "uncompressed-sha256": "78c8ad22501a7c93df6fa06c31ffaca703bd63de717977ac0463ca6d9c12e28a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7ed5f5c682344d1ff6102bb4abb70f11adb7f2546d2cdad6f0ff7bb496abfa7c",
-                                "uncompressed-sha256": "9469ebb36a4f4468e85f7716d5da3ea531f7cf46b68e6bd183e8e17bf22329d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a066922cb0b4f3b106fd9144f186bb19fc3dbc1ebb566e062849fb5fbd652032",
+                                "uncompressed-sha256": "d1d280a04f1d32610431b5e37e94ffa0a43cbbe83febec582e66cacde7b0353e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/aarch64/fedora-coreos-39.20240407.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "149e0f320c1cb2866500ad2908033d733333781215cd5038b11558548b5fdce3",
-                                "uncompressed-sha256": "a758606d7bf5dba665485633a130d78566fe1ed34ab6be46c4cdb170d52eab74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/aarch64/fedora-coreos-40.20240416.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7f725a7d49440039ae34505012f639b71a7a19b14c90dcd8a35772c3dcde42a9",
+                                "uncompressed-sha256": "0a599015e953556968c258c86a8cebad01a6985043b240836c11ee0e43c31649"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-013b28ef3b61bf89c"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0b02ec0def308834d"
                         },
                         "ap-east-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0d44c66a7b06018b1"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-087f1ccacea9d1c58"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-012f1b2fc74b87426"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0ec1c57928600678d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-00a943a004c821bac"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-04c9cf77b6de18af4"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-06d5211146bbab5ca"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0101f8fca58c1114f"
                         },
                         "ap-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-03a221d4d47b7aaab"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0e837e0a549dcbc3c"
                         },
                         "ap-south-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-07c78993ecd991217"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-060955da515a7937e"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-03c4b27fbb1b997fb"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0c08afaafcab88c69"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0b52e22a3b6c3b3a4"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-025f61eddcf8333ae"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0848ebf462778a036"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0723e41dab4086ecf"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0911c8a8a3bc1f700"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-086d07c709c12a563"
                         },
                         "ca-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0474ba563ac95a86c"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-04a4cabbff236e78d"
                         },
                         "ca-west-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0068f2d0de0434956"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-018cdb94ce776265c"
                         },
                         "eu-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0591320b746a6f116"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0f35396c657988e0b"
                         },
                         "eu-central-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0441e3086b6e2867f"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0131fe6db9e0e8b46"
                         },
                         "eu-north-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0114e6089fea70868"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-067d70a5ef1fe0eb3"
                         },
                         "eu-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-041789593b05849b1"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0df107ee0465c0506"
                         },
                         "eu-south-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0313db5b425b7210e"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-00ad85df21e503968"
                         },
                         "eu-west-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0257913d26295dfcd"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0f655e01e2963aca7"
                         },
                         "eu-west-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0920ecefed5327fad"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-092e4e158e239907f"
                         },
                         "eu-west-3": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0528ce952d25dd3af"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-068a9da1607c2e9a5"
                         },
                         "il-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-044d1734013867482"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0fc13e4c79ce129f4"
                         },
                         "me-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0a71e7ca5a185f5df"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0719858ee020a5bbf"
                         },
                         "me-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-020a55bb0473d9857"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0b28856fd41b78da0"
                         },
                         "sa-east-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-095acd62ba26109e3"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-01cb4d01679b5af29"
                         },
                         "us-east-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-021a0efb55804dfdf"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-03fd01ec4c2153690"
                         },
                         "us-east-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-06d172161f21c0c97"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0a58415985c6fd348"
                         },
                         "us-west-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0171f62d013b3f8c6"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0587a521f35bf6a0e"
                         },
                         "us-west-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0fdff140b1f434097"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0f805548b8c9eb043"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-39-20240407-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240416-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c767cc32b26684064c076dc7107dde0329b49675cc70ad4184427789a83116f5",
-                                "uncompressed-sha256": "2a3458aef824cdc26239552b3cc4a7314e90bca61bcc739c2082447db43b35ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6eb12406ec35434c343554e5e71d2e73d42e88b0a3097fbcee287547d1b13442",
+                                "uncompressed-sha256": "93c804381b5d038c0dc4a1d29a4b7994f859f3f247c479a42c912ea2a149559e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live.ppc64le.iso.sig",
-                                "sha256": "e38b1a833f0e4b96bc371c5680c24e695b314b3506a8ebfa009ca521e58d71ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live.ppc64le.iso.sig",
+                                "sha256": "727f235da8f84641b02cd66f08ab109fa210935009c6624fee20bd3801e96873"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "ae53d03ab28dcd102fa5dc7dd7b7e1a64d3f6f7ce4b7610ef11856c8c206f4d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live-kernel-ppc64le.sig",
+                                "sha256": "d829058051aac9a552d3f694854e8f8f5ce3a13d5f61d98a092c90ac4f5fc5ed"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5ca09bdd832dca38566d477a1d2f9fa8f058f70fd50af20de96898e78167b4d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "755768e9c3013a7e6b9327bb45f8ca32da996c3ee01b61f3fcc1a67a5b2c2cb5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "20441cfe63c189238571f4852966bf2a4273dfc37e7dc9b8cc11617740ce8660"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c7ed42a15615f58abd770f77031f488707a747ecca3c80ed84b382a71fc64f34"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "cfbdf0d03912d6f171ea76706f1fcfcbedc0084b2bc8a926462f7c7185483223",
-                                "uncompressed-sha256": "b71a369154452537aa2defa8c2e59eff8958132029cf9b1350cdb130a4e0300a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3c689b8114b8db90b67b63e40d124628f073862b773891f8781dc49903289d1d",
+                                "uncompressed-sha256": "f3d303887be837aa045a82d91846ec096d326f9c514c35c9028500d859285914"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "90a6d4fc7d04542bdbaaff80d9bb833916c5656ba60ae89f38ab71acef7bbfb5",
-                                "uncompressed-sha256": "3ee3562bd4e129fa97d7d1bd014b9464ba76c9fdbb4ef0a2689528bb5fd83cc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f269fa597e3803d75ffe15aa64c8d022bfd7e8a269d894518e9409949cbf58ce",
+                                "uncompressed-sha256": "0cd116e95403768aa3657e1cb7439e87e381bd1030436201becb0eb66c82bb9f"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "54f1b9a7766f861f74a9046e8b8ac3d5dfdcf5f6ffaf7340f4397b8ed797ba59",
-                                "uncompressed-sha256": "fe2f773c679cc4786955f2f88a9921b40ca7343c296e314420fd234451fc23c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5b0e2a41e0d3602afbadd46759102496d14f775ca79001f132d67ae19a06f070",
+                                "uncompressed-sha256": "abc3e7c482a88a992691caaf84b6acbc569c5dce4a901b9f79ecb7d6509108b3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/ppc64le/fedora-coreos-39.20240407.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "da50b58619c0ea3dbc7f229ba668a92ae70066728ea11006387ffcbbdb3bea20",
-                                "uncompressed-sha256": "27b88e4ff92f0cc8f7a6015d8e766c537651cc1921f3621e678c15bad7ac5f60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/ppc64le/fedora-coreos-40.20240416.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "cfd14138841dc076918968c8225d44250026ea0eb9ac8f8ff7c1af958ad431cf",
+                                "uncompressed-sha256": "b031e4fd053709c70113ced0421eac73eee3921abac3ea28926100fb098da03c"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "72acfa94356b9df70ebc8b6c5bfd5512ecfd9773de7eb2550c9e44546158fc22",
-                                "uncompressed-sha256": "a99105138821174b22cf7d63b246fd15e5f69962dc64458782d9e3e21225f70f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4f9f008ca49be15fa33b655890e6cc43d89eb386d28dd397647ea2c4c80e6eef",
+                                "uncompressed-sha256": "cc46f28eb2fbfa1eafca9599e8316875b1ea9e820785c349606c6a302c225c95"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8cfd7fb659f9499ef9a6c306d60a1bcdff1492173e2d618865f8ccc7fb473eee",
-                                "uncompressed-sha256": "7dd8804bb8dd9236bd399da16f845d3ff8c5b201697acaeefe620ef2ed1ab9fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e2de6984e1450e65fb922fb3d7e50de18232cf2b7d97058170da9b5d0fecd355",
+                                "uncompressed-sha256": "0e3eb655f703e58c7af4f28ed0960895e8b1fb0ee0dd44dc570d76910f8483b8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live.s390x.iso.sig",
-                                "sha256": "da79ec749c0eb7bacbc5607c8396e312c2280395390570e6537e2ecb8c7bf1c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live.s390x.iso.sig",
+                                "sha256": "a6dbec23f481ce82d91428532bdb280b72ef88ba77916b365751d83c67408255"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-kernel-s390x.sig",
-                                "sha256": "2ca011ae1580244de18d048b10b0092614a64d8786e3c182764977c036b81dc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live-kernel-s390x.sig",
+                                "sha256": "f8e229d00405633e55de979cdaec9df069baa6d715005cdf003728c6c0ed0a01"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3f52f236c55c383006c3092c2ee98723391cf27cf0aaa8aa81ae5a09b694fcb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "3e369c002b444746dedd57b363a7f6f8f4fecf6cfbaf195e04b61fac8156098b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d8de4f6b5dfcc49168e9e1d629c6cc6955afa652eed184f54fb08c56fef42472"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "79946fa3568c9317a72cf17b69f66a5050127b1c06a1e0ba45d855cee3179ea7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4e6153fac54e02b235c23cb4710e154d127643857935806ea3eecb53401599b2",
-                                "uncompressed-sha256": "e5431ebb97c64c154867aeda6600986d1ba00f98cdb532d968f9598b99a023be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "bcec212b19ea5f6f55f04ff463c90273932a92d2d306b87a3a4edb1f6017ca05",
+                                "uncompressed-sha256": "49d720aed16a3b518d85bd4115f9aa5a3dccdcf8d6cd2cb05eb669fe7e48b075"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "dd65bba61d4b53b241eaae4625c34a2bf9c38731dc38c537e10932cec3f6abc7",
-                                "uncompressed-sha256": "82200f5e1635fdb12ff5ec9835656737aaa600902d7119fac1d70f83d15ebe0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5b15f70ea42c30e61e035b9448e7c00021ec789386eb58a6730c5760353085fe",
+                                "uncompressed-sha256": "7ddd32c1c70d6d92a733f24ea4d24db8e3b69e9be2954950f8c4ace877cd68e6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/s390x/fedora-coreos-39.20240407.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "795f69d323d198d132e259d85f6b1f8b64bde3d894478ea37e2191a38ea5595b",
-                                "uncompressed-sha256": "39f9817f9757aa75b18259738f072bbcb749258d64f4bb45cbe5cf0091ea1758"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/s390x/fedora-coreos-40.20240416.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f10a4d6485e410e5fcbb216f33e24a5512176f46b4043c7f738ad26cbff38c19",
+                                "uncompressed-sha256": "c8b3949257d6116cb433c6d2f55283474aa329d6de8e3c709ea201668ad9bc62"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9fbe615e53e7f05edffc34088d0c2c71348cbce374b5e406af92e34efd83ea13",
-                                "uncompressed-sha256": "38d447b97264f097cb864df6e32c62e35cc032c012b6040837065339e4a32bd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c7330fc601596264e77eeb6b8fa8d7970a7dc8f42a61c3e15c6bd420de8bd2b9",
+                                "uncompressed-sha256": "f6c35e676f8db784f2a9820efa9f91945424e90849f01fa8f410d0faff2e84d3"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "7232d7866e3f6d1e678778cdb7243e745a11102d8372a0a72294acef311ef4c5",
-                                "uncompressed-sha256": "73398ed027345e144a10a36c96ef1bd3f1ac07a96915170d0a2274f0f5109be0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6e827f3e5bef03fdd740da8a855e965a645e1356766af7b5f7d1063ed6e7499c",
+                                "uncompressed-sha256": "fe75d25d5ed1e0aba39b146f33dcd585cc7bad7940a6270194d91460a352f4f9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "87212c874a5329752a4532fc47b8eeb5cb8ec252f105445150176b83504916a6",
-                                "uncompressed-sha256": "cf189e79dee6cc8dd0c8211dac7687f3e1dfacbcd7c306da1e1f4492c9edfc67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d0ca633a02429049247067d1dc1ef315bbdeb348bd6b1b4397c44e57de39fe52",
+                                "uncompressed-sha256": "c79544e998a755d2124e05b8c14b72c0e981beadc397d790448e8aa1f4901877"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f7e2b6102f2f65a2c1e4808920da4a55b2c0f104dd9bf4dd4b71b9a0b3673cce",
-                                "uncompressed-sha256": "392595841c4351962572031ba29455409bdbc17fbcf83b29c573be7c95b999a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "aac9cb0187f4469dbabeb002530c68cf62564f23087766274480d74df5d0127a",
+                                "uncompressed-sha256": "c1e70790aff685bc3b0379784384a59ebc2068842094aaca3bb7b43fedfd0adc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "895011629e8f63239a24233deb2b15b1c30fa4f05588b2c2538a9177e8efe3b4",
-                                "uncompressed-sha256": "129c4d95a1f34075db9e88e0909cfd56fb25174f4059f45f9abbc2cf5a7e3f1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "44f55d5bc9f7c103d0e28a3f2e58eefad504f8d5e8c0150c1b9d8c78932080c6",
+                                "uncompressed-sha256": "0f39134af84a2f7097054849cfc35e951adf7558ecd5155700c5594931e5e7f7"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9c908e9666a650844a5ca6944763218a88efa99d46636d15dc093277e4b29f89",
-                                "uncompressed-sha256": "9cf6ea31f06a0afa9b644ec42239632deb998cc7a476f5f47e8b0ad130d71da9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7970d3af0b9c07721a3c9f92355287005d8ba77b314b9173669f76cd2ed53033",
+                                "uncompressed-sha256": "e86ee19f55ee6a39a2c51afb1b7f047656c7ef87b0d92c4db779ba16efbccfb8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b4b7c0a938ba10f20d97ef0d0fc2f510aa8e5dcc83ed03339d7ed8195f02c65c",
-                                "uncompressed-sha256": "bb951fb98bf153181b3a81668569cd5dd5ecaa660db09118e2b82a57c99b6008"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3f88f8c40480d8c5f5dc80c90be860abbe39e6cfdc757f16492ea3e0065e693c",
+                                "uncompressed-sha256": "f0538834de79076d406290dcf18fc902bfde7459ffca83f789fd71e407918c25"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "19bcf8336bdfbf9240c9e3d7edcf841cce4d851e6084738d76aa927422ebd23d",
-                                "uncompressed-sha256": "8ae4a76fc12b8aaa1ea3d6f3139efc326a2fe8f69b06172b2eb224835aaecebc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "dbc98b803315ee46c284f7f082ee5180c5632f890b0551356c901e64723b3504",
+                                "uncompressed-sha256": "c11132c643cfc43c4b7f19485aab592c8f29fc517331aa9e82f3d06113a7c921"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "545deb671e3945de77520298a761e3a4e26c2ee7476f4edaf1f8067070598cdd",
-                                "uncompressed-sha256": "73f4fd4b6ec2597000b775659ab58427dbac497f18439f6ebbf8cbf2ea7a906d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c48f0d7828d606e77c58b3db7c077a5ba84bf7503b588cdec36319484510b086",
+                                "uncompressed-sha256": "96f17b74375c654b9ec2ce801cc38479d9176dd85dd1e96a4621f52b67177a52"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "304dc64b9f1f75b6b2fdf64bbe1100a9462b5a77d8ed02d5a51a990719dc40ca",
-                                "uncompressed-sha256": "778de7b202d3f198e7c6f1e185e022b3041228e0b32f17902842a98a9cb43ba0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ff9f17ac18a74b7c0e70166f330b1a539200092ba65f996ea758b45224096994",
+                                "uncompressed-sha256": "16905f8bd434dabb76eb31458d78d65d3bdc435e61f6bcc97669d3926dbe3e9e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e70a650645e632f81ce3cd764276cb09fb5c137cedabcc0e4a91d1b1fa59b051"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ff152f1a185f8d19c2f581e0c022206464f2159f7ca57ca49dd12377947a0b29"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "47464ab4fe5a876568c91ca642b73a96383a174ac857dd4eb31a9a5d902ab7a7",
-                                "uncompressed-sha256": "434508eed304cd73ec02c6255271d4f1a74b198a9e4ed8be20826267ed2a3cb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8a564328e6e86d14e2ca814522a83888236c361b63cb8138c70d7eb71f52d6cd",
+                                "uncompressed-sha256": "e585740409c38d895ca9df596a832c5e5b613b40c0ae9f81566ad3e274a4ca8b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live.x86_64.iso.sig",
-                                "sha256": "c49ac47800dbd0c5d53e5156565f093d5b7ec791094987bc4ca5bae2d7b061b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live.x86_64.iso.sig",
+                                "sha256": "4cd031f924044e83d02244c23f8cdd0b6c634c2f9e686a2ef1c7e3a8cd6ff260"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-kernel-x86_64.sig",
-                                "sha256": "c1a86e0cdd001817105aab0ecff410f58dfa371d31533b186a28872b4b305190"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live-kernel-x86_64.sig",
+                                "sha256": "09cf5df01619676e91e998fac6c456d67ec3cac25ee9244898b59699c588bb86"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1d50bd16acad866a473877dd0ef1bdd8bdca6822144ae09990edbbf4000c7832"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "9eb0ddd2bac442903392565e26a29991c3b0482d7544369ad025b7c3cfe34c94"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f49a7f0f8a9b593439bda39b8ede403773e2b890c4b4b1f24773f40ecc59928e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "54ae9918753f36d4e9b9fe1a7f7fb7794589eadee42ef336f7713d17c5e473a9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3afe4898d644fdc7dc869c89454d8b7eb192cd6b545c51024de70e9fc38ea871",
-                                "uncompressed-sha256": "e7e5021e93b5e8ff4714af3538a23bee7a3db69d6dd70bfdfba38a9350416b12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "2a1138dba6277eaff67983a54139e933ac829ef3d7d24e56ef119ba897a1f05e",
+                                "uncompressed-sha256": "5f9e70533c63de649618809be1ab42ff98c408ff9ac58783bd88f1ff6a8e0cc9"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "88035965a7ca35ba0adeb44ba16fd1424fb86855ec2f69d06f4fe3737927a071"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "332aa7300ae390124c0cfa283b625a9616057af0215732312cdcecb8bffa09e0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7b1f2f5c55b841277e56107d6b8ce5613de66b0d6dd5ae117f658537a610aaf0",
-                                "uncompressed-sha256": "b1a0041efa06a2e912cd519210e36f20552ad1bf4fbc93e1b26568a93a57e312"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0daf1758a2c7a79ff39a283438b282aa9f86430942872deb0fd05c61547e321e",
+                                "uncompressed-sha256": "b879556ccde847c7d3b80ecf895a542d197aa395657b5e38b71486aa64b37a6d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d153a2e1cca1ce0797ddfed2b469d7d00ecd4b3b84f7aa079739b089cb1093c8",
-                                "uncompressed-sha256": "f38ceb37cbb4b7c7af87b49c5fde82a2b00344721936a818d041f7eba26846c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e617931594d6902cd9f9e215037f2d69ae05590295e3247a488d3080f103a86d",
+                                "uncompressed-sha256": "428d9332f2f22d71b1d41ac25b734cb75feca9eb120fb5fd3eef6f18c23b15c6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a0e4e243c3f2a33ad4ffeec9b16bc955cf630e5b627725fd6eeedb14e2221bbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "afa0b765359d56a6f782437d13d44d981edb78d8ab6a71e17452a31a6648689f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "be5d2284a3875aad14a4c3adc5c67f9e094636cf231386d749dbd411ad45fccb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "be51556ff2ca9141224db053bcd386511b43d3dc91e03204d61b58355b33957c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240407.3.0/x86_64/fedora-coreos-39.20240407.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "71514ad50550532233f05ef4443185034fc286fe212f30720dc01056faba5f2a",
-                                "uncompressed-sha256": "5d0d56051c4c72611ed753beaf686d67b46a9f17f6a1d26d26435d9f3049366e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240416.3.1/x86_64/fedora-coreos-40.20240416.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ad025fc21b3f304b37c4c7a0a704f52c324a8d21b9569f1be01e6c01d5151bc3",
+                                "uncompressed-sha256": "7f7e6dfdb015f433051bf19c2a20bbd647b2359f904d8d6e56989839cef1b85d"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-03b792b52ab4e8c53"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-061336b2dc2bfc786"
                         },
                         "ap-east-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-03d09109912bac5cb"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-06db599ba5abb2b6f"
                         },
                         "ap-northeast-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-09e91c5d0f1e3a564"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-08501bbcc4d9cb04d"
                         },
                         "ap-northeast-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-08052baafe5b05bf8"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-043916f5ae289aec6"
                         },
                         "ap-northeast-3": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0ddebb49b0821d70f"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-072e59eddd7cf49ee"
                         },
                         "ap-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-08160ae66cb742afc"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0c30514c3a07bbcb1"
                         },
                         "ap-south-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0e0d87b280bcfd764"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-05b08952ccd304deb"
                         },
                         "ap-southeast-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0dff9d974b0a8c311"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0b26651461c41b179"
                         },
                         "ap-southeast-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-01cc2131baa8c87aa"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0ab74909582a75c11"
                         },
                         "ap-southeast-3": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0d407c99cdb8c0683"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0ecd0de8cc213713f"
                         },
                         "ap-southeast-4": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0daa58be6ed96e154"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0ba00dd06cd4695d9"
                         },
                         "ca-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0d610ea9e88ab40d8"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-098c2e876bf46edf7"
                         },
                         "ca-west-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0bd43320538e5b8e1"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0e259411c4ea80267"
                         },
                         "eu-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0d497b7d3de3e3818"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-02154bee819b02ae5"
                         },
                         "eu-central-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-07cdac746c7020ec0"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0ee29e49846becb85"
                         },
                         "eu-north-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-09f7c3700ed84def4"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0558684c464cb943a"
                         },
                         "eu-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-029e3fdbf7aac823a"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0456e3559522e63b4"
                         },
                         "eu-south-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-00d164f7444a7e38d"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0b0afe5bfb5dee210"
                         },
                         "eu-west-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0525172c6650d9504"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-07171a3c814fd641a"
                         },
                         "eu-west-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-00981bc893691e490"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0afa602ce0b266140"
                         },
                         "eu-west-3": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-000db03f3ba156d36"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-07a3033d2ccca1434"
                         },
                         "il-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-026f32c46b75137d8"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-06e36d65f25fdd1b9"
                         },
                         "me-central-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-038bbb04d3ad61b63"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-00c0651e9437d460d"
                         },
                         "me-south-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0ae28312c96379cad"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0f99628f0c6bd9d1b"
                         },
                         "sa-east-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-08a0d9a15723519dd"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-09a0994ead719898e"
                         },
                         "us-east-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-094f5093032075d8b"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-050f038e128d008e1"
                         },
                         "us-east-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-0c7514b647922ce4b"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-055d09176e225e997"
                         },
                         "us-west-1": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-007f8fe367b0c8e14"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-0279e15ae521c0ae9"
                         },
                         "us-west-2": {
-                            "release": "39.20240407.3.0",
-                            "image": "ami-08904be33085ad1aa"
+                            "release": "40.20240416.3.1",
+                            "image": "ami-008df7cada990d4fb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-39-20240407-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240416-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "39.20240407.3.0",
+                    "release": "40.20240416.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5007e62310dce431902dd8e7766551bfcf49634fd94a59b14f6f4e8a72f36476"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0ca7aa7ca39828659647aa71bb5a9c8ba8a75a9745533849743dbd1f784caf41"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-04-23T13:40:55Z",
+        "last-modified": "2024-05-07T19:56:47Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1f46473431a5cffdc4d8864dceeaf343c4cc19a0848e50fbec3649ae268e5bc8",
-                                "uncompressed-sha256": "30acdeaa29e816db4b4a46f821bf67ec2b7fd76ce5c8e3057059f5143add0a0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "27cff8068e30d8515a2dce110c991db9da11d5a656bb5222e6f79eb0662bc823",
+                                "uncompressed-sha256": "d1fb51b308170db8d45f26a564ab5d4550f8ed27d0724a1a37ab22a48bedc68c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7e4d1629850e70e71a9345b62bac238a11b6c562a9bb8d871c8e345ca6b5e96f",
-                                "uncompressed-sha256": "3dd1659d7c026c7f3c7f2d54916f4c04f66b4ddb6faae60209f6bb40e6b38315"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ffeb27bca72ed68482b20bd17e18b31e9b31a18270fb0714bb9f3d539d9708eb",
+                                "uncompressed-sha256": "398eaab04ea299a8ff2e5aaf18d4c13f21440526e4f4beb0642286c0780e54b4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b24820c899d4b63a13add78cbd0aef4df1e7a66f0d918d3fa300ebc7bad6e220",
-                                "uncompressed-sha256": "dea8348826fd268bea26bd92e09c1a0896bae45f50c1a9992cbdaab30ccf52ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8cabfe052c20844b3659c3db2770dfd17c163e22f8c44972db82ce570e8ed121",
+                                "uncompressed-sha256": "e136ea79c3782b1e0b18af86bcd3a763ce29b7a198034ffc45629faaaa884ea5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3917d659e716262366909ef42a9ddcea86f97efdf7065d7a73a5351a6067cc95",
-                                "uncompressed-sha256": "5efe7414a3f73595c2efea3800ce0e08a266889b04772f5230f333864fbca598"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "cf72e9f7dd387b47c6e3a17397c92c8db996fc212a14bcefa2271c39314990ba",
+                                "uncompressed-sha256": "13935dbcb5dee46d364d4cfabe6acc93e3dfd7791c4cd4c3af3a1116277d41bb"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1042a20b8c10e59e24ab6b2868e4e5feafb707df9a5e3a5d14a0c6fc8da2619e",
-                                "uncompressed-sha256": "700fbbaae1ee078d4ed2b4e7f3172ec5ef2ca19f9cbf3b2ae1e9634feb2f7d1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4f99010c3fe040ba9603024a1a2e329dbb8197affd71a4abe57096c22a8ddd5a",
+                                "uncompressed-sha256": "8a65fb0ed1e1b19e4064126876f6c1d49baef557551b0d178b14e47f1c69ff1a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a3b83c6c647350d9692b9a418c7b49a3508ca983935253f58918f581e2063184",
-                                "uncompressed-sha256": "a4c3ea38cec2dbe7b1728bf7c24a16a122fbcaf72302758011cafc717c5e15f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b54b11d4706195a67029b00a976ad73d88b9ba6cf9b821a9644f2674669de931",
+                                "uncompressed-sha256": "ab8beff1bfa0923763b5137056c8fee8392486988d83d9b5e79d167be855004a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live.aarch64.iso.sig",
-                                "sha256": "15071875bdc25eb8eb7447cb34e10c2f6b79631ad58e9ee0e6924b7a7215888b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live.aarch64.iso.sig",
+                                "sha256": "7a26da80dd0dfc103ae37e81e833d6268e451e624c13b90487ef37d145c6d682"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live-kernel-aarch64.sig",
-                                "sha256": "57185f8b19ee9b41fafd9e79e0c61902ae9dd25230341c6eef4286923138f5a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live-kernel-aarch64.sig",
+                                "sha256": "22a76059b7d6d8be5caf551b38648d15e410f1e92e46b5508e164e8bec7d54ae"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "dd212755ae9a7d9f68ddb2f0ca5820cb9c4dd885378acc0e996f7935b708a31f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "81d64057ea56c739903414958f043dbfa7d523b0173a110c8bbd83aaefcaff8c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "b286b8950740b7a08447a326cd72751cc593e9c0e4482c04c319856910d5410f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8d3ab44d9b1033aa4fa8a3b735a1db02b9d6f1ac98b32d2e887f1dec33c65a56"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "cb655c73e90278767dd6a0b94e16e7146df6a21760811554ed874fdf7d5b5228",
-                                "uncompressed-sha256": "4fa499aba26ecf2cb48ba05ec2595ef7e4df8c5b82683dd321f5eeac7bc9c4b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "13e376dfe5d09f5091713610dbdc268b2afb41daeb4c2fbef2cda2cd10f077a4",
+                                "uncompressed-sha256": "2a74658defe10d85d92cc6d5d9c420c00c516c0e3b4b1e9997d08c5c369814b9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "501e51ca3eea324e1a11d67d84ef94b37e2a29b24ef5bee1640750c0f055cde2",
-                                "uncompressed-sha256": "18f2a60bd9175b3a995c779d7d772d4940b3031307a837d6f9500f17634e0b06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "632237d50f933fa55163ed4e6e630dd5b4613097f97bfa8b6de6e20b90693eab",
+                                "uncompressed-sha256": "c6615e7a70776a3af844d1c55af4771ac9e0ca4d60c118061fb8f106a302dc16"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/aarch64/fedora-coreos-40.20240416.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "71be6f10f114db4f4bbd136fd952029fa9856996866bb18f811dce729b675948",
-                                "uncompressed-sha256": "3a5102651ae0d6767f8c575ab34883655706dc043597615a920b3c5158a260e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/aarch64/fedora-coreos-40.20240504.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "171c0808ce33c550f640527687e0087feb3c89204ff6a90a67d5705382b645a5",
+                                "uncompressed-sha256": "b9359bf9fe89de59838a7585566bea89fbe35677efd558dd011f30ff744d2ce1"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-00933b7c30df9a174"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-066bc3b925d62c788"
                         },
                         "ap-east-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-099f8a60f68088377"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-04b1b645c7de39ceb"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-02c5a6f23d6902534"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0fb6909c591d0cc12"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0170d9a6d87dbc31e"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0afb9ae7a71b92dbf"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0e33b833e2d8d9ded"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-059347ce7e6451705"
                         },
                         "ap-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0051ac21b2613211b"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0f7b1f41679d3687b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0b1598ffef9ebdc79"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-058ee914072387e86"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-04e2803f453c9d1df"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-03215c02628849e57"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0385558b6f9890eac"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0776c83db3006d881"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0ed27d6054d69511a"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0c3c0dc29e9a2d5e0"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-078c1a7459cee29b1"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0cac612b281beacf8"
                         },
                         "ca-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0b9ce615aea345b99"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0b81dd9cf7f30e82e"
                         },
                         "ca-west-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-075b49421be20bb0a"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0a327009fca8ce30c"
                         },
                         "eu-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-056b33287fc8737ad"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0344fed2cfac4de1e"
                         },
                         "eu-central-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-01ecb4a1f0ef9c3e0"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-04863d94f3f9cf70f"
                         },
                         "eu-north-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-04957a2cf0cd75c66"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-014e5c9687743ebb4"
                         },
                         "eu-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-06c50d3aa8cc09e63"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-01fe86133856a0286"
                         },
                         "eu-south-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-00af5094555310998"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0326770a6519d5876"
                         },
                         "eu-west-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0c594aba6212ad9f8"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0ccd68761d79e0c1f"
                         },
                         "eu-west-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0b4db520abf9e16cb"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0578051f85be0af19"
                         },
                         "eu-west-3": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0845bec229f3b1b4b"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-00757fb0ffc7ce475"
                         },
                         "il-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0fff54412fb5db2d4"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-01ff11ee9cfac92c3"
                         },
                         "me-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-00164f3328106a686"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0578af8ac32f33295"
                         },
                         "me-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-03c3c0cb3d9a237a7"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-003f85909287cd08e"
                         },
                         "sa-east-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0f83a93d381f2b095"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-062f8aadbbe5c7132"
                         },
                         "us-east-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0dc232e81a36744eb"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0889471ed400b90c4"
                         },
                         "us-east-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0879eb90383cde783"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-02842d2aac5d82bd0"
                         },
                         "us-west-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-02f713c85014bd3bc"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0a15bd70d84766cec"
                         },
                         "us-west-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-044d4037c80cf92ef"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-073acc86c37cced1c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240416-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240504-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "782dd7c7c605204a7f57bbba55dce3643d89f522701c14beb81926fcd5971317",
-                                "uncompressed-sha256": "c9d823a4093038586dcd256e261646d4c7b29f312e41e886ffe823b554e9b883"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "12b4868bbb6c0f7eb4b8b78fd6ff9f52f602a999bd2a0f01a1f95c5b111cb576",
+                                "uncompressed-sha256": "81e315b3d654845b41a2fb98c09c0ea8c973f9767644a5e95392ff94b119fcb7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live.ppc64le.iso.sig",
-                                "sha256": "9c30e490a231243c158eaf0ec17f46ad786afb49857f5010ef970c48aef1cbb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live.ppc64le.iso.sig",
+                                "sha256": "80a701fbe57dd20ffda72069712020e70f489e8e3ae6e01c9ee2374201abbc5a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "d829058051aac9a552d3f694854e8f8f5ce3a13d5f61d98a092c90ac4f5fc5ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "ef98875e9d1bfde2b08ad5a7e18119c64ce4746699fe5940b03b07251b8f451b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b7692bc71bf483015ce008990328b75bbf3157f5c68457da9c3e12ca726197fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "3cde6cbae1d333f7850b23fff2d19c55196417c732f70b0bfb7b5568ea4e07bd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "544eec2b92ad4954916d35d5620d4b11ef853f63532e12865104fdcaf51ff793"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "783a898969ffae3b73150b771e33322a192d3fccdb5896018e995f767065d6f7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ca9b5602fc268d99e66d54163f0289d65514e6dfd008fa93eb174115433e4332",
-                                "uncompressed-sha256": "53ebd3359a3bc791fbcd0594c4ee8356d9ed5b1d08d05198b62acd44a7ef968b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e4e1925befb637e36d5bc0563e1fbcc9e88a85804b9baf510ce4979d15bdb2e5",
+                                "uncompressed-sha256": "dea1ad0a73344f0a56473059b9a6a8b96fd74bd0435cdef2a2ddc46eb6aab88c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "24a3232afda2ee5800dc28170bbdfe98ba2d04d233ca727fcabbb4e7e90b4520",
-                                "uncompressed-sha256": "f56758b8f0d155d646f2add596995d649de8dbee416d3bdfaa06d931b32eb39c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a7ea58f8f00b93ad9dea6c50aca7a0675f2ed1aab4aed7c497adb31e788c95c2",
+                                "uncompressed-sha256": "ef7e33b259cbb843e6a7d62a8bed6e4a0e08ba6278db0adc0d2e01c7ed35a88d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "e871aad7dcd84446dba0cf58ec86d76d9d716685d32e4ca90ef6f10d881b149b",
-                                "uncompressed-sha256": "f33f0efb377e9c582405ac23f2c4566cc46aacee541e648dc05b3497d06b868d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1d81178420bee815a2d15f1f4ce6c00d9a8264f6d25c19521d428961ef189bca",
+                                "uncompressed-sha256": "415af613aa0ccd8e2959953e7c0ab4eda6729d72dc8566c93f449361a898acf1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/ppc64le/fedora-coreos-40.20240416.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d3b41d5015b8709324bb46aae08bc2b205de8bea1219ca3d5294ea04653c9c24",
-                                "uncompressed-sha256": "64df0dd926e32570f70edc8b4cace4256549c1cc2e023bc31bba9fe270ab977f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/ppc64le/fedora-coreos-40.20240504.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7be7f4e1c7b8adba08f229689c2bea02ece2bf75e697c1f9a694510d48bb3d35",
+                                "uncompressed-sha256": "c2bd525282e09f5d76123d060c0fb98688a8f903080da8ab4062967c3598d155"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b23291ef016e67a9107f954faef55612f5bad59bd3daa4a170e3e2eb56cb7fb5",
-                                "uncompressed-sha256": "546db72a4b7ba49d15030e80343e3228c3884bb752160ad480cf3e37920d0215"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ca63303dfb5441a04569e2ba0d41340d2a6ca8f2763b028317b58d8271bd8a48",
+                                "uncompressed-sha256": "fc6665073bf06babdcdea0fe69a488ab287e6b8c092dfc2b3f2cf0db90bf7e30"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "62c7e9fc3799a08564ce665e0f9a102b538d3d7477b9720d8ddd91c65300fc2b",
-                                "uncompressed-sha256": "b43af5299e3adad4f3c81696bd218ed0bb405c76451c4e3987883936cf456313"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d25b96726d826e8fb6816fbf1e0e216fb1169c5593370b81416627343ffe6a18",
+                                "uncompressed-sha256": "ff32b50569ed12c7ecf99869aabd0937c010d71bbb06ba5188e68186184582dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live.s390x.iso.sig",
-                                "sha256": "5a0235478c0f4a00ec9ead957877c546eab7583acc8925299b200963766c6b5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live.s390x.iso.sig",
+                                "sha256": "c44aa6aaaae658a39eacafb3de60fa6b1ae29e0402266c63735fb71e9abd14f4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live-kernel-s390x.sig",
-                                "sha256": "f8e229d00405633e55de979cdaec9df069baa6d715005cdf003728c6c0ed0a01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live-kernel-s390x.sig",
+                                "sha256": "d093ef3f5a434b806892b5709b1ea1c2aa58b5064e0469632ac7e04454b2e410"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b15265c9d73f978d6840a262e905b03fb98cbad3aad7451e4a464135bfac4eeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "01b3c5e3aee62b17a984c05c710b932f2d07974859b8b24b8d38e4e16ced8d2c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a3a4c5cb8c834fc66226123d0b85c6e500ab486944c303db44bcdcbf01b7a939"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "bb775e115497bd5ef25a6707bc445a2490785310a8a57608290c85d53715e687"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "2f2c21065bd5b8c383494b99d70952e42a1fb9076e19f70a92305a4573ac0956",
-                                "uncompressed-sha256": "1f903cf3a980506986a9ab5b16b1ba93ad23f099b1fec5d96ed439d4c8cd9bc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "3a696cac08a18a144541b4fedcecb6b0589bd0d3748e97d72ef6192a148a23c5",
+                                "uncompressed-sha256": "829a3f390738d98ea96e6c61f672a25b1b3ff2bfaceb0ae11b61823190a741a1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "387d9e061d2684a8ed9074de0d78637871c3d0510b72a5a3522888afe669e226",
-                                "uncompressed-sha256": "d28acb9444a6a95dae356467accc5092ea1c2389c4523ff0ec93b01f78f585b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "359eeb8a89976e6eb505e9c091030e8b5a1ed3df9e24c5cc36c9716fc2da6545",
+                                "uncompressed-sha256": "bbd0c6e4d23c3c017cb0a04d23d5cdcad15d2dd12176e7f99c520a060e45099b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/s390x/fedora-coreos-40.20240416.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f44f901eb44ba2d5e121f60539bdcffcebe07954fc8c30a9d60c772daf408ecd",
-                                "uncompressed-sha256": "b03c8d88163be22277a65e000df8191e4cb06555e150ffa0635ac66a3197943c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/s390x/fedora-coreos-40.20240504.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5c6208013c102769223aa96039623a578913ea54573d4bd6a69b39edb69bad85",
+                                "uncompressed-sha256": "c45853ee9c33f26936e9d9d23600fbf7e56f2294e75a6ce6670aa0f9a6267006"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "492d09460e2bfb92f40f717d4b6404d8131d6d27aeecb479eb0077f6e20fe7f0",
-                                "uncompressed-sha256": "504dfbe9d679d8b72eb16960974b4cbfb9f792fb6de28f6e7c4c079a8df2e56f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8de0dd792bd9d1966ff4466822cd6e052e5ec39384bcac723b7ac059fe4cfa8f",
+                                "uncompressed-sha256": "16dc1125d9d75a13df4147fd0af59e3b222b2e7a51f49453ad93ccc655d401e3"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "90a7b6da18af744e5a7255967ad7a58a174214ecd48983d6e8b182b6f1510771",
-                                "uncompressed-sha256": "6735e9fa112af3eb7a90aeb2ddb5fe0590e9845e0d09faa8c4008820027f5fb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "752493f554e43ed5225a3585df121dcb490fe054a103fd8b1649564409fbad7a",
+                                "uncompressed-sha256": "627c3b2097cb70b95533bd869889cbb1474cc23569a0634e8e2fa7856cd0f985"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "726722bc10b37c7638608262fedbd3c573a253d92fc47572a0b9714a7df7b812",
-                                "uncompressed-sha256": "b750fb6248f0ccf921c4ca268756231704cacc2d48412c0487d59ed9ceb2b361"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9e2d22e489149990530d0ace5b2a9111d3299cf8f4166b254b1a9b720096071f",
+                                "uncompressed-sha256": "9544521393c5c97c2102e8a855215be937f021a2a094d1171c99f36547e847f8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "12edc57890f433a5a849c2e403add0f297e68d0b1ec018ac87a571b0d1928a4c",
-                                "uncompressed-sha256": "1a9848230ad65f4990e7bcc15e7467b494d88b75f29b1cc16650348ea982e23e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0baba72a6bc6d584a4fdecfcff8d8740cbb9c1bce58c61109514cfbdadf52ccf",
+                                "uncompressed-sha256": "89601e4d21cc0c3249aaa8964f590e1cae342784eeb551d8b5b3fc6e6a006baa"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "eb7572a6a70e0ac52fb6e851919eabdcb94adb4dcf9dff97eeb962110c0bd409",
-                                "uncompressed-sha256": "bb7ea6b90c7fdcb8f4cdca610367e204e9be4146e4d424a19f97d8184990a8d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "662f9c558c2f5e77727ff2b84b9854f642218d2b0d4ccf9870dcc704847eed06",
+                                "uncompressed-sha256": "6e84954814515c183271f5067b4a36cbbcb0b2657536c507498ed2fa1e79339f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "31b8e89e9ea2d55b0a8f7b81aec2009edf7894035b069bc3b67097284d8bfe14",
-                                "uncompressed-sha256": "f0ebbaf6d8fb5d4af9380b35bc363dc241f82530cde767bd5c95a93bba42a6ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e9d9f617bdcabf7544132f581e2047ce67ddfe2cb3865a0f9bd23125c7b852d7",
+                                "uncompressed-sha256": "7b2faa3fe03cbfe3ed5355bebe1241ea9aed6eed5c6a371068837bb9db258794"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f4664e040770e453870ccacb0de3e64b77aad1d0a46b673847c7fcf2237480a5",
-                                "uncompressed-sha256": "fa925391dad60fed2b1b58fee4979b839f2d5a1b354d5a2bacbf42414f72153c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1b358d7ac8b8d62f6c6e188415b295b87853b6a5e2b6cb85db7b4ce48a1f450c",
+                                "uncompressed-sha256": "3f59ad8b9356c4877f300c093e8644777ba18976263ea7200425eb7fe63935ae"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2839c6552fa137d89033972586918da967b94afb644622e4c3af96b57de91619",
-                                "uncompressed-sha256": "adea6b0c067dd0022c4314eec7693ebb5664620770ff92c1c50464700db93bf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b8315e3d53703e2fe2287dee8e1acc1d99ea0415862161996eea458340beb639",
+                                "uncompressed-sha256": "984fd03d49d063c222dfad885a9fd72e832af88dde4c1c4abce9bcef53d909a0"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "433b0fe02a388cc7c8264816bedcaaa71ec4ac78cb1e55949a7e5002c76b2450",
-                                "uncompressed-sha256": "846b5bea5a95a0b0150406425b1b942274fbb7948b99547b22c0ced71eaad228"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c2d96e53f033b0b80e43c367d63fa927d53acae9ba9223ee65bd38f3ce1da286",
+                                "uncompressed-sha256": "a4ef36b88062386167a093de9cfa5c1ee0c9939441f9d3164cffb0e073786242"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d8fb38c8ea009593abfbf8604521c8970ff8bccd7a2f5868919ea1c8aa0028a1",
-                                "uncompressed-sha256": "f16c96947948ffcb17297264d1641a6d77fe4333b95a94fbfc20a716829ac503"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "69390181955d48ad7f818dd33ed88d9420fd469d683bac964e3d7bafb6f67357",
+                                "uncompressed-sha256": "a7fe1eb50e69746c453c71d0a3115dba2ade4043d07942b08e93206cef241038"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "59595e111c1a33d3bf2f062c2d1a98ae5a4e4742f7b03c5242e07212d0172557"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "60f5a4e46c2a1358bc2c6b4a46abc881d4dacfed3c8672c2244850b207e6fead"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "55b05c533c14151a7b920070f29ec560ff592685924097ad8f1e16115f96ec75",
-                                "uncompressed-sha256": "6bdcb1f98e5fbea20bb1baaab39f8bd925ebd0bb67203803875d9625f2e8b7df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "126be0409d0ceac9ab9cdba775da66de94d22b84427a72dd9414661f93998db1",
+                                "uncompressed-sha256": "e446023ca04692f8590b8dd64ad60c7ff826fbb09094bb51fbcbf82482fe7c00"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live.x86_64.iso.sig",
-                                "sha256": "c1d9df2585d1c26a6ba5e0c5424def78c786ac989eebd845a7327afc13c56c11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live.x86_64.iso.sig",
+                                "sha256": "a056114ff0d3b54cc4451baf2ccc57ab22d2e3e4096401a75afe0bf8b863c852"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live-kernel-x86_64.sig",
-                                "sha256": "09cf5df01619676e91e998fac6c456d67ec3cac25ee9244898b59699c588bb86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live-kernel-x86_64.sig",
+                                "sha256": "56978c9bb331df1467947db3d4fdeb69fbda7f277fc090f2e647ac551363be4c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8c06a296b66b9b20286b4adf6e61ed79b0bc366b8e3a70d16ffae582e7f96059"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "162d18698291276999e7406aaa1cf2590939b187353d1fa28f233fef7ecce131"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "705a2a88eb62c4e36b86140b4858c23dfdd0d09167954641b4eff349c6ebab17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "356f541f8366830e450e75070602372220d71d50d0506001d8d972d18cc1beb6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "da62dc9810adf93dea23250f149c7721d48413fc5ac0675077a929c44cf3b314",
-                                "uncompressed-sha256": "a78e2be6e546589c148c47d05915591862dc58df2f147a60cb078d6185399c6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "96572da04c079767bb749e58a66aca992a9c31b5cb2622c8c7392753c7f5e150",
+                                "uncompressed-sha256": "a9047680583bd9228739cf30a69c384193fe86980ecb651d09c085f9fed07cc0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ae9a44cf20eaee00c4d5cae0eaace599130265d913284100cc0535a218de168a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "378c74165242e24adf4903edab87ccbeaad8c325b0b7d59bccc102cd60cfd80f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "45951de1835a156579471c6690c48a574431de046200faedd8c45cd3aa6b1643",
-                                "uncompressed-sha256": "a2cfa7d8f5c08465d6f39062915d1c15b96e9f0ce410e39a18a5781d011f46c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0a3801dee52b6c2b08902f25ef488df31e35a658d04468bf90a3a277418f0a19",
+                                "uncompressed-sha256": "b30d8607cf42c6f1d37c59eaa7b28eae3d6e2082cc6ac600c0f60b027da574e7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9be50235b7412e97c1e39dc0e4ed1d304c34cdf6c43c6bac8431374f912105ed",
-                                "uncompressed-sha256": "04b8005b2f66b1932ef29cc90bf0603f949dcb1ed6e45dd4ec347252414483e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7226c29a8e4adc89d5a0d4c2c5d96d621c52618b433e7543ed531c15d7cc17c7",
+                                "uncompressed-sha256": "df961570cbfc556ba2aef53abeadb9fa2476a942ce4bea3e39c2f95c92a62653"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c5afeace406e81396193ef17f11847746556a2b585e82c1787b8c44de1d42b8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "25e15dd6ff3973226a21bf709d0908453065aa4546a6a80c684b47a9f01ed6e8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "5b278d8181b7a7d689a7097523f2d55e13595fcb1414b90bbe5c66adbbb58531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "74448b2124eba525e9c10ef05bcfa4e34456f01d4aeb50c138d638f60a221081"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240416.2.0/x86_64/fedora-coreos-40.20240416.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4f2ed75f1a79446c5fab9ba1355e981bb3deb89e81301c508f40e096f283f4c5",
-                                "uncompressed-sha256": "c19693bc65356e9d2d487dc62ead4f5d5191b33bc12ffdf0fa8e199f4a55c0fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240504.2.0/x86_64/fedora-coreos-40.20240504.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3f21d03e264c2337ed180a71014c9331443567ef0956dce00e2cbc59d30641c8",
+                                "uncompressed-sha256": "2adeab23972a92d4433b2332d2097bb74bb7e0f0ec2283c27deb801e5f76a028"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-09d685c2cf8e984d1"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0f5c39ffe87c60b65"
                         },
                         "ap-east-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0e032eda474c04871"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-02fc159f473e064a1"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0d158e58b8a0b70f7"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-07a42e3a449de4993"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-030d4df2562716621"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0b31e1cb2fd913a9d"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-00b72bed670965970"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-041458fe13366ae93"
                         },
                         "ap-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-08a226d6bbd7a2329"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0dc3e3e4480fecbf8"
                         },
                         "ap-south-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0010d06b290a1bf35"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0ec82ca97e403af90"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-04370657602616e51"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0b3596fddd713c754"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0a913cb2015f9a48c"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-055a454b975c5b289"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0ed5127afa80ef005"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0916d89d7443b9dd3"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0e46517854e0241b3"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-09fc68b21a4749ead"
                         },
                         "ca-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0b3f0ff02691f097b"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0099c736934f727b4"
                         },
                         "ca-west-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0559ae8e32c9367c7"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0b12469807dadb8bb"
                         },
                         "eu-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0a9dcd0a558fbaa80"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-06195a72416bc3268"
                         },
                         "eu-central-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0297fe23757e46bfc"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-007529b08a86ff204"
                         },
                         "eu-north-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0a24a899b8d8eb06c"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-002d21c707a27f018"
                         },
                         "eu-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-093a5f760d24fd119"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-024fcb9d18bd38a6b"
                         },
                         "eu-south-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-036a50b0d7d978b49"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0c4899320abee4fad"
                         },
                         "eu-west-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-01a0ab9f6a169d98e"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0dd5a939dff4c6faf"
                         },
                         "eu-west-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0faf0bd88a2c127f3"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0d0fb8d97046039a7"
                         },
                         "eu-west-3": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0eb611b84ad75783b"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0605a8d6cc0e745e1"
                         },
                         "il-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-07d0da71f6472bb81"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0f5d2900d08395037"
                         },
                         "me-central-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0c0bba4025726c093"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-092a04195d8653dd9"
                         },
                         "me-south-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0d891c3e104078238"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-08077a96decd19c43"
                         },
                         "sa-east-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-08fa8a0aa5f167760"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-08a24c7280babb0a8"
                         },
                         "us-east-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-04b758cc99377feb0"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0fc5a67b81c8ea7fd"
                         },
                         "us-east-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0c5e8b40166148452"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0f0b7b7adf961963f"
                         },
                         "us-west-1": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-0f554718e46f6e580"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-0bd6d1adf1a7d9f3e"
                         },
                         "us-west-2": {
-                            "release": "40.20240416.2.0",
-                            "image": "ami-00f38f3a6bf063c56"
+                            "release": "40.20240504.2.0",
+                            "image": "ami-04beafd54d8b40298"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240416-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240504-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240416.2.0",
+                    "release": "40.20240504.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:00817fc64074504cabd98ddecdbe92e8137213936021a6316dc7a237b7007ddc"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0746b6c4d25247ce1a4cb5f39f70dde6cffe4a842d71473435fb0a472e8647de"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-04-23T10:39:57Z"
+    "last-modified": "2024-05-07T19:56:48Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240416.1.1",
+      "version": "40.20240421.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240421.1.0",
+      "version": "40.20240504.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1713880800,
+          "start_epoch": 1715176800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-04-23T10:39:55Z"
+    "last-modified": "2024-05-07T19:56:47Z"
   },
   "releases": [
     {
@@ -93,7 +93,7 @@
       }
     },
     {
-      "version": "39.20240322.3.1",
+      "version": "39.20240407.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -101,11 +101,11 @@
       }
     },
     {
-      "version": "39.20240407.3.0",
+      "version": "40.20240416.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1713880800,
+          "start_epoch": 1715176800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -95,6 +95,9 @@
     {
       "version": "39.20240407.3.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        },
         "rollout": {
           "start_percentage": 1.0
         }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-04-23T13:40:56Z"
+    "last-modified": "2024-05-07T19:56:48Z"
   },
   "releases": [
     {
@@ -113,9 +113,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -123,8 +120,16 @@
       "version": "40.20240416.2.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "40.20240504.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1713884400,
+          "start_epoch": 1715176800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).