### PR TITLE
Roll out stable 40.20240616.3.0, testing 40.20240701.2.0, next 40.20240701.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-06-19T10:36:04Z",
+        "last-modified": "2024-07-03T20:08:38Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "5222c4ad12c0426ef3888f8e99dc9b89b22bb84646ec7b46110bb207bdf22a96",
-                                "uncompressed-sha256": "854be70544fc1db9ffd150226a502697db7cc02620023837c6f67a53cbbafe13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "de1fe97bebc7f88aee35854d6a7bac9e8df80fddc5a242d125a741ccfcc0d34f",
+                                "uncompressed-sha256": "dc0ba4c3fccaa52de469f424231707af9eb3a76011cb00c89bf58d142b258e04"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2f6d7d71df441d15d1b8c29b0cb419bd0b7599e2965e70ed0de5b03419952c53",
-                                "uncompressed-sha256": "56afdcca7acd674f5accce92c3e45be1dc98c58ca2bde55bb1dd2d469d2e7dfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b09207885471bf44e39940987dc3598225337d80b95941d82cf5740885114189",
+                                "uncompressed-sha256": "f258475e2e5631ac243edd863887c61d5e7115fbdb923169532f2499357a954b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "910dc58381b495236cad6adddef0db21a50f0d7489385ee7771985a3d0a31540",
-                                "uncompressed-sha256": "09306e8b48249dac4444c4b8362737145152a0b1455ba476cab26b1bc7c2bc5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b885dfe618ce9ea9071e44ae064c22a9957cb3e7ffa633e4f7edec4179487c0d",
+                                "uncompressed-sha256": "1e0bb859898dd060d240f960daf1216f72f41ddf2d84f08b6f1492c5081e2dc4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "66bb034fcf1b9b0bbcea50cba06533d8dee454e6012cec9166d19f3954c802af",
-                                "uncompressed-sha256": "812815df1dee30c38470e32ea3a1c00492f188c2b2881d014c2ac405030fbee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "5f5a4b94bab4c1f8db08f638fabf37f5a91ec1dc37c3ce4aaeb6827853e681ec",
+                                "uncompressed-sha256": "28d25d2b6f3573d70798519f8cb6ef1a456c94e978f8f370986cb4e03b622444"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "72e78e820151694cb236b3c46284ce31d78b79b8ec4e7118b0fcbc51630c303a",
-                                "uncompressed-sha256": "c330b3af54f01335445b3207afe7c15197a21f285f6b30d3828d56e28070ad31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "9fc87a0be8ccc2286b7eedbae59a19b6539df742b06cefe5d0deb7a7f711a36a",
+                                "uncompressed-sha256": "806f1a40ff4e06c71d721547f1a19711b8cef73d95018d8d0bca8430497def64"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ca1659a28c41ed197645687b5d65237af77c5a1931437e0e08dadd95ca44d56e",
-                                "uncompressed-sha256": "6a72b37d6a6f713d5bb2798745f25a50bec9428e78326f68569ab525b9885384"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8e48bd53b12b7236ac23038519f9039d960bcebd8af6d2fc1b673d5f902b99d9",
+                                "uncompressed-sha256": "35b34f04c039aa90ec4bf3e100617edf590958df1e62d21fbc3402f816bdc84b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live.aarch64.iso.sig",
-                                "sha256": "748542dfd40ff9b856ca3d5393ceedb21e8d3e9555eae9a4daf2627f35cdc02f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live.aarch64.iso.sig",
+                                "sha256": "fcfff3b62afe8093964cc20a29d54d2d66d747057c1275f4890d1520da9dcead"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-kernel-aarch64.sig",
                                 "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a2831c73737c5ec881c50782f8f312aeeed1c7ba41ed7bcf47b7486b214dcd11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "29e95876d6c0f1a8bf4f09c9964ca68d7b99376fd3bc38beabca50cbd37d2d88"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "8c7d24187e233d682cda05d1d5ed78ada11b0b0a67ba4ea2289657ba75951a48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "87e2080f7c26e5871ecd55d641616c943d3f99fd0abb17dabe7e6d40db4b84a2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0034027662a1345224f2e4b81a2ddca8297f359ad13ee582fac2d1c82c434d2c",
-                                "uncompressed-sha256": "322041ae3e3f4c608a52bdbbcf0e9d127aa14cefcfa15858989352baea3c11cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "8e2d028de5c3d2b75a05e5fae436ae0a78f74bbe8f04f4c3b0d16930307c43b9",
+                                "uncompressed-sha256": "449c9ae58cbbfc85e820c4ffbf5a00e066b57dd08933a71ced5bdaa779855f7b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e56a1695f7928233717bcd9f520c5c17048d618437f8a4921a6de3401d2b5b25",
-                                "uncompressed-sha256": "e326feeeee38282168aea0a58ee03c2b63167b4b15f33538e665aeca62803205"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4e9904f248bd521bfda45d59e03645659497fb17e4c55b7b167fa4f7ae04cc8c",
+                                "uncompressed-sha256": "a38ff43248739b40b1ea3c477ce9ce42323067ab780267283ec06203b4dcd993"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/aarch64/fedora-coreos-40.20240616.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "04387226757412e97b5fa3cf2c71d9cfdb5fb6217096261b7f03d802664d0b0a",
-                                "uncompressed-sha256": "053a0349ff1ac92c3964e5bc5826d5e0278eb12b192bc6c5257a676f09919aed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "50f9939fd71061432c08dbd1502b8918eebd9e35b71a99027f926834a529bfd3",
+                                "uncompressed-sha256": "36ae2f37cc6e0552b43e0be3fba218f08ed68b4b77037fa3a5625bb8ca650d99"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-03ab94c94d603f7c0"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-002b8e69f54650ee7"
                         },
                         "ap-east-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0ef5de02d5aa24a6a"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0ad99c090e17324a0"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0e38248b3aa3cdce2"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-03fc2155bf0d759b8"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0b158db084a1d92d0"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0c2a6fa0a9ab1ecca"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-070a9023230f00970"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-085c073e720d07be1"
                         },
                         "ap-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-075026373984f54b7"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0382042674840fefe"
                         },
                         "ap-south-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-07cc374163b292517"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-078853ad4103e2fc9"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0cd83dfcdd8fb179b"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0e9f467560e5eeb81"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0bf57adcd68c7df21"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-08ecf829d4af3516e"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-05b9259e445d8cd13"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-051a0a0f962c6e596"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0f900c871ea1b7c9b"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-08b64bc6a4bfb858e"
                         },
                         "ca-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0610eec8986c48957"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-038625bbc8e4fd5c4"
                         },
                         "ca-west-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0da08d4ed88b13cd8"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-01a4448eae580261e"
                         },
                         "eu-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0575d48b4dd8f695e"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0257299c853838262"
                         },
                         "eu-central-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0bd2f17b34ae418eb"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-00e78c9e3cff57d53"
                         },
                         "eu-north-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-06bd03a6bdef8d9fc"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-09106aece84d6324b"
                         },
                         "eu-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-00ce02000a0778b2a"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-050f862991985b2e5"
                         },
                         "eu-south-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0057a4bcdfd92e6ef"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-02e97d6a0e59278ae"
                         },
                         "eu-west-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0c8f9c2a8211abb37"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0cb7b592cb168bc6f"
                         },
                         "eu-west-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0c5e00b0e7c5b5740"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-05d97623f7f50836c"
                         },
                         "eu-west-3": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0a8d4e09bbdf7cb67"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0c5f619c7be100d85"
                         },
                         "il-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0a0f75128ab765240"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0e2ade57bc4500091"
                         },
                         "me-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-01c8a824abac4b9af"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0a7d2e65639a655d7"
                         },
                         "me-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0958d2ab3249134fe"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-01196875553156bfd"
                         },
                         "sa-east-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-08c393b5984ce920e"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0a2884b5600d3cb72"
                         },
                         "us-east-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0c1daeff258afb0aa"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0c412cd1c975b524b"
                         },
                         "us-east-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-084ed8e90360d1288"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-087a84c187ec91f2d"
                         },
                         "us-west-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0651f6be2cf11134b"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0ba1f287c608480d0"
                         },
                         "us-west-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-022b718f36e5d1b11"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-05a28e88d22546fd9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240616-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240701-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3fbe023f2430dc2aed2d9eaf789b14d388102eb4bca6ed4782be9c99566177b3",
-                                "uncompressed-sha256": "bc7acb6610bfe5186b9356a8e852d175c3256b7063238166767fb17b2bf0ddee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "5a5a0706ec48d37f17fdd4c085944bed14484378c7049bf798059efe8a90c327",
+                                "uncompressed-sha256": "298b392f30539bf37c8a275e283274418cd2133306171ee7bee9ac8f85aa845c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live.ppc64le.iso.sig",
-                                "sha256": "5e8f312eba012d2f049acf54fea5beb7d91b0c83c3cb97607fefb50db2e9f71f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live.ppc64le.iso.sig",
+                                "sha256": "6eec436f97e0fd04a2d1dc4bc3c0ba52fb511afa64360ffaef80d9f8ceb096d6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-kernel-ppc64le.sig",
                                 "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "97c235f8a0e8b6ae113193c6bc5daf7d62bbc399573a4b05f96ff50af5b7d8cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e091e87690d0364202196bb4b26f7b05ed79115887417d4f3118a742e3770baa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "726ff1f540c0393c732677becfb65e6bc9c7515695fcd1793a112b691011b06b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "2058d1c9e0753228afe4b5d3cda4a9305d85fa77760f98ceceeef541f89a8ca8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a5e5c305b1b43d50ebd4252d297a883fed2a5433328935f204c7a0c3bd146e4e",
