### PR TITLE
Roll out stable 40.20240602.3.0, testing 40.20240616.2.0, next 40.20240616.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-06-05T16:57:46Z",
+        "last-modified": "2024-06-19T10:36:04Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "10155a7eadc2d48c982bee56c4e7042dcd2973990645fc28a409df5453cfcb07",
-                                "uncompressed-sha256": "bbe8bb01490454f17f3837a3344970d536ea105698d16c549e7a7813bbc8d0bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "5222c4ad12c0426ef3888f8e99dc9b89b22bb84646ec7b46110bb207bdf22a96",
+                                "uncompressed-sha256": "854be70544fc1db9ffd150226a502697db7cc02620023837c6f67a53cbbafe13"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9d16258fb775593bca8fa3e63d08ade7be7e1f4ad04aaa980029be96a3dbe797",
-                                "uncompressed-sha256": "5e5ec71d2af70954619bd190bdf080c1ddd036dd4c8c2a8e040e02cf08e85434"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2f6d7d71df441d15d1b8c29b0cb419bd0b7599e2965e70ed0de5b03419952c53",
+                                "uncompressed-sha256": "56afdcca7acd674f5accce92c3e45be1dc98c58ca2bde55bb1dd2d469d2e7dfd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "29e95a23e794e6a43907f71985b2ce8813e801d630b4d1e00afe0f1d1ed935be",
-                                "uncompressed-sha256": "25e4e314bcb7f581a3d3002778316164700a6df3b5313c9d7f2334338e4149df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "910dc58381b495236cad6adddef0db21a50f0d7489385ee7771985a3d0a31540",
+                                "uncompressed-sha256": "09306e8b48249dac4444c4b8362737145152a0b1455ba476cab26b1bc7c2bc5b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "b1b1565f2bbd504976eacc9b9af05788e83b2001311d7f37ef9faacbfa941e91",
-                                "uncompressed-sha256": "9a70f7e163394634129d746a40ad45eae46df00f51b3c40750350de714c4561c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "66bb034fcf1b9b0bbcea50cba06533d8dee454e6012cec9166d19f3954c802af",
+                                "uncompressed-sha256": "812815df1dee30c38470e32ea3a1c00492f188c2b2881d014c2ac405030fbee4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "19c4c571bf29ba82413fc4ef236bc45a885e472dbd0d9525a8e3f7621e3d075e",
-                                "uncompressed-sha256": "aec2e108bb4ebddb87bd1fe4afd8a9ab8c56d84cae3fc449196f25b21f9134fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "72e78e820151694cb236b3c46284ce31d78b79b8ec4e7118b0fcbc51630c303a",
+                                "uncompressed-sha256": "c330b3af54f01335445b3207afe7c15197a21f285f6b30d3828d56e28070ad31"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f5a7c94aee4fd6ac306685de57f299791fa52d4f2d7dc80b07135120db4618cd",
-                                "uncompressed-sha256": "1ae40294665bbe8e4ed9edd0bdc1cade86bf694e401e0b59fde9646d25fd0f84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ca1659a28c41ed197645687b5d65237af77c5a1931437e0e08dadd95ca44d56e",
+                                "uncompressed-sha256": "6a72b37d6a6f713d5bb2798745f25a50bec9428e78326f68569ab525b9885384"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live.aarch64.iso.sig",
-                                "sha256": "912a6c382237a9fcfae330e4cee75a3f5e81abcc16b42c2d0f70922cfafaaed4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live.aarch64.iso.sig",
+                                "sha256": "748542dfd40ff9b856ca3d5393ceedb21e8d3e9555eae9a4daf2627f35cdc02f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-kernel-aarch64.sig",
                                 "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "99082406cf1e8e107b36612f49b87089066c7ce9f16ae8f95e493956a07de004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a2831c73737c5ec881c50782f8f312aeeed1c7ba41ed7bcf47b7486b214dcd11"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "219f0bb0d0369191f911f8f3e88c7c06f9bd20515d5d077931cfcdab74f7de94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8c7d24187e233d682cda05d1d5ed78ada11b0b0a67ba4ea2289657ba75951a48"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a27624dd8f830228b557c8847c6f20c0403ad0bca7af813108cdfe2cd38d71d0",
-                                "uncompressed-sha256": "79974fbcc2c5359e9e32fb6c4612462a980368d1ad9c9de1209dc5a0763be067"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0034027662a1345224f2e4b81a2ddca8297f359ad13ee582fac2d1c82c434d2c",
+                                "uncompressed-sha256": "322041ae3e3f4c608a52bdbbcf0e9d127aa14cefcfa15858989352baea3c11cf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3931b5452ced16953d4b68d3b812a758ac2e75533fcb66a7d848e738b358df8d",
-                                "uncompressed-sha256": "a86501e410f426dba737eed752faa49a7a5fd20eccf44a1629fcb454987695a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e56a1695f7928233717bcd9f520c5c17048d618437f8a4921a6de3401d2b5b25",
+                                "uncompressed-sha256": "e326feeeee38282168aea0a58ee03c2b63167b4b15f33538e665aeca62803205"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/aarch64/fedora-coreos-40.20240602.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d1de1622c94a3b9a2def210a02f2ae7ce13700e1253d43a5bf65ec18d4156b27",
-                                "uncompressed-sha256": "26789f38a891ec574ecd5071b3959cf53ff3d14bbc829962b12dfec0e04119a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "04387226757412e97b5fa3cf2c71d9cfdb5fb6217096261b7f03d802664d0b0a",
+                                "uncompressed-sha256": "053a0349ff1ac92c3964e5bc5826d5e0278eb12b192bc6c5257a676f09919aed"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-07876685f3bfada3e"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-03ab94c94d603f7c0"
                         },
                         "ap-east-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0894be23aa08d0543"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0ef5de02d5aa24a6a"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-073fe6edc7607c49a"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0e38248b3aa3cdce2"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-02bb0334bc153f65b"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0b158db084a1d92d0"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0b7b44c743884c080"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-070a9023230f00970"
                         },
                         "ap-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-03462a83e6921dfbf"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-075026373984f54b7"
                         },
                         "ap-south-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-02584e82c7811cd0e"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-07cc374163b292517"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0a188c4afd95cf40a"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0cd83dfcdd8fb179b"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0ebc7850cb550d41f"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0bf57adcd68c7df21"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-017ad8307c2e1fbb2"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-05b9259e445d8cd13"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0e147410f7cc32477"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0f900c871ea1b7c9b"
                         },
                         "ca-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-09be176a5b4c65d61"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0610eec8986c48957"
                         },
                         "ca-west-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0a131bd4d0a2328be"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0da08d4ed88b13cd8"
                         },
                         "eu-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0119bccf5086efc4e"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0575d48b4dd8f695e"
                         },
                         "eu-central-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0489d4b8f4d1a4114"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0bd2f17b34ae418eb"
                         },
                         "eu-north-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0af0391c9e1ec8e6e"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-06bd03a6bdef8d9fc"
                         },
                         "eu-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-007ccab71b04b60ca"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-00ce02000a0778b2a"
                         },
                         "eu-south-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0836b9d0eed03dcfd"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0057a4bcdfd92e6ef"
                         },
                         "eu-west-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0067189e000b41353"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0c8f9c2a8211abb37"
                         },
                         "eu-west-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0511e5dbef4ff30eb"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0c5e00b0e7c5b5740"
                         },
                         "eu-west-3": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0b773d3dd16a497c9"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0a8d4e09bbdf7cb67"
                         },
                         "il-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-007710da5c83311b5"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0a0f75128ab765240"
                         },
                         "me-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0ea842ff645532b1c"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-01c8a824abac4b9af"
                         },
                         "me-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-00032d10cf43e35db"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0958d2ab3249134fe"
                         },
                         "sa-east-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-026ad5150bf86b325"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-08c393b5984ce920e"
                         },
                         "us-east-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0320bec5bf217bfac"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0c1daeff258afb0aa"
                         },
                         "us-east-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0bf5eb966e230d358"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-084ed8e90360d1288"
                         },
                         "us-west-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0b5d05552ca6a750f"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0651f6be2cf11134b"
                         },
                         "us-west-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-08883867f1bda3503"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-022b718f36e5d1b11"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240602-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240616-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "dbacf6a9f7b5d78b59376d1bf30f6882fef11e7273bd14641ac9679bd03fff21",
-                                "uncompressed-sha256": "9ab03dbaa5d7f4388925d8a5708c56791de63017d6a055414100deb5434bfefa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3fbe023f2430dc2aed2d9eaf789b14d388102eb4bca6ed4782be9c99566177b3",
+                                "uncompressed-sha256": "bc7acb6610bfe5186b9356a8e852d175c3256b7063238166767fb17b2bf0ddee"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live.ppc64le.iso.sig",
-                                "sha256": "702f1e076f31b2e00875db5741b27cbf86d9637e0eedc28863f33e5040cb9e9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live.ppc64le.iso.sig",
+                                "sha256": "5e8f312eba012d2f049acf54fea5beb7d91b0c83c3cb97607fefb50db2e9f71f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-kernel-ppc64le.sig",
                                 "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "9d4ed3238e55ab76c608c471f194459e6a93ef079450da01040ec60e584ba17f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "97c235f8a0e8b6ae113193c6bc5daf7d62bbc399573a4b05f96ff50af5b7d8cd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e2c6b738cc662c83d4ac73e20ab3fa7f870985b306c6f670c84b1542b9f677b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "726ff1f540c0393c732677becfb65e6bc9c7515695fcd1793a112b691011b06b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e0aa35db6440e59593ec07e8f765a0cf762f78469f169b5ef6d39e637e048d91",
