### PR TITLE
Roll out stable 40.20240701.3.0, testing 40.20240709.2.0, next 40.20240709.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-07-03T20:08:38Z",
+        "last-modified": "2024-07-17T15:37:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "de1fe97bebc7f88aee35854d6a7bac9e8df80fddc5a242d125a741ccfcc0d34f",
-                                "uncompressed-sha256": "dc0ba4c3fccaa52de469f424231707af9eb3a76011cb00c89bf58d142b258e04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "be257b4d279a73392c6b35fc5f5b92527a3662f1415dfe07104543da365dd10a",
+                                "uncompressed-sha256": "46a0a10eb8e6a0f3efbff3d83ad81adcf617c8b5fe182e3d729d9f8e07229e7c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b09207885471bf44e39940987dc3598225337d80b95941d82cf5740885114189",
-                                "uncompressed-sha256": "f258475e2e5631ac243edd863887c61d5e7115fbdb923169532f2499357a954b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "efda2006924e703682421e4c2913a4056a2619cc09bcee511f5ab7b493e6f937",
+                                "uncompressed-sha256": "cc6e638710e9ab6fa14ad1c50ad75538d4650fca21044127a9bfc3dbc75c0e4f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b885dfe618ce9ea9071e44ae064c22a9957cb3e7ffa633e4f7edec4179487c0d",
-                                "uncompressed-sha256": "1e0bb859898dd060d240f960daf1216f72f41ddf2d84f08b6f1492c5081e2dc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "673aa19ed8ea0a227959a8088f235a31571c76aa66c33f6ed5f3cbb670dcd7ed",
+                                "uncompressed-sha256": "f470764331855a67748115f6c91ea85bab31b9b70d6c891b8e3d401b0cee369c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5f5a4b94bab4c1f8db08f638fabf37f5a91ec1dc37c3ce4aaeb6827853e681ec",
-                                "uncompressed-sha256": "28d25d2b6f3573d70798519f8cb6ef1a456c94e978f8f370986cb4e03b622444"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d5e5d5a203b7560ea67fb7bcf01be3186f58ae8936ec7f24927f1cbe1c195f3f",
+                                "uncompressed-sha256": "8c401cfaee60e5ab50dda6f6ef04219c810542a3f61fbbfa5353014a35e544bc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "9fc87a0be8ccc2286b7eedbae59a19b6539df742b06cefe5d0deb7a7f711a36a",
-                                "uncompressed-sha256": "806f1a40ff4e06c71d721547f1a19711b8cef73d95018d8d0bca8430497def64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1b64ab7c1c5b3598f92e6f1913c723a27bb9e6c762ff2d68fd57870588348b07",
+                                "uncompressed-sha256": "074777008186b885e8e2af065342894a6f07bc4583ae24686dcd1b4fd868b4e8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8e48bd53b12b7236ac23038519f9039d960bcebd8af6d2fc1b673d5f902b99d9",
-                                "uncompressed-sha256": "35b34f04c039aa90ec4bf3e100617edf590958df1e62d21fbc3402f816bdc84b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "160cdd8a8c9e4e094007bc59f1afbb6fe304e3bfe2012a926c2922766937795a",
+                                "uncompressed-sha256": "788725ea56261f5e9a3b7b40c5a35ef958e71f857b54efc4f3e268768fcf8600"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live.aarch64.iso.sig",
-                                "sha256": "fcfff3b62afe8093964cc20a29d54d2d66d747057c1275f4890d1520da9dcead"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live.aarch64.iso.sig",
+                                "sha256": "fa3b158e8d9d64d4ad716cb0ae0624dc0b230fd903c75473cf776224cb787e1b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-kernel-aarch64.sig",
-                                "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-kernel-aarch64.sig",
+                                "sha256": "57983a9642bee5a62c26c9d3b441733d4755462c1cd3cc5e278953b12a3232f5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "29e95876d6c0f1a8bf4f09c9964ca68d7b99376fd3bc38beabca50cbd37d2d88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "7a835984bf2860a2464d471be4d87e0451cec22beff19c1ff7aff83ba29bccf2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "87e2080f7c26e5871ecd55d641616c943d3f99fd0abb17dabe7e6d40db4b84a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "ef56d640d0884a767bdfb56227aaf8cdc90527480a3c37b8e2be1067fd55655d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "8e2d028de5c3d2b75a05e5fae436ae0a78f74bbe8f04f4c3b0d16930307c43b9",
-                                "uncompressed-sha256": "449c9ae58cbbfc85e820c4ffbf5a00e066b57dd08933a71ced5bdaa779855f7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "79b7cc350bda3675d10a4e7fbda0ecaf997a9767a33caca107d16a62d62402e5",
+                                "uncompressed-sha256": "d395daa0920db8225961e50f24e2cd71e9cb204c1536afcaf37002a13000632f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4e9904f248bd521bfda45d59e03645659497fb17e4c55b7b167fa4f7ae04cc8c",
-                                "uncompressed-sha256": "a38ff43248739b40b1ea3c477ce9ce42323067ab780267283ec06203b4dcd993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "fdae6a9296ad00a583f9b7dbe37c6bdeb18cf0280dd0845851598fbe86136505",
+                                "uncompressed-sha256": "6f72f5d09f3596c7b8b9d68dad78e28fd4d71f637487b9347cd93e5f7741a14b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/aarch64/fedora-coreos-40.20240701.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "50f9939fd71061432c08dbd1502b8918eebd9e35b71a99027f926834a529bfd3",
-                                "uncompressed-sha256": "36ae2f37cc6e0552b43e0be3fba218f08ed68b4b77037fa3a5625bb8ca650d99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5e2f6f91fc57b588f60c9f658e9d451087862c961311300ef467e511f1ffd2aa",
+                                "uncompressed-sha256": "4f8c3086d7d36785c551e2a4a8d10e2ecd1428ed310674ce65d6f096dede1f4c"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-002b8e69f54650ee7"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0bcf6bdc70ea4d619"
                         },
                         "ap-east-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0ad99c090e17324a0"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-00ef4d3ecf13a3a09"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-03fc2155bf0d759b8"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-071ce4ce66f0384a1"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0c2a6fa0a9ab1ecca"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0bd6b0eefe688bd9a"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-085c073e720d07be1"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0749f66db3cdacb49"
                         },
                         "ap-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0382042674840fefe"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-02063174027bcc118"
                         },
                         "ap-south-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-078853ad4103e2fc9"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-041776630ccb32be4"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0e9f467560e5eeb81"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-016e55aff8443a333"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-08ecf829d4af3516e"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0761ab8ff1c07a7f3"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-051a0a0f962c6e596"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-030c351d6daccd4aa"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-08b64bc6a4bfb858e"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0c0a59e47551e44b8"
                         },
                         "ca-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-038625bbc8e4fd5c4"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-060008675bf9fd3a6"
                         },
                         "ca-west-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-01a4448eae580261e"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-02e95da85cd67b919"
                         },
                         "eu-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0257299c853838262"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-02939daa1ab3f34cc"
                         },
                         "eu-central-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-00e78c9e3cff57d53"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-088d1402c25207a6b"
                         },
                         "eu-north-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-09106aece84d6324b"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-031dc1ef403a8f8b3"
                         },
                         "eu-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-050f862991985b2e5"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-07a37e778387b6e62"
                         },
                         "eu-south-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-02e97d6a0e59278ae"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-05f6f4e0e8b5662a1"
                         },
                         "eu-west-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0cb7b592cb168bc6f"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-01403c07f5c2a3c3d"
                         },
                         "eu-west-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-05d97623f7f50836c"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0053d181b94bbad2c"
                         },
                         "eu-west-3": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0c5f619c7be100d85"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0694a694a732c7fb3"
                         },
                         "il-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0e2ade57bc4500091"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-06b40707f5f104126"
                         },
                         "me-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0a7d2e65639a655d7"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-09b1f60fe0fb68422"
                         },
                         "me-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-01196875553156bfd"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-059bbd119533988b6"
                         },
                         "sa-east-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0a2884b5600d3cb72"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-090da99040b833be6"
                         },
                         "us-east-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0c412cd1c975b524b"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0491a1af6775dc9d0"
                         },
                         "us-east-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-087a84c187ec91f2d"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0306a76b505807dd9"
                         },
                         "us-west-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0ba1f287c608480d0"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0add76405845008d5"
                         },
                         "us-west-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-05a28e88d22546fd9"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0f2650d100aefe42b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240701-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240709-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5a5a0706ec48d37f17fdd4c085944bed14484378c7049bf798059efe8a90c327",
