### PR TITLE
Roll out 40.20240519.3.0, 40.20240602.2.0, 40.20240602.1.0 today

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-06-05T16:57:46Z"
+    "last-modified": "2024-06-05T19:16:02Z"
   },
   "releases": [
     {
@@ -120,8 +120,8 @@
       "version": "40.20240602.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1717682400,
+          "duration_minutes": 2880,
+          "start_epoch": 1717615800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-06-05T16:57:45Z"
+    "last-modified": "2024-06-05T19:16:14Z"
   },
   "releases": [
     {
@@ -112,8 +112,8 @@
       "version": "40.20240519.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1717682400,
+          "duration_minutes": 2880,
+          "start_epoch": 1717615800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-06-05T16:57:46Z"
+    "last-modified": "2024-06-05T19:16:18Z"
   },
   "releases": [
     {
@@ -128,8 +128,8 @@
       "version": "40.20240602.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1717682400,
+          "duration_minutes": 2880,
+          "start_epoch": 1717615800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Let's roll out these releases today since we're already late in the week. That also allows us to set the rollout window to 48h without overlapping with the weekend.