-                                "uncompressed-sha256": "eccc5d38bd5a156728e8e14e4280584d4a0d339d0540223bb4f671b223363cd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a5e5c305b1b43d50ebd4252d297a883fed2a5433328935f204c7a0c3bd146e4e",
+                                "uncompressed-sha256": "f68ea85a38d2c65ca97e79a9815c6a7186b459572ba134ea16adb5b146ce0996"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9f1eb33784a4f9f8aa3820a3c942f7d969643ac2a0500c7303005035c45991fa",
-                                "uncompressed-sha256": "fcec1572b250e14ca33e6a671a17768219099b74372263c759771572c944fe35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a637b89a39b4ac541b1491b862f1dd0f9ef6a0034bc34018e18b8e83bf872950",
+                                "uncompressed-sha256": "a62f782b5970ace95cfe7ea0f2319ae4524c2a7a7c4b97131c02c39cbe702996"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f4c6c433ea0ee4db992c9194ffca6d1791fd876fb3fb57426459c92635796079",
-                                "uncompressed-sha256": "5ef9a4fac294939717dbfcd38034305c6a17081ede8678cd9d45539eb40d9a61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5ed27e15b5e3b503527a76600ca90b562a73612bd51eac79dfb57defb710efb2",
+                                "uncompressed-sha256": "f099aaa8e422a166894b41a952edb049524c8519fcd3a536bf665f4abbd88af4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/ppc64le/fedora-coreos-40.20240602.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5fe533ffc351f803db9e80aab4dc51746b98d1abb4fb7146d968240039cf2eab",
-                                "uncompressed-sha256": "8f28ea5f113657faca6940bdb049cec917f9bec4ffca01a04711ac3f3eede0b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "458f47b74de301d0c2621d7d425e7f243fcbb6cddb56e6f455bdd2b6599ca676",
+                                "uncompressed-sha256": "8401708f34513ee1671946d51da7cf2ec9675241ed57debece68d0769eee2e2c"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3b09ac9f052322dbd4b676d8098f5c30b00e2a1829ccc62a7deb14e7180cfb25",
-                                "uncompressed-sha256": "dacd377cc1d2d08feb76f3cabd1d86d8c8c4690d7e5124f09d182702f76fabe2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7ae5529991c83401eb9cda15ca2f866d2dd0bac77f034c4183cec9ae106769a4",
+                                "uncompressed-sha256": "d35b65f543327129c31713f2850b3a6fade9253441444df555ca2cd4f98062b7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1b219bc42cc5d7e8a8bcaa7e160ab74c96f2ad321339ae525f6f7e240e769414",
-                                "uncompressed-sha256": "6d31e57c563461a9ecb98c68c3ba5063aeb3210b3291352e8ead058a2f66304d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "887ac4857dd1ffe095bb3f6430c43b250068fb7d20f2f3454d946d67dc8bc6c7",
+                                "uncompressed-sha256": "30742ed6ed411d45809b1978908a811dd6d3a7a10ca5c141720be5dbf209439a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live.s390x.iso.sig",
-                                "sha256": "243f3c90dde813959998b331ec18df355930e4751496d34322e9ef00fac98c94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live.s390x.iso.sig",
+                                "sha256": "ce59334a2b6244b7147107fa8e2654d150dd125ac7040d7d489f2cac8a99403d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-kernel-s390x.sig",
                                 "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4be2386b37a78e479b5e929186f94a29fc491d7147b9fbdf75ee6b7d3dcc7841"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "962495cb8cf39ded19f24bdc742d84d2cad7524b62a3c8b77c53e535b4f194f6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9e2e433e23e74c4225ecd9faac152f6cbd5dab65c85e06db3132194a0a7a310f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f44c017031625716dbea8b37c9b182ad3b40cb974f1c970db63738d2727b016e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6fe9846f37c713b4289d863e71d14bea37a840060a8afb29373c328e6ada0110",
-                                "uncompressed-sha256": "21b027775bf7b9d1f168619fd6bf068f07dc3d9b10ce4ad7a07da36cce806190"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "0a3aa654ac42224bbe77a7c9144cf430d60b11b7997b67988d8011b9057cfb79",
+                                "uncompressed-sha256": "752fee457d0346b780fadcfb3ac25855100cadb18a8bef5cec165d0681c25633"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "eeeb6272b624c2ae153f422282f0128aa6fd22184fa7d375032886e200088639",
-                                "uncompressed-sha256": "b5690443daea51929e55446afade98d2215f99816f5ed7788e744e4b34e0ff9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2d8f2c96175db1f25ae9d46cbb3116e3bf77805e632b96a405c99080af14a643",
+                                "uncompressed-sha256": "082c5daa93b620d56cbfd05645a1e62ce26712d6eb21a8b4f4b56c578a8ec765"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/s390x/fedora-coreos-40.20240602.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "1e839e56fab71e5fc86cd1fb10959472a94bb708920b5e9db3b0cedcd4f0c35d",
-                                "uncompressed-sha256": "e704729b424fbe11dd4762db537549c3b24ca87c2b43ae3ecc863d83d4216319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c9858a4d2eba4fe86293166bd5403a972b3ca8672e6813a5e320f376e0bfb233",
+                                "uncompressed-sha256": "7ca5146912783965d36ce6c5df58fcb4b78e37f102206c21d25a9df10a335efc"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fba72d4157f19e8bd50e6701239890e0ed649dc0fe0dd8d05dfeec701eb53541",
-                                "uncompressed-sha256": "e73ac89d8a6092c51b664b03c3fbee8a26f2e18112197a1aca86d4fc5b09b85e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b1b5da3b27bfcd822f3dc093cf93d64924cbac2c51b9ed453afeb42d6fbf0a1c",
+                                "uncompressed-sha256": "a761db6c801d7de85ed23c6c30adb745a3f20dee187b21e677ccb08a8f45b355"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1a6ede94c8834e6c705cc6d89e475181779fa94ef5cb78156df8600a8d0d5547",
-                                "uncompressed-sha256": "b3eb0def6f0e7ea059c50e9ef8ec5870e3b5db4904913cf69546cc2b7071c3f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "c443d1d588b1c5ba1f3eaf84f1e5008cd805d73844cdf9298aed6e156b308939",
+                                "uncompressed-sha256": "96b44d9ac658295c20dea9c69fa2fecbb85abbc9281c2bb4a6858f32c6d7a833"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "02fd1d385a34bb7eb7effae0cab0d9966b3595dab112378cd547c98f98f982bd",
-                                "uncompressed-sha256": "94d688805e1c44fdc09d50ae5417f9158383254987e6bf824bc97cdbf32bd146"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "522b9da6aefed8f833d584d9c35f7f23787fb9897f90fa0c7625608f596cb2d0",
+                                "uncompressed-sha256": "3b25baa444bd266b6a9d5e6579b6e18a1458ec6bb9b827c2d1bb3c072c4108c7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f785c8dc2a156fc6da491ad24ccacc75bd89616f9064c8c6fbc3bf5f189d04a3",
-                                "uncompressed-sha256": "9813d04b6d2dee4f3659401cfe9b1319337fb749a68605cfc4608eaf69448da4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "bc3f1a78ec27729893c626a4e46872b00af11c4d77b20c3a6485b620d5c29d1b",
+                                "uncompressed-sha256": "c62b9f9e5896455e30e871de087391f4551a3fbda392f6a2f7d19633da33fd8e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d71fc86583afd85858d7c8894795f722b8f374f6524b3eb197069fc159a23baf",
-                                "uncompressed-sha256": "465046448346bc8dddcbc2122cbefa0cf684c08bd43842426b6afb113ed29b8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ea5ff54d344ad506e40f4df9446238ce4c2f8f4b58643e31dc3cdd8d20c62a68",
+                                "uncompressed-sha256": "73ba27026cbb15adf28b158e7e8f4584f54aefd080b31ee178937fcb730c2760"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "dc3277602a800bfeb65858fb9de28ce7338beec0db91c9ed2bb67c71cc003eff",
-                                "uncompressed-sha256": "a6bc9a61ff32df87b4e2c8aba228815d7728affaa8bd1465c059033325c3dfd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "cb17669a16f2833e8f2978ee52d9acf0bc693420fe0b76cbf9872ccdc7ac5739",
+                                "uncompressed-sha256": "db38a5cf3777d1d4f99ae23d6bad8460f87b72fadde82e2438bd6c39eb037f07"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "db86929ae1b1f66a9acd56dcc903249c87b47ce4d1a945e00a851890d1bf1636",
-                                "uncompressed-sha256": "8b449785ea668c50646cf898285715f7f63ad7b14e47d636a30cecbec13d11f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7e9cf3904e58a2b859e4ef2ff11100e5a907435bab834529873aa655e045ac24",
+                                "uncompressed-sha256": "557bbf5496b4b0d8c56d301aa5e6d1ada1b495e649640257b7425246e907329d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "481a3cb9079bad5124ebca4170eb2cd1a7ad4b3304dffbc20bfdfe7bbdc22dfd",
-                                "uncompressed-sha256": "cc5fddffdf06980adf6c38fb7628a9018f8c30de1e970b3b4d3403e938f30518"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "944456f7d47d3af9a809f2f91780371f5f2b1bad9ac14adf5cd38e5d41bd5601",
+                                "uncompressed-sha256": "679b377dea31b57b1eab890352d0f2bec34a7feb94a43f496293e908dc0327e5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "fad3a3fa95d9d7710be8f2cb28c4af580fbc62275973004c993c574f550e527d",
-                                "uncompressed-sha256": "66c644de1473daa16541cb0701858acd143c832101d6d7152373a8a271a68d08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "924c55d895caafd20a142535355a6b216bfd9a1259e3c5315b1e4d87e01392bd",
+                                "uncompressed-sha256": "24621c7ba3b583b68271cc6f1fb0a2b95416cabea6d76e1ac8d1509de6c86f0e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "be628e36db38b1d244979b720f41a478375b76020b27b1b3375545450df1c61c",
-                                "uncompressed-sha256": "5a8aa7702fd2ca8f87ee40402020948ae49a13c3ca08cb4375d8e85d5acb0ef2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cab62de8e6125862ea913dc43f092d385a20130b096e4a9edd5a5ac7f1e0885a",
+                                "uncompressed-sha256": "3bdc1c8ef32dfa9b14d813880f8b0763e9aa91cd0d2d9abb032ec6e0876631df"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a4b3d87e0481396c546b963a95dee2d166e4bee64495ffd834e6344c8fde971c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2562a4e684aedf2c453e5ebad568695d5b3aba03f631ac0e5017dc42f02f1f5d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c36e98855d90dc980b2956f9b9ac43302d8a1e9fc32d621385d1a4a87e852dd4",
-                                "uncompressed-sha256": "b25cbfaf4610f9623562e0e2509c6ad6b913922d17625a4522585475987c3ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b8926ebeac8d9eb949128fc2e0fc48049decff5291c547df68ddb6b6447ff8d4",
+                                "uncompressed-sha256": "1ced8b58e19d382dc0a474181aeeb1a3abec0cb845b71ce2424b8e317bdad877"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live.x86_64.iso.sig",
-                                "sha256": "3d91d1967bd0736a8732eea84d1c9d5f8b621d70ef5a0cb72f6f8cefd3ac5bea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live.x86_64.iso.sig",
+                                "sha256": "d85efbf72633caef5d14a62e4c295e390d64b7a1077ca940dc4089ce76c15424"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-kernel-x86_64.sig",
                                 "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "61090e22d769b49a215ac55343039c7eecbcb6527ba26a0278ae14ccdde9b9ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "fdeeeef2fb6b86458108f5a040e3f20beaa28ddce4b18e06394abb994de62d70"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ae9a24e7ce842b31410abea6a8a3a9868f2917117f932dd1ca04dd4ff726c1c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ebec24bc6a353a4d263eeca928eefdc8a3cf3ba2f210ec1c455eba8a064797df"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "568f4d9a80c0342ca34c605e91f746c2efbc17efcb6731ec83b12bba399763a9",