-                                "uncompressed-sha256": "f68ea85a38d2c65ca97e79a9815c6a7186b459572ba134ea16adb5b146ce0996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "baaaba534e9db91c8f5a18c287d6ba5b8a1a0803d2ff85287cf76f3685ee62a4",
+                                "uncompressed-sha256": "33fab344b677b0f1ba8d15a682097c9f034c6fa0b15e35cfeb3aa1f5053e0b42"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a637b89a39b4ac541b1491b862f1dd0f9ef6a0034bc34018e18b8e83bf872950",
-                                "uncompressed-sha256": "a62f782b5970ace95cfe7ea0f2319ae4524c2a7a7c4b97131c02c39cbe702996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "915fcf0ca6c0c39fcfaa79dcc8ea8f957d55cb70daddfba97e41611b18596ff8",
+                                "uncompressed-sha256": "d51109897c59020b323d299f64e63ab2c430b7eccf96ff3cfb3ff0dcf4ecd6db"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5ed27e15b5e3b503527a76600ca90b562a73612bd51eac79dfb57defb710efb2",
-                                "uncompressed-sha256": "f099aaa8e422a166894b41a952edb049524c8519fcd3a536bf665f4abbd88af4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "bc32570d6579f15d7ef35d22e953c96617c8878ba831424bfc6653596e405d14",
+                                "uncompressed-sha256": "e0f9016f94b94b78ec9a24acae79e2ba70ee4ae6d5e04356d1c6e7682266ed58"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/ppc64le/fedora-coreos-40.20240616.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "458f47b74de301d0c2621d7d425e7f243fcbb6cddb56e6f455bdd2b6599ca676",
-                                "uncompressed-sha256": "8401708f34513ee1671946d51da7cf2ec9675241ed57debece68d0769eee2e2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e92b36b08f9f00eb104cc846cae125bce300e12e389cf94e0e3f4b9d90f84f79",
+                                "uncompressed-sha256": "1b127e947eae7aca5440becf5aa459f5dd784f178f2b7a307f0170a73fd1b6df"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7ae5529991c83401eb9cda15ca2f866d2dd0bac77f034c4183cec9ae106769a4",
-                                "uncompressed-sha256": "d35b65f543327129c31713f2850b3a6fade9253441444df555ca2cd4f98062b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6ebbb564d37f8912a9abc7af61df5df3875df63304da077cee8309ba17edc675",
+                                "uncompressed-sha256": "c63a9e674f52c0a4af2b789414e1ab6681a6e79acdcdee23c2cc0e6c0d12f2a9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "887ac4857dd1ffe095bb3f6430c43b250068fb7d20f2f3454d946d67dc8bc6c7",
-                                "uncompressed-sha256": "30742ed6ed411d45809b1978908a811dd6d3a7a10ca5c141720be5dbf209439a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "737cd88da828897831199b5af94fd9163f907e5529e16e3f59a0531489d39c1d",
+                                "uncompressed-sha256": "a930643379ee4dc02f3f740d466f0c3e4b0b7bb826733a93a33a41acd63290df"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live.s390x.iso.sig",
-                                "sha256": "ce59334a2b6244b7147107fa8e2654d150dd125ac7040d7d489f2cac8a99403d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live.s390x.iso.sig",
+                                "sha256": "ad50cc995dbcb4f10f148afb24eb5d42239eb200185edbc5d8053e84ef9ef10a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-kernel-s390x.sig",
                                 "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "962495cb8cf39ded19f24bdc742d84d2cad7524b62a3c8b77c53e535b4f194f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "87de8385004230269809e6a2bd509b5dd7043492526a634d20a7e13b5213a884"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f44c017031625716dbea8b37c9b182ad3b40cb974f1c970db63738d2727b016e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9cccbab7c4e718f0d293e1c5f44d61149d4a604911dc31a6372c7b5d4c5c56b7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0a3aa654ac42224bbe77a7c9144cf430d60b11b7997b67988d8011b9057cfb79",
-                                "uncompressed-sha256": "752fee457d0346b780fadcfb3ac25855100cadb18a8bef5cec165d0681c25633"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "75d979e43ae99e6d662c3d26edf9cda88e32a37ea1884d436c50fdaa50ac9f50",
+                                "uncompressed-sha256": "1226a90f2c8edda2ef48abe52e8b3aa07b3349da99dbe0aa6e4a540515cb8be0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2d8f2c96175db1f25ae9d46cbb3116e3bf77805e632b96a405c99080af14a643",
-                                "uncompressed-sha256": "082c5daa93b620d56cbfd05645a1e62ce26712d6eb21a8b4f4b56c578a8ec765"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f9ad0bd57a56edcebe7e9bba74d1efd980f062a29ebc336106d16230dee48c66",
+                                "uncompressed-sha256": "a7bb4608454e249c1513d9bed1bed3bd1120be43e3fb57f5f1ca0fa766aaea07"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/s390x/fedora-coreos-40.20240616.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c9858a4d2eba4fe86293166bd5403a972b3ca8672e6813a5e320f376e0bfb233",
-                                "uncompressed-sha256": "7ca5146912783965d36ce6c5df58fcb4b78e37f102206c21d25a9df10a335efc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a4fd09863f47b8cdb225c04493ce7747307f68a80aaf46390b1715c8a483b230",
+                                "uncompressed-sha256": "2c11b01e4d513816bd89970e48c981d58b741cf746d2f6713a7c4e05a98b5800"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b1b5da3b27bfcd822f3dc093cf93d64924cbac2c51b9ed453afeb42d6fbf0a1c",
-                                "uncompressed-sha256": "a761db6c801d7de85ed23c6c30adb745a3f20dee187b21e677ccb08a8f45b355"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "21c4de8ab6bc11dca0d9930796650440ea8182a8d6ef0924ddf445a796ad9488",
+                                "uncompressed-sha256": "a50884f403bc78f6cc4a436ad0fa6b5839a794780cb61e83718c4c25a43705d8"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "c443d1d588b1c5ba1f3eaf84f1e5008cd805d73844cdf9298aed6e156b308939",
-                                "uncompressed-sha256": "96b44d9ac658295c20dea9c69fa2fecbb85abbc9281c2bb4a6858f32c6d7a833"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "7b6e70b955c62ddcb00245942315f3d52ff4e979e43126975fe0ba64e1faa8d2",
+                                "uncompressed-sha256": "0a28fe2edbcadb84c0ed480b5027d65bae517b1413e27765c0579b23ca41e8bc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "522b9da6aefed8f833d584d9c35f7f23787fb9897f90fa0c7625608f596cb2d0",
-                                "uncompressed-sha256": "3b25baa444bd266b6a9d5e6579b6e18a1458ec6bb9b827c2d1bb3c072c4108c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "13b0290f558c5162d86dc0ddc89a8d2ade4633c05d28bd3fc6dbc325e7eb1d80",
+                                "uncompressed-sha256": "6229d6fdc6255e73c490104480b405baa327b528549d6d79b0d8f86d563dc2dd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "bc3f1a78ec27729893c626a4e46872b00af11c4d77b20c3a6485b620d5c29d1b",
-                                "uncompressed-sha256": "c62b9f9e5896455e30e871de087391f4551a3fbda392f6a2f7d19633da33fd8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ec950ac985a1c5f107763bc11a57f7a8059b50644802684934cb9ac995d81dc3",
+                                "uncompressed-sha256": "0f120a410d2e86f7d0e175212884a769555cdc383bf8da2bc75f5bcdd0939b31"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ea5ff54d344ad506e40f4df9446238ce4c2f8f4b58643e31dc3cdd8d20c62a68",
-                                "uncompressed-sha256": "73ba27026cbb15adf28b158e7e8f4584f54aefd080b31ee178937fcb730c2760"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b86c1c9b986cff3128f61ee65dd98b7cbf06e1441a61b0af1db9ca534705bc2a",
+                                "uncompressed-sha256": "d77453d5adf6c8845d7c03dcc31767510d1930b6f72fa4fb21e44b8d24bb9a60"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "cb17669a16f2833e8f2978ee52d9acf0bc693420fe0b76cbf9872ccdc7ac5739",
-                                "uncompressed-sha256": "db38a5cf3777d1d4f99ae23d6bad8460f87b72fadde82e2438bd6c39eb037f07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7902e20e42fd2751dbc3e22748eb345b109c7aa40ccb44955add6fb779f6f346",
+                                "uncompressed-sha256": "eefe73057fd1e89a97f2578137d367413f80c5bb8ef5b6a73e6981530fd29e6f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7e9cf3904e58a2b859e4ef2ff11100e5a907435bab834529873aa655e045ac24",
-                                "uncompressed-sha256": "557bbf5496b4b0d8c56d301aa5e6d1ada1b495e649640257b7425246e907329d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "085a50cfb54b92c3c6ee407296474eba1f68d4c92cbfa879244744d1c004b280",
+                                "uncompressed-sha256": "f0643127eb4a21470001ef732862ef17400f3b0cb84cac2c145d793a22640767"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "944456f7d47d3af9a809f2f91780371f5f2b1bad9ac14adf5cd38e5d41bd5601",
-                                "uncompressed-sha256": "679b377dea31b57b1eab890352d0f2bec34a7feb94a43f496293e908dc0327e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "234fd5c1d2a6857ae631815894eaf5e21d1734069faec445295716ef347d1411",
+                                "uncompressed-sha256": "000f81510a5041c29466a37597424c0df10b6a0d811933d44652296966f5a6e8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "924c55d895caafd20a142535355a6b216bfd9a1259e3c5315b1e4d87e01392bd",
-                                "uncompressed-sha256": "24621c7ba3b583b68271cc6f1fb0a2b95416cabea6d76e1ac8d1509de6c86f0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "77abf803bfe7c1de9c824038fdef6bf7566a40d7463e7acc9497079d34ebfb09",
+                                "uncompressed-sha256": "2c8783eddad3bc67ada171e5ca77caf27e2b6c0d0dbc0e972d32e17b135eddba"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "cab62de8e6125862ea913dc43f092d385a20130b096e4a9edd5a5ac7f1e0885a",
-                                "uncompressed-sha256": "3bdc1c8ef32dfa9b14d813880f8b0763e9aa91cd0d2d9abb032ec6e0876631df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0179d35e73c4f8f3cb4a94ddda3ad65dc00617b75ac00586f6d4f8fb7aa0688c",
+                                "uncompressed-sha256": "7e6717b99284333e39781cf7f45fd89507de443743f7fdbcb799b9300880b3a5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2562a4e684aedf2c453e5ebad568695d5b3aba03f631ac0e5017dc42f02f1f5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2daf4f01cf102afda0ca0d1a2743361f1394c7e29cd88856ae5fce5a39b28192"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b8926ebeac8d9eb949128fc2e0fc48049decff5291c547df68ddb6b6447ff8d4",
-                                "uncompressed-sha256": "1ced8b58e19d382dc0a474181aeeb1a3abec0cb845b71ce2424b8e317bdad877"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "53389f9eda43bd3f197219dc47e79cd53b58f85c0b744059e73c639211d142c9",
+                                "uncompressed-sha256": "83702d55cae1ef2b13ae4259cf0685d86e6323a83fb9ffb4ff079f836fee10fe"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live.x86_64.iso.sig",
-                                "sha256": "d85efbf72633caef5d14a62e4c295e390d64b7a1077ca940dc4089ce76c15424"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live.x86_64.iso.sig",
+                                "sha256": "07fe507d1e70d27c872a63df6bec9c6900524d4e577d24dab7084a5067e094ab"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-kernel-x86_64.sig",
                                 "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "fdeeeef2fb6b86458108f5a040e3f20beaa28ddce4b18e06394abb994de62d70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7923721189ab40fce01bd76822d3718a31414afce70330681283d548e7426fd3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ebec24bc6a353a4d263eeca928eefdc8a3cf3ba2f210ec1c455eba8a064797df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "9489c8eff7e396f7009b59dfb7ec0c06a359717ae68f0dc95717a70ae33280c5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "5eff62f9a56e3d5208677e3cd2658d9b7934ca6284ad4659430a8b28d38a9a25",