-                                "uncompressed-sha256": "298b392f30539bf37c8a275e283274418cd2133306171ee7bee9ac8f85aa845c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0d40dcf0d595e06c12c1f30198488acad75a15e2d7b9ec8a30ccfa461cb5d5c0",
+                                "uncompressed-sha256": "861423c80859fb7bd04fbf64a0062c0c7dbcf3379544870a8178194556016a8b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live.ppc64le.iso.sig",
-                                "sha256": "6eec436f97e0fd04a2d1dc4bc3c0ba52fb511afa64360ffaef80d9f8ceb096d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live.ppc64le.iso.sig",
+                                "sha256": "3b56e62e2c582c755eed816bbd586091ea22af8aeb0e19e15b7c9a48bfcad746"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-kernel-ppc64le.sig",
+                                "sha256": "0a49db68d0a6618c4cbfc20a64c8227d12e4316b0342395fceb984379784c5b8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e091e87690d0364202196bb4b26f7b05ed79115887417d4f3118a742e3770baa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b15bf1d2f66c3d0189ac1c6440bac76444dc8bcf9a13343e5df923a5041d124e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "2058d1c9e0753228afe4b5d3cda4a9305d85fa77760f98ceceeef541f89a8ca8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e464089721a7264c53cae55ed5461f8d8ed726822be82ee290bd03e24f8de68c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "baaaba534e9db91c8f5a18c287d6ba5b8a1a0803d2ff85287cf76f3685ee62a4",
-                                "uncompressed-sha256": "33fab344b677b0f1ba8d15a682097c9f034c6fa0b15e35cfeb3aa1f5053e0b42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "78142f17eea37a612127300bd1aa6f991dec42948f0d1147869d0c88075284e1",
+                                "uncompressed-sha256": "408b3d6b5b79207147595d157e412304cf75b8f8bec8c70be1d7e9d925cbf716"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "915fcf0ca6c0c39fcfaa79dcc8ea8f957d55cb70daddfba97e41611b18596ff8",
-                                "uncompressed-sha256": "d51109897c59020b323d299f64e63ab2c430b7eccf96ff3cfb3ff0dcf4ecd6db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9c5ff71d301203abb94b4f0eeb9a12c063ca1336a50847b08754a7dea4e83dcf",
+                                "uncompressed-sha256": "f0090e4b0a0fb9bc3fa844b69e61341de1e35276d639a2c04b670cc98f909b23"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "bc32570d6579f15d7ef35d22e953c96617c8878ba831424bfc6653596e405d14",
-                                "uncompressed-sha256": "e0f9016f94b94b78ec9a24acae79e2ba70ee4ae6d5e04356d1c6e7682266ed58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b60609be8b5c86bf69766e2b7dd480268470753a4958e86b525337d9604ce880",
+                                "uncompressed-sha256": "4d4a706de7c9ae5fcceb332b8a34f7dc1c4bcdc9c4fa3db69314967d836eff1d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/ppc64le/fedora-coreos-40.20240701.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e92b36b08f9f00eb104cc846cae125bce300e12e389cf94e0e3f4b9d90f84f79",
-                                "uncompressed-sha256": "1b127e947eae7aca5440becf5aa459f5dd784f178f2b7a307f0170a73fd1b6df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2ce598c08e148f60f51ad90f6c1b77a83c366b3a448cb2b063d44455cf5bf210",
+                                "uncompressed-sha256": "431bbeb35bb51e2f23c3e45191b3d735fe5f2e3a4ca49be0175cd4b242f195db"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6ebbb564d37f8912a9abc7af61df5df3875df63304da077cee8309ba17edc675",
-                                "uncompressed-sha256": "c63a9e674f52c0a4af2b789414e1ab6681a6e79acdcdee23c2cc0e6c0d12f2a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "727e4eed48fd1f5982019d81471ac5e833951ad3f54b5042413452cc1aa016a4",
+                                "uncompressed-sha256": "c7b6b2fbee7b7155687954147aa1dd25fa5e3691f364d8e5a64776ef539ef664"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "737cd88da828897831199b5af94fd9163f907e5529e16e3f59a0531489d39c1d",
-                                "uncompressed-sha256": "a930643379ee4dc02f3f740d466f0c3e4b0b7bb826733a93a33a41acd63290df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c35f4ef6592fa67d098dbc804a9a4f39e3ba3e11c9962e498ddbc921d61d8528",
+                                "uncompressed-sha256": "d7f8482c6f9fbb32e3c2e2965b9af6ff76fce0bc12c9a50320fe00fcad04c7de"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live.s390x.iso.sig",
-                                "sha256": "ad50cc995dbcb4f10f148afb24eb5d42239eb200185edbc5d8053e84ef9ef10a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live.s390x.iso.sig",
+                                "sha256": "1bbe56788ce5ae342e71ae0284e142b47a785fa88940369d93fcb4501ecf34a6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-kernel-s390x.sig",
-                                "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-kernel-s390x.sig",
+                                "sha256": "ffd9104defb17c4e0699ceacc8c1a468d8b74f5b310ffbee37e0aa1391a3f293"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "87de8385004230269809e6a2bd509b5dd7043492526a634d20a7e13b5213a884"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "3daf0f4dae3e64368c23180bc7f3e7843c45b7cb121e453b30efee090ba6efe7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9cccbab7c4e718f0d293e1c5f44d61149d4a604911dc31a6372c7b5d4c5c56b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "7d0b369eedd31a53876dcf7c37ca461d331697485509df38c8e8733bf0392456"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "75d979e43ae99e6d662c3d26edf9cda88e32a37ea1884d436c50fdaa50ac9f50",
-                                "uncompressed-sha256": "1226a90f2c8edda2ef48abe52e8b3aa07b3349da99dbe0aa6e4a540515cb8be0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "290335b9b2e722bf04426101de040332b4df4937ea1ab378c7b452aa54d3507d",
+                                "uncompressed-sha256": "23ed80bdc3df65b1294a7b5325a7772316ca5af377f93e9d6ce647ddcac79425"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f9ad0bd57a56edcebe7e9bba74d1efd980f062a29ebc336106d16230dee48c66",
-                                "uncompressed-sha256": "a7bb4608454e249c1513d9bed1bed3bd1120be43e3fb57f5f1ca0fa766aaea07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1473948a957250f10c9b73bc549cd07501a1bb9b4e2b018062b66f52214f7490",
+                                "uncompressed-sha256": "63dec7079a893eafa1f0daa34371fbfc1d637619ad75be26d632db7bdd888257"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/s390x/fedora-coreos-40.20240701.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a4fd09863f47b8cdb225c04493ce7747307f68a80aaf46390b1715c8a483b230",
-                                "uncompressed-sha256": "2c11b01e4d513816bd89970e48c981d58b741cf746d2f6713a7c4e05a98b5800"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "903d222476007a52dc6eec9e275a57fe149dc47df705e359ddf99a67b49257ef",
+                                "uncompressed-sha256": "3feaa2f8a538bbad714423c07f173b60ba24dfbba68dd3044d45e20c5970c71c"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "21c4de8ab6bc11dca0d9930796650440ea8182a8d6ef0924ddf445a796ad9488",
-                                "uncompressed-sha256": "a50884f403bc78f6cc4a436ad0fa6b5839a794780cb61e83718c4c25a43705d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d59063dbc2a3b56f270e2515621606ccbaca08852668e7721a82eb10fd146558",
+                                "uncompressed-sha256": "47fabc61a2492483c9103c925f9c0ad3418742163ec38e0000163414d73ddf99"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "7b6e70b955c62ddcb00245942315f3d52ff4e979e43126975fe0ba64e1faa8d2",
-                                "uncompressed-sha256": "0a28fe2edbcadb84c0ed480b5027d65bae517b1413e27765c0579b23ca41e8bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "5c8034357273f2885ef233a0aaf6d3c6cf7e9e0f59844a70f9665fe55a13a07c",
+                                "uncompressed-sha256": "27f60af6045d9c52a26d1207a60096c4bced4bee4b2c964454d498096ca163c2"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "13b0290f558c5162d86dc0ddc89a8d2ade4633c05d28bd3fc6dbc325e7eb1d80",
-                                "uncompressed-sha256": "6229d6fdc6255e73c490104480b405baa327b528549d6d79b0d8f86d563dc2dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "50d10fb87ef9311ab41a4b6167198598d6df96ac0fab378ebf84377a67d67be6",
+                                "uncompressed-sha256": "ac46275cf1d165997587708d713dc55616825f745a2a1f4c0c8a0e67e7369113"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ec950ac985a1c5f107763bc11a57f7a8059b50644802684934cb9ac995d81dc3",
-                                "uncompressed-sha256": "0f120a410d2e86f7d0e175212884a769555cdc383bf8da2bc75f5bcdd0939b31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8fbe75d4b7f8693690f389030b7209fc0c483057950df08b5400b323fc47d370",
+                                "uncompressed-sha256": "489e634be3c84361786083374ac67974a35ce5dc62225cc8f008b1a9df8c4ea1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b86c1c9b986cff3128f61ee65dd98b7cbf06e1441a61b0af1db9ca534705bc2a",
-                                "uncompressed-sha256": "d77453d5adf6c8845d7c03dcc31767510d1930b6f72fa4fb21e44b8d24bb9a60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b53aea5a090cd4431e91031bd3afc89d9b94a063b2c07d5a6690c4dc51ce19d5",
+                                "uncompressed-sha256": "44e7b4f99623eca3d5a2138a57edd8008575804fbf2ec072a513919d10ba61ec"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7902e20e42fd2751dbc3e22748eb345b109c7aa40ccb44955add6fb779f6f346",
-                                "uncompressed-sha256": "eefe73057fd1e89a97f2578137d367413f80c5bb8ef5b6a73e6981530fd29e6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bbb7b7e3379fc4395e869cb1cc6b99c98a46ed8e36c1784bcb9564c20461ff56",
+                                "uncompressed-sha256": "9a38c663674ff1545fbd916be630a424c250338fc10972e49a0686da2f451f38"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "085a50cfb54b92c3c6ee407296474eba1f68d4c92cbfa879244744d1c004b280",
-                                "uncompressed-sha256": "f0643127eb4a21470001ef732862ef17400f3b0cb84cac2c145d793a22640767"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f93f8b3f4a9df7be1ad36b76e09621c2f0beefb9ff1001b332ce6367307fbbe3",
+                                "uncompressed-sha256": "6a861538a269d003e6dd54c653e5cfbd69b24a9888e4358cfd6d043225072a38"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "234fd5c1d2a6857ae631815894eaf5e21d1734069faec445295716ef347d1411",
-                                "uncompressed-sha256": "000f81510a5041c29466a37597424c0df10b6a0d811933d44652296966f5a6e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "15fbca4fcdd40b6a846f7b1c7b75126414688f31dc05bb7dbb875fb4595564ee",
+                                "uncompressed-sha256": "e20c5d7fea31c25e2a9339cdcb8fa668b964f70042059418463068c13f510be3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "77abf803bfe7c1de9c824038fdef6bf7566a40d7463e7acc9497079d34ebfb09",
-                                "uncompressed-sha256": "2c8783eddad3bc67ada171e5ca77caf27e2b6c0d0dbc0e972d32e17b135eddba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2332dfe98a8ee2636c4f8e299f848e4eb36696d0e0f3a89e731725827506a2d6",
+                                "uncompressed-sha256": "1f5fa127fac9ca607618333ed2dce1f00bc0f7227321a05d4d0a60f142842942"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0179d35e73c4f8f3cb4a94ddda3ad65dc00617b75ac00586f6d4f8fb7aa0688c",
-                                "uncompressed-sha256": "7e6717b99284333e39781cf7f45fd89507de443743f7fdbcb799b9300880b3a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b9d486877cc280cf7754533998d56e44ac9ef6134e6a39ba9ba98625122844ff",
+                                "uncompressed-sha256": "9c460a7ba7c7501c63d8b9ebc2f703c918965e0ce2e2ce7b38b21d2c35f0c02e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2daf4f01cf102afda0ca0d1a2743361f1394c7e29cd88856ae5fce5a39b28192"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "1aef02efb09fc9dfb8f6b140e0ebb9e0fe519c7b9b9716ebf59ffd09cfbae64c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "53389f9eda43bd3f197219dc47e79cd53b58f85c0b744059e73c639211d142c9",
-                                "uncompressed-sha256": "83702d55cae1ef2b13ae4259cf0685d86e6323a83fb9ffb4ff079f836fee10fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9331863f4ffabb68ba9fbaf0b2ff516251b46907591c2936fc7fcafd1c4a33d8",
+                                "uncompressed-sha256": "b26fc688f4f5c0eba77a8c97e2c6a7c7dee6b0d41d0aedbba29eed38e63037de"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live.x86_64.iso.sig",
-                                "sha256": "07fe507d1e70d27c872a63df6bec9c6900524d4e577d24dab7084a5067e094ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live.x86_64.iso.sig",
+                                "sha256": "391e264367423a8e7c335c92d66340a26b17728bbe46530e7f0b0a75845e71f0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-kernel-x86_64.sig",
-                                "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-kernel-x86_64.sig",
+                                "sha256": "17b1696ec6d7184205501409abb5c242d6ad0b14b4a5e78aee62c64b325ed4cc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7923721189ab40fce01bd76822d3718a31414afce70330681283d548e7426fd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "9a871690c84cf00210f175f66a6cc99554151bf119404db684e848c596bfd3c6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "9489c8eff7e396f7009b59dfb7ec0c06a359717ae68f0dc95717a70ae33280c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "5b4dd1e769d4823471551e6772827e99d4b13f93e1d76bb296a827420b93e0b4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d856b8bb4c25471a0b75b3ee48dc0809ef82449cad59e76c14d2f52bdb333b52",
-                                "uncompressed-sha256": "137ff2e0bcea5d49d417991b82702972f7ff70a1f7fb7c03f042051d8a44b3ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "b489564864d4e2c08d622c190e697aed7448f3886f9fe0edbb8422e32443db3b",
+                                "uncompressed-sha256": "9490019e70d11c03bc6e15519bcdaf2fc71f75b59154ca507988402faeb71ca5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "66a8a7f9d01c5e51e0516e804e77255d82fa0d19ac81652ca6882263d1503f44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1ad354062daf12f7c2638ed11003cf41dc63279361a2461d0e4fa2817a00c28c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9ba610a546e4d33106d51a6b1bbc3b7de442f6c81f76db12633a35b3907201d1",
-                                "uncompressed-sha256": "c6f9fc78e847cf195cd941d63e176041de6541e7a7735467bc33ac3fbee0fba0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b91fa34c09a82e283d9c2b99a831b713601741ae1ed72217ecfe941b33eeadac",
+                                "uncompressed-sha256": "494de08e79f5607ec526f5886c525ca121921750d868e59544c878cbc7bf6149"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "be24a0ee1816d8812304e4238e4a90af626126117dc182ba5d49a473db413851",
-                                "uncompressed-sha256": "25c2d94f0dbe000c2b6dee299d63d7a137a10000767480727c8abd6022363962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0cacc59a4682b165627bc7ffdd1271b19441330ffd67459d68a0022f4f42cb4d",
+                                "uncompressed-sha256": "137437a415a9d2732ed09b3448f34c2abed841aebf95db105e8eb7e2df0152de"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "16cedc1a06802e9ea4140fe862962f72b818bdabce4eee7a1eb8612930d96a68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "53bed9138fb52e6dc669e87c0b1fb854bbb7f1412f95b2661b3968eac48d057d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "10f44e1dbe7557ec30fdfabd9e6964bc25bcfdf3733a80534ab01109c0c85848"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "fba94cff96a784c6bfcc5c49979ec3577f3a62ba01a0063319cdf85575a92d93"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240701.1.0/x86_64/fedora-coreos-40.20240701.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "573c8f03e3f75cdbe752a29f79ad15f48e202da4995363bcfb70b0b1d6b5dc93",
-                                "uncompressed-sha256": "16ff4cced1616d3ed47f3a6db7b0b5dbb123ed142856ecf87fe85754c34c4f6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0a0b3f16d6597eed201126d4e193c7216e78b67c9f9796260c91fdcb0c146a3a",
+                                "uncompressed-sha256": "b9a1326be00e2cbe754e27115ed91703165871f292d4ce3cb4151c41d5d44cf7"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0022551bb619d3155"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0e829ad8ebc9b6949"
                         },
                         "ap-east-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0df1bb939a849bafa"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-083b09503c2e03e24"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-02f33ee6e54a81905"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-030bc21a7579b352a"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-010e8b560a01addbb"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0e3e5372b862a431a"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0cc50ea2d8f4bb548"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0ce88d7625f2e69b0"
                         },
                         "ap-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0d482a67602c3108f"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0e11af9e165305335"
                         },
                         "ap-south-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0849ee3a7d4af2e4d"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-04c575114ae955b25"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0da4dcb2bb65184cb"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-09817942da9868a39"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-032cf52657b434b89"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-06ec9b5811fd0e1f3"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-027d89587385a3e6d"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-06a2a935f2dc84f4a"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-03dbe67bf5e1cb90b"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-03120937d39b5b2cc"
                         },
                         "ca-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-09d80f99334c7f826"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0f3af4ac0ef95b210"
                         },
                         "ca-west-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-04d2866dec7726b4b"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0e1ebac3e9b08c949"
                         },
                         "eu-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-048b4b74f0ec69b10"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-033f698c3a4cbc13e"
                         },
                         "eu-central-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-090c2f60b9433158c"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-01790e2e93a0d2e27"
                         },
                         "eu-north-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0cf579e7547cf1af8"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0ae59bc88c104a00d"
                         },
                         "eu-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0c41493bd09732536"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0fa7df45123c88680"
                         },
                         "eu-south-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0fe89bd20cbef9633"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-044d5138f8a0ce759"
                         },
                         "eu-west-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-00175acfe45a0cc9b"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0283482aaccc9bd29"
                         },
                         "eu-west-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0e9528d970357bd70"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-06d14daf8fdc191ab"
                         },
                         "eu-west-3": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-05dda6ec986125ab5"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-014bb98cfbbbb2248"
                         },
                         "il-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-069628ede7be2d835"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-06180bc7deb7d0f59"
                         },
                         "me-central-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-03567f5f878188eb6"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-098b3c95fba95697d"
                         },
                         "me-south-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-05c3b7bc6028f2006"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0b924c075d6393cc1"
                         },
                         "sa-east-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-03b1f5719b5c871eb"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0362b0b58fc629abd"
                         },
                         "us-east-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-033a0811601155c61"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0f9eff2d3c9c441a6"
                         },
                         "us-east-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-0f3d4f38be18acb8b"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-0c2958772e276abff"
                         },
                         "us-west-1": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-07d8c84018b57d571"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-06ee150f27c772177"
                         },
                         "us-west-2": {
-                            "release": "40.20240701.1.0",
-                            "image": "ami-060359e426a867282"
+                            "release": "40.20240709.1.1",
+                            "image": "ami-08a60e829864a60ad"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240701-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240709-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240701.1.0",
+                    "release": "40.20240709.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:de5438475a67b73783e930d3e187bf0ed8b251be4167e46c90b71987ec89cb35"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f4ca1f8a8ff44505d11f5dd63f1bdcd7c32236a89b4efa33156d3863e4152a24"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-07-03T20:08:36Z",
+        "last-modified": "2024-07-17T15:37:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1c251732d570b4dce881319f2b0abe62fc4e52e9ed85078c2eedc07d337dacab",
-                                "uncompressed-sha256": "886b1b55cc11880171e1ebb0fd09fded27557b87a6d7125ae8170f9db2e73e75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ac97a07cf528b23c3d7fced7982ac387fc10008e671cab45fcbcd5711a1c48d9",
+                                "uncompressed-sha256": "6a98615f24ea7bb00d99ec5013f5a9fc0209d5f6898988ada2ac93e1a08930d2"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "6f3195b44f0675d1354f1b637411c29721083574fae4ce903c0b46ac02294e6a",
-                                "uncompressed-sha256": "3335efd6edee59051db72b32cddfe14e9d198dc5fc9e4b5f89a8d1e5768c18f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "90f097487d5a0b037a3161a4972ce267f580ca659686c18ec221127cd693cfe7",
+                                "uncompressed-sha256": "cbd06aab80dedd103a94e8e5fa5f2aa7585ca13aef3c6fc021f0b631702ef9ea"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "510403fe7be1d5bb337c3666a15cd1b45f0ab5408e4a033cda1ae75760d7342d",
-                                "uncompressed-sha256": "d4fbe535a9ba1b6917cbc4bdce6d5a2611859cf3d42bd871f92a22b68fe702c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "43fb63f189ef69218b2f9abe4a05f962b7591b512f8e7df1043785fd3a5711ea",
+                                "uncompressed-sha256": "48766186f8a66b6bf8fbbb1717496abfaa8b4c742858b8971eab2f8e19a1c89e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f95854a1547ab912089ad33c8ca14e45a709943b07fd791e70fc72bc7653f3e9",
-                                "uncompressed-sha256": "98ea6c11e7ce4ea4c193e4ec37ca7102866a0bb1b8b8002fad32b85048584550"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "553dbf5e367f1cf26cf1b572fbf4400ade36b83a5d47afd720cfe78558df4e6f",
+                                "uncompressed-sha256": "19a69a6585f704d6bce96dc2934a774947b1bff09bb7567b8805a7ade03e2648"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "558f24f0ba7b4dd175ea9b6ffc3bd49b405395cdca44b1341ef81010f57c29c2",
-                                "uncompressed-sha256": "3e0881e5ab70a749b81af408f34a98f938534b21c315c1132187f5a57de75dbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1ded4d053db17d202ab5f7853fa5edbf478e3796080c59753e7cf3361710475e",
+                                "uncompressed-sha256": "773d2698ed1eae1820bdee1e871aad1087fd15f49cb02841f950b3d1c00a0c63"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1c35754292298948c86556a177f31917d042c4e4ad29c2a28f470d6af860940d",
-                                "uncompressed-sha256": "68a23f8e2da672a30c42ead61c766eb9047c1a1348a213879bc7286653b1a477"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "51a7b0e8d8c544c05994f28d217b01bddbd15347f8f58dbaeb2173601301ba9e",
+                                "uncompressed-sha256": "eb6460c3b46e355bb200818c8e7cb2672d0633cd3c8768d17c128002bdb44c68"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live.aarch64.iso.sig",
-                                "sha256": "0385ac2680f7a195037f594b8ac0dcd95f618137070de2a6f3f62e2bc10ce3ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live.aarch64.iso.sig",
+                                "sha256": "40a8a8e5dad7194e263d6b823f4615c9acf63637350ff6079e6164caf89ddb54"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-kernel-aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-kernel-aarch64.sig",
                                 "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0fa28341e99cc288ad03c8d593307ee9c6c4d85d5c26d5eed60fb791d1be12eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e369656572804cab6820a7f71c07d21b7619339bbbcd0eb60a40b8a501c526e0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a149f512cf058275f1bbd312e81d7c900e399554cc4d66014a7e304ce7feb0a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "89d8778486a1d5a54fb3bd865353c442a152f856a5e2a49df516cc68a0b69e2e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "86846caf2f74d616e5b0598ab0c2c7ca59d7f8c3ed1a57f6a6cc1a2f976f0d5f",
-                                "uncompressed-sha256": "ebfd3abf9fbe252d7ee99920216d28f34979de7530af35a48fd13cb4066b63ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5d0eeae7f96e0bc6ef560f82d6a9dedc482792560ae703fb0c82009970a0f7e6",
+                                "uncompressed-sha256": "20b5b7bb3fe3dea10c9f9f051bca885ebfc767f8efd9cdaffb100e1c52081f09"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "eea5c128306d4bf921c85791ed4d8848e5c682387685bc682917c8ca845217e3",
-                                "uncompressed-sha256": "9fae8df91a0f2373579636b542bcd6df29f69bc952e09c7f6444e86dd765d7fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4e1ff03552a2f06684c1b4ab6e92ab5addb8222c998b40535d391a39ed3b0394",
+                                "uncompressed-sha256": "adce565bf1f46bb87248a497c77a48fe4f853e22eeccd97f326734e798dc7b61"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/aarch64/fedora-coreos-40.20240616.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5eeb01dbc4ae98167b9e575584ffdad8b043092ea0842e6b586aa91c32c22d8b",
-                                "uncompressed-sha256": "ca52c8e55abbcdf57ae9eea45d077cad3b56da79b87c6ae8fac3c0c9f9edc76e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2b12d3bcec98c8d8c41d9daa2dc0a80552f3d9a0d19e1ee016789c809eb03385",
+                                "uncompressed-sha256": "7d6af192c726f53d088f9184696cde15de6b5bb86a6415ba9278d95e6251972c"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0e13c1a6f49ddb433"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0ecee247c510e382f"
                         },
                         "ap-east-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0269f54f42c3a2bc5"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0decb9d0f0f82c55e"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0dcc4feac5a336c66"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-05fd85e98eaf0052e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0a79629baabb8f188"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0f9301febe369da1d"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-091b7bfa4206c28fa"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0f450d708060e7d0b"
                         },
                         "ap-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-006f2ffe688f4f50c"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-080140206975df558"
                         },
                         "ap-south-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-017c147e796bcc804"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0ba4ae617b90b53bf"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0d3d75c578f5f60ba"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-025f8dd009e681b78"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-02cd38f504d4f5c3b"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-07828f251096b52fb"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0d9ceb4d8ff00d247"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0cea7c980dd58c205"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-018a5dc7dacadb586"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0779cae86c180f114"
                         },
                         "ca-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-044631b00dcc14daa"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-049b221eac541b577"
                         },
                         "ca-west-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-069ec0cfda9a12237"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0b84b4926d4b8dfc2"
                         },
                         "eu-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-00a2959aef9adfcf6"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-06552155933f852c8"
                         },
                         "eu-central-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0bf18ce5648f5343b"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-08eb8276843c8ca50"
                         },
                         "eu-north-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-068ab49e61eb68ffa"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0bbf31f747123d1fb"
                         },
                         "eu-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-05e66615af68a6776"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-06b756d0d85651f3c"
                         },
                         "eu-south-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-08b13a87558f31301"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-062e77c86c130d074"
                         },
                         "eu-west-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-01f9689431ef64f26"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0b9bfdc89c4d0f4ba"
                         },
                         "eu-west-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-08253badff9b3baa1"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0ab31dd3817b92ebe"
                         },
                         "eu-west-3": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0a0328859eb7c39a9"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-035e0b0be15699ace"
                         },
                         "il-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0df77bcfc76f159ee"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0c8ed668ee220fad2"
                         },
                         "me-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-00b83b599ce0415b4"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0bd45e899bc8fba71"
                         },
                         "me-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-05d084ce9bdee0bfd"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-07f4988838f7deac8"
                         },
                         "sa-east-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0a5c770648bfa38fe"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0089819df99abe311"
                         },
                         "us-east-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0ff8025ec3df845a5"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0a67e652b4e367892"
                         },
                         "us-east-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0b15cf1a7621d90f4"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0f1e5870309501e2e"
                         },
                         "us-west-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-01fa7c8c6f5606244"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-093ff83af3cdfdf18"
                         },
                         "us-west-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0af7305b952b177bd"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-02ab90b95d47a151b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240616-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240701-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "9ef9f4e5d5d8f95750944ac2d7bfdeedb1865bc67694e7cabb53e1f13045b62f",