-                                "uncompressed-sha256": "c5d25466bad207e44f0c7dc7ebdff7af117d72b38c33ec54b2ddf408b6d36133"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5eff62f9a56e3d5208677e3cd2658d9b7934ca6284ad4659430a8b28d38a9a25",
+                                "uncompressed-sha256": "ccd32f1a9b62d9889cb7468efa8f4771967c3654df5ed55d927b939258f08cd4"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c3b751d97668fbd63415b535f1e825b2d8f4ff25a2ae86ffd2c136750ea7e070"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6e13a0d3b3a546c00f824cff085e1735c05690423467326d1f51fbb7c5f45263"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "be15992a25872b24f8fc8da01bba06321ddc23c86a8d657c633456a9e4cbfc40",
-                                "uncompressed-sha256": "be6fc0697e74814058cc028564a54cc24082a49c18cb1a632cb64c4e1608b752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ef1c481a3641d466dcd0993b29cb92bee3e40ff5e551c930c33b8f13f10b5815",
+                                "uncompressed-sha256": "ccb3751d9d6df6071effed44d1a9e4010ee882e8b7dd9baf2836339d57c68cde"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "20d77d2ad732ddb20492278f1d6fd8471fa293de5492b6ed3fbec48c3a5d0e92",
-                                "uncompressed-sha256": "adf8d4f793e99005b70ac20e5d107207d75e61268873bc15b84de4c4a2b5e8c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "89c035849dbb983cbecb64560f6a5fc13ab2bacaf3f7c8d5357bcfacc127366e",
+                                "uncompressed-sha256": "2dda45c9f41af6c047587fca26e694c12a90ff34c01ff08a83d6587a84d21e28"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b52ee4f657b4d7a682f0a41a792f067147294da7112a1e9110e35a2f60320672"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a7077b762cb27b8a05a8b312e64aabe588faf5c2d6da863e6af93c355a4b4e70"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "f1aeeee13401b6b3af9196edb5010a28189cad3247a0940b315be63876046488"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "8d265edfd7bc5b4420834497567878e98dce07e6e5d32b8e4a1afe4d591a0987"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240602.1.0/x86_64/fedora-coreos-40.20240602.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8aacbf72f64402fd23bd1814c404f2a89b9d9936900a0f207ecb3a8a6314b7f2",
-                                "uncompressed-sha256": "fa9aa42bada784ce87f3fad3307c65d10cfe5f43575b87f1b99c2da2b28f72cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4822440f212f26723b3908905e92a523ed1cbd957150470200e758479a51cdbf",
+                                "uncompressed-sha256": "93f4d288d47d7d9ff231fea1792f70a06dc6123a6f0f170425dbc16bfb6fd26e"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-03142b6ffa4234259"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-03491c5c5c9701579"
                         },
                         "ap-east-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-04112095512b03b4b"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0678225d5752fdd8e"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0bef46f7e3594e3ca"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-08ac2bef25070c63a"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-089d0137f300bb05d"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0c86424bf191f2840"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-033c1d5e09cd75d60"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-06cecd0d06c49b8d6"
                         },
                         "ap-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-01575a8d9040af34f"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0826001d97cbfb621"
                         },
                         "ap-south-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0b8c4acb284329c22"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0d28d0e63ed3f3af2"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-00c081210b755bbf1"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0ec07d2f8c9919f37"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0ff14519c4686b26d"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-09ad0b5308803e41b"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0ea46d81e61082684"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0c3a9018dae63bbbb"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0d47667894c8e6347"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-012a5378fbc452b14"
                         },
                         "ca-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0e7d1aa39cb3cb67f"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0a46e00ad9a305795"
                         },
                         "ca-west-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0a0107348254e696f"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-08bd5f36fbf2f32a3"
                         },
                         "eu-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-031eaf34e6cf71eb2"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-01e16d1bde880b4eb"
                         },
                         "eu-central-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0507c4de615c944ab"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-088ab60882e79edf0"
                         },
                         "eu-north-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0a6c2e995b3ca742d"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-045b2dc7691a876e9"
                         },
                         "eu-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0116b671343b4af96"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-020b9e0fbb24285d4"
                         },
                         "eu-south-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-072a3935a914dc1e0"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0e7fda9939f4ec34c"
                         },
                         "eu-west-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-07c4dbe9d9899092f"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0e13799abd5b8f20c"
                         },
                         "eu-west-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-084f6e2134a754f9b"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0d8728907703cefef"
                         },
                         "eu-west-3": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-098640a6c7054a48a"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0bf29ed25b6092773"
                         },
                         "il-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-04736df0375f04cd1"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-072d7c743e45d9c8e"
                         },
                         "me-central-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0bb1d0eda7d1d7413"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0709f5932cf866ce1"
                         },
                         "me-south-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0428bb23ce9bfae47"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-02d9483f96b791eaf"
                         },
                         "sa-east-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-06b540a1f72a714e2"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-05ed42064e8d9113e"
                         },
                         "us-east-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0a276a016c6fff9e5"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-0e44fe2b9401329a3"
                         },
                         "us-east-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0945c3ff4d6c3a3ea"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-07bee8f16ad014098"
                         },
                         "us-west-1": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-0271a2fe2b8f31710"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-00de1c9fc1a150635"
                         },
                         "us-west-2": {
-                            "release": "40.20240602.1.0",
-                            "image": "ami-018c1d84695a743c6"
+                            "release": "40.20240616.1.0",
+                            "image": "ami-02cb27b16001b8be5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240602-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240616-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240602.1.0",
+                    "release": "40.20240616.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:983332e332782ad6a3efc8803f02776bc7c31307f3a86e763530f09c72a17cf7"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a9d1c102f75fd20ad5e9734f894d3a3101d71dd70068627e6d0104419c5191d8"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-06-05T16:57:44Z",
+        "last-modified": "2024-06-19T10:36:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "c5b961422354b68674ff72044cbfc316068f1872878e419c54177600514e0d5e",
-                                "uncompressed-sha256": "cbc50f45fc223327e6a0af8980dfebbae46cd6e82c1c9a1f0b78ec7878db0be7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "bf6eff8e7c1ebd7eedfd2e190336c9052b3963aa72f23fd0a587bc7451bfc7c3",
+                                "uncompressed-sha256": "b3b6e7def5d89a3767a807d1ae0232a6575d9e3300564c30b569793fb50d369a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d6a402a37845c0f069a0a7a49ed803893461d48ca8dca8c95090cff1b8809142",
-                                "uncompressed-sha256": "f145a09e4120dbe15f59c3378952c7fc1d332c8bd0415f6db72e92511f15f3b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c57053847a23338a7d3444bf90de56e47d3aa62f8668f4179c041a5f6cb92f4b",
+                                "uncompressed-sha256": "8b380d114d8486a766f41311521ec05459bc5b1865faa35f4d067d0c1bfdcaf8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "54dfefe68573483866e56427987d4d8f3f723d805cf156ee19a82be80ae80c33",
-                                "uncompressed-sha256": "82dc6b7b43177431b5f0c561e3c2485c73c89aff38a6795411d5b07dbcff2c35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ab94e84abeb3db934f89ef675f400e03b2b18d651432de403cfd1de00ef59437",
+                                "uncompressed-sha256": "50e4ce1646e7b512a4e047061ab8305f64e1ccfa5919e76e6eb162db36339bc9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0d98471550181b9478de1034c9d676837c640dfcf27d611552995816d6c39c0d",
-                                "uncompressed-sha256": "863c5fceff7c25df21ca4e7eb2c4dcdb13acb4b9402c46178496922c7ed8712b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "46aeb92eea6c79cc18cb6f81d422357e00b85718bfb71cab598b0da2f0130ab7",
+                                "uncompressed-sha256": "62819bccf2e42d847caaab7eea72979f1d45d9dae3da6d64f4b7a0481720dc4f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "14588cf9622d5fd211cf3299f6a54b15277a769880482dabf8c124659c7e99ca",
-                                "uncompressed-sha256": "e199433390fcf4d38a85aee0091acf6729ebd4efb0f9d899d2874efc1d58da13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "9cd28cab42752ead47a55f74f1810d626d0016025d4d125caa7d02f383a6b041",
+                                "uncompressed-sha256": "f3de290f588bfbdeae4423480179ad331a3adbbb771b93bcdc25b8f2d362169d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "9eb0c027cc428d2cc261145b154d719a6d263fa2356d08490df6eae6afeccb70",
-                                "uncompressed-sha256": "118d77ba816a7d65f58d382c8ff437e511de50acb2a177fca3a2ab89c089da5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5ea6d369f7c38483904b21ff78f25a4c4bdfefabab9976c74d9b674bcd4b78ae",
+                                "uncompressed-sha256": "347746491d172bd6a5d91696f8cfa6fa3d047f15f6b56f2c42151df2a7e42907"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live.aarch64.iso.sig",
-                                "sha256": "01fe55848aff2b07793b7bb667b8bda4f9ae56bce3496eafaea7a7f9e0c3492d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live.aarch64.iso.sig",
+                                "sha256": "c8138eae22aa63c78bac2f19a84a8232bd6e5238b0e48a8ea12e8a716f7c7e16"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-kernel-aarch64.sig",
-                                "sha256": "75e477f7287e803e6861bfd9dd0e06572acbcb0b0e6b3bbe907544541a8a423e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-kernel-aarch64.sig",
+                                "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "aeecd66c0df1390bf63441e0539fac4b0ad3ffaf83718255e261c109192b5011"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d0993edd5bf99db66a9b3957c3697b06ad9625dc9b6cba7f90c7101b497cffc8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "72940ea3b2c345e2dac6df67c9fed22e72384ef026ad389edb583295fdf641bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "11362e63be0833e43385aeecfa7c96884e3819bc2878760b8fcb193dd70311e8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5c13041b345d273ab6fa0aefb6b3f95a7c56ed1c5f2a4edfbadc6eced9c1a3bd",
-                                "uncompressed-sha256": "399fc5f58e3bdbe9de634f00ef92ff1073412c5d7634ff763bb30d9be99e5017"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "22ac0fb34329b847012574d937ac6ad5b9c924e8087f6f233105ddbd62895d1d",
+                                "uncompressed-sha256": "5414a7309d5499e45fc5b1dc008f4647905298b99ca2a617281c73cb85f04d7d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1432053856b47ba3dacb620fbd4a98171cdf63b30043477bf05529a156ae621d",
-                                "uncompressed-sha256": "e3eb88e908c3550dcc3322443bacc65413d4d4defbd4c462b2e012e6b268be84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c1138b68068623826d82a3c25247d98ba6ecc5991507ca71ab06d0c32d0981df",
+                                "uncompressed-sha256": "a91d9d596a0e9a4d25dde58cf129abf3e397323657a7c772df77ea05d6ed1a33"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/aarch64/fedora-coreos-40.20240519.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8f5fe6dd51cfb0de822f8002f180fd72de79d6493fcaf77539b876468d7b29a0",
-                                "uncompressed-sha256": "e5776c0c2078c4bba8519c0134658d32e821b180c5e91716aac1f4170ba7402d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "731ce956df56c63f19ea32d27d84097fc2fb94ec70243a3e484a7b7b14558f0f",
+                                "uncompressed-sha256": "eb96cc6a7482ebc5b14f4bd502458b19b90bc07047db31433455f21ec12fde2c"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0444ccc82d0deb239"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-001349af5d515c4dc"
                         },
                         "ap-east-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-04fdb0e52a5ad9c5f"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-03602adabc80d54a6"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0472c5314810bef42"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0f706dc7b09359b79"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-08ee325b70e631335"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0bc6e44ade6d70e5b"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-05062ea7d5471ef5a"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-077b8972661cb0d30"
                         },
                         "ap-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0e17f215170948a46"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0ec5fc04ec088f47c"
                         },
                         "ap-south-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0aeeb0bd67311ff29"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-047f230c1d66115b6"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-08cf6d5fc991aba11"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0571870f062284b02"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-05b3c29af72768a91"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0576d26d19aa7c2ba"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-05d517a61e6b3d06d"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-04da8979b3485b1a5"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-06d99cb51064eac4d"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-06d2bcdf0721c4a56"
                         },
                         "ca-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0d7d78077133de2c2"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0389b1bddd93d400a"
                         },
                         "ca-west-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-08e444e849f943c80"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-06766cc21a4279f1d"
                         },
                         "eu-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0ed7dcb734ee07b1a"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0ab900403a00f51f6"
                         },
                         "eu-central-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-03ec898404c1afc49"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0f8efe965e6df6ae5"
                         },
                         "eu-north-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0938c8e0418145cae"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0d1bfdf63dcfe88e1"
                         },
                         "eu-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-088a8bf8dc2d169ca"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-01b75fa9d52aa0b3d"
                         },
                         "eu-south-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-075b79497af7c82be"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0de8c59f6e8512852"
                         },
                         "eu-west-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-056edb78f024f45bd"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0966246dc91a7eb11"
                         },
                         "eu-west-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0c40470816cee5b29"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0de8319a7633a80fa"
                         },
                         "eu-west-3": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-09b6b8d4ef0bf0ec9"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0580c78cc9b9c941a"
                         },
                         "il-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-069ad9d8dd22c2969"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-07811b3520b8ac398"
                         },
                         "me-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0206e0d31274ae0c2"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0129743024242b7ad"
                         },
                         "me-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0669fbbfbe66e3b55"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0be91df94fe9b302d"
                         },
                         "sa-east-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0bb35c34540a9ee7b"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0b0c554dc778f94cf"
                         },
                         "us-east-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0f7a88949f3448106"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-06154c92da4ae5a6d"
                         },
                         "us-east-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0fbe2a0b016c7a52d"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0bab8ab67758d5edf"
                         },
                         "us-west-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0ceee09a7d2c6a0e8"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-02600ddfe13cefbda"
                         },
                         "us-west-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-039e8dd821c97a5cd"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0d0d4f127d463fbeb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240519-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240602-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "af2ec45f58219bd91c05da16ab467f17ddeb4e0bb569df2e9a757c65d3ef798a",