-                                "uncompressed-sha256": "ccd32f1a9b62d9889cb7468efa8f4771967c3654df5ed55d927b939258f08cd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d856b8bb4c25471a0b75b3ee48dc0809ef82449cad59e76c14d2f52bdb333b52",
+                                "uncompressed-sha256": "137ff2e0bcea5d49d417991b82702972f7ff70a1f7fb7c03f042051d8a44b3ac"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6e13a0d3b3a546c00f824cff085e1735c05690423467326d1f51fbb7c5f45263"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "66a8a7f9d01c5e51e0516e804e77255d82fa0d19ac81652ca6882263d1503f44"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ef1c481a3641d466dcd0993b29cb92bee3e40ff5e551c930c33b8f13f10b5815",
-                                "uncompressed-sha256": "ccb3751d9d6df6071effed44d1a9e4010ee882e8b7dd9baf2836339d57c68cde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9ba610a546e4d33106d51a6b1bbc3b7de442f6c81f76db12633a35b3907201d1",
+                                "uncompressed-sha256": "c6f9fc78e847cf195cd941d63e176041de6541e7a7735467bc33ac3fbee0fba0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "89c035849dbb983cbecb64560f6a5fc13ab2bacaf3f7c8d5357bcfacc127366e",
-                                "uncompressed-sha256": "2dda45c9f41af6c047587fca26e694c12a90ff34c01ff08a83d6587a84d21e28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "be24a0ee1816d8812304e4238e4a90af626126117dc182ba5d49a473db413851",
+                                "uncompressed-sha256": "25c2d94f0dbe000c2b6dee299d63d7a137a10000767480727c8abd6022363962"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a7077b762cb27b8a05a8b312e64aabe588faf5c2d6da863e6af93c355a4b4e70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "16cedc1a06802e9ea4140fe862962f72b818bdabce4eee7a1eb8612930d96a68"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "8d265edfd7bc5b4420834497567878e98dce07e6e5d32b8e4a1afe4d591a0987"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "10f44e1dbe7557ec30fdfabd9e6964bc25bcfdf3733a80534ab01109c0c85848"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240616.1.0/x86_64/fedora-coreos-40.20240616.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4822440f212f26723b3908905e92a523ed1cbd957150470200e758479a51cdbf",
-                                "uncompressed-sha256": "93f4d288d47d7d9ff231fea1792f70a06dc6123a6f0f170425dbc16bfb6fd26e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "573c8f03e3f75cdbe752a29f79ad15f48e202da4995363bcfb70b0b1d6b5dc93",
+                                "uncompressed-sha256": "16ff4cced1616d3ed47f3a6db7b0b5dbb123ed142856ecf87fe85754c34c4f6f"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-03491c5c5c9701579"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0022551bb619d3155"
                         },
                         "ap-east-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0678225d5752fdd8e"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0df1bb939a849bafa"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-08ac2bef25070c63a"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-02f33ee6e54a81905"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0c86424bf191f2840"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-010e8b560a01addbb"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-06cecd0d06c49b8d6"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0cc50ea2d8f4bb548"
                         },
                         "ap-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0826001d97cbfb621"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0d482a67602c3108f"
                         },
                         "ap-south-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0d28d0e63ed3f3af2"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0849ee3a7d4af2e4d"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0ec07d2f8c9919f37"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0da4dcb2bb65184cb"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-09ad0b5308803e41b"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-032cf52657b434b89"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0c3a9018dae63bbbb"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-027d89587385a3e6d"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-012a5378fbc452b14"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-03dbe67bf5e1cb90b"
                         },
                         "ca-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0a46e00ad9a305795"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-09d80f99334c7f826"
                         },
                         "ca-west-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-08bd5f36fbf2f32a3"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-04d2866dec7726b4b"
                         },
                         "eu-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-01e16d1bde880b4eb"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-048b4b74f0ec69b10"
                         },
                         "eu-central-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-088ab60882e79edf0"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-090c2f60b9433158c"
                         },
                         "eu-north-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-045b2dc7691a876e9"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0cf579e7547cf1af8"
                         },
                         "eu-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-020b9e0fbb24285d4"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0c41493bd09732536"
                         },
                         "eu-south-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0e7fda9939f4ec34c"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0fe89bd20cbef9633"
                         },
                         "eu-west-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0e13799abd5b8f20c"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-00175acfe45a0cc9b"
                         },
                         "eu-west-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0d8728907703cefef"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0e9528d970357bd70"
                         },
                         "eu-west-3": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0bf29ed25b6092773"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-05dda6ec986125ab5"
                         },
                         "il-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-072d7c743e45d9c8e"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-069628ede7be2d835"
                         },
                         "me-central-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0709f5932cf866ce1"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-03567f5f878188eb6"
                         },
                         "me-south-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-02d9483f96b791eaf"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-05c3b7bc6028f2006"
                         },
                         "sa-east-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-05ed42064e8d9113e"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-03b1f5719b5c871eb"
                         },
                         "us-east-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-0e44fe2b9401329a3"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-033a0811601155c61"
                         },
                         "us-east-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-07bee8f16ad014098"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-0f3d4f38be18acb8b"
                         },
                         "us-west-1": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-00de1c9fc1a150635"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-07d8c84018b57d571"
                         },
                         "us-west-2": {
-                            "release": "40.20240616.1.0",
-                            "image": "ami-02cb27b16001b8be5"
+                            "release": "40.20240701.1.0",
+                            "image": "ami-060359e426a867282"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240616-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240701-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240616.1.0",
+                    "release": "40.20240701.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a9d1c102f75fd20ad5e9734f894d3a3101d71dd70068627e6d0104419c5191d8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:de5438475a67b73783e930d3e187bf0ed8b251be4167e46c90b71987ec89cb35"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-06-19T10:36:01Z",
+        "last-modified": "2024-07-03T20:08:36Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "bf6eff8e7c1ebd7eedfd2e190336c9052b3963aa72f23fd0a587bc7451bfc7c3",
-                                "uncompressed-sha256": "b3b6e7def5d89a3767a807d1ae0232a6575d9e3300564c30b569793fb50d369a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1c251732d570b4dce881319f2b0abe62fc4e52e9ed85078c2eedc07d337dacab",
+                                "uncompressed-sha256": "886b1b55cc11880171e1ebb0fd09fded27557b87a6d7125ae8170f9db2e73e75"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c57053847a23338a7d3444bf90de56e47d3aa62f8668f4179c041a5f6cb92f4b",
-                                "uncompressed-sha256": "8b380d114d8486a766f41311521ec05459bc5b1865faa35f4d067d0c1bfdcaf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "6f3195b44f0675d1354f1b637411c29721083574fae4ce903c0b46ac02294e6a",
+                                "uncompressed-sha256": "3335efd6edee59051db72b32cddfe14e9d198dc5fc9e4b5f89a8d1e5768c18f7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ab94e84abeb3db934f89ef675f400e03b2b18d651432de403cfd1de00ef59437",
-                                "uncompressed-sha256": "50e4ce1646e7b512a4e047061ab8305f64e1ccfa5919e76e6eb162db36339bc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "510403fe7be1d5bb337c3666a15cd1b45f0ab5408e4a033cda1ae75760d7342d",
+                                "uncompressed-sha256": "d4fbe535a9ba1b6917cbc4bdce6d5a2611859cf3d42bd871f92a22b68fe702c9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "46aeb92eea6c79cc18cb6f81d422357e00b85718bfb71cab598b0da2f0130ab7",
-                                "uncompressed-sha256": "62819bccf2e42d847caaab7eea72979f1d45d9dae3da6d64f4b7a0481720dc4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f95854a1547ab912089ad33c8ca14e45a709943b07fd791e70fc72bc7653f3e9",
+                                "uncompressed-sha256": "98ea6c11e7ce4ea4c193e4ec37ca7102866a0bb1b8b8002fad32b85048584550"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "9cd28cab42752ead47a55f74f1810d626d0016025d4d125caa7d02f383a6b041",
-                                "uncompressed-sha256": "f3de290f588bfbdeae4423480179ad331a3adbbb771b93bcdc25b8f2d362169d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "558f24f0ba7b4dd175ea9b6ffc3bd49b405395cdca44b1341ef81010f57c29c2",
+                                "uncompressed-sha256": "3e0881e5ab70a749b81af408f34a98f938534b21c315c1132187f5a57de75dbe"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5ea6d369f7c38483904b21ff78f25a4c4bdfefabab9976c74d9b674bcd4b78ae",
-                                "uncompressed-sha256": "347746491d172bd6a5d91696f8cfa6fa3d047f15f6b56f2c42151df2a7e42907"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1c35754292298948c86556a177f31917d042c4e4ad29c2a28f470d6af860940d",
+                                "uncompressed-sha256": "68a23f8e2da672a30c42ead61c766eb9047c1a1348a213879bc7286653b1a477"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live.aarch64.iso.sig",
-                                "sha256": "c8138eae22aa63c78bac2f19a84a8232bd6e5238b0e48a8ea12e8a716f7c7e16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live.aarch64.iso.sig",
+                                "sha256": "0385ac2680f7a195037f594b8ac0dcd95f618137070de2a6f3f62e2bc10ce3ac"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-kernel-aarch64.sig",
                                 "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d0993edd5bf99db66a9b3957c3697b06ad9625dc9b6cba7f90c7101b497cffc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0fa28341e99cc288ad03c8d593307ee9c6c4d85d5c26d5eed60fb791d1be12eb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "11362e63be0833e43385aeecfa7c96884e3819bc2878760b8fcb193dd70311e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a149f512cf058275f1bbd312e81d7c900e399554cc4d66014a7e304ce7feb0a3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "22ac0fb34329b847012574d937ac6ad5b9c924e8087f6f233105ddbd62895d1d",
-                                "uncompressed-sha256": "5414a7309d5499e45fc5b1dc008f4647905298b99ca2a617281c73cb85f04d7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "86846caf2f74d616e5b0598ab0c2c7ca59d7f8c3ed1a57f6a6cc1a2f976f0d5f",
+                                "uncompressed-sha256": "ebfd3abf9fbe252d7ee99920216d28f34979de7530af35a48fd13cb4066b63ee"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c1138b68068623826d82a3c25247d98ba6ecc5991507ca71ab06d0c32d0981df",
-                                "uncompressed-sha256": "a91d9d596a0e9a4d25dde58cf129abf3e397323657a7c772df77ea05d6ed1a33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "eea5c128306d4bf921c85791ed4d8848e5c682387685bc682917c8ca845217e3",
+                                "uncompressed-sha256": "9fae8df91a0f2373579636b542bcd6df29f69bc952e09c7f6444e86dd765d7fb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/aarch64/fedora-coreos-40.20240602.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "731ce956df56c63f19ea32d27d84097fc2fb94ec70243a3e484a7b7b14558f0f",
-                                "uncompressed-sha256": "eb96cc6a7482ebc5b14f4bd502458b19b90bc07047db31433455f21ec12fde2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5eeb01dbc4ae98167b9e575584ffdad8b043092ea0842e6b586aa91c32c22d8b",
+                                "uncompressed-sha256": "ca52c8e55abbcdf57ae9eea45d077cad3b56da79b87c6ae8fac3c0c9f9edc76e"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-001349af5d515c4dc"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0e13c1a6f49ddb433"
                         },
                         "ap-east-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-03602adabc80d54a6"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0269f54f42c3a2bc5"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0f706dc7b09359b79"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0dcc4feac5a336c66"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0bc6e44ade6d70e5b"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0a79629baabb8f188"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-077b8972661cb0d30"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-091b7bfa4206c28fa"
                         },
                         "ap-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0ec5fc04ec088f47c"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-006f2ffe688f4f50c"
                         },
                         "ap-south-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-047f230c1d66115b6"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-017c147e796bcc804"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0571870f062284b02"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0d3d75c578f5f60ba"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0576d26d19aa7c2ba"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-02cd38f504d4f5c3b"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-04da8979b3485b1a5"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0d9ceb4d8ff00d247"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-06d2bcdf0721c4a56"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-018a5dc7dacadb586"
                         },
                         "ca-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0389b1bddd93d400a"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-044631b00dcc14daa"
                         },
                         "ca-west-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-06766cc21a4279f1d"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-069ec0cfda9a12237"
                         },
                         "eu-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0ab900403a00f51f6"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-00a2959aef9adfcf6"
                         },
                         "eu-central-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0f8efe965e6df6ae5"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0bf18ce5648f5343b"
                         },
                         "eu-north-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0d1bfdf63dcfe88e1"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-068ab49e61eb68ffa"
                         },
                         "eu-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-01b75fa9d52aa0b3d"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-05e66615af68a6776"
                         },
                         "eu-south-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0de8c59f6e8512852"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-08b13a87558f31301"
                         },
                         "eu-west-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0966246dc91a7eb11"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-01f9689431ef64f26"
                         },
                         "eu-west-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0de8319a7633a80fa"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-08253badff9b3baa1"
                         },
                         "eu-west-3": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0580c78cc9b9c941a"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0a0328859eb7c39a9"
                         },
                         "il-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-07811b3520b8ac398"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0df77bcfc76f159ee"
                         },
                         "me-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0129743024242b7ad"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-00b83b599ce0415b4"
                         },
                         "me-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0be91df94fe9b302d"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-05d084ce9bdee0bfd"
                         },
                         "sa-east-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0b0c554dc778f94cf"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0a5c770648bfa38fe"
                         },
                         "us-east-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-06154c92da4ae5a6d"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0ff8025ec3df845a5"
                         },
                         "us-east-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0bab8ab67758d5edf"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0b15cf1a7621d90f4"
                         },
                         "us-west-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-02600ddfe13cefbda"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-01fa7c8c6f5606244"
                         },
                         "us-west-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0d0d4f127d463fbeb"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0af7305b952b177bd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240602-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240616-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6642248525bcdd9b89b9f9383199d516d8d3155c7dab49f92cc197a2588f2ffc",