-                                "uncompressed-sha256": "85eac420898639fd5edc76d41ec47df068cd20c6435547654cbd209a1bfdac41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "298c8fee1df2e1ffc2af3fac0c7ab79d2b85c976724a005fdfa567d2adf61295",
+                                "uncompressed-sha256": "6d744b50e35bae2398f9ef65bdf448f066b33bf7dfbc504256a04a273df32fb3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live.ppc64le.iso.sig",
-                                "sha256": "66b4fdf759f597e64307469c0ee2bcce7a8aa3dc69638e7773bbe364ac4cf053"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live.ppc64le.iso.sig",
+                                "sha256": "608ed8c22a5c56a7c4163910fc65f9a7f8de5be6e3a4978afeb3949225e9b45c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-kernel-ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-kernel-ppc64le.sig",
                                 "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "1cae5aaf3a0ac16f01df55e0c4c8970abc37f3a358c18df44108cc8372c97ee1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c7820c61bfcffe9ba6639af142c5366d6db92f4c30badad0344c0cb76780821a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "187188116b08264a0527928789f51c603bf7cab5445ce8577282cb19298f76a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "3c9153c52662a937a58857bfd15b1905594e20a2141c12792aee8017668a1c05"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b183e5e39e1ead93de8c1121a4ecbe0cb1f24d3ce391c083262c1b22669d7ca0",
