### PR TITLE
Roll out stable 40.20240519.3.0, testing 40.20240602.2.0, next 40.20240602.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-05-21T15:56:27Z",
+        "last-modified": "2024-06-05T16:57:46Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "30b5a44ea6504220da5a21e0eec880d1bf50c25bab0c84cb457217ccd23321bd",
-                                "uncompressed-sha256": "5ec7b06a7a5ba2d5b9eb7e6cd45187a36fbeb74b3fc395ca40ddb25e24c08449"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "10155a7eadc2d48c982bee56c4e7042dcd2973990645fc28a409df5453cfcb07",
+                                "uncompressed-sha256": "bbe8bb01490454f17f3837a3344970d536ea105698d16c549e7a7813bbc8d0bb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "52dca3a6a180798efc1b882e7b2fce051ee50069e618ae20ee4b28c9319cb288",
-                                "uncompressed-sha256": "1a8735633ee7e241a7b457cacff307159e092e1d0f051a1d65870307c4c149a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9d16258fb775593bca8fa3e63d08ade7be7e1f4ad04aaa980029be96a3dbe797",
+                                "uncompressed-sha256": "5e5ec71d2af70954619bd190bdf080c1ddd036dd4c8c2a8e040e02cf08e85434"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "aa1819d0b5cd229ddf16b1c30c56e76fc316e22e46905bff3f8a00b23f276610",
-                                "uncompressed-sha256": "c73efa8184c52e925c6b371da92d33cd642d40831b7b684ef3968cee02bc8e70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "29e95a23e794e6a43907f71985b2ce8813e801d630b4d1e00afe0f1d1ed935be",
+                                "uncompressed-sha256": "25e4e314bcb7f581a3d3002778316164700a6df3b5313c9d7f2334338e4149df"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e7822bc088fb93b9db6e694c5e6389a8cc1b9b0de0cf5995913ae6f290397bd9",
-                                "uncompressed-sha256": "7785fb1f5bd87dc32715e9aaaa027963ef0e3978facc81700dfd0cdb84f03516"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "b1b1565f2bbd504976eacc9b9af05788e83b2001311d7f37ef9faacbfa941e91",
+                                "uncompressed-sha256": "9a70f7e163394634129d746a40ad45eae46df00f51b3c40750350de714c4561c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "502cb21246358686250e48bd07441b45aa6e39e202bf1d53d2fa910cc3cbba24",
-                                "uncompressed-sha256": "04ba8f90e962ae88bdf1c37cb609d2b6d16c9cf97dca96c3bcd8edf9c7df40ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "19c4c571bf29ba82413fc4ef236bc45a885e472dbd0d9525a8e3f7621e3d075e",
+                                "uncompressed-sha256": "aec2e108bb4ebddb87bd1fe4afd8a9ab8c56d84cae3fc449196f25b21f9134fc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0849d9ad5840c3c26898be49bf1587ac0a6e47bcf0b8845d6d18507857c94a6c",
-                                "uncompressed-sha256": "764de49a742628189b0e2c264db8fa5bb038e345c52100aa2b5566293bff2ea3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f5a7c94aee4fd6ac306685de57f299791fa52d4f2d7dc80b07135120db4618cd",
+                                "uncompressed-sha256": "1ae40294665bbe8e4ed9edd0bdc1cade86bf694e401e0b59fde9646d25fd0f84"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live.aarch64.iso.sig",
-                                "sha256": "971ff94c9a710d8fb5e7dee0d250f8915cb396c1ea8bb72d48e74e868dcf8a58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live.aarch64.iso.sig",
+                                "sha256": "912a6c382237a9fcfae330e4cee75a3f5e81abcc16b42c2d0f70922cfafaaed4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live-kernel-aarch64.sig",
-                                "sha256": "75e477f7287e803e6861bfd9dd0e06572acbcb0b0e6b3bbe907544541a8a423e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-kernel-aarch64.sig",
+                                "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "4a43ca9f3e0f92c6883a8fcb991b28ea5f911e7263aab4e04af3f837081e4f25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "99082406cf1e8e107b36612f49b87089066c7ce9f16ae8f95e493956a07de004"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "574cfdb0cc78db4cc39b43844cb7628dc93bb8fde033dcefbac4c39902778c70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "219f0bb0d0369191f911f8f3e88c7c06f9bd20515d5d077931cfcdab74f7de94"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9440e2e5bdf98eba7a783c4b7865bd77339156fa4fc3d05b7831983da8126c8b",
-                                "uncompressed-sha256": "7c32a9b25808ce0b939f5213a0c59a09ea167930d665038f043b1e5d6623dd69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a27624dd8f830228b557c8847c6f20c0403ad0bca7af813108cdfe2cd38d71d0",
+                                "uncompressed-sha256": "79974fbcc2c5359e9e32fb6c4612462a980368d1ad9c9de1209dc5a0763be067"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3957a55b5ba71e6fccb13a8d042a2aa9f99606e8b719b50ec568994b69a846ee",
-                                "uncompressed-sha256": "10398a917f16e7345ff594d509f4ba5647efaee2247f336f3cb4ae2c3c9aac70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3931b5452ced16953d4b68d3b812a758ac2e75533fcb66a7d848e738b358df8d",
+                                "uncompressed-sha256": "a86501e410f426dba737eed752faa49a7a5fd20eccf44a1629fcb454987695a3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/aarch64/fedora-coreos-40.20240519.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8f116d81039307de64b2f94797c7c23f10c7f74924e24bd2cf66bda518c64788",
-                                "uncompressed-sha256": "a72afa665cc1c16a148b012f0db54f598fe9ca0e16b0ade8234a9aaad4d06081"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d1de1622c94a3b9a2def210a02f2ae7ce13700e1253d43a5bf65ec18d4156b27",
+                                "uncompressed-sha256": "26789f38a891ec574ecd5071b3959cf53ff3d14bbc829962b12dfec0e04119a5"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-09d74ddda6ee36d97"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-07876685f3bfada3e"
                         },
                         "ap-east-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0fc77a7c7eb333bd8"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0894be23aa08d0543"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-06317f36c094a38ba"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-073fe6edc7607c49a"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-075cd87e7009a7029"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-02bb0334bc153f65b"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0e7deeccdb2fc5c23"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0b7b44c743884c080"
                         },
                         "ap-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-05ddfc20a86771cfd"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-03462a83e6921dfbf"
                         },
                         "ap-south-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0893b6a4b0b81e249"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-02584e82c7811cd0e"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-02461ab0ddacf4f31"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0a188c4afd95cf40a"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-006a7786bf34c81b9"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0ebc7850cb550d41f"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0b704ac075860c7f3"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-017ad8307c2e1fbb2"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-007e40a80e0ae9389"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0e147410f7cc32477"
                         },
                         "ca-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-070b0053b21313afc"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-09be176a5b4c65d61"
                         },
                         "ca-west-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-02011de69cf75af84"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0a131bd4d0a2328be"
                         },
                         "eu-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0be389979f590d3b0"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0119bccf5086efc4e"
                         },
                         "eu-central-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-096d9d479a5c682e8"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0489d4b8f4d1a4114"
                         },
                         "eu-north-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0d5de83f287be5981"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0af0391c9e1ec8e6e"
                         },
                         "eu-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-006401d0a7c427ca1"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-007ccab71b04b60ca"
                         },
                         "eu-south-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-07a45b6fd1610224d"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0836b9d0eed03dcfd"
                         },
                         "eu-west-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0177dc1aee74eba0d"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0067189e000b41353"
                         },
                         "eu-west-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-09558466af8876968"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0511e5dbef4ff30eb"
                         },
                         "eu-west-3": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0d54796d7acb32851"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0b773d3dd16a497c9"
                         },
                         "il-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0c84c0e9a6ee47b69"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-007710da5c83311b5"
                         },
                         "me-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0b6fe0f8530433f5c"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0ea842ff645532b1c"
                         },
                         "me-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-002b9aaefcf8af482"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-00032d10cf43e35db"
                         },
                         "sa-east-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-079bdd751dfaf161f"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-026ad5150bf86b325"
                         },
                         "us-east-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0f704f10df5a39c01"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0320bec5bf217bfac"
                         },
                         "us-east-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-00986a778d278ba83"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0bf5eb966e230d358"
                         },
                         "us-west-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0038b0e5d71c6fc5e"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0b5d05552ca6a750f"
                         },
                         "us-west-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-09dadda3c2f5c6791"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-08883867f1bda3503"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240519-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240602-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "098c9fa31ce1abba0c8c46cdb914e08cb2c7643e508185a020044daea7a01f1e",