-                                "uncompressed-sha256": "fd93e8e0f7772a2bbf6a0b40b8cce1abd1c37d4bdc6e5f8fc0895eda38ccd5e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "9ef9f4e5d5d8f95750944ac2d7bfdeedb1865bc67694e7cabb53e1f13045b62f",
+                                "uncompressed-sha256": "85eac420898639fd5edc76d41ec47df068cd20c6435547654cbd209a1bfdac41"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live.ppc64le.iso.sig",
-                                "sha256": "d4acde9999f744291511496b6074b047d5695561486b939faffa4fcdd8b5ab26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live.ppc64le.iso.sig",
+                                "sha256": "66b4fdf759f597e64307469c0ee2bcce7a8aa3dc69638e7773bbe364ac4cf053"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-kernel-ppc64le.sig",
                                 "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "7819e5b6884cb28b021d7b0a2de048e1993f36cd8c31b48a245889c520a965cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1cae5aaf3a0ac16f01df55e0c4c8970abc37f3a358c18df44108cc8372c97ee1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1389db06dc92b9e0c38455d1c6339a3e097b4ec80b0acf62b88c2aa42c5da3e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "187188116b08264a0527928789f51c603bf7cab5445ce8577282cb19298f76a7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "8804c0eb3f922f2bc7e44d26657dd30d43a2d6448cf4997effe05e584bb746ae",
-                                "uncompressed-sha256": "5381693520873e3fbe8e5df1b1d6a74f8cba4455fa6ee6d579ecbd1ee90e5753"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b183e5e39e1ead93de8c1121a4ecbe0cb1f24d3ce391c083262c1b22669d7ca0",
+                                "uncompressed-sha256": "dc7934819688ae66567ca578d7c3cb7b0f50647dc322d354fe8e0bc47fcf3ff7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b725a11ac17284b45efd536d39658ecb51955db6e9f0438d056c1c577a47b844",
-                                "uncompressed-sha256": "8a4f1792fa17fe34a7f010c35d3b641021d9f6ec513d299f740a78937ff01687"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2ad6741617015a86234eb91f6cab14b528ca42287ac287d4edc05e94fd2d6816",
+                                "uncompressed-sha256": "be9e5fa41eed07add618d332d4183c89b12b8227db41a8b27511fc50c718375d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "91b3c437830ed1ad5f61c8ae6aa93cb053ab857481f6120ba45c2af6f25bcff5",
-                                "uncompressed-sha256": "00bf7a1f6ee5d07f0bcd061d9ee9044dfb58cfda4634b6f0235de54831f1852d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "41323b4655cac521a778fcc0e06d60bef6a540f16c7ee704f4a4a092571342c2",
+                                "uncompressed-sha256": "99b8eda372e6e4d271e0ac046950029fa9f1be3bdb8b1878707802d4abd6f6d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/ppc64le/fedora-coreos-40.20240602.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bb8821e0780685ce43232390860f71e86dc3c97a1c73ad1b1149c9ba92a17d4d",
-                                "uncompressed-sha256": "e37487c55b059c65cb877f355c6085d7136a2e2ef9c58b353eec8bad278f8581"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "908bc7cd919f35e7668353266295bc4f781f46b4bf44f9868202c85a74427173",
+                                "uncompressed-sha256": "23ba1126a8f7aceb5d65e5395d7e2c77ad11889e311acd01d61f7d06e4268875"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a800cce24c49caad30c83e20455144a8fd2d2262a6233d2e14c5717712ea1e60",
-                                "uncompressed-sha256": "29be61b690f6bc9457f1c664c33858d5bd8db1cb110960f66d01e46d4ab6fad2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "33009f66a70e12727217b8dfb27eefb646807f0d0acb9ded221bef6356a2426a",
+                                "uncompressed-sha256": "6c279511b6a1961fb36fc58ce98a5c8e92eada519f1ca9d56f9034374e697c3a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ea6f5577e706241e4916a04261dac60dc3b866aaf3849abf23232fb38509ac85",
-                                "uncompressed-sha256": "4fcdadd2a2a2a2f70989d723119c9aa7f2183b6971948369a35222333445dcae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "767ec1db76ea1aa9c0a893860943848b6c3556a53231b058fae5861eef6537ee",
+                                "uncompressed-sha256": "91b647fe175432247c5336ec5b0c0328e551461c0906737be241b0fb37120a08"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live.s390x.iso.sig",
-                                "sha256": "1f727c3640bd469f23c1c14ff5c9ac7d8bbc58f1bbd893cbac4b5dbc9de56f3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live.s390x.iso.sig",
+                                "sha256": "fc965489eb759ceb1104079ffd9bd0e79d925264b83d6019382bc0a399861ef8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-kernel-s390x.sig",
                                 "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c49147dfa2d110919802a8071286e1c16487df35f3f89730e08f13eb47ab9ee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8232e56649889f358ac01b972e64c2520bba17d36fc446960c2a0d1abeae1df6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "44531bf9af11bacfcdc9053b69e79f51f15827b9ad0c94108da3c54c918da097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "587dc8f9d694f4f913ad2eb3e89ec694746e75bbe1d0fee3606c60e877e41498"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a65d0d3a03f992a6b831a212543ca03e8bb66900c8316ea1393a405da766c504",
