### PR TITLE
release-notes: fix syntax error

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,5 +1,5 @@
 releases:
-  40.20240701.1.0
+  40.20240701.1.0:
     issues:
       - text: "CVE-2024-6387: OpenSSH 9.8: regreSSHion: RCE in OpenSSH's server, on glibc-based Linux systems"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1754"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,5 +1,5 @@
 releases:
-  40.20240701.2.0
+  40.20240701.2.0:
     issues:
       - text: "CVE-2024-6387: OpenSSH 9.8: regreSSHion: RCE in OpenSSH's server, on glibc-based Linux systems"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1754"


### PR DESCRIPTION
Fixes 61a9d2b ("release-notes: updates for the 20240703 releases").

Desperately need #628.