-                                "uncompressed-sha256": "e82eab64802a0105c8a9a8e1505d4ee9602b634bbc56610f180abf3425359695"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "dbacf6a9f7b5d78b59376d1bf30f6882fef11e7273bd14641ac9679bd03fff21",
+                                "uncompressed-sha256": "9ab03dbaa5d7f4388925d8a5708c56791de63017d6a055414100deb5434bfefa"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live.ppc64le.iso.sig",
-                                "sha256": "a0ae1c96e9bea9661393e755b1b51e6cda68c39b08282c2b41faeac9972bf164"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live.ppc64le.iso.sig",
+                                "sha256": "702f1e076f31b2e00875db5741b27cbf86d9637e0eedc28863f33e5040cb9e9c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "8f53478b329bb4bae46f71f16fad3a2c8349f79d49ab52dbd020543dd01c0d03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f8fb4f7972f55b4ce8ecf2e00c268d64c6b15c1e35ba4f9b45a7a016b61cfe81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9d4ed3238e55ab76c608c471f194459e6a93ef079450da01040ec60e584ba17f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e89b333ccbee1421f20f1154827c71faae7567ac4ca1b34f17b4c73e9a114d4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e2c6b738cc662c83d4ac73e20ab3fa7f870985b306c6f670c84b1542b9f677b4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "393603ba076de7aea1f25e3ccc442aa6b1907b369b32aef04c6112c643cdc2fa",
-                                "uncompressed-sha256": "1740e936f5c6c2d63b606c171176a12631dc7aa06413e1a425a8687deefe2caf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e0aa35db6440e59593ec07e8f765a0cf762f78469f169b5ef6d39e637e048d91",
+                                "uncompressed-sha256": "eccc5d38bd5a156728e8e14e4280584d4a0d339d0540223bb4f671b223363cd6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9d7e5373b600927b1cb0ecc7d29e546342ad72e70005619bd090ec38bf76a67d",
-                                "uncompressed-sha256": "a1f0842997eb70f6d73c683fe408661eb8edfce28b537d4f6f9215edfa40555a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9f1eb33784a4f9f8aa3820a3c942f7d969643ac2a0500c7303005035c45991fa",
+                                "uncompressed-sha256": "fcec1572b250e14ca33e6a671a17768219099b74372263c759771572c944fe35"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "a50d98b96b60baf92c271ce3d12b82bfa8e47523c9016b4c33ba3334242b5e4e",
-                                "uncompressed-sha256": "e0aa68ab4b93f8e570fa146841fda0c73970166f3e276114e99b690507a94607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f4c6c433ea0ee4db992c9194ffca6d1791fd876fb3fb57426459c92635796079",
+                                "uncompressed-sha256": "5ef9a4fac294939717dbfcd38034305c6a17081ede8678cd9d45539eb40d9a61"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/ppc64le/fedora-coreos-40.20240519.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9ba347778d44069b2c78898e36eaf71f5d872a7dd7b0dcd98f3e1831bed5caba",
-                                "uncompressed-sha256": "8a1996ae2cbc5ed9608189bdbf79d7504f397dd64f963d64d371c4752f4f66c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5fe533ffc351f803db9e80aab4dc51746b98d1abb4fb7146d968240039cf2eab",
+                                "uncompressed-sha256": "8f28ea5f113657faca6940bdb049cec917f9bec4ffca01a04711ac3f3eede0b4"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6442cf4c90a6f04ec38a3db7d54d9af557bb1e00237f35e6be51400f7ca5b857",
-                                "uncompressed-sha256": "ddcf223cad2bc4b8107a79997fb7abf44b8558d1a164ae65297bc6175bb9a19a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3b09ac9f052322dbd4b676d8098f5c30b00e2a1829ccc62a7deb14e7180cfb25",
+                                "uncompressed-sha256": "dacd377cc1d2d08feb76f3cabd1d86d8c8c4690d7e5124f09d182702f76fabe2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f5ba9852c90b7643525ced98e59cbd2f3fecb288196b7e2eea6b7197baafbb54",
-                                "uncompressed-sha256": "327203e6706b4c56be033966c4d3bde898101ff6054f5ebee82a5fd2ead2665d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1b219bc42cc5d7e8a8bcaa7e160ab74c96f2ad321339ae525f6f7e240e769414",
+                                "uncompressed-sha256": "6d31e57c563461a9ecb98c68c3ba5063aeb3210b3291352e8ead058a2f66304d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live.s390x.iso.sig",
-                                "sha256": "e0d02158d392cf39e13fa230beb1dc71af614a4efe7ea90db21b555de24e0a30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live.s390x.iso.sig",
+                                "sha256": "243f3c90dde813959998b331ec18df355930e4751496d34322e9ef00fac98c94"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live-kernel-s390x.sig",
-                                "sha256": "a90fe25c7cae5dc9b34f089c747c344e3b65a111365d80459cf38a3c3b71c45a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-kernel-s390x.sig",
+                                "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "8c58366ee58f7d73963aa9c906fdf978317535f26b3a8492106b33fa6686319e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4be2386b37a78e479b5e929186f94a29fc491d7147b9fbdf75ee6b7d3dcc7841"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4cb7976f4996f9e4eb0cdd49c02e563338f900ac6adbba0f1aff71895709194e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9e2e433e23e74c4225ecd9faac152f6cbd5dab65c85e06db3132194a0a7a310f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6a617fb65d18f9ec370be15cd6454da37c895a7a13618fbc96d8d6609289e9d3",
-                                "uncompressed-sha256": "0e539fc4aed1aaba40e7ea5815541f2569461275b2e7a749dd040aa566adf1ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6fe9846f37c713b4289d863e71d14bea37a840060a8afb29373c328e6ada0110",
+                                "uncompressed-sha256": "21b027775bf7b9d1f168619fd6bf068f07dc3d9b10ce4ad7a07da36cce806190"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4f395890352ea00b55dbf8b8c948b6dfe64e57da72d7f8c6fd9488245b213e8f",
-                                "uncompressed-sha256": "7b2b30dccca872104606d86b67c977265652a52c3ebd9fbee72421c1ef8ceed5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "eeeb6272b624c2ae153f422282f0128aa6fd22184fa7d375032886e200088639",
+                                "uncompressed-sha256": "b5690443daea51929e55446afade98d2215f99816f5ed7788e744e4b34e0ff9a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/s390x/fedora-coreos-40.20240519.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "89e140b6f88e3e7eebf5935d4ea132d2daa27ca05ef28b3bcd7544ea56bf22cc",
-                                "uncompressed-sha256": "3a03b62b36e19cd63a5ab039a771fd2118d1bf2d7a0e3cf7c75d0870849af300"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "1e839e56fab71e5fc86cd1fb10959472a94bb708920b5e9db3b0cedcd4f0c35d",
+                                "uncompressed-sha256": "e704729b424fbe11dd4762db537549c3b24ca87c2b43ae3ecc863d83d4216319"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "293af702c129ab222d431da2214c4dad653c52b334537e5c3fc3bf10316e8643",
-                                "uncompressed-sha256": "83675f3aaba066df99d047ca8c760c73890781bdd2e2fa7fd9b017c47dda3caf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "fba72d4157f19e8bd50e6701239890e0ed649dc0fe0dd8d05dfeec701eb53541",
+                                "uncompressed-sha256": "e73ac89d8a6092c51b664b03c3fbee8a26f2e18112197a1aca86d4fc5b09b85e"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5ef28f9ef4c0034b959d10fe17ca70b360422da0086072a9f39bab5690c0dc98",
-                                "uncompressed-sha256": "ec43d07bf20bc47a9d6b4d254454612b4708cdf8dd5bd08714fde70cbe67f0bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "1a6ede94c8834e6c705cc6d89e475181779fa94ef5cb78156df8600a8d0d5547",
+                                "uncompressed-sha256": "b3eb0def6f0e7ea059c50e9ef8ec5870e3b5db4904913cf69546cc2b7071c3f7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0211490175f944a044c5464961698d44ec93dc8ff5dc32ab4004e9c79ce88ab7",
-                                "uncompressed-sha256": "749655da08b34f9e531d767fe1440862aebabf1f334619de7e6e41e52f4ec58a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "02fd1d385a34bb7eb7effae0cab0d9966b3595dab112378cd547c98f98f982bd",
+                                "uncompressed-sha256": "94d688805e1c44fdc09d50ae5417f9158383254987e6bf824bc97cdbf32bd146"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6b4962445105fb8c3f8824e526eb1b86eb9c692219af56a3000c18dd2061505f",
-                                "uncompressed-sha256": "6f0ac8b90280bcea4e2dd6230ddd8c5f9cb93ccfc4d9bb9b316f88eebf8f01af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f785c8dc2a156fc6da491ad24ccacc75bd89616f9064c8c6fbc3bf5f189d04a3",
+                                "uncompressed-sha256": "9813d04b6d2dee4f3659401cfe9b1319337fb749a68605cfc4608eaf69448da4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1c31dab1bcc4a75a77a9d4b8c74a27a24a1e95d1575dcef3f9e397bbd6dfda89",
-                                "uncompressed-sha256": "7a0fb3c4d74572361473e2ec31628b1d5b53ed08a26cca3eea35c21e189425a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d71fc86583afd85858d7c8894795f722b8f374f6524b3eb197069fc159a23baf",
+                                "uncompressed-sha256": "465046448346bc8dddcbc2122cbefa0cf684c08bd43842426b6afb113ed29b8a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2adb33adc8fc66d8e5af2d2cbb1c898472761f3690e9cf6d5ecb64b61e1182c2",
-                                "uncompressed-sha256": "454765c2ba9567d06fc6e65b721ff16d77058c7cf0cd0017655e5743b1cce656"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "dc3277602a800bfeb65858fb9de28ce7338beec0db91c9ed2bb67c71cc003eff",
+                                "uncompressed-sha256": "a6bc9a61ff32df87b4e2c8aba228815d7728affaa8bd1465c059033325c3dfd9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "126ad943c0f6e72a9f52e09da6f128ef1dade9383ea440b81f2792f244f0d962",
-                                "uncompressed-sha256": "25a6070e393fd2fc49132e6275367b87e0497cb83da45f984190d3e2fa18a99d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "db86929ae1b1f66a9acd56dcc903249c87b47ce4d1a945e00a851890d1bf1636",
+                                "uncompressed-sha256": "8b449785ea668c50646cf898285715f7f63ad7b14e47d636a30cecbec13d11f5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fd4e1b5ee67224f9affafd0e4807002a465f457f132ebed457e38b6cf1bb7ae2",
-                                "uncompressed-sha256": "011ad8be7e02fe154dc34eadd0decc098346f693a5de42f668eb90f3bffc1a8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "481a3cb9079bad5124ebca4170eb2cd1a7ad4b3304dffbc20bfdfe7bbdc22dfd",
+                                "uncompressed-sha256": "cc5fddffdf06980adf6c38fb7628a9018f8c30de1e970b3b4d3403e938f30518"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e778621a87c107be5f4f04b7372e375718060f621df90814d32086f75b8931e4",
-                                "uncompressed-sha256": "b55454e2cd3ad45b551d5895d03dbaf37b42ed0dca27049c869b8e1741df7792"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "fad3a3fa95d9d7710be8f2cb28c4af580fbc62275973004c993c574f550e527d",
+                                "uncompressed-sha256": "66c644de1473daa16541cb0701858acd143c832101d6d7152373a8a271a68d08"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "45792f0419b026950138eee52a255ee1460904d67aeb3db956d42aaa0b9a2665",
-                                "uncompressed-sha256": "220dc4b6bd561fda3869e4eacac3f70fa4a2de8dfd88b47ebf566f2dcd46ab5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "be628e36db38b1d244979b720f41a478375b76020b27b1b3375545450df1c61c",
+                                "uncompressed-sha256": "5a8aa7702fd2ca8f87ee40402020948ae49a13c3ca08cb4375d8e85d5acb0ef2"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bd33158da76110a990fa8aa68b11bbe2e6b504d9e044e7a8ea162f4da3b0385a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a4b3d87e0481396c546b963a95dee2d166e4bee64495ffd834e6344c8fde971c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "79aa27fc9ebb7205b75b4df6d579dd5e23fbb5ecb8b9c2b93c1d562278b2680c",
-                                "uncompressed-sha256": "a4e028454bcf170a9122c997b859c4f4e51c12713734ac317ad288e941ce7567"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c36e98855d90dc980b2956f9b9ac43302d8a1e9fc32d621385d1a4a87e852dd4",
+                                "uncompressed-sha256": "b25cbfaf4610f9623562e0e2509c6ad6b913922d17625a4522585475987c3ab4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live.x86_64.iso.sig",
-                                "sha256": "cd67dee3c9a15b3a11e68e31fc79f17705633bad0dd202154b6cb0b2b3524dd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live.x86_64.iso.sig",
+                                "sha256": "3d91d1967bd0736a8732eea84d1c9d5f8b621d70ef5a0cb72f6f8cefd3ac5bea"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live-kernel-x86_64.sig",
-                                "sha256": "0c648d3aae973f24287a0999bb9c9301b963c4dcc8d5e0d0f5bf9533b6db1d74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-kernel-x86_64.sig",
+                                "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d67d0c8fce7866b72678b1c04e271c845e3dc105e1aff36a5f0431904bf8759d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "61090e22d769b49a215ac55343039c7eecbcb6527ba26a0278ae14ccdde9b9ad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "02ad71cb86a2cfd98192e0b59b0e5f311ce8566d3a0da5f53291d98327220f6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ae9a24e7ce842b31410abea6a8a3a9868f2917117f932dd1ca04dd4ff726c1c9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "db16fa841b4aa7b35290f0a20f688f3c3d746005a629c737905fddb7e1222397",
-                                "uncompressed-sha256": "d9a2d70e98c84e4af4cf75945d03303acb3fda79431815adb531656034cc0512"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "568f4d9a80c0342ca34c605e91f746c2efbc17efcb6731ec83b12bba399763a9",
+                                "uncompressed-sha256": "c5d25466bad207e44f0c7dc7ebdff7af117d72b38c33ec54b2ddf408b6d36133"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f26c87bf2bd9bb4f6e4322d0859f96968d87e691a2515f7eaac73d19648e6061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c3b751d97668fbd63415b535f1e825b2d8f4ff25a2ae86ffd2c136750ea7e070"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6dc458fa5ff12d82a9e12459a48af6c057370a9bb7ac29b0328ee29629684c84",
-                                "uncompressed-sha256": "81bfeb9bb14560362dddfe94d0a0a8f7944aa3416b797eb09c8228abde03b97f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "be15992a25872b24f8fc8da01bba06321ddc23c86a8d657c633456a9e4cbfc40",
+                                "uncompressed-sha256": "be6fc0697e74814058cc028564a54cc24082a49c18cb1a632cb64c4e1608b752"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c4c716f9775dcb56c0f342034a570a63b87d31e66541849689bc1608575ee473",
-                                "uncompressed-sha256": "3b7b7051cedcf5f928cb53630cafa8605f6f039d1b3d2afa56e41de2566b7b23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "20d77d2ad732ddb20492278f1d6fd8471fa293de5492b6ed3fbec48c3a5d0e92",
+                                "uncompressed-sha256": "adf8d4f793e99005b70ac20e5d107207d75e61268873bc15b84de4c4a2b5e8c1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "39528054673e7aa615801662b081f023201fd404a14092f699d54ed4c16f5f55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b52ee4f657b4d7a682f0a41a792f067147294da7112a1e9110e35a2f60320672"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "346deb1d561b485c9a1d004c1e2756f78ca9f42d717415b579d6add90f386fc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "f1aeeee13401b6b3af9196edb5010a28189cad3247a0940b315be63876046488"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240519.1.0/x86_64/fedora-coreos-40.20240519.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "744f0783fa247d275f82afe07d6ea4a55274fb519561c81e7193fb75a5f205a8",
-                                "uncompressed-sha256": "326c59b43b48eb99733a289ea7cc7236af57b8c506efb41f597e91f039568428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8aacbf72f64402fd23bd1814c404f2a89b9d9936900a0f207ecb3a8a6314b7f2",
+                                "uncompressed-sha256": "fa9aa42bada784ce87f3fad3307c65d10cfe5f43575b87f1b99c2da2b28f72cb"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-047df4cdad93a2698"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-03142b6ffa4234259"
                         },
                         "ap-east-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0f1c92639f8501e20"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-04112095512b03b4b"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-025f9a56227eba6dc"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0bef46f7e3594e3ca"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0a05a507e273d1f87"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-089d0137f300bb05d"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-04d058b2705af6db5"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-033c1d5e09cd75d60"
                         },
                         "ap-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-05b19f0c65b69e183"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-01575a8d9040af34f"
                         },
                         "ap-south-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-09a6d22a791962e41"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0b8c4acb284329c22"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-001e79a201057b2d8"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-00c081210b755bbf1"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0c6bc773d298a4055"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0ff14519c4686b26d"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0b1c70eb374e0f50a"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0ea46d81e61082684"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0896a977b8b077b7c"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0d47667894c8e6347"
                         },
                         "ca-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0599c1c6eb3c997ef"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0e7d1aa39cb3cb67f"
                         },
                         "ca-west-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-09e1865aae0089472"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0a0107348254e696f"
                         },
                         "eu-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-08d619f6ee4a9f179"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-031eaf34e6cf71eb2"
                         },
                         "eu-central-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-081ff4ae6a41f67d1"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0507c4de615c944ab"
                         },
                         "eu-north-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0b50c100b22a6218c"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0a6c2e995b3ca742d"
                         },
                         "eu-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0f9dc8d24cf319764"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0116b671343b4af96"
                         },
                         "eu-south-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-05a7f953d8a74a175"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-072a3935a914dc1e0"
                         },
                         "eu-west-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-029922962cdc8d289"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-07c4dbe9d9899092f"
                         },
                         "eu-west-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-02496e1a7c86f2583"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-084f6e2134a754f9b"
                         },
                         "eu-west-3": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-08b76e8877f272f02"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-098640a6c7054a48a"
                         },
                         "il-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-03d6d033db36027f1"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-04736df0375f04cd1"
                         },
                         "me-central-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-09cfead674a7131e6"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0bb1d0eda7d1d7413"
                         },
                         "me-south-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0a940034f45850f2c"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0428bb23ce9bfae47"
                         },
                         "sa-east-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-009d7dcd1c6fe8403"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-06b540a1f72a714e2"
                         },
                         "us-east-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-0a9594a19dd7caecd"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0a276a016c6fff9e5"
                         },
                         "us-east-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-046a0825d02acb565"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0945c3ff4d6c3a3ea"
                         },
                         "us-west-1": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-03a18441069ed2d05"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-0271a2fe2b8f31710"
                         },
                         "us-west-2": {
-                            "release": "40.20240519.1.0",
-                            "image": "ami-03194fc91212666ea"
+                            "release": "40.20240602.1.0",
+                            "image": "ami-018c1d84695a743c6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240519-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240602-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240519.1.0",
+                    "release": "40.20240602.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:94c58c55a18dea08f6cda52b87171f113ea018a96531f7b1006a3e0916d870f5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:983332e332782ad6a3efc8803f02776bc7c31307f3a86e763530f09c72a17cf7"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-05-21T15:56:23Z",
+        "last-modified": "2024-06-05T16:57:44Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "439ba9dceb242e8553cc13b428316d1b484de16500fe56e35958b74e565d455d",
-                                "uncompressed-sha256": "be72550f34ce985ab759a094db36396d120d4f4da77c4308e6386b841e35b1e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c5b961422354b68674ff72044cbfc316068f1872878e419c54177600514e0d5e",
+                                "uncompressed-sha256": "cbc50f45fc223327e6a0af8980dfebbae46cd6e82c1c9a1f0b78ec7878db0be7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "297c0f2f3fc25d64589e27a613de4fbdba7589c76cd2b7ab2371e88cce7ad325",
-                                "uncompressed-sha256": "ab475b939ddece1f6eb7ca752c844992409639d5ce4d5d27125d308d5de8338e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d6a402a37845c0f069a0a7a49ed803893461d48ca8dca8c95090cff1b8809142",
+                                "uncompressed-sha256": "f145a09e4120dbe15f59c3378952c7fc1d332c8bd0415f6db72e92511f15f3b9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "03beacedf488a8360c89257a1119572a3b9730707fac1243308c9ea0d8f799ec",
-                                "uncompressed-sha256": "e1bc45b5cfe299b82d023ba2b8314daef0de544836f7ae3bf93dc104412150d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "54dfefe68573483866e56427987d4d8f3f723d805cf156ee19a82be80ae80c33",
+                                "uncompressed-sha256": "82dc6b7b43177431b5f0c561e3c2485c73c89aff38a6795411d5b07dbcff2c35"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "17aee5a89e91c43a8b6852a5045b3d819e859302f163cb1625e2588ec45b5378",
-                                "uncompressed-sha256": "96a5f334654bd8049ec54b8d208eed72c2f6c9dc4ddd64fddbe4a378e1bee897"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0d98471550181b9478de1034c9d676837c640dfcf27d611552995816d6c39c0d",
+                                "uncompressed-sha256": "863c5fceff7c25df21ca4e7eb2c4dcdb13acb4b9402c46178496922c7ed8712b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "b16f8f241bd7bbf4d733f7e553602f16b1b9a3e4d1d91a9977a22915f904eccb",
-                                "uncompressed-sha256": "1d4a84df48238f8fabce73c41e55536115c1b8ccd516dfe2a17dd32fc3786f93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "14588cf9622d5fd211cf3299f6a54b15277a769880482dabf8c124659c7e99ca",
+                                "uncompressed-sha256": "e199433390fcf4d38a85aee0091acf6729ebd4efb0f9d899d2874efc1d58da13"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "099854e3ce2bed0b1ce9dedb9994d022283dd11ed0d5ed40219cbc6630b7babb",
-                                "uncompressed-sha256": "55e4caa0a6b782d3ea3d88b1ef3be1abb428cbe8ac2f7a1c46a4be8924866a23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "9eb0c027cc428d2cc261145b154d719a6d263fa2356d08490df6eae6afeccb70",
+                                "uncompressed-sha256": "118d77ba816a7d65f58d382c8ff437e511de50acb2a177fca3a2ab89c089da5a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live.aarch64.iso.sig",
-                                "sha256": "90edf8a7e06ffe8217cb09d3b9a26846fae53c2537f36c525c4b782d4092c550"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live.aarch64.iso.sig",
+                                "sha256": "01fe55848aff2b07793b7bb667b8bda4f9ae56bce3496eafaea7a7f9e0c3492d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live-kernel-aarch64.sig",
-                                "sha256": "22a76059b7d6d8be5caf551b38648d15e410f1e92e46b5508e164e8bec7d54ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-kernel-aarch64.sig",
+                                "sha256": "75e477f7287e803e6861bfd9dd0e06572acbcb0b0e6b3bbe907544541a8a423e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a9e00dab6f7ae3a3768d10f9ee54ba2e5a348e6cc9d52de531322ac6a878d17b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "aeecd66c0df1390bf63441e0539fac4b0ad3ffaf83718255e261c109192b5011"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "dfc1e4de2a93a2291050cdce95e9834185f48d8034f2b3bc4fbd779ea8d4f664"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "72940ea3b2c345e2dac6df67c9fed22e72384ef026ad389edb583295fdf641bc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ced167c6fae52e964941212a11a0f453c70f822538da93648e4b7dbc998d309b",
-                                "uncompressed-sha256": "a38d701a41a28bf154522aed417b98b1d3be44ecce45cf9cda3f1505a92051e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5c13041b345d273ab6fa0aefb6b3f95a7c56ed1c5f2a4edfbadc6eced9c1a3bd",
+                                "uncompressed-sha256": "399fc5f58e3bdbe9de634f00ef92ff1073412c5d7634ff763bb30d9be99e5017"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "52515872ffe379d491d3fbbd5cd322d15e6087eba79cf0c318e7d1eb59baf0f3",
-                                "uncompressed-sha256": "80004e868173128ada5c27e6ea55aee9c3daac151b65ad7b5dc6facd93a69ccd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1432053856b47ba3dacb620fbd4a98171cdf63b30043477bf05529a156ae621d",
+                                "uncompressed-sha256": "e3eb88e908c3550dcc3322443bacc65413d4d4defbd4c462b2e012e6b268be84"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/aarch64/fedora-coreos-40.20240504.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f524c4f0bf1b3833dc402043dc233da1782301a6512b3da395a71615c0a8f584",
-                                "uncompressed-sha256": "e34e1405080a9de7e9a011b68dd5afe2511502a15b4e6918f1d4d0cb815060e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8f5fe6dd51cfb0de822f8002f180fd72de79d6493fcaf77539b876468d7b29a0",
+                                "uncompressed-sha256": "e5776c0c2078c4bba8519c0134658d32e821b180c5e91716aac1f4170ba7402d"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0f25201b30e278e02"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0444ccc82d0deb239"
                         },
                         "ap-east-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0f906b0bc61e3cc61"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-04fdb0e52a5ad9c5f"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0018fc09eab5bf792"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0472c5314810bef42"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-046eef5d2c97e0293"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-08ee325b70e631335"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-07822673aa85fc26f"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-05062ea7d5471ef5a"
                         },
                         "ap-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-013c2e974d838674c"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0e17f215170948a46"
                         },
                         "ap-south-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-007be03759ec508fd"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0aeeb0bd67311ff29"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-00286a4baece759fa"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-08cf6d5fc991aba11"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-014afecdf89d19d4b"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-05b3c29af72768a91"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-09089b73787bda17d"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-05d517a61e6b3d06d"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-089b532451d295839"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-06d99cb51064eac4d"
                         },
                         "ca-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-04ea093bfb201c719"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0d7d78077133de2c2"
                         },
                         "ca-west-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-034400c829d5a22e4"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-08e444e849f943c80"
                         },
                         "eu-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0606006eb4d3cb313"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0ed7dcb734ee07b1a"
                         },
                         "eu-central-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-01115a4681f9322c3"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-03ec898404c1afc49"
                         },
                         "eu-north-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0221b72920ed14dee"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0938c8e0418145cae"
                         },
                         "eu-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-07065c8de50a97b5e"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-088a8bf8dc2d169ca"
                         },
                         "eu-south-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0de62d078237fb86f"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-075b79497af7c82be"
                         },
                         "eu-west-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0a765fb0b5a2a7a0c"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-056edb78f024f45bd"
                         },
                         "eu-west-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0ba21e4107855a365"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0c40470816cee5b29"
                         },
                         "eu-west-3": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-08233733aa06f60f3"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-09b6b8d4ef0bf0ec9"
                         },
                         "il-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-046e9205520f0b2d8"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-069ad9d8dd22c2969"
                         },
                         "me-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0dbf2c97968ca7965"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0206e0d31274ae0c2"
                         },
                         "me-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-05fb207f2804d7732"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0669fbbfbe66e3b55"
                         },
                         "sa-east-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0cedb45ee42b00859"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0bb35c34540a9ee7b"
                         },
                         "us-east-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0a6ffea8ad6ee21e5"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0f7a88949f3448106"
                         },
                         "us-east-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-09e49cd5a6292b4af"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0fbe2a0b016c7a52d"
                         },
                         "us-west-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0721390dff3c7c0e3"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0ceee09a7d2c6a0e8"
                         },
                         "us-west-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0df19b7f7e972c242"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-039e8dd821c97a5cd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240504-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240519-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "94d428b8833eb606a2ecfdb3ceb8ada24bc9b45c85fdf832805dea4007c1ae09",