-                                "uncompressed-sha256": "1500062e97d84153713c1238fab112336c257ac44ad049ce938fdf60865760d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6f29bf91f0515a87a083ad839d48b7deda9db58150cfbebf4334efe948eee665",
+                                "uncompressed-sha256": "b1d62f9a8e5fcb697102c670d59ad2471551fbf4a73d22649db4dd62d868217a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3e2d2dcce06aa9e3387edf6aa2d51efa9c874f51488322e603241af4be4dfb25",
-                                "uncompressed-sha256": "8c5b33a96d867622280a2340d9708cd24d9a77fdbefb202df782d215e78a695b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "28766e938f9fbd8fea2ad6db3fb2d6c1fbd45c424e2bd9dba7bc44217e2ee5bb",
+                                "uncompressed-sha256": "248bbad5e77b05bca6dabd669445d172ea06a64af22beb1c16e1ce23d0caed22"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/s390x/fedora-coreos-40.20240602.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "fa5c429bfee51e4c7f0659e1aad05f1182f5d4f4987b9d63072b31d7b7bb3b01",
-                                "uncompressed-sha256": "39505d7bae9be0025423c7b4972b470513d573fe914445da12a64a1f964ccdde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8dbf1c898ac677fdf6d86e24e37b81e08c3ba70c8bd8fe268f8499db1ab95b60",
+                                "uncompressed-sha256": "6e0a1045bcb570bb4a3fa88fa17b4a1890f48f8b1fcc6c2eb40d399d11111875"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7e889c8471b4bcb210a8e82d6d35b7cb38200d9d6ea18d147d10f3473bd6c059",
-                                "uncompressed-sha256": "ac895115659d84ca30f3fbe835a46df763984bde5c2c198daa65b0f95e18c7eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "25c1177e04e6c1d2d3a9a24af779f31199f5606172ed5dbd2e8dd206c3ed2965",
+                                "uncompressed-sha256": "71ff8f7867dafa08ddb258306ffd2c4db540d29f4a96ac304e3d768e0651a46f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "915738a31a15a1606926508cfdf5b5674c112025820a7e6948f4cc8ccfbb4278",
-                                "uncompressed-sha256": "6295d35bb10e6f61dda6d55a92b2bd1d0ec3a4b4224494b58f0995578263993f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "869d0cd311364b841e444c93e961cf3453f9d78bf920abfb717ffa84657c2fc5",
+                                "uncompressed-sha256": "71b6e5b2938e319fd7551b1d00c564387a4eb8e64bf054c1b61f42ac614d8c78"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "89223ec64b697f1a9ede3a79d6da28b1f216c8c1a4723a05437c22f33da51b9a",
-                                "uncompressed-sha256": "ee198b22bfc35d5adfa2b9a54712f67bd6f7a79abc6caaa03fe2b4a7bafc2007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8a4da5bf8f615ab356284f52739ea3f8bcb60be875eec7c35d3c012a1dc938d8",
+                                "uncompressed-sha256": "1d8a058c1bfa0f55f08f6842384407703cc10041fc447f7afe60197536571459"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8da55375c8bfb73f78edcf4bb4caacd9fd3b2ff2cc1e811cb714e23a61a26a7e",
-                                "uncompressed-sha256": "e4f09169c4d5b39aeaf92dd69ddb2c661eca6f8962226224d8cd2c45a5bc6476"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c389e9c085a4ddca82a179034806cbd41e10be98833e803b245ab462f6180f0f",
+                                "uncompressed-sha256": "998a1ad1cd9312a6e01e20c0316578a831bbc812e3c1882475e58d3f16bc4966"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "4e0b35feb0d7ebd3ecf59cf6ca2dcbb2cff7df13bd61701fc59922657b347e08",
-                                "uncompressed-sha256": "4bee588b6b41b2ebc31f59df0b5a00a1c9cdf6671d45f18106ddeb54011b7c01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6c7724fdce74840f4373b40db860c08c060d494310ed6785651eb95e0a215fab",
+                                "uncompressed-sha256": "6d96eaa73b571571c9b379501ddade5f17d85c8f5c6ed0c767b95c13b37db58f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1bb0d96cabf12130e0abb50251cd5d7b8dacc77a4dcd7b5c2f1209684e51cd07",
-                                "uncompressed-sha256": "76d4c42f31dfac8482498e9ac8e1619a887a21d90a6a15f3450b666ec5773acb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f1cf7fc899d5a4fec461465dd0e94fa5187c845088c36f1a378a69da57dbb2e3",
+                                "uncompressed-sha256": "bc5ae3db9bec35c2d9399bdcff50b0d4d5eb9e48b1e2c722ed285af4fb26d42c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7d3d35d5550fbed98784d4edfed7e2c9b38f05cefa41789de76fb607ebc7cd5e",
-                                "uncompressed-sha256": "cfa813571efee1b2c51589373043b2432a42bc2a18e4af970806d31e8a154607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3decb75db7eb189cf3917e53051aabb95a5a82e29ec5dea0b413c664080e4ea7",
+                                "uncompressed-sha256": "e122b50d522df21da7cf4e56266182c684d5cd73cfb2934f3291eb93017a0784"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "acb4b98c5282adbcee799656346273fbeabd6d60189be6d6bd41a56dea733c6e",
-                                "uncompressed-sha256": "2731d4c7cb85f63e30d24e43ad0660c85847d075ecd3dfb61758a35e9e5ccb0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "40910b9ccd0ad1e0468fe55e439b9ac7c185fd42f10d19f1b1144c49eacb7de4",
+                                "uncompressed-sha256": "93ab34a48c1de62cfdd92dea96a5bd358f0e514caea89756667407c61f462594"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d8c0fe4ec0ba8e5ac3180375d1fa65852c37378c30fcd35528bfa85dd449f267",
-                                "uncompressed-sha256": "cf139a77205440f692020215cfdac5872342008cbe8a0759648e57e316ec3d6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "62e29a08772a2b77dcbfef58dbcbf789b9d07ff0a13f8019e95541c4cc569b0d",
+                                "uncompressed-sha256": "9b7834310d7c8a2251f515595178e84e227585938e46256d97b2f3aee940c3ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "12c9d9a2404da0aa3c87ae2a84e56e881de221992578258e2cd3e096019b85b1",
-                                "uncompressed-sha256": "e485925a8999da2eeac7de9e5269e3c8b682bee3f460f2aab4b408406369744e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "63899d7b35601f2116c56f04722b0995c32a7af81120ba4cadd19f2370585215",
+                                "uncompressed-sha256": "4e20c45a338718477281c22d7e7b28ebae13faa1fd74667f3b6bb4738a709e64"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "18116e8a487242489cc234e40f6f15fc7d2d3a0a1b34f20aaa5345edab7be973"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "66dbc78fde5f71e49f0a1d3ad23e1bb1f8af0d177866e08426e02817c8827364"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f1c9d27d2fe8ce4e510bd9c3041875f6702f5dc234f32f558cef6b9e63514e99",
-                                "uncompressed-sha256": "ad084c907d17aa82f4111f1dcd5b4ef55ecbdb7e4e04ba96d88a5e1ec6f65ac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6deaf2f20e4d41997390da1acf9ad427a7944d3ceab32b093b95f4a638fb9813",
+                                "uncompressed-sha256": "06b8f1584099988f9faaf480618b42f256991b7a4c005d8ab8dcac42de3801bf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live.x86_64.iso.sig",
-                                "sha256": "d5998f8da6d7fe2299faf2a250358089d8bd440611623e261987452633b94a9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live.x86_64.iso.sig",
+                                "sha256": "527f76d12942ad4a305421adbb35247fd93ae3588b5c2bb7f03534e2d603c0a8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-kernel-x86_64.sig",
                                 "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "22550a65bb3cc8606a533ecba1bf5934d298921dad216a25333d5373cb19bd55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9a6e34a3a7e5f606525a960f8a9fc0d71d34bf64d680085ce17bc53da32ff4e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e82293023c541b2d4051d2162f139666275e9c5124d47608c8d66a528857f1ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6e140c6964afd242787e2bea8ae77bd7c0bf22c438d57803394ce2d05a108931"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "aa25ba879b6ba2443c31753bf7d767a27b7384070a7734f549063bff89f774fb",