-                                "uncompressed-sha256": "dc7934819688ae66567ca578d7c3cb7b0f50647dc322d354fe8e0bc47fcf3ff7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "643aca23443236b229084873fe03242200ff9503bd78e41e8bd75dad60109566",
+                                "uncompressed-sha256": "9d4c615d1aadabfe720a0a24737540242e80aefef8638013e340499434450451"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2ad6741617015a86234eb91f6cab14b528ca42287ac287d4edc05e94fd2d6816",
-                                "uncompressed-sha256": "be9e5fa41eed07add618d332d4183c89b12b8227db41a8b27511fc50c718375d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1aeaad551b090569939996ffd022810a570cec5a96f8af05f3bc1caf939e78b2",
+                                "uncompressed-sha256": "4fa548f5dad29ad78061a2ff13a8f7d13fa7a4fd4ccc6d35f10903c6de6afcb4"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "41323b4655cac521a778fcc0e06d60bef6a540f16c7ee704f4a4a092571342c2",
-                                "uncompressed-sha256": "99b8eda372e6e4d271e0ac046950029fa9f1be3bdb8b1878707802d4abd6f6d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "6002e1d5ba31531108a47c6898177bfc558a119b50f10c4061278a29b706d046",
+                                "uncompressed-sha256": "b20aedc6a78dd29ad61eeffcbfbf435f569e717a929fe939e946e7abd1c966dc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/ppc64le/fedora-coreos-40.20240616.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "908bc7cd919f35e7668353266295bc4f781f46b4bf44f9868202c85a74427173",
-                                "uncompressed-sha256": "23ba1126a8f7aceb5d65e5395d7e2c77ad11889e311acd01d61f7d06e4268875"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "0016299f852b8172f63569acf630c94726c3c81c55f9dce874620d23ef0513a6",
+                                "uncompressed-sha256": "ffa9d5719baa7859a2212c08b90f65593f14f80f6704c653a0370d05e3676642"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "33009f66a70e12727217b8dfb27eefb646807f0d0acb9ded221bef6356a2426a",
-                                "uncompressed-sha256": "6c279511b6a1961fb36fc58ce98a5c8e92eada519f1ca9d56f9034374e697c3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "2decedf185c66fe3e5adab16d13ab203d3a5c296ffb74f8fd565234c2d645fb5",
+                                "uncompressed-sha256": "32a88c9ad92862d23f4549b5800264f6da7359063880b2b1a35e35857abea707"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "767ec1db76ea1aa9c0a893860943848b6c3556a53231b058fae5861eef6537ee",
-                                "uncompressed-sha256": "91b647fe175432247c5336ec5b0c0328e551461c0906737be241b0fb37120a08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f025b67f65a57fb2a57879b3aa36eaec6a260388392525451b65730e919e9c6e",
+                                "uncompressed-sha256": "c05e1e1b3442171d89455941afdbfa52983f65292fee8a8ff02c9796bbc2a9a4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live.s390x.iso.sig",
-                                "sha256": "fc965489eb759ceb1104079ffd9bd0e79d925264b83d6019382bc0a399861ef8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live.s390x.iso.sig",
+                                "sha256": "12ecfbbd356ca9fedd2c54618f11b55a1c7d8f49c9fedf298c2d17d4636a223f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-kernel-s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-kernel-s390x.sig",
                                 "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "8232e56649889f358ac01b972e64c2520bba17d36fc446960c2a0d1abeae1df6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "24ff5b783dc9cb0e949f67fe4db7f4e13d854e35466b22c6a28c5f19cdb678d8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "587dc8f9d694f4f913ad2eb3e89ec694746e75bbe1d0fee3606c60e877e41498"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "94c2e8c70a347174690da5959023d9598ec42215f46bef6e62165e677f397bfa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6f29bf91f0515a87a083ad839d48b7deda9db58150cfbebf4334efe948eee665",