-                                "uncompressed-sha256": "d6fccb070e2e2d4b4b6bb522612f53b04e18997b3b1b52fae5a1c269308047da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6642248525bcdd9b89b9f9383199d516d8d3155c7dab49f92cc197a2588f2ffc",
+                                "uncompressed-sha256": "fd93e8e0f7772a2bbf6a0b40b8cce1abd1c37d4bdc6e5f8fc0895eda38ccd5e0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live.ppc64le.iso.sig",
-                                "sha256": "8a6ac1b913a4b68ab26ef809eb8e6d558155a08ab4477e02383ed11bcfd7fb48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live.ppc64le.iso.sig",
+                                "sha256": "d4acde9999f744291511496b6074b047d5695561486b939faffa4fcdd8b5ab26"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "8f53478b329bb4bae46f71f16fad3a2c8349f79d49ab52dbd020543dd01c0d03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "6b3e1ca7b964254b69b61ab6218049dde09a3fd1c7fd39c8a0c6ac3f94904a6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7819e5b6884cb28b021d7b0a2de048e1993f36cd8c31b48a245889c520a965cc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "4cbb910e006d8c318eb63cd9e6f437c864f40ba8cac375e1e9cc45aad029df21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1389db06dc92b9e0c38455d1c6339a3e097b4ec80b0acf62b88c2aa42c5da3e1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "33913a54bf6a5d6e37d4c60ecf675dedcf5af5a2b576608bbe3e23a3bb3b2288",
-                                "uncompressed-sha256": "00638c796cabc48122a724fdd42ff15a2861970cfbbca7f8b5f7952aa40989d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "8804c0eb3f922f2bc7e44d26657dd30d43a2d6448cf4997effe05e584bb746ae",
+                                "uncompressed-sha256": "5381693520873e3fbe8e5df1b1d6a74f8cba4455fa6ee6d579ecbd1ee90e5753"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f608b3a5a856070eb9686c936a207e960a2bdfbc06a4836deaa0297f26196f13",
-                                "uncompressed-sha256": "0d1c073cf5cfc659f6f6c785a4abaa222b55c9e8171d8ac691b0a9686bf08541"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "b725a11ac17284b45efd536d39658ecb51955db6e9f0438d056c1c577a47b844",
+                                "uncompressed-sha256": "8a4f1792fa17fe34a7f010c35d3b641021d9f6ec513d299f740a78937ff01687"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2a42cef34296620eaa903fe14fae50ad1b6556e6062a321ddb6bacb0f21be5eb",
-                                "uncompressed-sha256": "a596de91a0ffd2c90678a8af6bed027d8e610fba02bd2faaa826e9773696ac7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "91b3c437830ed1ad5f61c8ae6aa93cb053ab857481f6120ba45c2af6f25bcff5",
+                                "uncompressed-sha256": "00bf7a1f6ee5d07f0bcd061d9ee9044dfb58cfda4634b6f0235de54831f1852d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/ppc64le/fedora-coreos-40.20240519.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "cc6ad2cfbc1105e0473108ea0e038a83e4771ffae91f818cbba730bc5bd7371b",
-                                "uncompressed-sha256": "21a8c5cabc051e9c4ddeb6fdc2fccb79a4d8646425ca41830f353e0c0b235e70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bb8821e0780685ce43232390860f71e86dc3c97a1c73ad1b1149c9ba92a17d4d",
+                                "uncompressed-sha256": "e37487c55b059c65cb877f355c6085d7136a2e2ef9c58b353eec8bad278f8581"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "5252b7230970f75beae1d17de97f89e64acf032859beea9e6a6310c3e30c0569",
-                                "uncompressed-sha256": "a3e79c19788339779a3cb90a5828559ced1c564ab68959ad949de6e8af0a2e83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a800cce24c49caad30c83e20455144a8fd2d2262a6233d2e14c5717712ea1e60",
+                                "uncompressed-sha256": "29be61b690f6bc9457f1c664c33858d5bd8db1cb110960f66d01e46d4ab6fad2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "6d6f7a1a0f5a4aafa7d14635ad32cb76253d18d7219c3565ff83e7410b8b2197",
-                                "uncompressed-sha256": "eff4b88ac97b2bf634595f1c4a17ab782b0c6465636e8fcbb32f5551d6cd6bd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ea6f5577e706241e4916a04261dac60dc3b866aaf3849abf23232fb38509ac85",
+                                "uncompressed-sha256": "4fcdadd2a2a2a2f70989d723119c9aa7f2183b6971948369a35222333445dcae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live.s390x.iso.sig",
-                                "sha256": "5e835f80b54ba382fbb025b60d4967c06f5134578845a70cb32c9ccb90d3d3d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live.s390x.iso.sig",
+                                "sha256": "1f727c3640bd469f23c1c14ff5c9ac7d8bbc58f1bbd893cbac4b5dbc9de56f3b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-kernel-s390x.sig",
-                                "sha256": "a90fe25c7cae5dc9b34f089c747c344e3b65a111365d80459cf38a3c3b71c45a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-kernel-s390x.sig",
+                                "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b39ee89ff0ac367c20d49fff44522679cb8f7eaf762c25cb6f2aac1c7fee64f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c49147dfa2d110919802a8071286e1c16487df35f3f89730e08f13eb47ab9ee2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "7745fc01f7d0e8a7bd56924f8708e965ecdeb7fbee537a75f9f5285aa0080616"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "44531bf9af11bacfcdc9053b69e79f51f15827b9ad0c94108da3c54c918da097"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a3388fca33cb7b69d2405b5342617880fbec93f585b2fe7fc5ed78fd684b9529",
-                                "uncompressed-sha256": "433324caab357fa78c992a962c5f9eb099b8e38190aacc79d4316075c38597c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a65d0d3a03f992a6b831a212543ca03e8bb66900c8316ea1393a405da766c504",
+                                "uncompressed-sha256": "1500062e97d84153713c1238fab112336c257ac44ad049ce938fdf60865760d9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0da768d4482958bfadb1586a45cb479ca4f809e4362d9ecd8c935e1302b2cf09",
-                                "uncompressed-sha256": "a5ab7a24a6b23cfa006a08562b274ccc5cf5090c60ae2395454fe78de61387f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3e2d2dcce06aa9e3387edf6aa2d51efa9c874f51488322e603241af4be4dfb25",
+                                "uncompressed-sha256": "8c5b33a96d867622280a2340d9708cd24d9a77fdbefb202df782d215e78a695b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/s390x/fedora-coreos-40.20240519.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b6ba8be2374220e61eb978bfc49106776f0421a6d6adb69f4ff6da1213ec4449",
-                                "uncompressed-sha256": "65631d2e2181043ba9ac902a6c8daa7daabdb9c1333f924885cc12e1fdaf057c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "fa5c429bfee51e4c7f0659e1aad05f1182f5d4f4987b9d63072b31d7b7bb3b01",
+                                "uncompressed-sha256": "39505d7bae9be0025423c7b4972b470513d573fe914445da12a64a1f964ccdde"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "90cb29c622a4b9e585aab661f442cc70177b440a5995cf7c19bd042d86704039",
-                                "uncompressed-sha256": "e659b4b1208320ef8a8e33de8a782a15b82f8dd3a01e4c2117f15801671caf57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7e889c8471b4bcb210a8e82d6d35b7cb38200d9d6ea18d147d10f3473bd6c059",
+                                "uncompressed-sha256": "ac895115659d84ca30f3fbe835a46df763984bde5c2c198daa65b0f95e18c7eb"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "750d3800e6bc1c6787d52cf54cb4aca29e4c07990b74398611e0e9b15e38db82",
-                                "uncompressed-sha256": "bff39c263dd022a60d732c63d0591aed4842e19e12cd5300f0e86d78db57b2f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "915738a31a15a1606926508cfdf5b5674c112025820a7e6948f4cc8ccfbb4278",
+                                "uncompressed-sha256": "6295d35bb10e6f61dda6d55a92b2bd1d0ec3a4b4224494b58f0995578263993f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "76c4bda83bb53aef18d05c9ce2bc16625cb839fd02e07d80d88341874b819863",
-                                "uncompressed-sha256": "3aec63fbdabc0b0f4eb49be9b00cb83a4bb33b68830aafc89fe3b3d5ffeffd44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "89223ec64b697f1a9ede3a79d6da28b1f216c8c1a4723a05437c22f33da51b9a",
+                                "uncompressed-sha256": "ee198b22bfc35d5adfa2b9a54712f67bd6f7a79abc6caaa03fe2b4a7bafc2007"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ab986d5153ecea0f40c5eda4a8856de99f27d40a5fe66e10d8d8962c514a032f",
-                                "uncompressed-sha256": "e59f1bae0f5592c56497c3e6d00a18ec968940a2a22b7d534adce7b9ae59d4ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8da55375c8bfb73f78edcf4bb4caacd9fd3b2ff2cc1e811cb714e23a61a26a7e",
+                                "uncompressed-sha256": "e4f09169c4d5b39aeaf92dd69ddb2c661eca6f8962226224d8cd2c45a5bc6476"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6e1fb3a34050198554f9eb224c3baf8305aee79b31aad550b5dfbfa06fa1431d",
-                                "uncompressed-sha256": "9912c58f15afa92133b2a3fd137458f1c0caac9694b33fffa8dd32bd217acaab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "4e0b35feb0d7ebd3ecf59cf6ca2dcbb2cff7df13bd61701fc59922657b347e08",
+                                "uncompressed-sha256": "4bee588b6b41b2ebc31f59df0b5a00a1c9cdf6671d45f18106ddeb54011b7c01"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "75fc078ef006b6b2dc45d634d5751af79b46ac8e724196f7fa159fd356f349ab",
-                                "uncompressed-sha256": "7f2231d9b59a8442fccda65c1cdd3c3a9872e3f42c9aaf5fbd3c1f58ce35dc4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1bb0d96cabf12130e0abb50251cd5d7b8dacc77a4dcd7b5c2f1209684e51cd07",
+                                "uncompressed-sha256": "76d4c42f31dfac8482498e9ac8e1619a887a21d90a6a15f3450b666ec5773acb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6e82550a5b77c946f5fa35213882342d6efce59e013a22492858576c980b6971",
-                                "uncompressed-sha256": "1f0bea478148a9184a10124330224b7a82342cb1fb5085cb2960f42cd2f0d5bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7d3d35d5550fbed98784d4edfed7e2c9b38f05cefa41789de76fb607ebc7cd5e",
+                                "uncompressed-sha256": "cfa813571efee1b2c51589373043b2432a42bc2a18e4af970806d31e8a154607"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "10c358cb2f6b8105dcdae623d5b03445b3916850c5452a0db7cb4367d09d2687",
-                                "uncompressed-sha256": "b155eaff2f797bbcf6e40d9f8fc38f8da8e53969c5b1fa6155af85d4df23e67d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "acb4b98c5282adbcee799656346273fbeabd6d60189be6d6bd41a56dea733c6e",
+                                "uncompressed-sha256": "2731d4c7cb85f63e30d24e43ad0660c85847d075ecd3dfb61758a35e9e5ccb0c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9bf1e83c71723fc89101c5493d0408c2ae5ec48e7a0b96bbdb2925ec2d2167c9",
-                                "uncompressed-sha256": "e91947bb7580f18e20f67e781107d2753acc91163a5ef02b988fd095365e5928"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "d8c0fe4ec0ba8e5ac3180375d1fa65852c37378c30fcd35528bfa85dd449f267",
+                                "uncompressed-sha256": "cf139a77205440f692020215cfdac5872342008cbe8a0759648e57e316ec3d6e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c30f6128cc259eb67f575e8356d9744d4c848303ed2d205f3359dac0edfeed0f",
-                                "uncompressed-sha256": "5bbe98f6d2c39490c4667c530885709471d2ef1b61f808a3303b6c0be1b03449"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "12c9d9a2404da0aa3c87ae2a84e56e881de221992578258e2cd3e096019b85b1",
+                                "uncompressed-sha256": "e485925a8999da2eeac7de9e5269e3c8b682bee3f460f2aab4b408406369744e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5f17261b2f75085ba180190a135897b31ba177910da6af5aa5aa1ffc2ba8730a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "18116e8a487242489cc234e40f6f15fc7d2d3a0a1b34f20aaa5345edab7be973"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9329ea3d28711d2faff2f461ebbf02cfa939e477dca31832791cb1f718013037",
-                                "uncompressed-sha256": "a4a6f1089c3d9fd03a4de802caee30564677c96b3efc7ff51f478d57958f02fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f1c9d27d2fe8ce4e510bd9c3041875f6702f5dc234f32f558cef6b9e63514e99",
+                                "uncompressed-sha256": "ad084c907d17aa82f4111f1dcd5b4ef55ecbdb7e4e04ba96d88a5e1ec6f65ac9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live.x86_64.iso.sig",
-                                "sha256": "477373eeff65051d48f0c405b17a7e88d4f860ce3ddcfaa963f932c7980ace49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live.x86_64.iso.sig",
+                                "sha256": "d5998f8da6d7fe2299faf2a250358089d8bd440611623e261987452633b94a9d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-kernel-x86_64.sig",
-                                "sha256": "0c648d3aae973f24287a0999bb9c9301b963c4dcc8d5e0d0f5bf9533b6db1d74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-kernel-x86_64.sig",
+                                "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "98415aea5adfde500013dfbe499ab7727ea5a4acedb812d7cb08e0bd1ca480ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "22550a65bb3cc8606a533ecba1bf5934d298921dad216a25333d5373cb19bd55"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "39066e93c7fb0f78cac357ce6e17514f3e206ac79874a32e950513d0ee811927"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e82293023c541b2d4051d2162f139666275e9c5124d47608c8d66a528857f1ae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4fc90e687043b6cbf125a838100c2da80a6ed5f2ec32eb752401857bfed4883b",
-                                "uncompressed-sha256": "fe331bf1807526d16cfdb02436fe7944e4e1b592daa9942b7a75a2590fc17827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "aa25ba879b6ba2443c31753bf7d767a27b7384070a7734f549063bff89f774fb",
+                                "uncompressed-sha256": "ae565bfed71bd28f276f7a7acdd080f8c695af8401be3d12129d81d6a7f2729a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "785e79d1919659c7bfa61844def169ffd882b1e67a385ed9634765841a31c432"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "10f79e612758a750515be44f74427ad4c0b71d50e7a4dbc42c72f19c8f87ac6e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bdadffd362130fa6fbb218b54651851d27806b1a320986274bab3fbd4f604a5d",
-                                "uncompressed-sha256": "fcd0fa5c82b6d746b0829949497e898045c742c31ea0ca53e709804984b2f294"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "57df3eb458de53464dc63820d059f52d7f61e3ff6127949864914f70ae041280",
+                                "uncompressed-sha256": "e2a6729735eff64c9cb68b25b8443557ff45c7997298a832145af3a18ad858ad"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2683ccaeb4a445baf086b24d6f6f7b7d3254922c37487acef6df419cb7b4a14b",
-                                "uncompressed-sha256": "37c471d6d23de1221397b2ad2ec03acbf020974d50b443a9a1bc4e7c7a5d0a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d7c4d3b2f9789b033468534d732e2979c78d57c8cc61842dde8735cacdf43df6",
+                                "uncompressed-sha256": "35c5fe3dd90ef68cce2ae7976e8ed723be4fd97fbb43f39cbf426dd64b870ab0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0d03131de4c9a72a0f6bbea71ce09dafad29abc9d30da25f30bcc232676f806c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b0b5eff5c68aa5c51af4d06d0758e4b96a8f248c8ee9ac77b4763197d038ae42"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "1a58ee3ca1f36741893029816ebe3c2f48406dffbe6415bd97505cf3a3b6f04d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "6f2840a213f34fd30aff4d37f55187f5f0869cdff1f4c750f536e4a8515ab0e8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240519.3.0/x86_64/fedora-coreos-40.20240519.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0c2cc2dbc3b10d4b8e3529b994edaeacafaa9ea2de514c73b62f387e81c7d3fc",
-                                "uncompressed-sha256": "1d503e28730feb38fee209088c730b72dbc53596b727b431669350a69ab4d36c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a56910493dd5ba588ca0e8432f9638d44560087aaa1c3004c46779877ae57179",
+                                "uncompressed-sha256": "f27d5e28153f629cfdd73200e0da61ccc98df27e35b2e0ce6a4afda91532e446"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0d2f46dc3762d801b"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0c8129fbc1a4db87e"
                         },
                         "ap-east-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-069ca951291745185"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0abc6c51cbe6e0b47"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-07797133310028b6f"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0c41140a398287c9e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-082c32011d76e483f"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-033f7eff185d36afc"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0e8184837864bfccf"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-08ca4b0a5f6b6eb48"
                         },
                         "ap-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-048e757034697e2a7"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-02d9364368bf4a85e"
                         },
                         "ap-south-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0a711d438ac567a65"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0dac5bfee3ef25274"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0c2b46bcae3558c25"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0cffcbe184eb79267"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-01938f99b0bb5ad2d"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-06202852763b9fe55"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0b2fb8bdfeb312cab"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-09633d0b2acbcb834"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-00e4e1ad82724f387"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-099ece642b1b95b70"
                         },
                         "ca-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0bd397f7170f16353"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0fc8202adeb02eb65"
                         },
                         "ca-west-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-030502ed3ffcdcd59"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-011ba20bf5869b6ae"
                         },
                         "eu-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-06128ecf4b4101217"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-061252070e2e6e92c"
                         },
                         "eu-central-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-04317d12e75527614"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0b71d93ede274d300"
                         },
                         "eu-north-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0fe0d1c915deca061"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-09b9805233126edbd"
                         },
                         "eu-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0888318a273aa2184"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0f91c2165ccb3019b"
                         },
                         "eu-south-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0881347de36c21e6e"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0fede9872ceb5d4fc"
                         },
                         "eu-west-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0196f947de5974267"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-075f0393fbc4767af"
                         },
                         "eu-west-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-077578b69671d8fda"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-09f9c18713b5aab60"
                         },
                         "eu-west-3": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-034f092a97604546d"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-02fff30de1fa5cfd6"
                         },
                         "il-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0beb6b5ac0d0d4bb9"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0958e9ba4610387bf"
                         },
                         "me-central-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0586d69f2bc87d23b"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0aa09d7c241104db1"
                         },
                         "me-south-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-095c186095d2b425b"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0aa88bfe754b23f03"
                         },
                         "sa-east-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0615dd2ce84dd65e1"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0be3537cafa91be72"
                         },
                         "us-east-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0c9792091982af821"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-06eebbdcc9a3f0712"
                         },
                         "us-east-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-048e9fc46f49f403c"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-02bafb04c5e0e1c3b"
                         },
                         "us-west-1": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-0040bba44abb4acb1"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-0f4aeca93eb04bdc1"
                         },
                         "us-west-2": {
-                            "release": "40.20240519.3.0",
-                            "image": "ami-07720a9e1909196e0"
+                            "release": "40.20240602.3.0",
+                            "image": "ami-076fcdf587ce056cd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240519-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240602-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240519.3.0",
+                    "release": "40.20240602.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:afc6c5d892bf09c4d10e32d75b06dc5be3d1a0b36056e7c9e5e2991d4a1459be"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:df27794fed42558fd33e1eb147d756a42033a5b2aa6514e595dc9a2ff5a99ca4"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-06-05T16:57:45Z",
+        "last-modified": "2024-06-19T10:36:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f723b20f80f3334f7baa9fc1efe8751a0f27cb96c66e77d9fa9b8930f8ee8ca1",
-                                "uncompressed-sha256": "c32b71fc6ac16d17106cb59aadb1526664f03de2e0661db99cca1d8ba1695991"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "b6ef7cf85b78b404aa186def8420849da369db66c2946080e4c23f8e56340d4f",
+                                "uncompressed-sha256": "27ff1ca55d51ca5b74e07ef6c8ae59427bce7898e3f5914ccdb9e4c910ce855a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d98caeaf951ef8e6ead78e4a42d356f2087ee56fae3f8089421492b1a8aeb124",
-                                "uncompressed-sha256": "cf39624729b0a48c0eb578a654b5c0442725c72c2305531a1c8e0b3aa8098160"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c22dbc0c235dc6d1009335470bd238d1e9c51a9b9477a6716b88a6ffecdf6a2f",
+                                "uncompressed-sha256": "ad0cccb540c8206e1bf11f99597e40bdc13dceca4309a7b867c8c62ebd38dc25"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0645f0e4e0f9d55c6fe1bc02679bdb91ca6c8ee28773aeff60eb01224fdef008",
-                                "uncompressed-sha256": "8a816fde20fcaf8dca0dcf259a24d15dbb904a116784959245848c6463be9fd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1aeb2cac48ab069c8743a6c47bc7b74567bb3e50cc982cc5221a99df92bf735d",
+                                "uncompressed-sha256": "d045e28ddb6b391ef5ab34a2453f88f9c843865f6620832d6a09aab13e9ec7d4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a52e4eda52bdd4e3cd838386983d91b6b07f9c4e0205b864943b5a62dfb0d934",
-                                "uncompressed-sha256": "c47e1bf322a3d97676058882c2870e34ff3f5ce3d8bbfd1b8b32a09a320f6968"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "af40a92bf94d63414fd322ee62edda0886a0b8bbc8e36784c39760d60590f6fc",
+                                "uncompressed-sha256": "705bb5f8e285663aa82327937b0168d121e64ccb5324c8ed8b66e900a692c857"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "b34abc73ca430f22f621f73a14253db8719319d04a2abe05c94454ae70876d20",
-                                "uncompressed-sha256": "24db140c7bc0109c88f271b755b2612c8eeeb60f671be22007be2d9c50230b7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "2020d93ed48d53875eb515c338d268271958b9f38989240aa0b0f7d19291ee76",
+                                "uncompressed-sha256": "974a396e02d7608bbd7cede3fd9a1fb45372e8456154430a1d5fc91665cf0860"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a8055248419d04103999f2667f527f407116111757ab36caf1761043488be5b6",
-                                "uncompressed-sha256": "1b5f41a58d5bf66ccccbe210ee4c7e6ac41b93af8e2be04cef0ad2d633508c69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f141d941c8c6908ea6dfd895163bae8b0a1654c329bf829fbc015f3138ed8fe5",
+                                "uncompressed-sha256": "374325ef51e8cb264be9d8983ba68bc1f4d8f959077eef06d7cd2a36ad42ab6d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live.aarch64.iso.sig",
-                                "sha256": "e8ac807b73c5bcbb90770583f7c5bad07981f4ab2a3ae07b9f55d35709db4702"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live.aarch64.iso.sig",
+                                "sha256": "d1aec99f75ff01e6d3dde90429f248d7dcb511509b08719ea871f0ab16e4b151"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-kernel-aarch64.sig",
                                 "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1653f492a01dc95ec624ef8778d52ae3a191ce1732aa885ad6a03c8b15daff49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ba09093c7f92a5090081a6ec9f21cab7ffc7da43510a96ceabdd23f543a61d0c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5fbfaf18c15eb1ca72fed92a0e754ca5de33e2b2ebaa70d51188b455c12fa95d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "1e2f85d59879542e26210a5693f841768b9354cd2d752b4edc71bc6856659b56"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "8fc6b55a1f81b60e13fba1d953c117c23f05dd32824694b5486b7147d3b5bbe6",
-                                "uncompressed-sha256": "7845b11769681e84cb2fc841d162c317d085c885d41bd81b4db5f4191dff1fa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2fb29e29e3b228a393e118bb9e2fec58ac9e340e16bcc7e79ee554242fd50d9c",
+                                "uncompressed-sha256": "55561e678d8a7ddc465bad70462fdea4894d7c92abc9de54a423a6db8443754b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "353d1de53fb21c223f1481e89c4e53133193920041e37e446f40abb833b836fa",
-                                "uncompressed-sha256": "345a0e120a9281f8eb6a47517fa08ad22c66cd8f2462fb4e9e147322df15e80b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "68fc0f820e773a68c86bdeeab80e4f3c767f60d2e5c7e796dd57346f83007d17",
+                                "uncompressed-sha256": "810cc34fed1f242340f087f340f863c666f4ac0536333f5f24ceefeb092820c1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/aarch64/fedora-coreos-40.20240602.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f84f50b1da17d491cf1f18067019d50534b42c92fed9ed1269bd77f3732c19f1",
-                                "uncompressed-sha256": "a2b48ae82053efd487e36eb7891e6546c8f6a35248cf73da79bb9db6cc806852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "702db132e1acd1a448b3f59f0b7a17ae029cab8975db0ee84f9c26148ff3149e",
+                                "uncompressed-sha256": "9e792dbffaeb1b515bf1fdfb3b0423ea2067287ac1db4ea1831f8cf8b8e0b0f0"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0e42dc546c93488cc"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-07471dcd640639740"
                         },
                         "ap-east-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-086d630ab24fbe0de"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-06f8b2a8de408c253"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-022344dbe492cb023"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-01d6b54ef0ee5bbe8"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0b3cedb47179230c6"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-084419b19d5b308b4"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-05630b4e85e34e8e2"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0f5ae761b3b675aec"
                         },
                         "ap-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0f65cb21431296010"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0ce85f5f6124b6b31"
                         },
                         "ap-south-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-083e20f32d9037d26"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-06cd372aee0381e48"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-02efcb61e261d665d"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0d0ddcd240cfe9cbc"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-06d7e4c79c6e33325"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0dd77980a0a0ae0e5"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-07daba5c361e835b3"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0d2091e6ffbbc1781"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0ee0bf9e4ce156499"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0c987d7123fde44a2"
                         },
                         "ca-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0e602643cd54e7300"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0fa974787da3afe4d"
                         },
                         "ca-west-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0e2a4d4462228347c"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-095e581286d8f1b33"
                         },
                         "eu-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-01670fe90fb7ffb82"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-054216d7b3955d99c"
                         },
                         "eu-central-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-03905473789ebe203"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0c47379f19f1a58ae"
                         },
                         "eu-north-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0a0c5570ecf728d10"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0c0e18947c9d5ba80"
                         },
                         "eu-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0bfe27a924e73ec41"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0475aa0f8e2e1e254"
                         },
                         "eu-south-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-03a58a6cb1d8ade3c"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0253c8013b8ce3939"
                         },
                         "eu-west-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-01a49e89ac3b56982"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0d5c2f2ade33ad999"
                         },
                         "eu-west-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-071622bd99bb08141"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0363e75a702fe86f4"
                         },
                         "eu-west-3": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0c96b374028758780"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0aff071932c0701f5"
                         },
                         "il-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-07ed71a74974bb0a3"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0cab566b5370039dc"
                         },
                         "me-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0d70cc88088b5554e"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-045484cec108df6da"
                         },
                         "me-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0d67ecbe7934cfc7b"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0fee3f09b3c4eb51e"
                         },
                         "sa-east-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0384fa6ef5cb15d46"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-058556fdb9b94c73b"
                         },
                         "us-east-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-03111a4916e10a37a"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-08a6b6cf93336e27c"
                         },
                         "us-east-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0db99563fff5d5890"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-09a902b550b4b7cc4"
                         },
                         "us-west-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0937d9a091c7e8294"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0fee55bccb19fc5b2"
                         },
                         "us-west-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0ded3e48bc4f6d73b"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0157c34ae981e2b9e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240602-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240616-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f557b93dac860efb636228173d104b8e41ac71763ae316c11a4562288a8bacf9",