-                                "uncompressed-sha256": "ae565bfed71bd28f276f7a7acdd080f8c695af8401be3d12129d81d6a7f2729a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3993fa77ee7d379425fadab11726a57eb3ba460d3e53252c56e53510a986d59c",
+                                "uncompressed-sha256": "457797c79e5d3b4770edd16aae322ac11a2cbe89a4fd8720b5f57a06431e5433"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "10f79e612758a750515be44f74427ad4c0b71d50e7a4dbc42c72f19c8f87ac6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "21084a7bbec7229afd1004047af0372e024ef52ade572bd70ba7734423496961"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "57df3eb458de53464dc63820d059f52d7f61e3ff6127949864914f70ae041280",
-                                "uncompressed-sha256": "e2a6729735eff64c9cb68b25b8443557ff45c7997298a832145af3a18ad858ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5dbb60df92579de62d9fd876639ebcba5c611bd94e1593a440243f2e17f97177",
+                                "uncompressed-sha256": "7169776007b9a98ecfcc39ab57f2addd930525cb1af9c44fc75e1e94eea34fdb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d7c4d3b2f9789b033468534d732e2979c78d57c8cc61842dde8735cacdf43df6",
-                                "uncompressed-sha256": "35c5fe3dd90ef68cce2ae7976e8ed723be4fd97fbb43f39cbf426dd64b870ab0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0267432faadaeefa3a41d8fac0233875d15e79ca5c3c59efdfb27fea4d0afbba",
+                                "uncompressed-sha256": "494b80710d443866338dc4c716c25349f17b559dd09ca3579f0b70ee02f8cd8f"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b0b5eff5c68aa5c51af4d06d0758e4b96a8f248c8ee9ac77b4763197d038ae42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7a46e029efbf19c85b7916f1d52a1e58a001c6b0f3bec6672edcf034741424f2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "6f2840a213f34fd30aff4d37f55187f5f0869cdff1f4c750f536e4a8515ab0e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "ed997b9e3c950ae3b0d49f2c3bbc2b3b8c7d27ea5176753064d8f68b9c337419"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240602.3.0/x86_64/fedora-coreos-40.20240602.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a56910493dd5ba588ca0e8432f9638d44560087aaa1c3004c46779877ae57179",
-                                "uncompressed-sha256": "f27d5e28153f629cfdd73200e0da61ccc98df27e35b2e0ce6a4afda91532e446"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "65368543d5ea65057df80166e2ced34457f12de85b2679e47ef47f545ee41ca2",
+                                "uncompressed-sha256": "f339d1833a70d5caf467b115d72bea4de2384a6b7dfc9a7c9a63cb276ad8e725"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0c8129fbc1a4db87e"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-05a0b17e6274d577b"
                         },
                         "ap-east-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0abc6c51cbe6e0b47"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-09fe630032aacb460"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0c41140a398287c9e"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-061049e69b8c3e5d8"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-033f7eff185d36afc"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-097e2cc566c38cbbb"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-08ca4b0a5f6b6eb48"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-05d1b8d93fee61d3f"
                         },
                         "ap-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-02d9364368bf4a85e"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0e19f751e72f39097"
                         },
                         "ap-south-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0dac5bfee3ef25274"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0092dcf3e180fa7f7"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0cffcbe184eb79267"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-08bfdce81e58a8010"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-06202852763b9fe55"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-081997cc94dce04ae"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-09633d0b2acbcb834"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0c429aa94ec22750b"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-099ece642b1b95b70"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-008ff01ae9a61599c"
                         },
                         "ca-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0fc8202adeb02eb65"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-055e1fba881618fe3"
                         },
                         "ca-west-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-011ba20bf5869b6ae"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-03ab9ef853f4f2315"
                         },
                         "eu-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-061252070e2e6e92c"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0e94ed7ad58307805"
                         },
                         "eu-central-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0b71d93ede274d300"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0564b824d12b7b7b5"
                         },
                         "eu-north-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-09b9805233126edbd"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0f4a00357f13538f1"
                         },
                         "eu-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0f91c2165ccb3019b"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0fd542009fad861d6"
                         },
                         "eu-south-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0fede9872ceb5d4fc"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0e152b412276bfb67"
                         },
                         "eu-west-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-075f0393fbc4767af"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0b3032628cb3fba0c"
                         },
                         "eu-west-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-09f9c18713b5aab60"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0320ee9d0b14c85e9"
                         },
                         "eu-west-3": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-02fff30de1fa5cfd6"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-020e5972c327af01a"
                         },
                         "il-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0958e9ba4610387bf"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0a43d78e8ac881799"
                         },
                         "me-central-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0aa09d7c241104db1"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0948cc2298a0ebe60"
                         },
                         "me-south-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0aa88bfe754b23f03"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-087cd04a13f521680"
                         },
                         "sa-east-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0be3537cafa91be72"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0b7d372e18c178be1"
                         },
                         "us-east-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-06eebbdcc9a3f0712"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-068493ac5013f0936"
                         },
                         "us-east-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-02bafb04c5e0e1c3b"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-04000bc04ccee958e"
                         },
                         "us-west-1": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-0f4aeca93eb04bdc1"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-0c460801fd7c3c91d"
                         },
                         "us-west-2": {
-                            "release": "40.20240602.3.0",
-                            "image": "ami-076fcdf587ce056cd"
+                            "release": "40.20240616.3.0",
+                            "image": "ami-00e824ad8aec76dbe"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240602-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240616-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240602.3.0",
+                    "release": "40.20240616.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:df27794fed42558fd33e1eb147d756a42033a5b2aa6514e595dc9a2ff5a99ca4"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:eeaf9e4c075862eb9f878abd20f522f17068c7f00fdf0ae9f138ce3f64456b2d"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-06-19T10:36:03Z",
+        "last-modified": "2024-07-03T20:08:37Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b6ef7cf85b78b404aa186def8420849da369db66c2946080e4c23f8e56340d4f",
-                                "uncompressed-sha256": "27ff1ca55d51ca5b74e07ef6c8ae59427bce7898e3f5914ccdb9e4c910ce855a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c90db63fc21b356efca496b2122cabe56c415a0fee6bb7fdbe15c1b9db1b9541",
+                                "uncompressed-sha256": "223785efe8db07d39536c93b04dbfc11c4b2b9d062f6f23610b362a27731f7c3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c22dbc0c235dc6d1009335470bd238d1e9c51a9b9477a6716b88a6ffecdf6a2f",
-                                "uncompressed-sha256": "ad0cccb540c8206e1bf11f99597e40bdc13dceca4309a7b867c8c62ebd38dc25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0328a84984f8f2ee870a6ec52148f9bb287c2656937d3af2458df64122db113e",
+                                "uncompressed-sha256": "be9e7333577df6aa011d5a39786e5b25bb4208881220a14696756b2ad90d5052"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1aeb2cac48ab069c8743a6c47bc7b74567bb3e50cc982cc5221a99df92bf735d",
-                                "uncompressed-sha256": "d045e28ddb6b391ef5ab34a2453f88f9c843865f6620832d6a09aab13e9ec7d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "db9119c73252501aaa64bd94f9b80a38e7a44abfc2cf3e513bfab9f13a012227",
+                                "uncompressed-sha256": "c02e0c6723955d38383603cad46e1c4d43a8689507b719c4bdf09e447ac3fda8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "af40a92bf94d63414fd322ee62edda0886a0b8bbc8e36784c39760d60590f6fc",
-                                "uncompressed-sha256": "705bb5f8e285663aa82327937b0168d121e64ccb5324c8ed8b66e900a692c857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "5498ffe1e90e4f0f6719dbad4ea44484d4981434735f71b7a5f208811b19afd6",
+                                "uncompressed-sha256": "3e757bfa8c15f3f2b79d92f3547ac0a1fc0e4f03b7285078134b587bf79f2286"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "2020d93ed48d53875eb515c338d268271958b9f38989240aa0b0f7d19291ee76",
-                                "uncompressed-sha256": "974a396e02d7608bbd7cede3fd9a1fb45372e8456154430a1d5fc91665cf0860"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "da7e38fed67afec7c1d12a2912588df4bc5f7b38db7f100ff0618af7487a0348",
+                                "uncompressed-sha256": "525de8ffe949c4c61cfcd51a218483c78b3794fd26fb82ef974f10ccbc24cdfd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f141d941c8c6908ea6dfd895163bae8b0a1654c329bf829fbc015f3138ed8fe5",
-                                "uncompressed-sha256": "374325ef51e8cb264be9d8983ba68bc1f4d8f959077eef06d7cd2a36ad42ab6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2d75c22744a72a6ec5585e4a774ab1a091eaacdc5a87c8245d3b24cd00afe6f0",
+                                "uncompressed-sha256": "70840bf73f39e8c8856c8978ef3ff138ef8763ad39646ade268383a0d9ce8e00"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live.aarch64.iso.sig",
-                                "sha256": "d1aec99f75ff01e6d3dde90429f248d7dcb511509b08719ea871f0ab16e4b151"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live.aarch64.iso.sig",
+                                "sha256": "474562c743d12790ae8cb007e8f7db40c7b93955a9025bb94243b24aaea5cca3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-kernel-aarch64.sig",
                                 "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ba09093c7f92a5090081a6ec9f21cab7ffc7da43510a96ceabdd23f543a61d0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a8a5d79142b739a1e913127ed1b635775d8b4e839a4bb9e685f4fe786cc43b46"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "1e2f85d59879542e26210a5693f841768b9354cd2d752b4edc71bc6856659b56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8a78c33cf0d27d24344ad796a85b0f28226ecf2d06048410546d895218eeb077"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2fb29e29e3b228a393e118bb9e2fec58ac9e340e16bcc7e79ee554242fd50d9c",
-                                "uncompressed-sha256": "55561e678d8a7ddc465bad70462fdea4894d7c92abc9de54a423a6db8443754b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "17a19b2e19e329187dd4d03fcaf3a83ce4e7dd3e1eb2e7b5e1ed01a713764136",
+                                "uncompressed-sha256": "4f8ff22f340b0bfa6baff386dd54ae4e586fcb4ee4a63b0caf653c6dd824b48f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "68fc0f820e773a68c86bdeeab80e4f3c767f60d2e5c7e796dd57346f83007d17",
-                                "uncompressed-sha256": "810cc34fed1f242340f087f340f863c666f4ac0536333f5f24ceefeb092820c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "041fb161250467e04363bb409120908334b8a50b65ca5aad09ceafcae6b609bb",
+                                "uncompressed-sha256": "7842975da957b00a3476451523c3aeaa092e93c5550729279742711211b44663"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/aarch64/fedora-coreos-40.20240616.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "702db132e1acd1a448b3f59f0b7a17ae029cab8975db0ee84f9c26148ff3149e",
-                                "uncompressed-sha256": "9e792dbffaeb1b515bf1fdfb3b0423ea2067287ac1db4ea1831f8cf8b8e0b0f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "27c320b9cfbd4d3c2c943b1b04dfd280699e29a5ecf2abcfef91e5e4de1166ab",
+                                "uncompressed-sha256": "731cceb1a9554dca79b756ce9cad7cf9f4190f46c49cd245d12e6ae8cdad4046"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-07471dcd640639740"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0bcf4476ffccef8e9"
                         },
                         "ap-east-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-06f8b2a8de408c253"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-013231385fc5aa1ee"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-01d6b54ef0ee5bbe8"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0e7ff2b47f49c990b"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-084419b19d5b308b4"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-05999cd4a10f4b1e4"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0f5ae761b3b675aec"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0b4f0f0495af6a74d"
                         },
                         "ap-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0ce85f5f6124b6b31"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0e1de23fcecd35b66"
                         },
                         "ap-south-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-06cd372aee0381e48"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-045ad65156c7a2cda"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0d0ddcd240cfe9cbc"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-07a430d89ec58110f"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0dd77980a0a0ae0e5"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0312837618359d622"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0d2091e6ffbbc1781"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-05a3cc753cab979aa"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0c987d7123fde44a2"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-00ff1ebe2e1287fd4"
                         },
                         "ca-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0fa974787da3afe4d"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-03bf1766524c09611"
                         },
                         "ca-west-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-095e581286d8f1b33"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0617b8213297d365a"
                         },
                         "eu-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-054216d7b3955d99c"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0cdf6ff2d878c3c17"
                         },
                         "eu-central-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0c47379f19f1a58ae"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-00fe57cc260adeeed"
                         },
                         "eu-north-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0c0e18947c9d5ba80"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-075f01057e6135b41"
                         },
                         "eu-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0475aa0f8e2e1e254"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-00fcf19b28f048417"
                         },
                         "eu-south-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0253c8013b8ce3939"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-014c393a1312687f5"
                         },
                         "eu-west-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0d5c2f2ade33ad999"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0ebfb5805c6dc34c2"
                         },
                         "eu-west-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0363e75a702fe86f4"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0cc1261d9075f5eff"
                         },
                         "eu-west-3": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0aff071932c0701f5"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-09280691d03272387"
                         },
                         "il-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0cab566b5370039dc"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-05a1de92d447091ca"
                         },
                         "me-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-045484cec108df6da"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-025c3e04c2fbb00c3"
                         },
                         "me-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0fee3f09b3c4eb51e"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-00713f6431c60effb"
                         },
                         "sa-east-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-058556fdb9b94c73b"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-03666335d577d104f"
                         },
                         "us-east-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-08a6b6cf93336e27c"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0b6cdcb768ebabe0b"
                         },
                         "us-east-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-09a902b550b4b7cc4"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-021ba5f11de963f27"
                         },
                         "us-west-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0fee55bccb19fc5b2"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0cede7de335da525d"
                         },
                         "us-west-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0157c34ae981e2b9e"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0e26dfc31004c9b0c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240616-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240701-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a07fd51a955ed45707d793d22f129188da8ce4a9b1286f5fb28c4f9a55558c51",