-                                "uncompressed-sha256": "b1d62f9a8e5fcb697102c670d59ad2471551fbf4a73d22649db4dd62d868217a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "aa66f8c4ac3b5938fa3749e86838992e6d4de7bf49a56bb1a46a0dc4e20f07fe",
+                                "uncompressed-sha256": "02ff3f358cd2b7b4ea3014bc43c3f7f825e427d3ea5d4784e566a54123e5e0b7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "28766e938f9fbd8fea2ad6db3fb2d6c1fbd45c424e2bd9dba7bc44217e2ee5bb",
-                                "uncompressed-sha256": "248bbad5e77b05bca6dabd669445d172ea06a64af22beb1c16e1ce23d0caed22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9f2189edbac542b75385a30bf60365eb617503d0b5132a909354f8c0451d9361",
+                                "uncompressed-sha256": "37a18d0b2d339457f5796cf8c4d9599554ed0e155c5afcbcba0f870bb60f579b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/s390x/fedora-coreos-40.20240616.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8dbf1c898ac677fdf6d86e24e37b81e08c3ba70c8bd8fe268f8499db1ab95b60",
-                                "uncompressed-sha256": "6e0a1045bcb570bb4a3fa88fa17b4a1890f48f8b1fcc6c2eb40d399d11111875"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b10d7e2ca56658dae02666c75f039160942405990831e77a56aaa45e2aec9219",
+                                "uncompressed-sha256": "b1c7f56450e7f0f9c8f7c25556f74dbd6eee91a92e1149cf1b37d64a7107d026"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "25c1177e04e6c1d2d3a9a24af779f31199f5606172ed5dbd2e8dd206c3ed2965",
-                                "uncompressed-sha256": "71ff8f7867dafa08ddb258306ffd2c4db540d29f4a96ac304e3d768e0651a46f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4a587380b95d2a9d923fef136c33908e29cdcd7bbdc088ccaff0ef0765ad4dcc",
+                                "uncompressed-sha256": "4abfda8d2fb3598af6a70d82fb21a2c3ed36df6a04e98e78acf94ad111721c43"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "869d0cd311364b841e444c93e961cf3453f9d78bf920abfb717ffa84657c2fc5",
-                                "uncompressed-sha256": "71b6e5b2938e319fd7551b1d00c564387a4eb8e64bf054c1b61f42ac614d8c78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "82bcf95d7a835793caaf0d6c866d92bbf8c784600fa29c82dc1670fcbf468e11",
+                                "uncompressed-sha256": "d410bed7fb5458a4db8f58ab6f7afe5cd61baf5cc0c9e0aa01d9e4f4e4fc19d5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8a4da5bf8f615ab356284f52739ea3f8bcb60be875eec7c35d3c012a1dc938d8",
-                                "uncompressed-sha256": "1d8a058c1bfa0f55f08f6842384407703cc10041fc447f7afe60197536571459"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0a7bb34ec113f9b6d6357c53428b58d156ccd6934538afe5978ad65a1929b9ca",
+                                "uncompressed-sha256": "f9c7ee3e552d67f52fc930f034fdfc50055e7db744309e577a04445e7562f864"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c389e9c085a4ddca82a179034806cbd41e10be98833e803b245ab462f6180f0f",
-                                "uncompressed-sha256": "998a1ad1cd9312a6e01e20c0316578a831bbc812e3c1882475e58d3f16bc4966"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c1121de49407f0a4e226d3b09aa2ccf55adf102b49fa9214d02a5e8bbdc8923d",
+                                "uncompressed-sha256": "453bf53713deb77faedcb56464be9f8963d579385efb4095a7c8fd0f70e79df6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6c7724fdce74840f4373b40db860c08c060d494310ed6785651eb95e0a215fab",
-                                "uncompressed-sha256": "6d96eaa73b571571c9b379501ddade5f17d85c8f5c6ed0c767b95c13b37db58f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f62c52fe8609aa8448970650c4285dda96ce51b8deea39beee6af97c181026c3",
+                                "uncompressed-sha256": "6be18d7211977745a9d02f1be9bfdc32ff3b9447d017d939ad1bd25e34441aa5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f1cf7fc899d5a4fec461465dd0e94fa5187c845088c36f1a378a69da57dbb2e3",
-                                "uncompressed-sha256": "bc5ae3db9bec35c2d9399bdcff50b0d4d5eb9e48b1e2c722ed285af4fb26d42c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "62c73492630a9c7e42c35edbe83950c6e94dcca1e07ad86503baed32c554c240",
+                                "uncompressed-sha256": "ec7bfd7e68dbed6c3d93d729fb8abdaa2fb00a3dacb19f3fb92c86aa6da283f2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3decb75db7eb189cf3917e53051aabb95a5a82e29ec5dea0b413c664080e4ea7",
-                                "uncompressed-sha256": "e122b50d522df21da7cf4e56266182c684d5cd73cfb2934f3291eb93017a0784"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "941ad7db3eeb5c0225d77a81dadc3306ba12e1152e46ff73c2f3bd1eda0536dd",
+                                "uncompressed-sha256": "4800b21d0c8049cc5b646ff578a937d5487665590dab163d210d3825770911aa"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "40910b9ccd0ad1e0468fe55e439b9ac7c185fd42f10d19f1b1144c49eacb7de4",
-                                "uncompressed-sha256": "93ab34a48c1de62cfdd92dea96a5bd358f0e514caea89756667407c61f462594"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9d85ccf595a64fdca35e446fad37c9a244d2cc3dd466abf7181a2b5cba54df4e",
+                                "uncompressed-sha256": "1b2353461a62282a4abf8f4207f8195547554c727f3071ebcda51c87a327dc41"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "62e29a08772a2b77dcbfef58dbcbf789b9d07ff0a13f8019e95541c4cc569b0d",
-                                "uncompressed-sha256": "9b7834310d7c8a2251f515595178e84e227585938e46256d97b2f3aee940c3ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2e64703f500cfb690a01c22bd9ef1746d01a764eb8b2bbe06edc0ddbc05ca18d",
+                                "uncompressed-sha256": "fa4b638df376f960822d4842e855cb7d9dd08eb5581d3354de73556289e6ceba"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "63899d7b35601f2116c56f04722b0995c32a7af81120ba4cadd19f2370585215",
-                                "uncompressed-sha256": "4e20c45a338718477281c22d7e7b28ebae13faa1fd74667f3b6bb4738a709e64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "12be915243f2daa1d6c978b8fbe42777fa41390d3436a2e79744106beb755979",
+                                "uncompressed-sha256": "b279dfb7684676f8e10821573e3ec390e1e6e89bdf76ab06a25f74219d2dbe8c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "66dbc78fde5f71e49f0a1d3ad23e1bb1f8af0d177866e08426e02817c8827364"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "9e0f4250c12b18912d733960a06ee1bab7f13c3f23129ac81e57a5d1fad8110e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6deaf2f20e4d41997390da1acf9ad427a7944d3ceab32b093b95f4a638fb9813",
-                                "uncompressed-sha256": "06b8f1584099988f9faaf480618b42f256991b7a4c005d8ab8dcac42de3801bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "58acb45eedbfa0a52ee607698d223b6b42c31e0883427f072190a721e9b6cbdd",
+                                "uncompressed-sha256": "5f6d7a87175f9d70e6eea8e48f0f0e1638eed292ac54acfa3e573e9091f4da4f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live.x86_64.iso.sig",
-                                "sha256": "527f76d12942ad4a305421adbb35247fd93ae3588b5c2bb7f03534e2d603c0a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live.x86_64.iso.sig",
+                                "sha256": "8021d12231ab454fc1b24be4b30841ea62bb5cd1f710ea03916b76ee902875cf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-kernel-x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-kernel-x86_64.sig",
                                 "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9a6e34a3a7e5f606525a960f8a9fc0d71d34bf64d680085ce17bc53da32ff4e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "68178043b935357a18983b3e731104252f1b2f22412af756a5f072211d7a924f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6e140c6964afd242787e2bea8ae77bd7c0bf22c438d57803394ce2d05a108931"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5ee737322135be305a08f5dd0914dfeaf395fff0b4decac7bd65cd19f73235b4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3993fa77ee7d379425fadab11726a57eb3ba460d3e53252c56e53510a986d59c",