-                                "uncompressed-sha256": "8f437b39c9ba2cbaf32e51bf9d0f56dbb2189a2581269e5813995d4c946f4132"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a07fd51a955ed45707d793d22f129188da8ce4a9b1286f5fb28c4f9a55558c51",
+                                "uncompressed-sha256": "a8e43a2ff684e48bc0a0b4badd9f3fe18f9392720c8245eb2862b8cc99807a8b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live.ppc64le.iso.sig",
-                                "sha256": "34f97277181f68857ef843ae60a7e098c93df7d19e654959fa2a24d827274ef5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live.ppc64le.iso.sig",
+                                "sha256": "74482c10767280fd4ec41d346bd21a69726b8ad5fbaf32c13b037d0662806a2e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-kernel-ppc64le.sig",
                                 "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5899db627d403d0d5d6ba1b129d7debe627a6a7f629543aac859051c52e39dc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "a479ad09f56f251e71d080bc39b779a9605d41aa70836ccaaf95a2f3688975d4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c9a82dc6a00de9effe5c73845f33b74bc600534f74653c6d52e963ab00bdd206"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "24d3090afbda3dba381cdcb12f165ee7131bc5f57e8ff246a9a7ab0475de46ef"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "52476b34bc65b37153ba62ba48e1fe47a0f616e40d25922ca802753da105e94e",