-                                "uncompressed-sha256": "a8e43a2ff684e48bc0a0b4badd9f3fe18f9392720c8245eb2862b8cc99807a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "dc9a69df00da36b2de97d00cb455ff1e28e95bbb5c5f96c7274730f615842dbb",
+                                "uncompressed-sha256": "57e27b076855510d14dac6456b0c7955ea35beb811a48bf685708da2ede03c0e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live.ppc64le.iso.sig",
-                                "sha256": "74482c10767280fd4ec41d346bd21a69726b8ad5fbaf32c13b037d0662806a2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live.ppc64le.iso.sig",
+                                "sha256": "0e1c2167edeaf8d2c002a2e7a9504fa76e277354b5d83820715d37aebdd34343"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-kernel-ppc64le.sig",
                                 "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "a479ad09f56f251e71d080bc39b779a9605d41aa70836ccaaf95a2f3688975d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ae109284c1cfe7eb04658df3ac489a4e93435bd96ce3a43aa7f2208730cfc867"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "24d3090afbda3dba381cdcb12f165ee7131bc5f57e8ff246a9a7ab0475de46ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "06be87b0b84f9fb75b5f342988fbb20e3dc1f442177a3cd94c0ce257c42ee1ee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "0200b41a5f28400f724bfc11e8fd89751e189eaa0ec43cb9b513c5aaa43d8d69",
-                                "uncompressed-sha256": "a881e3ce70f27e9f32b81c04edd2a8d48ae1484e358f845780810b9c9c21fa4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "24c36595ae889365eb30c405b3e9423c1772be1c38e3a0411449904473363f2a",
+                                "uncompressed-sha256": "3e3f607406ad68e0dd8f4563a2426043cdca1b33a8e5269c6d7ca5e9aad1b79e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "8082163af86a6f5022fbed30f19489166217a11042a756c15a805635d049eede",
-                                "uncompressed-sha256": "58cdd041ed07788f8ed867d2200dca531d41cad52a0a115d74fc1da0aba87d67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "d0fb7602fc03962f3e254f8337169e8cbc32e4aa5d6e689c8ad903520523ed25",
+                                "uncompressed-sha256": "d1b33bab345229fc32cef5f4b28a2b93c27961c828caff24e7702420024e72a7"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "1e9c6b8510d10b6badc2a0c77b8c172c3d3f90f588c60415f7e531ddf9096791",
-                                "uncompressed-sha256": "80ee31e24550f5796c66ceafa0fb911ffb8b514b8da1d22f25371d836fadbe35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2fb82fc4437b6e1cb36aea76b9698254dbc7968a1c3793b269f79e92e552a64d",
+                                "uncompressed-sha256": "bf78cf99c8bbfb8e2ba11bcd9992f84ba2c214d704e5a6e3aef037df3efa1016"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/ppc64le/fedora-coreos-40.20240616.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d19b4ddcda4e00c48ab5fb23a2b7d0bfaa280ba59e7f57bef2837bdff16bab0c",
-                                "uncompressed-sha256": "1e73cf16431a9c3541cf4ea609c9db36c9aacb198e5ef51bc72471d5f859a9b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d21c6170ee0f954ce8809f4ccc6b3da6faabf807869850f489cb80955c3cde9b",
+                                "uncompressed-sha256": "05265f1b6a35bf3f781cbdb9ce1b4a810083b9c2b0fa2afd4c81f507e3885f4b"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6b8b4271e010457e016fbe9dd80c566790a7749d8aba48eb46cbd8ddbb2ae4df",
-                                "uncompressed-sha256": "8230031d8862aa3fc95d96401e611c5607f4752d20d6cc2567172f9e4ccc1085"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "425ab42657a130859adb9255b69fcdf975a858ac3aff04746bff619a59ab8939",
+                                "uncompressed-sha256": "596325f4db1e7d31cbc6b46e3c1cb14b6439d6b378c2c767e27163e4db49c62b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ef1129925d57396a855ab3666af25162dd89e0aec911b75b0191c6533ba2f0f0",
-                                "uncompressed-sha256": "22c2156ffa6828eac4e9524a5fc4afc082d41c3735ba88cb11eb76fcaafc5c35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "41e4ba9190786b4d5b6ec6ca4668173ffb3b983a57a74a01247fae9f0a576496",
+                                "uncompressed-sha256": "84e83cc05f3a2115918d8e67014549f76430ab91b8562c5cc7390fae6ce32a55"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live.s390x.iso.sig",
-                                "sha256": "43ae93b7b0b2d8460e879ed6c532127c9792a3b89191e3aa16fd50bdb2bc3361"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live.s390x.iso.sig",
+                                "sha256": "58f01a68d8d34a0624d968ea766e0604791dd757de5154098f3d1446f9cc2ff8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-kernel-s390x.sig",
                                 "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7d9404f855354f1fcc9a29bb5cb89a7fea6533617acd6cb5143eb7058a85f332"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "78defd10806b588c12298dd384029ded63d6651da7aa5ff64ac12e20dc0ad184"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b668c96ca3114480f445cb87678ff14c8fb4149164d27b5f37cf03fc863e4812"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4432a811eb8ddbfdb82195d59a8e75c59beab5dcccb12cb5d3422778226e0cc6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "9fd3ae5e17a2884325a7839ba99c4d217ba1481ee5786623b98e45df2b9eddff",
-                                "uncompressed-sha256": "eab48ecff65471ad04432ab8e1857268a47356809152f1fe514f124c77ae7b9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e98e617c5a1d11107024fae46446098bfd8cfb91ccb564e034a23a0b8883fd8b",
+                                "uncompressed-sha256": "f48ae17179d1434128807b2162aa76caac28ba8ca1176fc682e86f105e76a6b6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "fcce7d32dfce0e2df920e2e6f76b88c4a1fc48beb8de23abe7fc454f9b336150",
-                                "uncompressed-sha256": "6e557136caee4639b5991e3bdec3e78b3b39c2414adbb728d44f7104f9fb571f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "178158c4701522cf12d3ce20282b09124ce7a7e0d0ab33ea415366843e67d114",
+                                "uncompressed-sha256": "5aed278fcd44a96bf99a3abd2dda60cdfeb92183e9aeed5c41beedd8645045d7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/s390x/fedora-coreos-40.20240616.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "99fe3344e5ab2112f288e84dd49c28e26cfc967226ee69cd658ffca370067b12",
-                                "uncompressed-sha256": "d666d9041f243a971406e6c8bff5da3c539aaa9af3aac28696ba13f54b7990fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bdfc71575a81dc3b54b0cea5c59cb67fac82860fe05a28d09d93c515baf75e37",
+                                "uncompressed-sha256": "6e5641d60125cd338573b39e125cd0faaff61b060ad013bbf795de730f18654c"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d46d26a77e99e76c3e980674c304d2c4babfc21b253ba4e9179f87839a7dea42",
-                                "uncompressed-sha256": "5a52447e74fd7cfd96e9c01709eb20ba8caa3f5fdb2cc2a880245301bd55b537"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ad85ec015da37681efb98457b747de83f4f2f3289b35d6e3159791ea782209e9",
+                                "uncompressed-sha256": "150ad4b494ce0b0c072ae8eb4db814b61ecffa12cce9a9c1905e2988af8d3afc"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "120b3a7b30f9b647a4efd9d64030b90d096274a6d6aa64b65320584bd2b3e2f4",
-                                "uncompressed-sha256": "77f8d3d387692c6c72e5e3b9f55e50d8038f3e5f196dd8e44d450e955bdb15aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "71cd2055f092f1a50a58592de7c5f727c744a7c2983f4df055ce3576fb141add",
+                                "uncompressed-sha256": "d909a5b1091dcd916e424fc8ae709d2b546396c41fb918242d84de1bcf4b2309"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "256239b277613a2a90054a1d1c8378989a6121ff454ff7f5c2e9c5a87d09a37c",
-                                "uncompressed-sha256": "5e1464de4ac4a1cfe64c1fa706a3d4888f3acb67c1875c41c5fa8c505d256df6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4907e7d88abccefc5c10622041814248dd378f238d0d9e562d76cc481fa39632",
+                                "uncompressed-sha256": "475e887eabbaaa0253d80172e1b28bde29ba06d3caf663c222c3198403e378cc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2a38e556740a22e5fb853fd621fa21679f679213ba9a1d683f75cebafff73797",
-                                "uncompressed-sha256": "dcd0ce3e9363765ef678329f06dabeebb5d8767c29b9787fbc4b7266856d731a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5f70dfb10204a2b2f5665a0aa9398fcb394f230548a1efdc0d075380df326dab",
+                                "uncompressed-sha256": "15b4ada108a1fa17fb5495e3aa7b1fbd344a90c720ef1305010fe8d54bc37751"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b6362d57462c401cf427345af6510ef0f4404baebbf5f1be09a000ad8f3dcbee",
-                                "uncompressed-sha256": "73ad39b83a027fedcb8e32e5c60da5cdd8d91fe5f8ad572a273fde9bb5032652"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c8a5d2dea20caa019be0da8e2183fce36477a7b6606afe28d8fcc75ad621a80c",
+                                "uncompressed-sha256": "55320adad9c0a96ae68474ff142f88963385b5ff8bcecd3af34a87ee3bd82ea5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "42278e19b4ec06d29ff9dddbf947eb177a0b4e7c31666ce9a2bbd7f23f4534f5",
-                                "uncompressed-sha256": "bb392d8a063a07128a2e8b70300ea74f77f760738b3820da7c15511f36997edd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "dc3d64b4a10d8b620c1dfc8759a19edce0faac8f2a228936aedbc633174ce688",
+                                "uncompressed-sha256": "607b7c6c9d2c028b0fc5c8336dd977452829e8ccd83bca666e1e589898e1dee5"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9f9afc1800c437adb0ba1c4a36545708186a65e625a79bde0362251a81170732",
-                                "uncompressed-sha256": "dfedaa73f991f41636c50aa0dde328d8abb58cea8a39e321f7356bed703b1252"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "88487c4649a6e6560441ebdda71050ffc6790663712217b216193e0a6bd94888",
+                                "uncompressed-sha256": "d541b6a652193d5ac41de3d24670678ae70c090fe03c982164442f346ff48aac"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ec3e32b9c8db96194482df110f425524dbbe94cad92b512831e462441697ba1f",
-                                "uncompressed-sha256": "78524fd516ec979d0622c9da3a77f0078fe307abb6533b46d1bd3bc4519ffe3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cee5c99182c84199bbab2ddc75e947dbf6b586ebef1dc8e65bf6ff39b76dd0a3",
+                                "uncompressed-sha256": "16b463be4aeabbf4260634bf6eecfb48c3b6dab222e13b201c6b9df3e690ff8a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "57494ddcee58a6cfd76ed83a9e7cbb07c3d5f82644304a80c003c2ede0de7975",
-                                "uncompressed-sha256": "0b997860930fb1f6fbd73b52509e8531761f9841fba4bd9f8c2b1facb3fc5ffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "80c857c235a057732e3f765080085f50f04eedf34861d0063346631104cb0a67",
+                                "uncompressed-sha256": "963f3eff472d8dd982dbfe99bc047b0a82d9e0517fcefee23fcea0565c06256a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0bbf451b8aef191ee3cdd85106db1f179df0aa02810fb69be331596e8bb99320",
-                                "uncompressed-sha256": "dad60b4fec0b688f786d5a4139071b9fcd1bd01024847e1d687c9a95f8ba6aac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "79f4d0832bdd1657e323413433845b6e43f4f1b2e004180459257d60280ed564",
+                                "uncompressed-sha256": "119b4698de8c9fe577f8227692ddc4231b1b0f1f202a6d0cb55395668f8d742d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a59ae9b4d283a3c96be8350bf78ff75c10896b777b8af9ce639e03ffdbd8e049"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "563cc30e174d78c2e268fa5535edf35475d83b2f15b012b2c672c02ad767bf46"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e78ade03490c98b9200d6115ac4e44f7fad68a6652854083986aa3803ec39b71",
-                                "uncompressed-sha256": "c8b7e3ad3c94e32b877bda031b5616259017bb795595df6ebe673ae1fba85d89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5c05c8084edc651c32b204906a76409a062b09d896e349183dc6b2641691bf1e",
+                                "uncompressed-sha256": "4f24ac779f8f04040e895602c41edff3149a2d5e792ea29f0c65ca786fd7db0d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live.x86_64.iso.sig",
-                                "sha256": "329fb44c48188691b751690f82bc2b3bf6219994ab4f74e6d80b573ab16c01a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live.x86_64.iso.sig",
+                                "sha256": "1404289fbfbefd48437208d4612701f821f3bb1e1543d9aa5d0869ac6c1509fe"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-kernel-x86_64.sig",
                                 "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "66bd0f68cad50a37f9c97b2975f9e28acf4ec8bd41e1c740754e871cc573960a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ccf603831bbc5068901ff70366b36b5cbe9440d637e451c749dca0470813d1d4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5adc764a45c222b4858eb07001bd33f0c6e71136d2f528335c291bcfea29031b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5c9259b8f8f49b8f9293310499ec28ecb41e1605b319968eb991ca9a9fa78528"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "981692971b3372410ee646c40f12bcedf8706c70eae91ce79fce0d42fb94b346",