-                                "uncompressed-sha256": "bcfc2cd9c8bce1fcb3f030d24eec2bd7a4686fe36a34be2940e752049556dadb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "af2ec45f58219bd91c05da16ab467f17ddeb4e0bb569df2e9a757c65d3ef798a",
+                                "uncompressed-sha256": "d6fccb070e2e2d4b4b6bb522612f53b04e18997b3b1b52fae5a1c269308047da"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live.ppc64le.iso.sig",
-                                "sha256": "63651fc824952db94f540d71b81510dd39595ea1b014db64ba8a0cc6a6e53bdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live.ppc64le.iso.sig",
+                                "sha256": "8a6ac1b913a4b68ab26ef809eb8e6d558155a08ab4477e02383ed11bcfd7fb48"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "ef98875e9d1bfde2b08ad5a7e18119c64ce4746699fe5940b03b07251b8f451b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "8f53478b329bb4bae46f71f16fad3a2c8349f79d49ab52dbd020543dd01c0d03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "c5cf6f8990d35c24f54e5d2997ec2c6e5b931818cbac2f4d298b42e75c240d48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "6b3e1ca7b964254b69b61ab6218049dde09a3fd1c7fd39c8a0c6ac3f94904a6f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f08101dfe01a23f86c80434f71a809a2f9f290c924859e8b86166bc670aa14a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "4cbb910e006d8c318eb63cd9e6f437c864f40ba8cac375e1e9cc45aad029df21"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "28aa0ed3f74e018ef57a2d1923e15d5be0be1c49de75f971be4f01fe93f97d8c",
-                                "uncompressed-sha256": "b47e84fc402cd85d371bdd4e729a4ae3467ac9a8d238c0f2d02b89aba72f4170"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "33913a54bf6a5d6e37d4c60ecf675dedcf5af5a2b576608bbe3e23a3bb3b2288",
+                                "uncompressed-sha256": "00638c796cabc48122a724fdd42ff15a2861970cfbbca7f8b5f7952aa40989d7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "315f5229a7d461b0c204d1516b2e89804bf586c192e0cb2fa6ebb7c366771081",
-                                "uncompressed-sha256": "7911c5e482b5d030a152d748cbcc612f14c96c56d4a3c0bc84e2d72ce8f8493f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f608b3a5a856070eb9686c936a207e960a2bdfbc06a4836deaa0297f26196f13",
+                                "uncompressed-sha256": "0d1c073cf5cfc659f6f6c785a4abaa222b55c9e8171d8ac691b0a9686bf08541"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "33dfe721dd76de7f32aa0ed69e1bba16607bf7f7e6a0892f9392a9955feed1e0",
-                                "uncompressed-sha256": "1e1250ba7df6110370089c5cd034db596356310cc6a55c157919c77c9d57c716"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2a42cef34296620eaa903fe14fae50ad1b6556e6062a321ddb6bacb0f21be5eb",
+                                "uncompressed-sha256": "a596de91a0ffd2c90678a8af6bed027d8e610fba02bd2faaa826e9773696ac7d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/ppc64le/fedora-coreos-40.20240504.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "317dc79d6c6d3e39bf60fd89a116bdd7285534f4e1dee92056b351f2453ca10d",
-                                "uncompressed-sha256": "98dc1c59802bdc1517ffa4f40dbce2745ce5fbd33fdec24041250f8f6089f461"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "cc6ad2cfbc1105e0473108ea0e038a83e4771ffae91f818cbba730bc5bd7371b",
+                                "uncompressed-sha256": "21a8c5cabc051e9c4ddeb6fdc2fccb79a4d8646425ca41830f353e0c0b235e70"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "bf547e204e076bbad882b6681f9f02d5a05aa8034660f9d62cee8802405d2fe2",
-                                "uncompressed-sha256": "b32d4fead74876c1704f8b5df795dd4c7c6fbc1cffea7975b4c27714948a72a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5252b7230970f75beae1d17de97f89e64acf032859beea9e6a6310c3e30c0569",
+                                "uncompressed-sha256": "a3e79c19788339779a3cb90a5828559ced1c564ab68959ad949de6e8af0a2e83"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8d6052df69720e0820d48abdaa87b07e12f06c0f8fa32af5bbf5237b9cd93ddb",
-                                "uncompressed-sha256": "68f7f45b1e8f048fd46d392abb372fc8b254202513eb390472df6a56dce962f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6d6f7a1a0f5a4aafa7d14635ad32cb76253d18d7219c3565ff83e7410b8b2197",
+                                "uncompressed-sha256": "eff4b88ac97b2bf634595f1c4a17ab782b0c6465636e8fcbb32f5551d6cd6bd0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live.s390x.iso.sig",
-                                "sha256": "0a42e49776987bc94280f6b57197cef2752b6cf3ed13e1e16ba76777d4fd0d81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live.s390x.iso.sig",
+                                "sha256": "5e835f80b54ba382fbb025b60d4967c06f5134578845a70cb32c9ccb90d3d3d5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live-kernel-s390x.sig",
-                                "sha256": "d093ef3f5a434b806892b5709b1ea1c2aa58b5064e0469632ac7e04454b2e410"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-kernel-s390x.sig",
+                                "sha256": "a90fe25c7cae5dc9b34f089c747c344e3b65a111365d80459cf38a3c3b71c45a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "438ddcfeff4ebee6e9bed5b9cb252f884db05cb1cd7c0f48260b2f74393bf056"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b39ee89ff0ac367c20d49fff44522679cb8f7eaf762c25cb6f2aac1c7fee64f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d9b0cd5705f85c1a1daf216cb167a7d8253780898291d62861c9089a561cc6c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7745fc01f7d0e8a7bd56924f8708e965ecdeb7fbee537a75f9f5285aa0080616"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "96d28652ae14fed83af3a307bd586da9bf99cc60866ac98cb4fcbe541a248b00",
-                                "uncompressed-sha256": "ea923bae13e03ccb67849d796baa6b888e1219f999bfd4d2cb8758707de79eb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a3388fca33cb7b69d2405b5342617880fbec93f585b2fe7fc5ed78fd684b9529",
+                                "uncompressed-sha256": "433324caab357fa78c992a962c5f9eb099b8e38190aacc79d4316075c38597c9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c30e0a2f11e63b0d19cadfbd7844adbafa9adbe7b1482ef427eae5b0d77e6c30",
-                                "uncompressed-sha256": "55309e8410abcd37eeb10a32ee8318c2a7d7f22c89eccf53e12be1f5ac14b777"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0da768d4482958bfadb1586a45cb479ca4f809e4362d9ecd8c935e1302b2cf09",
+                                "uncompressed-sha256": "a5ab7a24a6b23cfa006a08562b274ccc5cf5090c60ae2395454fe78de61387f8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/s390x/fedora-coreos-40.20240504.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5d360a754d24025d54904f8b015384902718fd57cee9cc897d5ab19daf43c9ce",
-                                "uncompressed-sha256": "255a78210f0268c594aa9ba7103c2756fcec3b867248ff7f9396f57da3d874e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b6ba8be2374220e61eb978bfc49106776f0421a6d6adb69f4ff6da1213ec4449",
+                                "uncompressed-sha256": "65631d2e2181043ba9ac902a6c8daa7daabdb9c1333f924885cc12e1fdaf057c"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ccb98049b4fe4042a1a0f7251ec024ec16ba14f2774c893b73b269db927841e1",
-                                "uncompressed-sha256": "b2b0812fc67636c841b24a386c66480f096c460676a7457084223179bed96eb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "90cb29c622a4b9e585aab661f442cc70177b440a5995cf7c19bd042d86704039",
+                                "uncompressed-sha256": "e659b4b1208320ef8a8e33de8a782a15b82f8dd3a01e4c2117f15801671caf57"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8061d80009d837b21434c0883de6540a8d76510b681329599b8bfeb4fb632ab7",
-                                "uncompressed-sha256": "53a0e45feeb720ab94bf4ac8b93965b6133e59a8bd41a26ba92230588732b30b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "750d3800e6bc1c6787d52cf54cb4aca29e4c07990b74398611e0e9b15e38db82",
+                                "uncompressed-sha256": "bff39c263dd022a60d732c63d0591aed4842e19e12cd5300f0e86d78db57b2f7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "669aaea8d6dc71c81563b2215619ce01a57c1a5bf55234f2dd5a006e358b9f84",
-                                "uncompressed-sha256": "67b50b7fe26af53603438614a0122f54733abbda770f756b2c495fe7c577eed5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "76c4bda83bb53aef18d05c9ce2bc16625cb839fd02e07d80d88341874b819863",
+                                "uncompressed-sha256": "3aec63fbdabc0b0f4eb49be9b00cb83a4bb33b68830aafc89fe3b3d5ffeffd44"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "926af37677a37cb80d0e365215c55a82f556523dff33da0145fb5b11664246f3",
-                                "uncompressed-sha256": "d261402835b8253e98fefbfcf764780d71963f9ff1d4dbe1444539fa438794fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ab986d5153ecea0f40c5eda4a8856de99f27d40a5fe66e10d8d8962c514a032f",
+                                "uncompressed-sha256": "e59f1bae0f5592c56497c3e6d00a18ec968940a2a22b7d534adce7b9ae59d4ec"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "481f6202e81300af8ac628df162dedf54c7570bdc9ee6d493aa3c46a1a32b738",
-                                "uncompressed-sha256": "1bfbda8529af14360ea9e8dbd2ec0574723962113582cbb2a9938d9436425e0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6e1fb3a34050198554f9eb224c3baf8305aee79b31aad550b5dfbfa06fa1431d",
+                                "uncompressed-sha256": "9912c58f15afa92133b2a3fd137458f1c0caac9694b33fffa8dd32bd217acaab"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a70adecea34b1ba728082a74ad25b540a08819fb7ac61ef42bb6d1ffaa9a808f",
-                                "uncompressed-sha256": "b18c2efcd1f5b908e8691e936ae6503c82a24d6b70a09aac97800e0d54d0fa8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "75fc078ef006b6b2dc45d634d5751af79b46ac8e724196f7fa159fd356f349ab",
+                                "uncompressed-sha256": "7f2231d9b59a8442fccda65c1cdd3c3a9872e3f42c9aaf5fbd3c1f58ce35dc4c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0a75a3afd969aa37a85a8a56d54e93862a61f151b13db4684c03244073f35c74",
-                                "uncompressed-sha256": "568ca45782cdd396f1dee1a7ec992bc29d2a61c5b246d5a226a9521dc1db7b31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6e82550a5b77c946f5fa35213882342d6efce59e013a22492858576c980b6971",
+                                "uncompressed-sha256": "1f0bea478148a9184a10124330224b7a82342cb1fb5085cb2960f42cd2f0d5bd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b918d525c7c8b0d08e358d54d267f33d39344bf6d1b8b9f10d7b95fce00ccfbf",
-                                "uncompressed-sha256": "3d9e568642453c9c86051ef1dd9de3cfd15aeb28804dbf997bcb5ba45fb1a666"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "10c358cb2f6b8105dcdae623d5b03445b3916850c5452a0db7cb4367d09d2687",
+                                "uncompressed-sha256": "b155eaff2f797bbcf6e40d9f8fc38f8da8e53969c5b1fa6155af85d4df23e67d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "23f18e1173d4f439cc4adf1f2f9f6833303154ce977d7ae8a5a6377d4ed17750",
-                                "uncompressed-sha256": "5eabbdb48ae5a175676bd303a3fc23403595da6ee84d013a2652b4e274a498af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "9bf1e83c71723fc89101c5493d0408c2ae5ec48e7a0b96bbdb2925ec2d2167c9",
+                                "uncompressed-sha256": "e91947bb7580f18e20f67e781107d2753acc91163a5ef02b988fd095365e5928"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "42146ea47678b53d590640de9961eca117d0372ab6f71a39bfca857baa892575",
-                                "uncompressed-sha256": "2eed98a56170e7574a1b651828be819ed7d5646d4884300e1f4d63cca3342300"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c30f6128cc259eb67f575e8356d9744d4c848303ed2d205f3359dac0edfeed0f",
+                                "uncompressed-sha256": "5bbe98f6d2c39490c4667c530885709471d2ef1b61f808a3303b6c0be1b03449"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6eb54e1cbde4569b76cdc63cd34d56b3a519f1118ca94181e998a699e5bb38ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5f17261b2f75085ba180190a135897b31ba177910da6af5aa5aa1ffc2ba8730a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e654c386dc85b0bee1de020d81273d7dd52d775e2af815290cb556b2662591c6",
-                                "uncompressed-sha256": "dd5738b6032266453d6249b4a4f065873a319eac92f1525b581a0acd131ca2b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9329ea3d28711d2faff2f461ebbf02cfa939e477dca31832791cb1f718013037",
+                                "uncompressed-sha256": "a4a6f1089c3d9fd03a4de802caee30564677c96b3efc7ff51f478d57958f02fb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live.x86_64.iso.sig",
-                                "sha256": "838bb77bcbd6b795475be7e52452ce43c35b54f207bb53acc1805e8dfe92103f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live.x86_64.iso.sig",
+                                "sha256": "477373eeff65051d48f0c405b17a7e88d4f860ce3ddcfaa963f932c7980ace49"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live-kernel-x86_64.sig",
-                                "sha256": "56978c9bb331df1467947db3d4fdeb69fbda7f277fc090f2e647ac551363be4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-kernel-x86_64.sig",
+                                "sha256": "0c648d3aae973f24287a0999bb9c9301b963c4dcc8d5e0d0f5bf9533b6db1d74"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8b98c90365c9219f29c5621122efb4cc26ffb33dcf1fc7268a7fda5a24a1eb1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "98415aea5adfde500013dfbe499ab7727ea5a4acedb812d7cb08e0bd1ca480ee"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5197e3e800be255862f629c6de916b082ec3d3ea0ff582d4292993b1c5a7a923"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "39066e93c7fb0f78cac357ce6e17514f3e206ac79874a32e950513d0ee811927"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "289b154533f7adf4902aff52d78f6b77400edcbbb5ff5dedd9fc8edd0ae3fa02",
-                                "uncompressed-sha256": "f7c4cfa543e9c576370d99270bce145a84b52e4387707a3c29766cbaa95d2178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4fc90e687043b6cbf125a838100c2da80a6ed5f2ec32eb752401857bfed4883b",
+                                "uncompressed-sha256": "fe331bf1807526d16cfdb02436fe7944e4e1b592daa9942b7a75a2590fc17827"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a3e7681c006647e38542152960cd41ffa330ea633420f59cbe92bc9e81c8ccb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "785e79d1919659c7bfa61844def169ffd882b1e67a385ed9634765841a31c432"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "31a846edf809083dae6fe8c74e337e263ac78af106d9459f1e8f453ed462932c",
-                                "uncompressed-sha256": "8f83826bc3dc9aa465bf112e735c8279b361cd377fae10fc0ddb4f8568ffe5b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bdadffd362130fa6fbb218b54651851d27806b1a320986274bab3fbd4f604a5d",
+                                "uncompressed-sha256": "fcd0fa5c82b6d746b0829949497e898045c742c31ea0ca53e709804984b2f294"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c644e6f057637e5da8a23af2eaf969f6055fc8ba840b83e81d44c5b91ffd207c",
-                                "uncompressed-sha256": "c957b531408032b498a5b05b3502bedd72c9fc57e77b2fd183231a014d114977"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2683ccaeb4a445baf086b24d6f6f7b7d3254922c37487acef6df419cb7b4a14b",
+                                "uncompressed-sha256": "37c471d6d23de1221397b2ad2ec03acbf020974d50b443a9a1bc4e7c7a5d0a5d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "6eca80ad0286355d7d377e480b60bbf17c43829a2cf843e8603a753b641814ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0d03131de4c9a72a0f6bbea71ce09dafad29abc9d30da25f30bcc232676f806c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "f608c34bf9d6acf5b668e21776d74b7ac94ea5b1267b9d78386e5d4f502788a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "1a58ee3ca1f36741893029816ebe3c2f48406dffbe6415bd97505cf3a3b6f04d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240504.3.0/x86_64/fedora-coreos-40.20240504.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "67bff757a9b58f6b80b2eddbffda41bb6f9abe92f84e975ca478978bad8787a6",
-                                "uncompressed-sha256": "2d4eef88143f96c9aa4713832cdad81e1ca295b20741d2b81d5054d4fb64a221"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0c2cc2dbc3b10d4b8e3529b994edaeacafaa9ea2de514c73b62f387e81c7d3fc",
+                                "uncompressed-sha256": "1d503e28730feb38fee209088c730b72dbc53596b727b431669350a69ab4d36c"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0b5adcc7dce9bae51"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0d2f46dc3762d801b"
                         },
                         "ap-east-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0a852a96cd62d29ad"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-069ca951291745185"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0a3955ef4363b10f2"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-07797133310028b6f"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0dcd5683780951082"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-082c32011d76e483f"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-07bda2c14ccd9779e"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0e8184837864bfccf"
                         },
                         "ap-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-04b1793d9e4e3b169"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-048e757034697e2a7"
                         },
                         "ap-south-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-02cada6720266ad57"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0a711d438ac567a65"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-01707c507bf9bbab7"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0c2b46bcae3558c25"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0f1ef391c571374b2"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-01938f99b0bb5ad2d"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-01c5062ab07f62956"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0b2fb8bdfeb312cab"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-073333136b8e81f61"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-00e4e1ad82724f387"
                         },
                         "ca-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-00c035d392bdfc3a6"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0bd397f7170f16353"
                         },
                         "ca-west-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-01ae0acc6a3cf6d7d"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-030502ed3ffcdcd59"
                         },
                         "eu-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0e9237b6b18456066"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-06128ecf4b4101217"
                         },
                         "eu-central-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0298d48de6ba3912a"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-04317d12e75527614"
                         },
                         "eu-north-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0c9ee04504992cdf0"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0fe0d1c915deca061"
                         },
                         "eu-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-08ff0874b028b449c"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0888318a273aa2184"
                         },
                         "eu-south-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-026e833b3d45a4c77"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0881347de36c21e6e"
                         },
                         "eu-west-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-01ee249c50fc51fc1"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0196f947de5974267"
                         },
                         "eu-west-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-06f07cff82ac8121d"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-077578b69671d8fda"
                         },
                         "eu-west-3": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-093c91cd5790fc605"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-034f092a97604546d"
                         },
                         "il-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0089d2d94a5993c63"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0beb6b5ac0d0d4bb9"
                         },
                         "me-central-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0853ffcb6fc295247"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0586d69f2bc87d23b"
                         },
                         "me-south-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-01c50789fff891fb1"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-095c186095d2b425b"
                         },
                         "sa-east-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-06600718d28e4c707"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0615dd2ce84dd65e1"
                         },
                         "us-east-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0c7aa428b855c6082"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0c9792091982af821"
                         },
                         "us-east-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-006404db098cf9240"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-048e9fc46f49f403c"
                         },
                         "us-west-1": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0b04ee599b4feb995"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-0040bba44abb4acb1"
                         },
                         "us-west-2": {
-                            "release": "40.20240504.3.0",
-                            "image": "ami-0b70ccf7fefc0ed40"
+                            "release": "40.20240519.3.0",
+                            "image": "ami-07720a9e1909196e0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240504-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240519-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240504.3.0",
+                    "release": "40.20240519.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6ab6476b1c0ff7a31032685c10b5cc28925f3dcb2993a062607ef058780b99a3"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:afc6c5d892bf09c4d10e32d75b06dc5be3d1a0b36056e7c9e5e2991d4a1459be"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-05-21T15:56:25Z",
+        "last-modified": "2024-06-05T16:57:45Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "8d2a1f918e0100bfd62754897b11322f72ad13759a793e3d9e3431b23d750180",
-                                "uncompressed-sha256": "6f340218854837b392975c77b31d5dbef69fcbc7f62e4c0d2b0a398357df087c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f723b20f80f3334f7baa9fc1efe8751a0f27cb96c66e77d9fa9b8930f8ee8ca1",
+                                "uncompressed-sha256": "c32b71fc6ac16d17106cb59aadb1526664f03de2e0661db99cca1d8ba1695991"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "11e5d00f17ed4b018d8c4fec5b4d925e749105e0ed3ebf4826a65122b9a7a7e3",
-                                "uncompressed-sha256": "d99efa372c4f8df3d41d6f79edb69c6415ad1d5eff11ef7d321913cff04d781f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d98caeaf951ef8e6ead78e4a42d356f2087ee56fae3f8089421492b1a8aeb124",
+                                "uncompressed-sha256": "cf39624729b0a48c0eb578a654b5c0442725c72c2305531a1c8e0b3aa8098160"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cfa1759416de169f29eef54a940731dce74a36f361aa793d7fe7a8ed35a70aff",
-                                "uncompressed-sha256": "9a450d04233b5022f20bd227f5d6d5c6e38e4a237fac3989025ceadcc9044713"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0645f0e4e0f9d55c6fe1bc02679bdb91ca6c8ee28773aeff60eb01224fdef008",
+                                "uncompressed-sha256": "8a816fde20fcaf8dca0dcf259a24d15dbb904a116784959245848c6463be9fd8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "b0450eb77db935827d7be73bf42f209412548173949d398dcc3255cb0ef9d2d6",
-                                "uncompressed-sha256": "abe74137a778c6db45fabab7764a3cf85802f5b844b1d6b90c09c7640568c65f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a52e4eda52bdd4e3cd838386983d91b6b07f9c4e0205b864943b5a62dfb0d934",
+                                "uncompressed-sha256": "c47e1bf322a3d97676058882c2870e34ff3f5ce3d8bbfd1b8b32a09a320f6968"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "71c7660aba70d5b642e6e7cef41029c0ad1e24ddd3ca8efa7308fadc739647ba",
-                                "uncompressed-sha256": "1bf70b8dced9882dfe90d1434cea8e62768d1f2e61ef4dc98902a45fa2078d7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "b34abc73ca430f22f621f73a14253db8719319d04a2abe05c94454ae70876d20",
+                                "uncompressed-sha256": "24db140c7bc0109c88f271b755b2612c8eeeb60f671be22007be2d9c50230b7f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5821535741adef818a9fdf8aef448659faf1e8a659c37ec75a847e27b22f5e08",
-                                "uncompressed-sha256": "fd4f606aa090369f7a521e16f06d483b09ef0da044a527c577b12a7409421028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a8055248419d04103999f2667f527f407116111757ab36caf1761043488be5b6",
+                                "uncompressed-sha256": "1b5f41a58d5bf66ccccbe210ee4c7e6ac41b93af8e2be04cef0ad2d633508c69"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live.aarch64.iso.sig",
-                                "sha256": "b56198501a1efa9da7d572bc843d019fd7905ce69d983171408186a3b7130085"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live.aarch64.iso.sig",
+                                "sha256": "e8ac807b73c5bcbb90770583f7c5bad07981f4ab2a3ae07b9f55d35709db4702"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live-kernel-aarch64.sig",
-                                "sha256": "75e477f7287e803e6861bfd9dd0e06572acbcb0b0e6b3bbe907544541a8a423e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-kernel-aarch64.sig",
+                                "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "acdd73b8c019c61684e9ae029a4918dc7f70a83a1bb5b3702f2b52ce54f75860"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1653f492a01dc95ec624ef8778d52ae3a191ce1732aa885ad6a03c8b15daff49"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c8f6b6843c4be84f8a5d00e4c06a2d92d8e073213bdd7ab20e532ae89335586a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5fbfaf18c15eb1ca72fed92a0e754ca5de33e2b2ebaa70d51188b455c12fa95d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "b694f9437b6151e0ddf00625a37cdeeb679831e742703a3b1a9a6cd95c50a585",
-                                "uncompressed-sha256": "47c7531fbf473a81d5d9bda9a4999c6ff1194743188151f24e1ef0fb91a91717"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "8fc6b55a1f81b60e13fba1d953c117c23f05dd32824694b5486b7147d3b5bbe6",
+                                "uncompressed-sha256": "7845b11769681e84cb2fc841d162c317d085c885d41bd81b4db5f4191dff1fa7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fd9a7a6cbb4791e16fe427fc58a88d366d905d47e37e04341962dc95ea37b309",
-                                "uncompressed-sha256": "96ec1dac840fb189c840f562592a3e5601f2f0e4f2d7cbc9a02149ec4fc17acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "353d1de53fb21c223f1481e89c4e53133193920041e37e446f40abb833b836fa",
+                                "uncompressed-sha256": "345a0e120a9281f8eb6a47517fa08ad22c66cd8f2462fb4e9e147322df15e80b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/aarch64/fedora-coreos-40.20240519.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2680b2ad11ea10a2413b771030e03aac2b58d25c2a92ab0785ee4c4512a5a04d",
-                                "uncompressed-sha256": "eaf09d6d7098b2ad404a63ba901956659e622fe6bf36e01ba2a951f7bfa2b50b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f84f50b1da17d491cf1f18067019d50534b42c92fed9ed1269bd77f3732c19f1",
+                                "uncompressed-sha256": "a2b48ae82053efd487e36eb7891e6546c8f6a35248cf73da79bb9db6cc806852"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-01ca405b0fcde90ba"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0e42dc546c93488cc"
                         },
                         "ap-east-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0b26e21a5aa766004"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-086d630ab24fbe0de"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0d851f0bb592f74eb"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-022344dbe492cb023"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0f53391133ea6ceb0"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0b3cedb47179230c6"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-098a83b23c708f37a"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-05630b4e85e34e8e2"
                         },
                         "ap-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0f10ae05b657fdd1d"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0f65cb21431296010"
                         },
                         "ap-south-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0e1a3420d3c602e83"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-083e20f32d9037d26"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0dc122ee93fb020fb"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-02efcb61e261d665d"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-004a4125e7bb4e783"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-06d7e4c79c6e33325"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-01678dee31eb0d1b8"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-07daba5c361e835b3"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0bf5b1348de9a24b6"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0ee0bf9e4ce156499"
                         },
                         "ca-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-028034786c8367478"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0e602643cd54e7300"
                         },
                         "ca-west-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-01374844f9032a799"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0e2a4d4462228347c"
                         },
                         "eu-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-026077643a23c1506"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-01670fe90fb7ffb82"
                         },
                         "eu-central-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0f6deed91022de508"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-03905473789ebe203"
                         },
                         "eu-north-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0e188a2cdee0591b5"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0a0c5570ecf728d10"
                         },
                         "eu-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-09d8f01675e2726a0"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0bfe27a924e73ec41"
                         },
                         "eu-south-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-038562e56f98f80a9"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-03a58a6cb1d8ade3c"
                         },
                         "eu-west-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-073ded28969cd0f89"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-01a49e89ac3b56982"
                         },
                         "eu-west-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0bb8da79f83cce8ce"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-071622bd99bb08141"
                         },
                         "eu-west-3": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-003852be117197198"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0c96b374028758780"
                         },
                         "il-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0ea57fa431fba22e0"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-07ed71a74974bb0a3"
                         },
                         "me-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0e942a1e6860e7233"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0d70cc88088b5554e"
                         },
                         "me-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-04642bf2f2e131e43"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0d67ecbe7934cfc7b"
                         },
                         "sa-east-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0e995f5a09e6494ea"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0384fa6ef5cb15d46"
                         },
                         "us-east-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-09dab63f2846cd59c"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-03111a4916e10a37a"
                         },
                         "us-east-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-048b2479e45843511"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0db99563fff5d5890"
                         },
                         "us-west-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0e6999bb641eabf3a"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0937d9a091c7e8294"
                         },
                         "us-west-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0011ce44224607039"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0ded3e48bc4f6d73b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240519-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240602-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "76eef60a2c5623d5eba9fd2832579bde40f3cde80137cc286402218167294d78",