-                                "uncompressed-sha256": "457797c79e5d3b4770edd16aae322ac11a2cbe89a4fd8720b5f57a06431e5433"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "af99abeec23f238caeae923dfee7085567efe599ff489aaab18920e0160d166d",
+                                "uncompressed-sha256": "6abe90a6a199df9aa1eecad5b6f07cbce0c8b5043fada4a0063dd115521f4e0a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "21084a7bbec7229afd1004047af0372e024ef52ade572bd70ba7734423496961"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "34e2ced90dd468d871f6bb2b1a0a8c5f40c9cfa9637346b19cf8182449787d51"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5dbb60df92579de62d9fd876639ebcba5c611bd94e1593a440243f2e17f97177",
-                                "uncompressed-sha256": "7169776007b9a98ecfcc39ab57f2addd930525cb1af9c44fc75e1e94eea34fdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ac6b2cea29e34d11e3076d04e34d307e444c5eae8fa3ee835fadfe0daadac222",
+                                "uncompressed-sha256": "b356a1e1bdb4edecde543bf1566b2151465edba3e1f3069397e3b9703ac73fa8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0267432faadaeefa3a41d8fac0233875d15e79ca5c3c59efdfb27fea4d0afbba",
-                                "uncompressed-sha256": "494b80710d443866338dc4c716c25349f17b559dd09ca3579f0b70ee02f8cd8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "97575d133ab9fe7b88ea99d0ae5548ac3cc0432dfb5f0cbbdc89de7bf994f63d",
+                                "uncompressed-sha256": "cd410deb8a6aac66323dd8b3b67e9dea52b3d59e596f899efb63710037c8bcbe"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7a46e029efbf19c85b7916f1d52a1e58a001c6b0f3bec6672edcf034741424f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b65bc4a56bf97291247f6f5b212e9fa4412a5429bea5f9d5fca959fb2103a1ee"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "ed997b9e3c950ae3b0d49f2c3bbc2b3b8c7d27ea5176753064d8f68b9c337419"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "d2532c5369ee22e31ee1e38940ba0343070d3f73f2e589f4f378878b7fde207f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240616.3.0/x86_64/fedora-coreos-40.20240616.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "65368543d5ea65057df80166e2ced34457f12de85b2679e47ef47f545ee41ca2",
-                                "uncompressed-sha256": "f339d1833a70d5caf467b115d72bea4de2384a6b7dfc9a7c9a63cb276ad8e725"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "cffe1acdd05a3e901b74d0142d9feab208d0f15991bbe8ea4923571d87a5f228",
+                                "uncompressed-sha256": "3b012638e0aa108d4a147633f91115153dc927b8c2ea7433ddeea37ecb0d8bfd"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-05a0b17e6274d577b"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0659689cc0caa0d64"
                         },
                         "ap-east-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-09fe630032aacb460"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0759ec8b8fbf21696"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-061049e69b8c3e5d8"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0046110f45e4e056e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-097e2cc566c38cbbb"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0f871fd7839ec7685"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-05d1b8d93fee61d3f"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0f386d465f5a9986a"
                         },
                         "ap-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0e19f751e72f39097"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-066e380de7aeb3adf"
                         },
                         "ap-south-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0092dcf3e180fa7f7"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0cca7abd8c17c56a2"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-08bfdce81e58a8010"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-01fa3bacf28b0df05"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-081997cc94dce04ae"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-06efd3128336c3bb7"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0c429aa94ec22750b"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-028fea5b0029541a2"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-008ff01ae9a61599c"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-014adb8aa1eebf00e"
                         },
                         "ca-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-055e1fba881618fe3"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-069aa43d8d6f9bd1c"
                         },
                         "ca-west-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-03ab9ef853f4f2315"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-057a8b6959cb03a13"
                         },
                         "eu-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0e94ed7ad58307805"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0fc80d02f73ec2adb"
                         },
                         "eu-central-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0564b824d12b7b7b5"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0089b449cb3a32856"
                         },
                         "eu-north-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0f4a00357f13538f1"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-07daa39363096b5e7"
                         },
                         "eu-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0fd542009fad861d6"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0cd0c670705167457"
                         },
                         "eu-south-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0e152b412276bfb67"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-093ba8e8ab1cb09d0"
                         },
                         "eu-west-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0b3032628cb3fba0c"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0572b8bc59d03e4cc"
                         },
                         "eu-west-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0320ee9d0b14c85e9"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0646aa0a742bc953f"
                         },
                         "eu-west-3": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-020e5972c327af01a"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-004c7763585b023f0"
                         },
                         "il-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0a43d78e8ac881799"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0ac61891a6ef5833a"
                         },
                         "me-central-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0948cc2298a0ebe60"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-039b2e0ef177b400a"
                         },
                         "me-south-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-087cd04a13f521680"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0174696365beb4cc0"
                         },
                         "sa-east-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0b7d372e18c178be1"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-069a2aee38def4c51"
                         },
                         "us-east-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-068493ac5013f0936"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0b78c87ffaa1015be"
                         },
                         "us-east-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-04000bc04ccee958e"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-04af9187073a3bcc4"
                         },
                         "us-west-1": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-0c460801fd7c3c91d"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-0d71bf3247419c5b1"
                         },
                         "us-west-2": {
-                            "release": "40.20240616.3.0",
-                            "image": "ami-00e824ad8aec76dbe"
+                            "release": "40.20240701.3.0",
+                            "image": "ami-077382a4d20277841"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240616-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240701-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240616.3.0",
+                    "release": "40.20240701.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:eeaf9e4c075862eb9f878abd20f522f17068c7f00fdf0ae9f138ce3f64456b2d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:66b23715dda6924833652638b3939dc81d5479c909a6d5d912cce5bcf17a3cd5"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-07-03T20:08:37Z",
+        "last-modified": "2024-07-17T15:37:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "c90db63fc21b356efca496b2122cabe56c415a0fee6bb7fdbe15c1b9db1b9541",
-                                "uncompressed-sha256": "223785efe8db07d39536c93b04dbfc11c4b2b9d062f6f23610b362a27731f7c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "788e7cc3e1a36ae09e1a7633caabff39d84f81571dd07a01937ec290d150c5c3",
+                                "uncompressed-sha256": "893f6e708bb070909e60ba5a6eae4bde6303cf696a58b08873f6e7a88d58c951"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0328a84984f8f2ee870a6ec52148f9bb287c2656937d3af2458df64122db113e",
-                                "uncompressed-sha256": "be9e7333577df6aa011d5a39786e5b25bb4208881220a14696756b2ad90d5052"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b480cdece792a0319ec0f54032b09f079f6def1605c0d02fdb53a871bb46e3c9",
+                                "uncompressed-sha256": "49cd2d8578b5d71a0ac6cab5443d423e9ca3a7eadce5cfa9fc5eaa6e86fd2bfd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "db9119c73252501aaa64bd94f9b80a38e7a44abfc2cf3e513bfab9f13a012227",
-                                "uncompressed-sha256": "c02e0c6723955d38383603cad46e1c4d43a8689507b719c4bdf09e447ac3fda8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d137bbe67642c9eaff86dc949793c55b6c084f46c3b87c9481ea8ba78a79b010",
+                                "uncompressed-sha256": "9e5a161e8ec13713ec9487d938fd0579bd3990475497bebac0b76be0c8fcca5a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5498ffe1e90e4f0f6719dbad4ea44484d4981434735f71b7a5f208811b19afd6",
-                                "uncompressed-sha256": "3e757bfa8c15f3f2b79d92f3547ac0a1fc0e4f03b7285078134b587bf79f2286"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "4adad3e8992474ecd3d4b24f8519b521a59db1e2bae170ae6de0726bbfe3fb18",
+                                "uncompressed-sha256": "d9ec03237637e07fc14941a015a9ba01146d599637cc0566f0159a24d2961272"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "da7e38fed67afec7c1d12a2912588df4bc5f7b38db7f100ff0618af7487a0348",
-                                "uncompressed-sha256": "525de8ffe949c4c61cfcd51a218483c78b3794fd26fb82ef974f10ccbc24cdfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "66a800359078a83c469ec29f992ae7061c2d1d4e9abd466ff6a717b042e54ac3",
+                                "uncompressed-sha256": "815e126247a260159121b9838b81210a54fb9d6f7c0d0304d4a48a953e81c7c9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2d75c22744a72a6ec5585e4a774ab1a091eaacdc5a87c8245d3b24cd00afe6f0",
-                                "uncompressed-sha256": "70840bf73f39e8c8856c8978ef3ff138ef8763ad39646ade268383a0d9ce8e00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "4c2a4c60835bb3139a87128ce6c8f85a7749409d020f2a722d8cf3fd9f979b6b",
+                                "uncompressed-sha256": "da9ce4404f2d146c60bd7f7443d3c71dbedad06852041665c4675703790bcff4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live.aarch64.iso.sig",
-                                "sha256": "474562c743d12790ae8cb007e8f7db40c7b93955a9025bb94243b24aaea5cca3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live.aarch64.iso.sig",
+                                "sha256": "29f0fca8c7da4522c8f5163432b11dc527f226d82b3f3c38d5df9441a86d1e68"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-kernel-aarch64.sig",
-                                "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-kernel-aarch64.sig",
+                                "sha256": "57983a9642bee5a62c26c9d3b441733d4755462c1cd3cc5e278953b12a3232f5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a8a5d79142b739a1e913127ed1b635775d8b4e839a4bb9e685f4fe786cc43b46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "4b2a08c924f2ba40a72deaa1d9675c6ea8d1659b459e8adbb5ee871aae68139b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "8a78c33cf0d27d24344ad796a85b0f28226ecf2d06048410546d895218eeb077"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ea95c06a12f64547adeb667fead8de3023b49996f1eb76f90a82c355ac244841"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "17a19b2e19e329187dd4d03fcaf3a83ce4e7dd3e1eb2e7b5e1ed01a713764136",
-                                "uncompressed-sha256": "4f8ff22f340b0bfa6baff386dd54ae4e586fcb4ee4a63b0caf653c6dd824b48f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5bf57fb0f8504921787f2049ffebc2c8ce1017302db4af9a4f2790d2ceee9b43",
+                                "uncompressed-sha256": "a537c27bb56984ce7cde0394bcda6c471060960d4761e74dabefca1b2f9262b2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "041fb161250467e04363bb409120908334b8a50b65ca5aad09ceafcae6b609bb",
-                                "uncompressed-sha256": "7842975da957b00a3476451523c3aeaa092e93c5550729279742711211b44663"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "399280bcf7775fdcd3ebbc2e259240505b573b5dcfc45d00377e1f7ed5207798",
+                                "uncompressed-sha256": "793c1ff718f357d186ffe661ee77d50f4fca20ee12929beb934ac7eac56d8f83"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/aarch64/fedora-coreos-40.20240701.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "27c320b9cfbd4d3c2c943b1b04dfd280699e29a5ecf2abcfef91e5e4de1166ab",
-                                "uncompressed-sha256": "731cceb1a9554dca79b756ce9cad7cf9f4190f46c49cd245d12e6ae8cdad4046"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "54ab6b3468dd27597978f5ad850f837cbcff7ca7c738a0d9807fe792192148e0",
+                                "uncompressed-sha256": "5ddf73835abe5c42d5373cd4c461f15353572e626b6c2a3c0ab40cd52445ff6a"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0bcf4476ffccef8e9"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0974fd4ce7b9e4bb9"
                         },
                         "ap-east-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-013231385fc5aa1ee"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-07c07fdf6c9ea1d2a"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0e7ff2b47f49c990b"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-03efe50a9b1cc869e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-05999cd4a10f4b1e4"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-04f39453c623c5830"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0b4f0f0495af6a74d"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-06b4434e1cc5a4a73"
                         },
                         "ap-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0e1de23fcecd35b66"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0aae0fcc921311a1d"
                         },
                         "ap-south-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-045ad65156c7a2cda"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-06158551bf33951e5"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-07a430d89ec58110f"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-02cda90cc23424fff"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0312837618359d622"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0e30896ca6c7cab01"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-05a3cc753cab979aa"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-049528e82c17616af"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-00ff1ebe2e1287fd4"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-02625a31dffe949e9"
                         },
                         "ca-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-03bf1766524c09611"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-04f24ad7a18173806"
                         },
                         "ca-west-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0617b8213297d365a"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0968f6d40f211ed32"
                         },
                         "eu-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0cdf6ff2d878c3c17"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0e1a98c5be7569a8b"
                         },
                         "eu-central-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-00fe57cc260adeeed"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-064048f2fddc84ac5"
                         },
                         "eu-north-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-075f01057e6135b41"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0b45b5f4c8d929519"
                         },
                         "eu-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-00fcf19b28f048417"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0c59c9d57e74a81d3"
                         },
                         "eu-south-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-014c393a1312687f5"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-08dd71f19bf33c93e"
                         },
                         "eu-west-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0ebfb5805c6dc34c2"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-072abb62496785d9c"
                         },
                         "eu-west-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0cc1261d9075f5eff"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-01aa0799f2ce54d00"
                         },
                         "eu-west-3": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-09280691d03272387"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0f2ee4c3fde6c31a4"
                         },
                         "il-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-05a1de92d447091ca"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-06cd7b471d4a37eab"
                         },
                         "me-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-025c3e04c2fbb00c3"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-04433141fd97e6723"
                         },
                         "me-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-00713f6431c60effb"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0a6bf5d011585bda6"
                         },
                         "sa-east-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-03666335d577d104f"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0b739e6bdb5376c7f"
                         },
                         "us-east-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0b6cdcb768ebabe0b"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0aaec4358a8b6b658"
                         },
                         "us-east-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-021ba5f11de963f27"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-07179c31914d42c11"
                         },
                         "us-west-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0cede7de335da525d"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0cc11c40a7398ac94"
                         },
                         "us-west-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0e26dfc31004c9b0c"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-00117edc14ba908b4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240701-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240709-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "dc9a69df00da36b2de97d00cb455ff1e28e95bbb5c5f96c7274730f615842dbb",