-                                "uncompressed-sha256": "9a68e99ebe6ea949ee0e893571211c64abd9abe0c9b690e2b44f720e120185d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0200b41a5f28400f724bfc11e8fd89751e189eaa0ec43cb9b513c5aaa43d8d69",
+                                "uncompressed-sha256": "a881e3ce70f27e9f32b81c04edd2a8d48ae1484e358f845780810b9c9c21fa4d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "7f3538579c05aa5c522d134ff98aa2e4d6c9abd2347fc50bd5c3f1c4cae20d18",
-                                "uncompressed-sha256": "46fa64711f55e8f2c1b014d9b43c7348582182bd1546eec21f3b42404ee9028d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "8082163af86a6f5022fbed30f19489166217a11042a756c15a805635d049eede",
+                                "uncompressed-sha256": "58cdd041ed07788f8ed867d2200dca531d41cad52a0a115d74fc1da0aba87d67"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "8faf16447d20eebd8d59955c4027db5f13a6cdb62745cbcc9feafdbfd4b7f024",
-                                "uncompressed-sha256": "8b9dd454392d6328009375fa3d042a4f3766c7f6945764891ffe2f2802b3fa9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1e9c6b8510d10b6badc2a0c77b8c172c3d3f90f588c60415f7e531ddf9096791",
+                                "uncompressed-sha256": "80ee31e24550f5796c66ceafa0fb911ffb8b514b8da1d22f25371d836fadbe35"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/ppc64le/fedora-coreos-40.20240602.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bf9040ef1e04dfabc3f1b7cdf21fdc1adbec9b5f7bab37ac9d86f704f6ed87f5",
-                                "uncompressed-sha256": "b189b8b0340616f6baf7d4e5b2e4b0cba1442b6fab70eabd600dd3069dd15fe1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d19b4ddcda4e00c48ab5fb23a2b7d0bfaa280ba59e7f57bef2837bdff16bab0c",
+                                "uncompressed-sha256": "1e73cf16431a9c3541cf4ea609c9db36c9aacb198e5ef51bc72471d5f859a9b0"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "10e81923c112a2cc88ec166901ec3b3497229d32c4a9082bf74113b654484365",
-                                "uncompressed-sha256": "f841349967495a74576fe5f7f9fed3c25f099df5c54bd2b736aa40991b10d958"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6b8b4271e010457e016fbe9dd80c566790a7749d8aba48eb46cbd8ddbb2ae4df",
+                                "uncompressed-sha256": "8230031d8862aa3fc95d96401e611c5607f4752d20d6cc2567172f9e4ccc1085"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3611dee1db2e2f4b4e0db8a7377dfb2c0bcd5a165e03c2de0eef82446c7f71b2",
-                                "uncompressed-sha256": "9d87054857f90b1580a7b69ccbdd82245deffedcbcedbafb9881196c302647fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ef1129925d57396a855ab3666af25162dd89e0aec911b75b0191c6533ba2f0f0",
+                                "uncompressed-sha256": "22c2156ffa6828eac4e9524a5fc4afc082d41c3735ba88cb11eb76fcaafc5c35"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live.s390x.iso.sig",
-                                "sha256": "37d35135d466a18f59e48c5523cba6a03335c67639ab05436f268bfd6cbc5779"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live.s390x.iso.sig",
+                                "sha256": "43ae93b7b0b2d8460e879ed6c532127c9792a3b89191e3aa16fd50bdb2bc3361"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-kernel-s390x.sig",
                                 "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a172f1b56b3150de214cda5523b2af7d334268805e6052084c44926534ac3097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7d9404f855354f1fcc9a29bb5cb89a7fea6533617acd6cb5143eb7058a85f332"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6201656adca014c6bdd59918444a9ea2c6688a31f1f0b86b42b705f423588390"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b668c96ca3114480f445cb87678ff14c8fb4149164d27b5f37cf03fc863e4812"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "236456a5589932a27f6e907d496808431ab9a0322c989041d6fb95b4640b462c",