-                                "uncompressed-sha256": "02db632187ff1a71a3a788d48e2656485d36e3e9cabba42c47eac12f7c9bcbc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f557b93dac860efb636228173d104b8e41ac71763ae316c11a4562288a8bacf9",
+                                "uncompressed-sha256": "8f437b39c9ba2cbaf32e51bf9d0f56dbb2189a2581269e5813995d4c946f4132"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live.ppc64le.iso.sig",
-                                "sha256": "7178bd8ffb84263934bcf386eb5e8a4fa7a57233d9a13065281a2cbad5f8e95b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live.ppc64le.iso.sig",
+                                "sha256": "34f97277181f68857ef843ae60a7e098c93df7d19e654959fa2a24d827274ef5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "8f53478b329bb4bae46f71f16fad3a2c8349f79d49ab52dbd020543dd01c0d03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5baea8d4cf0233c1c7c03831301b7b8db0093340de7ceba405e897afd20cd550"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5899db627d403d0d5d6ba1b129d7debe627a6a7f629543aac859051c52e39dc2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "8eb844e6bc382f2061e3138bbb9d30afdd74d79cdc68753f8b02afb7076bdb0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c9a82dc6a00de9effe5c73845f33b74bc600534f74653c6d52e963ab00bdd206"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "5054873240d47a7067c490654c030aed95454131541c0ea47edd88565e25bc4b",
-                                "uncompressed-sha256": "e423e54dda0a8c8d863461345bb5af2d45e56a2af95f7d1997d2a579b3597856"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "52476b34bc65b37153ba62ba48e1fe47a0f616e40d25922ca802753da105e94e",
+                                "uncompressed-sha256": "9a68e99ebe6ea949ee0e893571211c64abd9abe0c9b690e2b44f720e120185d2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "633eb0390cdd4598b90640aea64a71554fca86f71aae52932dee1c0429090775",
-                                "uncompressed-sha256": "73200ae183888d79c20c793975e9294141a424e2f41ab44f4fa63bef7001e515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "7f3538579c05aa5c522d134ff98aa2e4d6c9abd2347fc50bd5c3f1c4cae20d18",
+                                "uncompressed-sha256": "46fa64711f55e8f2c1b014d9b43c7348582182bd1546eec21f3b42404ee9028d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "552db73e0e51e0fbae6caf476dc1035c7c584e3d822cac14ec7e30bc0f235b7e",
-                                "uncompressed-sha256": "b06ab93a04432ff28700a22baea26c9a3ffa61537a346113b3cb08643dbf1aef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "8faf16447d20eebd8d59955c4027db5f13a6cdb62745cbcc9feafdbfd4b7f024",
+                                "uncompressed-sha256": "8b9dd454392d6328009375fa3d042a4f3766c7f6945764891ffe2f2802b3fa9e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/ppc64le/fedora-coreos-40.20240519.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a8d070f885675fe66b37fecb530d51152a91cd9c3566d61a8b297683d03f1467",
-                                "uncompressed-sha256": "f9752cf49284087b116b54c9333df3d33e3d4575ac277e020db3c5f97582727b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bf9040ef1e04dfabc3f1b7cdf21fdc1adbec9b5f7bab37ac9d86f704f6ed87f5",
+                                "uncompressed-sha256": "b189b8b0340616f6baf7d4e5b2e4b0cba1442b6fab70eabd600dd3069dd15fe1"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cf64cf48d221102e7bae8e5b8c6ab9f7584071a23604fbe8c2e5087957155cd0",
-                                "uncompressed-sha256": "8d7685503e494f49a1f391bdd89975215d7e79875e3520f8684571a52a161066"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "10e81923c112a2cc88ec166901ec3b3497229d32c4a9082bf74113b654484365",
+                                "uncompressed-sha256": "f841349967495a74576fe5f7f9fed3c25f099df5c54bd2b736aa40991b10d958"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "51a3b4d99c4dbee16c889e8c47090e103b3c1af7aa2605876ceaa052be096db4",
-                                "uncompressed-sha256": "a72d0a2905d7faae5b18a7ca521dd6c83c35beacf5372e09f89a7ccbff1831b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3611dee1db2e2f4b4e0db8a7377dfb2c0bcd5a165e03c2de0eef82446c7f71b2",
+                                "uncompressed-sha256": "9d87054857f90b1580a7b69ccbdd82245deffedcbcedbafb9881196c302647fd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live.s390x.iso.sig",
-                                "sha256": "56205379e3f9719168e235235fb220d10ee6abb7522e8741daa44f4be14c8859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live.s390x.iso.sig",
+                                "sha256": "37d35135d466a18f59e48c5523cba6a03335c67639ab05436f268bfd6cbc5779"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live-kernel-s390x.sig",
-                                "sha256": "a90fe25c7cae5dc9b34f089c747c344e3b65a111365d80459cf38a3c3b71c45a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-kernel-s390x.sig",
+                                "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ba6608229487e2336298c55bd4e4f6116a86a48cc3a4a360df44df48ec487a61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a172f1b56b3150de214cda5523b2af7d334268805e6052084c44926534ac3097"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d15dedfcaf5a56561354c1e69eaffb5d4067df9037805966d1d1aebe6905da82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6201656adca014c6bdd59918444a9ea2c6688a31f1f0b86b42b705f423588390"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "5fbadbb486aa24b2cecb33bfc5e2ea5850324ce3637ed494bd2373b5fed16415",
-                                "uncompressed-sha256": "0c693fa87fd1a736e69e1844982de057d2da539cde8583dd27c8acd3fcfcf95d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "236456a5589932a27f6e907d496808431ab9a0322c989041d6fb95b4640b462c",
+                                "uncompressed-sha256": "ed0c1d1af63a1c421a8604f3f7512406f6b1843ccc1cd769a52f2392abf4ebad"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d1885af85f9091e11939cc6e5193d4c61fb5659f6f5efd64602961889d099649",
-                                "uncompressed-sha256": "c3adf6245267cbc6fb0d765bcf7df004cf55c87f1eb711d0479f8abbd83c91cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c6ada473cb5b01b7743453d8e01bfc979d00c42df5c31d3d0c2decbc8169ede9",
+                                "uncompressed-sha256": "96ce00880835261d3989d1abe2c91c76697eb55dda85ad359d76a171c85f8e84"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/s390x/fedora-coreos-40.20240519.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "185d9b93dc2ef6e77034d7b683a12fb1976dccd45971708f73bc9e45f99a6fd1",
-                                "uncompressed-sha256": "4980e1494bf8c001e53387ea5781236bd9ece9056409ba4f2aeee4a7789210f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9b86bec5d4000b2d8c063983de897130b60b57f8d90becdb8f3938dfcc851eb9",
+                                "uncompressed-sha256": "6d3d2e408bc07340614c9b43409a3d2849062d422724851f44f2376364921a1c"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "aa6640df2ab59e3e2a05e02718ae5fa9699704b5841f2d9311cb46ac985f1e38",
-                                "uncompressed-sha256": "f45d40ad67a3cc6d38527345b12bfd06de0416c07212d5ed787bcfe51b05f282"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e6e324250a911f61dc1aade729949f3f6e283650071012714eddb5fa20351c52",
+                                "uncompressed-sha256": "1d1cdda2ef1c5bc1fb99a1817cdfa5baf84cd8aad361ee296cc7339f94ed8328"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f723c1b50ae1c0c4249dc5ef1972659adc586b5218db4a971e5539cf2a9a4e11",
-                                "uncompressed-sha256": "5042307551a32cc125c865f34e8191121e0cb58ed77d900766f48bafdf4e668f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8f88114cf0e00a58ae0fc11cf989e5458a45e545128cf9700885fb5e1e2025f7",
+                                "uncompressed-sha256": "9d499cc81c6bcf0b8d0620f3c5e0729400b5f16cb39ed1a28edc0f869fffce6d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a4d3c3e54d19140bf6bedbae1c0969f39af7e2c2295d4f003b7a86d250a267ec",
-                                "uncompressed-sha256": "f8c7117d23d0321c7f9c2fb01193aa9812d6ea8115a2e08a10258adb39a5bb88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4e00b9d43a2bbbab39b2272ab59b41ca017a0cee8e8eee28f2eaab30802cc03b",
+                                "uncompressed-sha256": "b1edec563b595c3e89a4b5535243cd7aec873991958cd518b54626dc743145d2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "23fe215be45ca29c30599bc7f71bfa2c977ccc9f7f4a54d51aae4adbbd340cb3",
-                                "uncompressed-sha256": "41fdbeda7acc8c60e202640bcf2802f66a00ee29cb4b7c1093381deab42ffd79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c5f5f166141a32a9977dcfedfa1cbfe0289e8d9c29e22ba2bcac50787f567fad",
+                                "uncompressed-sha256": "130904f140401f1607bec59fa481a695d2608ffdd3e3a244c590cd6ee3356fff"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "27f9a2c17a967778953a8f3be9ace844f3480f1f67d5b7bbedc1e4d8f62f46fa",
-                                "uncompressed-sha256": "0a852acb0992b9fb2c626f134963d68f1c589c6f2ee02a155af76b57bab1e943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8346895d66db2f587943c4cded22d04e38b7420d38afbbcab0c79c14d24e2dbf",
+                                "uncompressed-sha256": "a053e622f98130b2def102b191d9923588bb7b62d837a2ad7e5f0fdba1d948e8"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5a39017379def9e889e7427d98f7d5d14869184c34752bff7c43a0d47c34a8b4",
-                                "uncompressed-sha256": "110fef8001666b5e928603058b20a4c666f2e71e87c3909ecb184603ddc82e83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "43084c3c1de3fd4b3717c25ccecfda293bb195fa5f812af65ae90e9d0f5851e7",
+                                "uncompressed-sha256": "5792a278e9633c9d76cbe923b2c9578c96efa0003f967174c728f5ffe45a1e48"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "cbc75b9abbad830d61b05ec2b2451ab948dde737aa6ba6ba45443762fc340fa0",
-                                "uncompressed-sha256": "10dd987b304853c3d55a6375c36dcb48c6c13d4469c03a175a4e5ecc99154d64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b07a6d3b717efe47387a4012022014ebb78b84921a1649223b4bb0e975b9a274",
+                                "uncompressed-sha256": "caee79955a504a3bc45f76769ea3b7d543ee4aa1c6ba689ed21eef501f368552"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "66b57c0d8613933cebef41dea2c8fe5c7189ad17d8753cac24853284cb4f10a2",
-                                "uncompressed-sha256": "1c191c3468dada52d4cceda0e1632b307721d8cabed3dea45d54366e395c5223"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a4734b0d45a162243d0f559bcf6bd162800648e61f8749f1ff05a9104fd4dfe1",
+                                "uncompressed-sha256": "58567a13bc4ed06a86a0cec526b67c55ad958ed84a2c2a72e6366dc24ca2fdee"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e27e1737d9eb3383167d5891bc97328916c9e9d392d05bd42e883c5febd31c09",
-                                "uncompressed-sha256": "2126ccda786a2aec4015aa0f2e9075ed8962bd221315e6c104d458a349908c6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "22d5e273b9fc254a195c0ab1f4bdd63ec2e21a5a5a18bd2c20d170c5ba496d9c",
+                                "uncompressed-sha256": "dae1e3bfbcef9811211db2ba145284377bcc0008f776dd0250d0c0e6764b8c30"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "195bb24fb8e5ba81337048d00675809515c9a4018ad0340db8991dba933c0000",
-                                "uncompressed-sha256": "0f8e7152c2114b4161febc86c45fa5b2e9f5610b0e83573b0e59e80abfe4de7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9da917000964235b2f8c0cedbf64095291ee7ec59c76697c6ab466a35d123454",
+                                "uncompressed-sha256": "902a59c44701a05176241a434a8ab818398315e30a30bf904cfd44c0bf356244"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "1aa80d6cccd8d62909c4d406894bcc50a644b8a07a97694f5d8dce02673d4592"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "9afc6aed2dfe8f59719f7d15e9e5cd2a68449385a1ee2f9c114b1265a0998787"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f8cc3d633d312f113a0d78499cd0c3c57c95e86fc8d50ce8d356401fafe11463",
-                                "uncompressed-sha256": "37d9a7a06c4da7975d4bdd12b581f788c644eb37bf6e673b0ad7c1cb99652187"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6b309bf31d84a95dba88ac7a86ec400004da24a76adaf2ce2fad16df93228c12",
+                                "uncompressed-sha256": "ef6553698e2c477875aecde95bcd1c92607b5327aed6ec4a31bba664254c60a5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live.x86_64.iso.sig",
-                                "sha256": "1833772537bc9445fe07fb301e270fa79c89a32a907cb7f026e6b1c2188cb225"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live.x86_64.iso.sig",
+                                "sha256": "227b37bf293765251532e3e1f9a6f7e812f8b17fd934831edd29a3fb9e937f29"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live-kernel-x86_64.sig",
-                                "sha256": "0c648d3aae973f24287a0999bb9c9301b963c4dcc8d5e0d0f5bf9533b6db1d74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-kernel-x86_64.sig",
+                                "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3c7cf4985c9b3c661f02e14bb0d524fdad26c8366ce8f02898311ff154281e60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "52bcdabb05e7c0b23de8de08bdc6e15f79b959e805649a1fc00b2f41c8eff8eb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c1cfe7dd1f338f90c7925e3223c76dae2237df1bba08e54cf00b93dda44f9739"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1946c87a7ba8ce83cf008d6ced5bd9f2b3006e20c095ff52a4a07e9571dd969a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f61008e2c335023f637a595ca384d1b4f69e5fb46369500e62a2dd496c095dd6",
-                                "uncompressed-sha256": "bc391e81d8d384cacbcf1884437302fb1070a90425d118073c670443cd4bfbc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a679f69b3f3d4cc1a22b8583c1565ad24ff1ea5453715208c502ff404e8530c7",
+                                "uncompressed-sha256": "cbde25d8e18ef56f095e0b311a0545ec6e9d55cef58b4a566555f0569c9d63e2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d732214701242fd10d997d82cd79eca29ba081d050c5540b21b5c7922434910a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "37dd48e7d60cf8aef194e9893d7d1aaf7d7db51de3c4812d3fcc3bd046377904"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6786a1b1e4990ca81f39bdea760500c8371c5add3f4e3aff8d8095576adcf34e",
-                                "uncompressed-sha256": "4df1f3c7032b410595a7b57f8fccfa4bc21f7f1291b7bf4bc0ee4df32587a572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6b61bc1a053d67354ec6487fa8e880c71055a8964527f732deb75386fd9d177c",
+                                "uncompressed-sha256": "7423814f309a1065fb42471721c54701761f476661bf44ec66faed3b9382cf7b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "50ac4d65ccaa98e7e29d33ae04bcb3ff80550c8c16e10f84164f11c6abcdf12a",
-                                "uncompressed-sha256": "a41e85c9c3a3558da0023fa886cd5cb8a471fa21334c126a2871102752a1cc69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "cea682184021ba98d552625e2e712b5107181fd708134c68523f893fd6e87f52",
+                                "uncompressed-sha256": "ec881972867320ff43fc925d527291a79735bf15349f812ca7fe928e171dc241"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a19e4983cfdbd8f38dcac370d5184f513ae624c51dbc50904ad8cbcc41425b6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "fe0c50a1aa88ef5b757b1c5126eb64c5561b45503a4f1818cb814577a40a5ed7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7a1d100bfe5f27a592fc4a0c1e486ec6212bb3015c0309a5883c5028ccd407d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "f558d4f1850b04466ad8aee98238cf0e341b726f08ccd6d3b6b9db839aaec320"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240519.2.0/x86_64/fedora-coreos-40.20240519.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d82ea92b2d130461cd0b20a0a26ff6335ddf0f904f828aa8125f60c5edb56385",
-                                "uncompressed-sha256": "a42c193d409e444453311559690095b8f5df35729d34a89ff74024f324cb20d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7681fff6fdf8e1a3304832f8c517c5dc2ef94668c47171f41122ab2f4d0e801e",
+                                "uncompressed-sha256": "ecc4530bca95f55763dafbe8a57243ae4d861f64e5e6aeeb9840e4148bd1cb39"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-08f96f59def850574"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0933b4634efc5b49a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0a9d7f65485558e06"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0c2de5e2791ec697a"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-078b8b35ddcaddf4d"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-07cad28dc274d84ff"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0df23a9772ac71b40"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0d906f9721f475975"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-05ade0913ccc722b4"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-03ae4fbe1fd5fca12"
                         },
                         "ap-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-01320bc49fb5faa9c"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-05446121376a9e3c7"
                         },
                         "ap-south-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-00e6fc6c30598590a"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-047e09c02a8a5ed98"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-00b4bdd1b3221a815"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0b842f97e0e07019c"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-079557be811527649"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-02cf42fee37cf28af"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-004a3c85f78769b99"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0b3acb651a0574933"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0b1b2facf0900591a"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0d6b13b299b3b992c"
                         },
                         "ca-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0ddb87a7588e8b306"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0297632448811f939"
                         },
                         "ca-west-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-09dad3a67376e4118"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0a4aecf952efa0d32"
                         },
                         "eu-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-070d6daf1f4698920"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-008e2a6f271050b41"
                         },
                         "eu-central-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0421b7fac46559222"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0f5639ce07339ab98"
                         },
                         "eu-north-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-08de71d87c167573b"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0b742371e8e24612d"
                         },
                         "eu-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0a352f898549e515a"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-028cbe6b2e54d183c"
                         },
                         "eu-south-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-03fdf0427d3a8be3b"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0431515bd41642b73"
                         },
                         "eu-west-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-04af5915f3c0c79f4"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-094fa2d6d702f1f4e"
                         },
                         "eu-west-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-03901e0c3687dcc5f"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-09e916cd2b3e65ce8"
                         },
                         "eu-west-3": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0d4ef9ee9346be11c"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-02e6df10bbc0abaea"
                         },
                         "il-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0823046a31e0cbd34"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0824aa98466359a8e"
                         },
                         "me-central-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-09b68622d755c7faa"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-087824e76bf3135c0"
                         },
                         "me-south-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0cd42a75687f8a403"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-021706614510115f2"
                         },
                         "sa-east-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0acdc6de8aa44cb34"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-010db164a3a2767d3"
                         },
                         "us-east-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0eb152112566bfcb4"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-07da7a2e22ce24792"
                         },
                         "us-east-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0a029c9d1ca606cd3"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-0d8f3d756a1ff4413"
                         },
                         "us-west-1": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-045d49c4c18763a35"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-046418e194e87b389"
                         },
                         "us-west-2": {
-                            "release": "40.20240519.2.0",
-                            "image": "ami-0ec58cc561df2a697"
+                            "release": "40.20240602.2.0",
+                            "image": "ami-009fb0f5671da3bbb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240519-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240602-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240519.2.0",
+                    "release": "40.20240602.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dbc6cce6114426e39ae06f3c99e167eaf5cc40501a1a8aaa6d09cf1930737d81"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:33d402f3b296fc2dcfe9b302fe1703c4e32c168909b065da8fe962e9b77a5a2a"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-05-21T15:56:28Z"
+    "last-modified": "2024-06-05T16:57:46Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240504.1.0",
+      "version": "40.20240519.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240519.1.0",
+      "version": "40.20240602.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1716310800,
+          "duration_minutes": 1440,
+          "start_epoch": 1717682400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-05-21T15:56:25Z"
+    "last-modified": "2024-06-05T16:57:45Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "40.20240416.3.1",
+      "version": "40.20240504.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "40.20240504.3.0",
+      "version": "40.20240519.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1716310800,
+          "duration_minutes": 1440,
+          "start_epoch": 1717682400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-05-21T15:56:26Z"
+    "last-modified": "2024-06-05T16:57:46Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "40.20240504.2.0",
+      "version": "40.20240519.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "40.20240519.2.0",
+      "version": "40.20240602.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1716310800,
+          "duration_minutes": 1440,
+          "start_epoch": 1717682400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).