-                                "uncompressed-sha256": "1e2b6e6f2cf3860fab775e2973c944f405b944d8d4ed1881d74be763eeed64fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f2246a63e16f2761c0d5cbaf14124faa2323e7d06dc5852c698fd074caf661cd",
+                                "uncompressed-sha256": "7782c91a19e572187f016eaf16a8e50334e63c5c648e495f71f69e4dbe00cfe3"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "199c5577bc9783dc164fa026a3656793e72dcf3126c0aa38234bf5de407d6de9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d01f8068c42d823e729f04bec3a88a7b04b2e686197fd3c50e33fa340254ff31"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "198f844010b82343b9e005d44a8c4ff892ca3ce9ef3c5688eb4b481795032f43",
-                                "uncompressed-sha256": "589986d33389d596078e8ff1bd54e0d0cfe9d8f8a3f0889e7494241fa3c133f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7b0d407d9321675763b7e616f6ddd061ca14dc2d15c9d024e9800082c642c0fa",
+                                "uncompressed-sha256": "cc2104762f15c32f52e22ce229ef8085aa6bfd79ebf8997735b9cc403a74f3e2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "10f9ac36e6c31c712e97fe0477263ad1747b5969651c9e42731a687e412ac8d8",
-                                "uncompressed-sha256": "e868a76868e4b4bce17d913c4e3b8c5e52098e731c3e433853c87a7dc0a289a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b7b1913e46e83d0b94300913a4ef07c24514980201becb19c5bf72186b337945",
+                                "uncompressed-sha256": "59678fd48a396bb23185c4ce28445edfa40cd1c793658ea24ed5a1572431d156"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "6410d9f4fa40d992022d45a771518c3bd37aacfdfdbf28017dc75c94403c30a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a8f03c15011ee9c78ea811742120025705e1248b2985ebf8539c3272a6dd5a88"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "f5cec8c08641af6b3aa0d9ac6dc6a096d6c2d71c98c70082125680817c2badf3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "e743ec838001e2b8c81827fdaefb1acef00b2ae511eb2167273aa83383ad8343"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240616.2.0/x86_64/fedora-coreos-40.20240616.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c9689a0be6d7eadc05de0350971d11c7a99447fc6509a23d1b384d1f1837831a",
-                                "uncompressed-sha256": "084aa2acb3e71c40f0b99917c335b7736cb5d40d87b7f364367e68f253e5513f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d25fa08fc8438e9548ba3541079ba3760d2d0a128b69c8345e564c86c678e828",
+                                "uncompressed-sha256": "a93a0924108c8be74023f82e56933be254f231afd9f4b1d3783d79f7f81910db"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-097eecb647fc7c476"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0fa62243b7011cd7a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0d06fb6920a63e047"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-05644188d266d89b3"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-00329859dac10deb5"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0ba879fecca1d70b9"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0510e70a43100300d"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0b048b43b9676d778"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0183acb8a886467ec"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-01b912aa2b50ecc1e"
                         },
                         "ap-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-03ae524da9494035b"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-07c492b32d417bfbf"
                         },
                         "ap-south-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-02e627c5afec70e2d"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0e26c7937edcc14b0"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-005ddbbdc02969444"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0daf497268e6e2139"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-05a4c818b9020c675"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-046d96500d053a605"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0f880917eeec20894"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-021c41e7526c74b76"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-06477c939424ac47c"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-048aa32f49cca2794"
                         },
                         "ca-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0edbbcb76264c306e"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-043557166890caf6d"
                         },
                         "ca-west-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0b95176ebf69a625f"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0e5bebf53c8bcf879"
                         },
                         "eu-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0e7b86d5e8745c244"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0c271dd22d82c7b71"
                         },
                         "eu-central-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0e1d66bb333bfd986"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0b4718df326704fce"
                         },
                         "eu-north-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0966baa146bee4d5d"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0ab72ce27cb010de7"
                         },
                         "eu-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0bd44dc303e8dda9c"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0369699deb6b81e60"
                         },
                         "eu-south-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0154905418e075976"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-099a69f3e4ff6d433"
                         },
                         "eu-west-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-02cc2503d31727446"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-0b31f34aebb5b1c76"
                         },
                         "eu-west-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0a087f7a4926d8cd4"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-017cd7fac959677db"
                         },
                         "eu-west-3": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0c29c154c46face63"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-056c5a04be3b1d6ad"
                         },
                         "il-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-003d28646e0074852"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-03507377e73c72415"
                         },
                         "me-central-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0eb99f4c89b47657d"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-095a9655c6cdc4f29"
                         },
                         "me-south-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-080324773585badfb"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-04273032000bcdb60"
                         },
                         "sa-east-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0e83784644478bac4"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-08f8e53c9bfa626e1"
                         },
                         "us-east-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-04957bb20bd6be869"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-09d593d025bb2f737"
                         },
                         "us-east-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0f99d750b77f4cd3a"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-08842b2ab068b3327"
                         },
                         "us-west-1": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-0299b11ed39a5cd0b"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-003e84f20e2c64b1f"
                         },
                         "us-west-2": {
-                            "release": "40.20240616.2.0",
-                            "image": "ami-067bc912ba1245c89"
+                            "release": "40.20240701.2.0",
+                            "image": "ami-039bde86d21865df9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240616-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240701-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240616.2.0",
+                    "release": "40.20240701.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5035854b522d3a9b4b7ff172f0535cfd0b6bc92cf09d8cf17038c346e58e7085"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:39d7198cc867c9e063258bc914b41a8adae17bbadf1aeb3a8f52c973d6104040"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-06-19T10:36:04Z"
+    "last-modified": "2024-07-03T20:08:39Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240602.1.0",
+      "version": "40.20240616.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240616.1.0",
+      "version": "40.20240701.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1718794800,
+          "start_epoch": 1720038600,
           "start_percentage": 0.0
         }
       }

--- a/updates/next.json
+++ b/updates/next.json
@@ -119,6 +119,9 @@
     {
       "version": "40.20240701.1.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1720038600,

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-06-19T10:36:03Z"
+    "last-modified": "2024-07-03T20:08:37Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "40.20240519.3.0",
+      "version": "40.20240602.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "40.20240602.3.0",
+      "version": "40.20240616.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1718794800,
+          "start_epoch": 1720038600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -127,6 +127,9 @@
     {
       "version": "40.20240701.2.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1720038600,

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-06-19T10:36:03Z"
+    "last-modified": "2024-07-03T20:08:38Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "40.20240602.2.0",
+      "version": "40.20240616.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "40.20240616.2.0",
+      "version": "40.20240701.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1718794800,
+          "start_epoch": 1720038600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).