-                                "uncompressed-sha256": "ed0c1d1af63a1c421a8604f3f7512406f6b1843ccc1cd769a52f2392abf4ebad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "9fd3ae5e17a2884325a7839ba99c4d217ba1481ee5786623b98e45df2b9eddff",
+                                "uncompressed-sha256": "eab48ecff65471ad04432ab8e1857268a47356809152f1fe514f124c77ae7b9e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c6ada473cb5b01b7743453d8e01bfc979d00c42df5c31d3d0c2decbc8169ede9",
-                                "uncompressed-sha256": "96ce00880835261d3989d1abe2c91c76697eb55dda85ad359d76a171c85f8e84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "fcce7d32dfce0e2df920e2e6f76b88c4a1fc48beb8de23abe7fc454f9b336150",
+                                "uncompressed-sha256": "6e557136caee4639b5991e3bdec3e78b3b39c2414adbb728d44f7104f9fb571f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/s390x/fedora-coreos-40.20240602.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9b86bec5d4000b2d8c063983de897130b60b57f8d90becdb8f3938dfcc851eb9",
-                                "uncompressed-sha256": "6d3d2e408bc07340614c9b43409a3d2849062d422724851f44f2376364921a1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "99fe3344e5ab2112f288e84dd49c28e26cfc967226ee69cd658ffca370067b12",
+                                "uncompressed-sha256": "d666d9041f243a971406e6c8bff5da3c539aaa9af3aac28696ba13f54b7990fb"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e6e324250a911f61dc1aade729949f3f6e283650071012714eddb5fa20351c52",
-                                "uncompressed-sha256": "1d1cdda2ef1c5bc1fb99a1817cdfa5baf84cd8aad361ee296cc7339f94ed8328"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d46d26a77e99e76c3e980674c304d2c4babfc21b253ba4e9179f87839a7dea42",
+                                "uncompressed-sha256": "5a52447e74fd7cfd96e9c01709eb20ba8caa3f5fdb2cc2a880245301bd55b537"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8f88114cf0e00a58ae0fc11cf989e5458a45e545128cf9700885fb5e1e2025f7",
-                                "uncompressed-sha256": "9d499cc81c6bcf0b8d0620f3c5e0729400b5f16cb39ed1a28edc0f869fffce6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "120b3a7b30f9b647a4efd9d64030b90d096274a6d6aa64b65320584bd2b3e2f4",
+                                "uncompressed-sha256": "77f8d3d387692c6c72e5e3b9f55e50d8038f3e5f196dd8e44d450e955bdb15aa"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4e00b9d43a2bbbab39b2272ab59b41ca017a0cee8e8eee28f2eaab30802cc03b",
-                                "uncompressed-sha256": "b1edec563b595c3e89a4b5535243cd7aec873991958cd518b54626dc743145d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "256239b277613a2a90054a1d1c8378989a6121ff454ff7f5c2e9c5a87d09a37c",
+                                "uncompressed-sha256": "5e1464de4ac4a1cfe64c1fa706a3d4888f3acb67c1875c41c5fa8c505d256df6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c5f5f166141a32a9977dcfedfa1cbfe0289e8d9c29e22ba2bcac50787f567fad",
-                                "uncompressed-sha256": "130904f140401f1607bec59fa481a695d2608ffdd3e3a244c590cd6ee3356fff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2a38e556740a22e5fb853fd621fa21679f679213ba9a1d683f75cebafff73797",
+                                "uncompressed-sha256": "dcd0ce3e9363765ef678329f06dabeebb5d8767c29b9787fbc4b7266856d731a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8346895d66db2f587943c4cded22d04e38b7420d38afbbcab0c79c14d24e2dbf",
-                                "uncompressed-sha256": "a053e622f98130b2def102b191d9923588bb7b62d837a2ad7e5f0fdba1d948e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b6362d57462c401cf427345af6510ef0f4404baebbf5f1be09a000ad8f3dcbee",
+                                "uncompressed-sha256": "73ad39b83a027fedcb8e32e5c60da5cdd8d91fe5f8ad572a273fde9bb5032652"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "43084c3c1de3fd4b3717c25ccecfda293bb195fa5f812af65ae90e9d0f5851e7",
-                                "uncompressed-sha256": "5792a278e9633c9d76cbe923b2c9578c96efa0003f967174c728f5ffe45a1e48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "42278e19b4ec06d29ff9dddbf947eb177a0b4e7c31666ce9a2bbd7f23f4534f5",
+                                "uncompressed-sha256": "bb392d8a063a07128a2e8b70300ea74f77f760738b3820da7c15511f36997edd"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b07a6d3b717efe47387a4012022014ebb78b84921a1649223b4bb0e975b9a274",
-                                "uncompressed-sha256": "caee79955a504a3bc45f76769ea3b7d543ee4aa1c6ba689ed21eef501f368552"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "9f9afc1800c437adb0ba1c4a36545708186a65e625a79bde0362251a81170732",
+                                "uncompressed-sha256": "dfedaa73f991f41636c50aa0dde328d8abb58cea8a39e321f7356bed703b1252"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a4734b0d45a162243d0f559bcf6bd162800648e61f8749f1ff05a9104fd4dfe1",
-                                "uncompressed-sha256": "58567a13bc4ed06a86a0cec526b67c55ad958ed84a2c2a72e6366dc24ca2fdee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ec3e32b9c8db96194482df110f425524dbbe94cad92b512831e462441697ba1f",
+                                "uncompressed-sha256": "78524fd516ec979d0622c9da3a77f0078fe307abb6533b46d1bd3bc4519ffe3c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "22d5e273b9fc254a195c0ab1f4bdd63ec2e21a5a5a18bd2c20d170c5ba496d9c",
-                                "uncompressed-sha256": "dae1e3bfbcef9811211db2ba145284377bcc0008f776dd0250d0c0e6764b8c30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "57494ddcee58a6cfd76ed83a9e7cbb07c3d5f82644304a80c003c2ede0de7975",
+                                "uncompressed-sha256": "0b997860930fb1f6fbd73b52509e8531761f9841fba4bd9f8c2b1facb3fc5ffe"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9da917000964235b2f8c0cedbf64095291ee7ec59c76697c6ab466a35d123454",
-                                "uncompressed-sha256": "902a59c44701a05176241a434a8ab818398315e30a30bf904cfd44c0bf356244"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0bbf451b8aef191ee3cdd85106db1f179df0aa02810fb69be331596e8bb99320",
+                                "uncompressed-sha256": "dad60b4fec0b688f786d5a4139071b9fcd1bd01024847e1d687c9a95f8ba6aac"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "9afc6aed2dfe8f59719f7d15e9e5cd2a68449385a1ee2f9c114b1265a0998787"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a59ae9b4d283a3c96be8350bf78ff75c10896b777b8af9ce639e03ffdbd8e049"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6b309bf31d84a95dba88ac7a86ec400004da24a76adaf2ce2fad16df93228c12",
-                                "uncompressed-sha256": "ef6553698e2c477875aecde95bcd1c92607b5327aed6ec4a31bba664254c60a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e78ade03490c98b9200d6115ac4e44f7fad68a6652854083986aa3803ec39b71",
+                                "uncompressed-sha256": "c8b7e3ad3c94e32b877bda031b5616259017bb795595df6ebe673ae1fba85d89"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live.x86_64.iso.sig",
-                                "sha256": "227b37bf293765251532e3e1f9a6f7e812f8b17fd934831edd29a3fb9e937f29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live.x86_64.iso.sig",
+                                "sha256": "329fb44c48188691b751690f82bc2b3bf6219994ab4f74e6d80b573ab16c01a9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-kernel-x86_64.sig",
                                 "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "52bcdabb05e7c0b23de8de08bdc6e15f79b959e805649a1fc00b2f41c8eff8eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "66bd0f68cad50a37f9c97b2975f9e28acf4ec8bd41e1c740754e871cc573960a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1946c87a7ba8ce83cf008d6ced5bd9f2b3006e20c095ff52a4a07e9571dd969a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5adc764a45c222b4858eb07001bd33f0c6e71136d2f528335c291bcfea29031b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a679f69b3f3d4cc1a22b8583c1565ad24ff1ea5453715208c502ff404e8530c7",