-                                "uncompressed-sha256": "57e27b076855510d14dac6456b0c7955ea35beb811a48bf685708da2ede03c0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c5823029be5d5293fe4c8e2a547b3e22e8d588be37dc228e06988cbbef94f8be",
+                                "uncompressed-sha256": "a726454e131eec2cdcaa4b92685f7d8103eef3c41bdd7ec0ad95a53a40fa3400"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live.ppc64le.iso.sig",
-                                "sha256": "0e1c2167edeaf8d2c002a2e7a9504fa76e277354b5d83820715d37aebdd34343"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live.ppc64le.iso.sig",
+                                "sha256": "1cc14169ceb9eb6353cb0867d7a47b358b8864796781c124f6549b317a18455a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "0a49db68d0a6618c4cbfc20a64c8227d12e4316b0342395fceb984379784c5b8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ae109284c1cfe7eb04658df3ac489a4e93435bd96ce3a43aa7f2208730cfc867"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "56acd3477db215c5503347c33a126985e3860e8ff7051e30ce6a959390a50ffe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "06be87b0b84f9fb75b5f342988fbb20e3dc1f442177a3cd94c0ce257c42ee1ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "154f4f708e1401f1519bee2d9d8f94c793ad56b975ae2bb0576687ab981aac82"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "24c36595ae889365eb30c405b3e9423c1772be1c38e3a0411449904473363f2a",
-                                "uncompressed-sha256": "3e3f607406ad68e0dd8f4563a2426043cdca1b33a8e5269c6d7ca5e9aad1b79e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "74eb66a46e7e630d7de43299cf6c784ae3a50500785049a47ea5978641ff55a9",
+                                "uncompressed-sha256": "0a0eb2a54ae8bcc333e3f1aab23f89bc050f89c110d05b0a8d272f0a0469de81"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d0fb7602fc03962f3e254f8337169e8cbc32e4aa5d6e689c8ad903520523ed25",
-                                "uncompressed-sha256": "d1b33bab345229fc32cef5f4b28a2b93c27961c828caff24e7702420024e72a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "27dfd648bd3b74356e8458fb0f11c4a45c658f28afcf010add46877227759b9b",
+                                "uncompressed-sha256": "101fde96a597ea37e68e3bf7d04025f1206921ff86038f528a7c4f6f30768dfb"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2fb82fc4437b6e1cb36aea76b9698254dbc7968a1c3793b269f79e92e552a64d",
-                                "uncompressed-sha256": "bf78cf99c8bbfb8e2ba11bcd9992f84ba2c214d704e5a6e3aef037df3efa1016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "36e5534241a22ddb7110207b7506855f7b98ab92736185e3fad9660d7d8a23cd",
+                                "uncompressed-sha256": "123ca0b8f2a3d89b8a732842d87eeb5fa6624b32e29eb27d9b18093f5e72e67f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/ppc64le/fedora-coreos-40.20240701.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d21c6170ee0f954ce8809f4ccc6b3da6faabf807869850f489cb80955c3cde9b",
-                                "uncompressed-sha256": "05265f1b6a35bf3f781cbdb9ce1b4a810083b9c2b0fa2afd4c81f507e3885f4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "1e4d078b78f1348f235390574d3b5142e997c41a89c3f1118698fbf13e4a245b",
+                                "uncompressed-sha256": "244b9471a323ece890c7a47e3c08a803b1527ad15456cb9960f0dae8321db3b0"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "425ab42657a130859adb9255b69fcdf975a858ac3aff04746bff619a59ab8939",
-                                "uncompressed-sha256": "596325f4db1e7d31cbc6b46e3c1cb14b6439d6b378c2c767e27163e4db49c62b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e09ee3a87fe4ae178a198988270183874738526cd4dc83c6a0051b45e9c7a954",
+                                "uncompressed-sha256": "178e500f7afcbc4c9e21e928ee5bf4eb3019ba0fc2878e53d346de37229cdddb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "41e4ba9190786b4d5b6ec6ca4668173ffb3b983a57a74a01247fae9f0a576496",
-                                "uncompressed-sha256": "84e83cc05f3a2115918d8e67014549f76430ab91b8562c5cc7390fae6ce32a55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c5d7eb7239866ba38a487fbb733b91377b9808c0a9197f500ddbc4de5fbd9c0c",
+                                "uncompressed-sha256": "e5cda17f9f38842521ab5431211aa06f7372aafd22bdc8edff93409b72e94813"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live.s390x.iso.sig",
-                                "sha256": "58f01a68d8d34a0624d968ea766e0604791dd757de5154098f3d1446f9cc2ff8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live.s390x.iso.sig",
+                                "sha256": "648780bc7bc219291732b74018e868f8d3c169b1b23753899715d27adeec2bd4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-kernel-s390x.sig",
-                                "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-kernel-s390x.sig",
+                                "sha256": "ffd9104defb17c4e0699ceacc8c1a468d8b74f5b310ffbee37e0aa1391a3f293"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "78defd10806b588c12298dd384029ded63d6651da7aa5ff64ac12e20dc0ad184"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "dc063304741b54aa0201cfc80ba426585d03feebb00b8c872124169bc67c1357"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4432a811eb8ddbfdb82195d59a8e75c59beab5dcccb12cb5d3422778226e0cc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "8c58f533b6c625da2ab7cc585374c664e12adec7c6ca91ca8b95f0cd4ed40bf6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e98e617c5a1d11107024fae46446098bfd8cfb91ccb564e034a23a0b8883fd8b",
-                                "uncompressed-sha256": "f48ae17179d1434128807b2162aa76caac28ba8ca1176fc682e86f105e76a6b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1832b6ca404bdac01595b4c21ae3ce8221f130eafc80c642a71a9dadc4da9cbc",
+                                "uncompressed-sha256": "f10dbc369ff56da3ba4d871b422b06f0f21fb116bcca05123f1a6baa57ecbfb8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "178158c4701522cf12d3ce20282b09124ce7a7e0d0ab33ea415366843e67d114",
-                                "uncompressed-sha256": "5aed278fcd44a96bf99a3abd2dda60cdfeb92183e9aeed5c41beedd8645045d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7dc06b823693d31289e8c6f556bd6c23509d28cb9a6451afc61fda98684fb2be",
+                                "uncompressed-sha256": "aa8eba0a6eaf2821fb4618f57844319f5ae802ab1b4254b7f0a845c80133996a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/s390x/fedora-coreos-40.20240701.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bdfc71575a81dc3b54b0cea5c59cb67fac82860fe05a28d09d93c515baf75e37",
-                                "uncompressed-sha256": "6e5641d60125cd338573b39e125cd0faaff61b060ad013bbf795de730f18654c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "757bc2f59cb2d5fdb4acce3e6c09ad81ba2f51389fee7e18de0e068b9dd1d974",
+                                "uncompressed-sha256": "ef14646698dccdb6927ff2414ca1acbecfc5bedc726aeeaa2a6024559e421ebf"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ad85ec015da37681efb98457b747de83f4f2f3289b35d6e3159791ea782209e9",
-                                "uncompressed-sha256": "150ad4b494ce0b0c072ae8eb4db814b61ecffa12cce9a9c1905e2988af8d3afc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "954c06a6b7de0fbfecabdc5faa358fa78ce47828637f6901f140517f12bed89a",
+                                "uncompressed-sha256": "06c82ccfea3a2e53b48c21d1d9c01366fd2d3171445b2015f82b1d75dfe32efe"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "71cd2055f092f1a50a58592de7c5f727c744a7c2983f4df055ce3576fb141add",
-                                "uncompressed-sha256": "d909a5b1091dcd916e424fc8ae709d2b546396c41fb918242d84de1bcf4b2309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ca0f93828a7bcdf218017ae162ce8e1750c02b440d87d3984adc116480f8eb3c",
+                                "uncompressed-sha256": "1dc6c68951dd26020ec41ca83cabe90400695fbb2812ec52fef898fcdc245c19"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4907e7d88abccefc5c10622041814248dd378f238d0d9e562d76cc481fa39632",
-                                "uncompressed-sha256": "475e887eabbaaa0253d80172e1b28bde29ba06d3caf663c222c3198403e378cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a4f878a5a677d0aef3344922cd9f442e8eb9f74433be1eaba548fc4d469ec8f0",
+                                "uncompressed-sha256": "7f9ac7c509c8614a92623b224dc4188415ace3b9f48bb9ee0a850cd1000435ef"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5f70dfb10204a2b2f5665a0aa9398fcb394f230548a1efdc0d075380df326dab",
-                                "uncompressed-sha256": "15b4ada108a1fa17fb5495e3aa7b1fbd344a90c720ef1305010fe8d54bc37751"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0ae904314e20bf9317785addbc1f933ee56a42126b542f5ce4605331bd4f906b",
+                                "uncompressed-sha256": "adbf5de489b3e604ed9c4be1c042517e73df1dc107e5d45676575730a3c3b3a4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c8a5d2dea20caa019be0da8e2183fce36477a7b6606afe28d8fcc75ad621a80c",
-                                "uncompressed-sha256": "55320adad9c0a96ae68474ff142f88963385b5ff8bcecd3af34a87ee3bd82ea5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5fdacd7ec0c46043d33edb35901fa14fa2607399732b2db348bbd2ebd6a20911",
+                                "uncompressed-sha256": "f430f6359932995d6c1ef2bd0d400f2a9426530fc28cfe39e647337da833cf22"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "dc3d64b4a10d8b620c1dfc8759a19edce0faac8f2a228936aedbc633174ce688",
-                                "uncompressed-sha256": "607b7c6c9d2c028b0fc5c8336dd977452829e8ccd83bca666e1e589898e1dee5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "18273a3582c3157c46c674c59a4e6746eeb6e260967f40bba36adb62060b04c7",
+                                "uncompressed-sha256": "837010dfd750de40a18ee314aeb0b0db15036da02fb67897beb6bfd104262ace"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "88487c4649a6e6560441ebdda71050ffc6790663712217b216193e0a6bd94888",
-                                "uncompressed-sha256": "d541b6a652193d5ac41de3d24670678ae70c090fe03c982164442f346ff48aac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2fd4f2c4667c9fda607a01f7df0f908a81970cd05509a1cbf0e753246da5961e",
+                                "uncompressed-sha256": "0d8a1d97df06419d7566f959abbe30d6c2de63294ec26ee6ebc18f08ae6ff63f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cee5c99182c84199bbab2ddc75e947dbf6b586ebef1dc8e65bf6ff39b76dd0a3",
-                                "uncompressed-sha256": "16b463be4aeabbf4260634bf6eecfb48c3b6dab222e13b201c6b9df3e690ff8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "eabfb0251aff53a34fec1aa0f01220d55ffa78ea252ff95b60692d977176a2d3",
+                                "uncompressed-sha256": "2868307db5b3c5288e6df278471691f01b414f40cdb547816e010fc34a55b3e5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "80c857c235a057732e3f765080085f50f04eedf34861d0063346631104cb0a67",
-                                "uncompressed-sha256": "963f3eff472d8dd982dbfe99bc047b0a82d9e0517fcefee23fcea0565c06256a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2dfabefd14e059101d618c6e019e74a84a34004e0936cf59959178212873a237",
+                                "uncompressed-sha256": "094871b5f511b307803c4b476f2517bd2d8eb9b484d0e99f36cd970eb14f3b72"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "79f4d0832bdd1657e323413433845b6e43f4f1b2e004180459257d60280ed564",
-                                "uncompressed-sha256": "119b4698de8c9fe577f8227692ddc4231b1b0f1f202a6d0cb55395668f8d742d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "747ebe3f6247d57e31f142dd84fcca160263f02932d21002d5f6e44b1047b5a9",
+                                "uncompressed-sha256": "fabf988cbcf25a4e667bd029965c1be2d682f946b8f6b11d5f5685d4f322fb83"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "563cc30e174d78c2e268fa5535edf35475d83b2f15b012b2c672c02ad767bf46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "1a108a85517429c375345139de11630cc13ae7ef728c4c4d8ae65af1f56a139b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5c05c8084edc651c32b204906a76409a062b09d896e349183dc6b2641691bf1e",
-                                "uncompressed-sha256": "4f24ac779f8f04040e895602c41edff3149a2d5e792ea29f0c65ca786fd7db0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "dbba3760f1f379290f2479b01fd9149c1f235916dda300cd1a897bc329a2ee1f",
+                                "uncompressed-sha256": "bf07004587ce291a5f15be0ac6b6b01edbe8b92ea47918f0ea9a06ce09b0cf20"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live.x86_64.iso.sig",
-                                "sha256": "1404289fbfbefd48437208d4612701f821f3bb1e1543d9aa5d0869ac6c1509fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live.x86_64.iso.sig",
+                                "sha256": "1de8df412b4fb05fdd5bf3c559126719660d61c348af979ac851fda5e8bfdfac"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-kernel-x86_64.sig",
-                                "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-kernel-x86_64.sig",
+                                "sha256": "17b1696ec6d7184205501409abb5c242d6ad0b14b4a5e78aee62c64b325ed4cc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ccf603831bbc5068901ff70366b36b5cbe9440d637e451c749dca0470813d1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ba2e601ad08dd5ed0ae7f554750056337ad6405309f474dda37e382c38a9ed43"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5c9259b8f8f49b8f9293310499ec28ecb41e1605b319968eb991ca9a9fa78528"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f15ff790d8790e8763de68a412edb5892679914582451149a9849837e0aa89a4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f2246a63e16f2761c0d5cbaf14124faa2323e7d06dc5852c698fd074caf661cd",
-                                "uncompressed-sha256": "7782c91a19e572187f016eaf16a8e50334e63c5c648e495f71f69e4dbe00cfe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c5b9d8b4ad4e2f262b4d8e6533e85666a2541ee32d3ea8c5a38aa65bc0cda64b",
+                                "uncompressed-sha256": "82944cbde34285d534a53935166793334069dde175a14c345f5c3755882ec37c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d01f8068c42d823e729f04bec3a88a7b04b2e686197fd3c50e33fa340254ff31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "62da48b26ae9d260c2b717f9c2a0849cd368b939d8ecb510877596749a34dc1d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7b0d407d9321675763b7e616f6ddd061ca14dc2d15c9d024e9800082c642c0fa",
-                                "uncompressed-sha256": "cc2104762f15c32f52e22ce229ef8085aa6bfd79ebf8997735b9cc403a74f3e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c1db42b1384619812ffcb619fb2d3bab499656eafeefb3a07c6b5dc3276613f1",
+                                "uncompressed-sha256": "896b7c257ffbd63804e57bdccf52c8b91d161803305c97e11556000642f145fc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b7b1913e46e83d0b94300913a4ef07c24514980201becb19c5bf72186b337945",
-                                "uncompressed-sha256": "59678fd48a396bb23185c4ce28445edfa40cd1c793658ea24ed5a1572431d156"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "af89414ea325c62534c3b12fc274ef406cd05a716f9c04fb3457e6fe271be3ea",
+                                "uncompressed-sha256": "ce1d8392ab001cfd010bfb9dcbc22966892cb4a61cfec9111b7f3ea7870ef61a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a8f03c15011ee9c78ea811742120025705e1248b2985ebf8539c3272a6dd5a88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f809ee03303ab3ff27ecdf8ce60821964ee9f138ea178e876ea5b9d7db26386f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "e743ec838001e2b8c81827fdaefb1acef00b2ae511eb2167273aa83383ad8343"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "22724890974f926df895208fe3aaeaa0ffd873b0b1a7396d3a1edd496824c85a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240701.2.0/x86_64/fedora-coreos-40.20240701.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d25fa08fc8438e9548ba3541079ba3760d2d0a128b69c8345e564c86c678e828",
-                                "uncompressed-sha256": "a93a0924108c8be74023f82e56933be254f231afd9f4b1d3783d79f7f81910db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "305334a8bd6e50c7bc8d14cff2918f3e44c4e664c39ad5a096ceeec7fd482c2e",
+                                "uncompressed-sha256": "332d2b569eddbc3e0a2cb13d92c47c7b3e9255af5a5161e49602c53d6aa976a3"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0fa62243b7011cd7a"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-00665e50df1e4da14"
                         },
                         "ap-east-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-05644188d266d89b3"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-036c0c597ad3315e2"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0ba879fecca1d70b9"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-08df37b5df85cbc79"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0b048b43b9676d778"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-007c872481e7cb32f"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-01b912aa2b50ecc1e"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-04075282a6a73b2ab"
                         },
                         "ap-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-07c492b32d417bfbf"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-005e014576197f002"
                         },
                         "ap-south-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0e26c7937edcc14b0"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-087933e8dbc916799"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0daf497268e6e2139"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-06a890adda9892396"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-046d96500d053a605"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-047758b150b4d939d"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-021c41e7526c74b76"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-091a99bdecd56c7fa"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-048aa32f49cca2794"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0e7ca52b3bbecd96d"
                         },
                         "ca-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-043557166890caf6d"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-064acf457543ab422"
                         },
                         "ca-west-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0e5bebf53c8bcf879"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-047abdd627777a26e"
                         },
                         "eu-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0c271dd22d82c7b71"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0e0efb14cf077aab5"
                         },
                         "eu-central-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0b4718df326704fce"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0dba1d8d511a4344e"
                         },
                         "eu-north-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0ab72ce27cb010de7"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0b7c3d5a8e3a78498"
                         },
                         "eu-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0369699deb6b81e60"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0bbfc72eaf06acfa8"
                         },
                         "eu-south-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-099a69f3e4ff6d433"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0a5ec09736ab9b013"
                         },
                         "eu-west-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-0b31f34aebb5b1c76"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0068b9c9c4fea2430"
                         },
                         "eu-west-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-017cd7fac959677db"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0e5d98400c9969b88"
                         },
                         "eu-west-3": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-056c5a04be3b1d6ad"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-08240c35d875a3a0e"
                         },
                         "il-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-03507377e73c72415"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0e3b6da637c1d7076"
                         },
                         "me-central-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-095a9655c6cdc4f29"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0934232303f9c6637"
                         },
                         "me-south-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-04273032000bcdb60"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-04fa70c5a35a98a87"
                         },
                         "sa-east-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-08f8e53c9bfa626e1"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0bf6a1dd8ba9973d3"
                         },
                         "us-east-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-09d593d025bb2f737"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0f2d53490f0f95e40"
                         },
                         "us-east-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-08842b2ab068b3327"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-034d54fdea7ab2cef"
                         },
                         "us-west-1": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-003e84f20e2c64b1f"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-037ef368973e063d6"
                         },
                         "us-west-2": {
-                            "release": "40.20240701.2.0",
-                            "image": "ami-039bde86d21865df9"
+                            "release": "40.20240709.2.0",
+                            "image": "ami-0ce37c23182487533"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240701-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240709-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240701.2.0",
+                    "release": "40.20240709.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:39d7198cc867c9e063258bc914b41a8adae17bbadf1aeb3a8f52c973d6104040"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4e741f9bfc009d582685bf050311df43a1a4f813ff0c398ddae06f2c6da3b6fa"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-07-03T20:08:39Z"
+    "last-modified": "2024-07-17T15:37:14Z"
   },
   "releases": [
     {
@@ -109,22 +109,22 @@
       }
     },
     {
-      "version": "40.20240616.1.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "40.20240701.1.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "40.20240709.1.1",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1720038600,
+          "start_epoch": 1721232000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-07-03T20:08:37Z"
+    "last-modified": "2024-07-17T15:37:12Z"
   },
   "releases": [
     {
@@ -101,7 +101,7 @@
       }
     },
     {
-      "version": "40.20240602.3.0",
+      "version": "40.20240616.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -109,11 +109,11 @@
       }
     },
     {
-      "version": "40.20240616.3.0",
+      "version": "40.20240701.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1720038600,
+          "start_epoch": 1721232000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -111,6 +111,9 @@
     {
       "version": "40.20240701.3.0",
       "metadata": {
+        "barrier": {
+           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
+         },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1721232000,

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-07-03T20:08:38Z"
+    "last-modified": "2024-07-17T15:37:13Z"
   },
   "releases": [
     {
@@ -117,22 +117,22 @@
       }
     },
     {
-      "version": "40.20240616.2.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "40.20240701.2.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "40.20240709.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1720038600,
+          "start_epoch": 1721232000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).