-                                "uncompressed-sha256": "cbde25d8e18ef56f095e0b311a0545ec6e9d55cef58b4a566555f0569c9d63e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "981692971b3372410ee646c40f12bcedf8706c70eae91ce79fce0d42fb94b346",
+                                "uncompressed-sha256": "1e2b6e6f2cf3860fab775e2973c944f405b944d8d4ed1881d74be763eeed64fc"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "37dd48e7d60cf8aef194e9893d7d1aaf7d7db51de3c4812d3fcc3bd046377904"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "199c5577bc9783dc164fa026a3656793e72dcf3126c0aa38234bf5de407d6de9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6b61bc1a053d67354ec6487fa8e880c71055a8964527f732deb75386fd9d177c",
-                                "uncompressed-sha256": "7423814f309a1065fb42471721c54701761f476661bf44ec66faed3b9382cf7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "198f844010b82343b9e005d44a8c4ff892ca3ce9ef3c5688eb4b481795032f43",
+                                "uncompressed-sha256": "589986d33389d596078e8ff1bd54e0d0cfe9d8f8a3f0889e7494241fa3c133f2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cea682184021ba98d552625e2e712b5107181fd708134c68523f893fd6e87f52",
-                                "uncompressed-sha256": "ec881972867320ff43fc925d527291a79735bf15349f812ca7fe928e171dc241"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "10f9ac36e6c31c712e97fe0477263ad1747b5969651c9e42731a687e412ac8d8",
+                                "uncompressed-sha256": "e868a76868e4b4bce17d913c4e3b8c5e52098e731c3e433853c87a7dc0a289a9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "fe0c50a1aa88ef5b757b1c5126eb64c5561b45503a4f1818cb814577a40a5ed7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "6410d9f4fa40d992022d45a771518c3bd37aacfdfdbf28017dc75c94403c30a7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "f558d4f1850b04466ad8aee98238cf0e341b726f08ccd6d3b6b9db839aaec320"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "f5cec8c08641af6b3aa0d9ac6dc6a096d6c2d71c98c70082125680817c2badf3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240602.2.0/x86_64/fedora-coreos-40.20240602.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7681fff6fdf8e1a3304832f8c517c5dc2ef94668c47171f41122ab2f4d0e801e",
-                                "uncompressed-sha256": "ecc4530bca95f55763dafbe8a57243ae4d861f64e5e6aeeb9840e4148bd1cb39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c9689a0be6d7eadc05de0350971d11c7a99447fc6509a23d1b384d1f1837831a",
+                                "uncompressed-sha256": "084aa2acb3e71c40f0b99917c335b7736cb5d40d87b7f364367e68f253e5513f"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0933b4634efc5b49a"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-097eecb647fc7c476"
                         },
                         "ap-east-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0c2de5e2791ec697a"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0d06fb6920a63e047"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-07cad28dc274d84ff"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-00329859dac10deb5"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0d906f9721f475975"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0510e70a43100300d"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-03ae4fbe1fd5fca12"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0183acb8a886467ec"
                         },
                         "ap-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-05446121376a9e3c7"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-03ae524da9494035b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-047e09c02a8a5ed98"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-02e627c5afec70e2d"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0b842f97e0e07019c"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-005ddbbdc02969444"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-02cf42fee37cf28af"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-05a4c818b9020c675"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0b3acb651a0574933"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0f880917eeec20894"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0d6b13b299b3b992c"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-06477c939424ac47c"
                         },
                         "ca-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0297632448811f939"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0edbbcb76264c306e"
                         },
                         "ca-west-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0a4aecf952efa0d32"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0b95176ebf69a625f"
                         },
                         "eu-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-008e2a6f271050b41"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0e7b86d5e8745c244"
                         },
                         "eu-central-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0f5639ce07339ab98"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0e1d66bb333bfd986"
                         },
                         "eu-north-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0b742371e8e24612d"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0966baa146bee4d5d"
                         },
                         "eu-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-028cbe6b2e54d183c"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0bd44dc303e8dda9c"
                         },
                         "eu-south-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0431515bd41642b73"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0154905418e075976"
                         },
                         "eu-west-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-094fa2d6d702f1f4e"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-02cc2503d31727446"
                         },
                         "eu-west-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-09e916cd2b3e65ce8"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0a087f7a4926d8cd4"
                         },
                         "eu-west-3": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-02e6df10bbc0abaea"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0c29c154c46face63"
                         },
                         "il-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0824aa98466359a8e"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-003d28646e0074852"
                         },
                         "me-central-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-087824e76bf3135c0"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0eb99f4c89b47657d"
                         },
                         "me-south-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-021706614510115f2"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-080324773585badfb"
                         },
                         "sa-east-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-010db164a3a2767d3"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0e83784644478bac4"
                         },
                         "us-east-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-07da7a2e22ce24792"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-04957bb20bd6be869"
                         },
                         "us-east-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-0d8f3d756a1ff4413"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0f99d750b77f4cd3a"
                         },
                         "us-west-1": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-046418e194e87b389"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-0299b11ed39a5cd0b"
                         },
                         "us-west-2": {
-                            "release": "40.20240602.2.0",
-                            "image": "ami-009fb0f5671da3bbb"
+                            "release": "40.20240616.2.0",
+                            "image": "ami-067bc912ba1245c89"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240602-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240616-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240602.2.0",
+                    "release": "40.20240616.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:33d402f3b296fc2dcfe9b302fe1703c4e32c168909b065da8fe962e9b77a5a2a"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5035854b522d3a9b4b7ff172f0535cfd0b6bc92cf09d8cf17038c346e58e7085"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-06-05T19:16:02Z"
+    "last-modified": "2024-06-19T10:36:04Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240519.1.0",
+      "version": "40.20240602.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240602.1.0",
+      "version": "40.20240616.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1717615800,
+          "start_epoch": 1718794800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-06-05T19:16:14Z"
+    "last-modified": "2024-06-19T10:36:03Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "40.20240504.3.0",
+      "version": "40.20240519.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "40.20240519.3.0",
+      "version": "40.20240602.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1717615800,
+          "start_epoch": 1718794800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-06-05T19:16:18Z"
+    "last-modified": "2024-06-19T10:36:03Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "40.20240519.2.0",
+      "version": "40.20240602.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "40.20240602.2.0",
+      "version": "40.20240616.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1717615800,
+          "start_epoch": 1718794800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).