### PR TITLE
Roll out stable 40.20240709.3.1, testing 40.20240728.2.1, next 40.20240728.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-07-17T15:37:13Z",
+        "last-modified": "2024-07-30T21:17:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "be257b4d279a73392c6b35fc5f5b92527a3662f1415dfe07104543da365dd10a",
-                                "uncompressed-sha256": "46a0a10eb8e6a0f3efbff3d83ad81adcf617c8b5fe182e3d729d9f8e07229e7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "facb45d339a3cf822e62e262f7127617476521bc102df3f2b582f743b9a2eb2f",
+                                "uncompressed-sha256": "8b82de451d0d6bb7e264ca43bb6b8e9d249c30f542b0675ef1758307a363df4d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "efda2006924e703682421e4c2913a4056a2619cc09bcee511f5ab7b493e6f937",
-                                "uncompressed-sha256": "cc6e638710e9ab6fa14ad1c50ad75538d4650fca21044127a9bfc3dbc75c0e4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a42936b17085f15663e5c9432ea8fb244ebb47da933884e0a988c932e941a4a9",
+                                "uncompressed-sha256": "f1fd32f39241af766b9ded3ed34a69e1f1ae64dcde6de58c5cede1363b235842"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "673aa19ed8ea0a227959a8088f235a31571c76aa66c33f6ed5f3cbb670dcd7ed",
-                                "uncompressed-sha256": "f470764331855a67748115f6c91ea85bab31b9b70d6c891b8e3d401b0cee369c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "392b0b52364129aeef46689a370576ab09cc184e94c732ee3c373fb696cc465e",
+                                "uncompressed-sha256": "efcc91763988d893be56ddc789b3bdfaaf0d28a89866febc50d41606ff0a9c1d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d5e5d5a203b7560ea67fb7bcf01be3186f58ae8936ec7f24927f1cbe1c195f3f",
-                                "uncompressed-sha256": "8c401cfaee60e5ab50dda6f6ef04219c810542a3f61fbbfa5353014a35e544bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d5ae7f5f51f2e1d6993c08f221a8d4ba5b6e04c583503ead8d2f4712b76a88f9",
+                                "uncompressed-sha256": "7d18c1a3263f419b271cb334af71972a025ea0233a036e7564242ae421ee9029"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1b64ab7c1c5b3598f92e6f1913c723a27bb9e6c762ff2d68fd57870588348b07",
-                                "uncompressed-sha256": "074777008186b885e8e2af065342894a6f07bc4583ae24686dcd1b4fd868b4e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "674a02030a84a4e211b18e19f24e68cd04565cdaeb0ef774de0971afdea94038",
+                                "uncompressed-sha256": "dca183911c4d7d5f00fe5d52d2e410d13aeaedb2fc36875142af3a8d701c1e8c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "160cdd8a8c9e4e094007bc59f1afbb6fe304e3bfe2012a926c2922766937795a",
-                                "uncompressed-sha256": "788725ea56261f5e9a3b7b40c5a35ef958e71f857b54efc4f3e268768fcf8600"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "de4f6b76f4d0e2eb6291dd4db973fcacf31b28ff7a838b2dfb54deeb2b3d45d1",
+                                "uncompressed-sha256": "d1e9a94a495ee4618931498ce93e4a7230f7670683716a7f01d96f60795d3f3f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live.aarch64.iso.sig",
-                                "sha256": "fa3b158e8d9d64d4ad716cb0ae0624dc0b230fd903c75473cf776224cb787e1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live.aarch64.iso.sig",
+                                "sha256": "bf8e9b791eed78d407bc98559d75eb8d4ffbbb0668c9b15e94de930687560081"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-kernel-aarch64.sig",
-                                "sha256": "57983a9642bee5a62c26c9d3b441733d4755462c1cd3cc5e278953b12a3232f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-kernel-aarch64.sig",
+                                "sha256": "c346e94ccbbdce6450144add99eabf90f14b20176a6e401a912b642d6ef702af"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "7a835984bf2860a2464d471be4d87e0451cec22beff19c1ff7aff83ba29bccf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "7fb858acf8e5b11808e6643b9b24a8ce061a0d5bb6eafabe082784307688886d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "ef56d640d0884a767bdfb56227aaf8cdc90527480a3c37b8e2be1067fd55655d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "1f204f2446de14c6fdbff39e2f47ff80a5fdc653cbab7eda8a522e828e4fe157"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "79b7cc350bda3675d10a4e7fbda0ecaf997a9767a33caca107d16a62d62402e5",
-                                "uncompressed-sha256": "d395daa0920db8225961e50f24e2cd71e9cb204c1536afcaf37002a13000632f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "f637bcd513c118212fe76a6a020fb4b24a3199681913aef25958c08f865396ed",
+                                "uncompressed-sha256": "9f0f198637c70f38bae47bd9ec7aa5261b6b702da7aaa48f77df6a09aea13bf3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fdae6a9296ad00a583f9b7dbe37c6bdeb18cf0280dd0845851598fbe86136505",
-                                "uncompressed-sha256": "6f72f5d09f3596c7b8b9d68dad78e28fd4d71f637487b9347cd93e5f7741a14b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2d59ce7f96a4d2ea6269dea8588247571c01cd721def2c0adc7ef019158dfb57",
+                                "uncompressed-sha256": "de2796045143f72211b00d9318fbd7a291a05c2f7e653dce4b8568b6cc419278"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/aarch64/fedora-coreos-40.20240709.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5e2f6f91fc57b588f60c9f658e9d451087862c961311300ef467e511f1ffd2aa",
-                                "uncompressed-sha256": "4f8c3086d7d36785c551e2a4a8d10e2ecd1428ed310674ce65d6f096dede1f4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7e8bee325c775a52c110dea969c7c2d9163b089e9481cc8083505d3299d264e9",
+                                "uncompressed-sha256": "5790f51ed658d310ce56aaa7c5ac17b0c7c04c4340756a2d9d1f1b5172e210f9"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0bcf6bdc70ea4d619"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0594e411d6de6ba1d"
                         },
                         "ap-east-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-00ef4d3ecf13a3a09"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0199f0a3669be5f53"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-071ce4ce66f0384a1"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-044134edf82c9b54b"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0bd6b0eefe688bd9a"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0b850c2888493103e"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0749f66db3cdacb49"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-02813059e5b968c81"
                         },
                         "ap-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-02063174027bcc118"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-04c85310c9b10863b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-041776630ccb32be4"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0af66fca5a5ea121e"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-016e55aff8443a333"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-03f5bfaad0ca74178"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0761ab8ff1c07a7f3"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-064210105a4aa7a6c"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-030c351d6daccd4aa"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0406520c2b0206f7e"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0c0a59e47551e44b8"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0f046df81fb38bf45"
                         },
                         "ca-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-060008675bf9fd3a6"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0e6cb8fa8f570f646"
                         },
                         "ca-west-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-02e95da85cd67b919"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0550a2b203b34b209"
                         },
                         "eu-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-02939daa1ab3f34cc"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0b07430d85a6d6b71"
                         },
                         "eu-central-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-088d1402c25207a6b"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-00d343d546904ac16"
                         },
                         "eu-north-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-031dc1ef403a8f8b3"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0cb8b7af1c3b5826e"
                         },
                         "eu-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-07a37e778387b6e62"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0f4d58256f8f2880a"
                         },
                         "eu-south-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-05f6f4e0e8b5662a1"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0e71e3aca6e58be81"
                         },
                         "eu-west-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-01403c07f5c2a3c3d"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-01bca6b38631254aa"
                         },
                         "eu-west-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0053d181b94bbad2c"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-08df3c9c5a6beec83"
                         },
                         "eu-west-3": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0694a694a732c7fb3"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0e3476682413d26c6"
                         },
                         "il-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-06b40707f5f104126"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-07b616313b87a27a7"
                         },
                         "me-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-09b1f60fe0fb68422"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-01c147aee5e0b7b59"
                         },
                         "me-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-059bbd119533988b6"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-00d568b3b78ed2fba"
                         },
                         "sa-east-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-090da99040b833be6"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-01a112ac981b5f366"
                         },
                         "us-east-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0491a1af6775dc9d0"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-01020169579d28307"
                         },
                         "us-east-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0306a76b505807dd9"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-05ef3fc3207207c26"
                         },
                         "us-west-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0add76405845008d5"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0d3b2b8c1f786a214"
                         },
                         "us-west-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0f2650d100aefe42b"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0eeb9b7cae17377b3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240709-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240728-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "0d40dcf0d595e06c12c1f30198488acad75a15e2d7b9ec8a30ccfa461cb5d5c0",
-                                "uncompressed-sha256": "861423c80859fb7bd04fbf64a0062c0c7dbcf3379544870a8178194556016a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b6a1d398122d7c0636e6aec7ba227b927cc3af72346bf7061631388733c4105d",
+                                "uncompressed-sha256": "a36ecf7c89d5d09d36e7294f44b0d45e3525bb0f634f7a74dcff49e7f82d8a04"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live.ppc64le.iso.sig",
-                                "sha256": "3b56e62e2c582c755eed816bbd586091ea22af8aeb0e19e15b7c9a48bfcad746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live.ppc64le.iso.sig",
+                                "sha256": "d1252fbb3312f4d9ac4ecd9958edc08d6701f258e5e92c87a036f8f715dc781a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "0a49db68d0a6618c4cbfc20a64c8227d12e4316b0342395fceb984379784c5b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-kernel-ppc64le.sig",
+                                "sha256": "b9f76fc0668f1d6919f8691b9fc6bf0daf4d4f562229d40150fbcdad92cbfd62"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b15bf1d2f66c3d0189ac1c6440bac76444dc8bcf9a13343e5df923a5041d124e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e9f367b6d5beb6ba399cd63ab770499d34b4e15e6673a769a1d15de535e02958"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e464089721a7264c53cae55ed5461f8d8ed726822be82ee290bd03e24f8de68c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "848a24c1abc71ea4cc4ee1f91b1576451645be3b24a8903bec9b2dccab24dede"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "78142f17eea37a612127300bd1aa6f991dec42948f0d1147869d0c88075284e1",
-                                "uncompressed-sha256": "408b3d6b5b79207147595d157e412304cf75b8f8bec8c70be1d7e9d925cbf716"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "56ae7b82611f82d796b04c0ab2939b9c69a40be35579fc8df2b97b4487b6aa3c",
+                                "uncompressed-sha256": "f8b4c8dc845e2d6d4a74438e2e03133ba8ae5057203660cc447f9e2c27969640"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9c5ff71d301203abb94b4f0eeb9a12c063ca1336a50847b08754a7dea4e83dcf",
-                                "uncompressed-sha256": "f0090e4b0a0fb9bc3fa844b69e61341de1e35276d639a2c04b670cc98f909b23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a662cb72d52eb37506d1993623e578fee5b06d6ba257b68f608d7a54b0482aa7",
+                                "uncompressed-sha256": "1f62d553b75fbb2bc67ffce74dd8f6667fb3f0e6e42255f4a7235c2161ac2d62"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b60609be8b5c86bf69766e2b7dd480268470753a4958e86b525337d9604ce880",
-                                "uncompressed-sha256": "4d4a706de7c9ae5fcceb332b8a34f7dc1c4bcdc9c4fa3db69314967d836eff1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "17cf160988cba88c44f1aa512877ff7f5e9236a062c5a5b33892c34b9529fe2a",
+                                "uncompressed-sha256": "1bd0366ec0f86c47257307d4734f5311012a35752ddbea7eadfc0e8c1226943e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/ppc64le/fedora-coreos-40.20240709.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2ce598c08e148f60f51ad90f6c1b77a83c366b3a448cb2b063d44455cf5bf210",
-                                "uncompressed-sha256": "431bbeb35bb51e2f23c3e45191b3d735fe5f2e3a4ca49be0175cd4b242f195db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2d14706daf47a4cfb5d1b49d5e7a1158059d630ef75cd538e273b39fac607791",
+                                "uncompressed-sha256": "ddd5c01820dd242e88a437e80f125a130036f3d3238ba38385504c1b6bcca507"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "727e4eed48fd1f5982019d81471ac5e833951ad3f54b5042413452cc1aa016a4",
-                                "uncompressed-sha256": "c7b6b2fbee7b7155687954147aa1dd25fa5e3691f364d8e5a64776ef539ef664"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8205a95f65210f8320bb0b36fb749fbade240921e204ee2c1197b4517de1a92e",
+                                "uncompressed-sha256": "f74826fd5b8311decb762668d1fa064bf4dbddd9b9b52cb6df2aa1aacfad8f12"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c35f4ef6592fa67d098dbc804a9a4f39e3ba3e11c9962e498ddbc921d61d8528",
-                                "uncompressed-sha256": "d7f8482c6f9fbb32e3c2e2965b9af6ff76fce0bc12c9a50320fe00fcad04c7de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "779bd7a938420c516eba98acf7b3080740ac732b27cd8f80a64d5165fc21722e",
+                                "uncompressed-sha256": "b2c9f81300222173fa90cd566989d0675d938ba5e03b6828559c152568513a1f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live.s390x.iso.sig",
-                                "sha256": "1bbe56788ce5ae342e71ae0284e142b47a785fa88940369d93fcb4501ecf34a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live.s390x.iso.sig",
+                                "sha256": "10fd8e00aa9ce87544e2a637e078437ad1e861742dbe12ad5ae63c929878ac55"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-kernel-s390x.sig",
-                                "sha256": "ffd9104defb17c4e0699ceacc8c1a468d8b74f5b310ffbee37e0aa1391a3f293"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-kernel-s390x.sig",
+                                "sha256": "41173681081a1d01c78df1a4f60e8480b0d0485cb7c49163154096dfc05f47ed"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "3daf0f4dae3e64368c23180bc7f3e7843c45b7cb121e453b30efee090ba6efe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "e65bb2c99d8522a890218e6b5cf59c265b3400570e406b66fa2cf91f40f18d50"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "7d0b369eedd31a53876dcf7c37ca461d331697485509df38c8e8733bf0392456"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "ad49d3f94ca269ab42481177b835cce67ba81c70202da7deb58be3a83efaca74"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "290335b9b2e722bf04426101de040332b4df4937ea1ab378c7b452aa54d3507d",
-                                "uncompressed-sha256": "23ed80bdc3df65b1294a7b5325a7772316ca5af377f93e9d6ce647ddcac79425"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "f0fe67063d2d780719eb30af5a72b67a1bbdc1a253e0bc1c548cb6adedb075f6",
+                                "uncompressed-sha256": "246f34702a394bd5d164dc1d1124c3a729bdb58db4f44eff2df8c172caad314e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1473948a957250f10c9b73bc549cd07501a1bb9b4e2b018062b66f52214f7490",
-                                "uncompressed-sha256": "63dec7079a893eafa1f0daa34371fbfc1d637619ad75be26d632db7bdd888257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4462e128b6814d1abfb8e0d072fb7b9c8545cc49821634a3b79f062cf6f442e8",
+                                "uncompressed-sha256": "c4fc186ae4be8291327672d837f321dda7e0f93fc4bec61c79178d3d149fd41e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/s390x/fedora-coreos-40.20240709.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "903d222476007a52dc6eec9e275a57fe149dc47df705e359ddf99a67b49257ef",
-                                "uncompressed-sha256": "3feaa2f8a538bbad714423c07f173b60ba24dfbba68dd3044d45e20c5970c71c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d6bbd46896e320464982c657c1e195eeb65b5dbaf778d381ba1943e7eb7ea3b9",
+                                "uncompressed-sha256": "9a86fab918edd8b9f1cc89898fdee4fff555c29012e00bf96534a55d98f0fb4d"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d59063dbc2a3b56f270e2515621606ccbaca08852668e7721a82eb10fd146558",
-                                "uncompressed-sha256": "47fabc61a2492483c9103c925f9c0ad3418742163ec38e0000163414d73ddf99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c5de822aff1c50ad13e320fd8b65affd131245109e5f103546b65828a8922eb0",
+                                "uncompressed-sha256": "2938d41635dde2b8b72693da5505799fd2d18840e7f4fcc9d0bc00506bc7c1f0"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5c8034357273f2885ef233a0aaf6d3c6cf7e9e0f59844a70f9665fe55a13a07c",
-                                "uncompressed-sha256": "27f60af6045d9c52a26d1207a60096c4bced4bee4b2c964454d498096ca163c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "bd89fc2429b4f55707ba0b8fd4612779eae57d4f7cff3e837a5b52821fec531a",
+                                "uncompressed-sha256": "67c7bab55a9fab29dab37e9b4d18c8ec716270cbfa0db0e4982e1f048fa11d9b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "50d10fb87ef9311ab41a4b6167198598d6df96ac0fab378ebf84377a67d67be6",
-                                "uncompressed-sha256": "ac46275cf1d165997587708d713dc55616825f745a2a1f4c0c8a0e67e7369113"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4380ceb6b10a6c7aeefb0a02392d3be0848dbd05cc0cefa9512d6e2c49858a3e",
+                                "uncompressed-sha256": "30250d7a11616e2a4a6b017db91d485e08312a4ceca9412d64fc71c1426d3053"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8fbe75d4b7f8693690f389030b7209fc0c483057950df08b5400b323fc47d370",
-                                "uncompressed-sha256": "489e634be3c84361786083374ac67974a35ce5dc62225cc8f008b1a9df8c4ea1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "230a32dff7854e899091ff6208c1e7b5126750f25011999be4968d25fbaff4cb",
+                                "uncompressed-sha256": "10e613a4f034b0ce77c2d0e13fa55220f810c4f42881dbfb818fe1414e9f3024"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b53aea5a090cd4431e91031bd3afc89d9b94a063b2c07d5a6690c4dc51ce19d5",
-                                "uncompressed-sha256": "44e7b4f99623eca3d5a2138a57edd8008575804fbf2ec072a513919d10ba61ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cf1b029a6217deed91aa31023842e3b4440648903366b75add10d7031316a37f",
+                                "uncompressed-sha256": "a7cb656184a8fff37c09bd394a1e61af8dfb97c2a1122d612572b5c374e8095f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bbb7b7e3379fc4395e869cb1cc6b99c98a46ed8e36c1784bcb9564c20461ff56",
-                                "uncompressed-sha256": "9a38c663674ff1545fbd916be630a424c250338fc10972e49a0686da2f451f38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "0c0225a51df713f5f75afde15671f94c68ed233540df7965e5f4476ff7396851",
+                                "uncompressed-sha256": "a9ce18ef6256c710d14c00af0cbc27806840c857e991134cbc843db826e7355d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f93f8b3f4a9df7be1ad36b76e09621c2f0beefb9ff1001b332ce6367307fbbe3",
-                                "uncompressed-sha256": "6a861538a269d003e6dd54c653e5cfbd69b24a9888e4358cfd6d043225072a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a6ec65bd1107de8c29422763a3a3a18ef8b0fe723857227cb0cd6777ac91ae9b",
+                                "uncompressed-sha256": "f61649dd63b6e2b48bcbc5e6429453337acc7e6540f94886a437a2f85b8432bd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "15fbca4fcdd40b6a846f7b1c7b75126414688f31dc05bb7dbb875fb4595564ee",
-                                "uncompressed-sha256": "e20c5d7fea31c25e2a9339cdcb8fa668b964f70042059418463068c13f510be3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d9a1b5271af698966431c7da772dc8a991a791b89bc3c537f043557cde3f7678",
+                                "uncompressed-sha256": "1abe70e60004eefc9f42afc824aec42c7727a58e2fd423e1dfbc2b483a349327"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2332dfe98a8ee2636c4f8e299f848e4eb36696d0e0f3a89e731725827506a2d6",
-                                "uncompressed-sha256": "1f5fa127fac9ca607618333ed2dce1f00bc0f7227321a05d4d0a60f142842942"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7f873cd9a1b096c30f8e3daaf53a2d5b03cab5341013f0d091bf6414f9d06786",
+                                "uncompressed-sha256": "5b7fae50b1569a28be9b729765dc1f8e7f6fc343059f015edd79ef6a8acb152b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b9d486877cc280cf7754533998d56e44ac9ef6134e6a39ba9ba98625122844ff",
-                                "uncompressed-sha256": "9c460a7ba7c7501c63d8b9ebc2f703c918965e0ce2e2ce7b38b21d2c35f0c02e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "520a342d3e2f9f866320f0d09307c9ac1b6f306de74f6c50826a2b0b07203d5b",
+                                "uncompressed-sha256": "4692b27559a4fc5d9bfa4356370eae761bb7be3796d433d864e015f92feebfd7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "1aef02efb09fc9dfb8f6b140e0ebb9e0fe519c7b9b9716ebf59ffd09cfbae64c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "05e20a0408011f85c3ec3503d464b03af62d23d7d3c97c680702068d3edd9067"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9331863f4ffabb68ba9fbaf0b2ff516251b46907591c2936fc7fcafd1c4a33d8",
-                                "uncompressed-sha256": "b26fc688f4f5c0eba77a8c97e2c6a7c7dee6b0d41d0aedbba29eed38e63037de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "08ade7f9bdb3fbe05293e5d2463be1619700ab4139970c4853ee22ea84717b99",
+                                "uncompressed-sha256": "b7dfbe453773d6e32a299edd7d6356f9e34d9f13debbcb045760a52055f5adc8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live.x86_64.iso.sig",
-                                "sha256": "391e264367423a8e7c335c92d66340a26b17728bbe46530e7f0b0a75845e71f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live.x86_64.iso.sig",
+                                "sha256": "9a23e05c8e53d4b0e7fea7ad517f05ba02a1ebac33b2d9d06bcd4bb4d78b724a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-kernel-x86_64.sig",
-                                "sha256": "17b1696ec6d7184205501409abb5c242d6ad0b14b4a5e78aee62c64b325ed4cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-kernel-x86_64.sig",
+                                "sha256": "559b86e867a743956204d1f17e492c3273c6ef288accf3aa0c4356e16a9aa439"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "9a871690c84cf00210f175f66a6cc99554151bf119404db684e848c596bfd3c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "2849468e2ea992838bf7f4c28f1bd3d97a5eebd930b67ad7250dff785d4927bd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "5b4dd1e769d4823471551e6772827e99d4b13f93e1d76bb296a827420b93e0b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "1128c4956a3b392d1396a8c4eda53b1d7164194920b9872f909e3a60ce0e7822"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "b489564864d4e2c08d622c190e697aed7448f3886f9fe0edbb8422e32443db3b",
-                                "uncompressed-sha256": "9490019e70d11c03bc6e15519bcdaf2fc71f75b59154ca507988402faeb71ca5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "fce59adb40948538f42f350c4dd81204085de1ae8ed81c7326b0820c07d92357",
+                                "uncompressed-sha256": "2e29d8cd7d73fa311fece39a7b81d31ec0a428fed723e12db79e10b48bf5ae58"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1ad354062daf12f7c2638ed11003cf41dc63279361a2461d0e4fa2817a00c28c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "432cf05d50f106a2708cb72596ce7764f802e407f94fee72ebc84840efd2bfe5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b91fa34c09a82e283d9c2b99a831b713601741ae1ed72217ecfe941b33eeadac",
-                                "uncompressed-sha256": "494de08e79f5607ec526f5886c525ca121921750d868e59544c878cbc7bf6149"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3678bb8d8a38c4423b2e0b93e097a31cc0691757dd5435723be0589500376999",
+                                "uncompressed-sha256": "0f673299e8511e86072b1189d000c9b27a5f2b007392eeda6145f2e23269fb92"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0cacc59a4682b165627bc7ffdd1271b19441330ffd67459d68a0022f4f42cb4d",
-                                "uncompressed-sha256": "137437a415a9d2732ed09b3448f34c2abed841aebf95db105e8eb7e2df0152de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "df7f2e05baa090b3dfcebc1b4ba3945eae11fe6e072ae3d7cc65ae651069a82e",
+                                "uncompressed-sha256": "212a167e3c42f5b05ea8bb64a72bc41ddac45d79ff60a0304a89f901542adaa1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "53bed9138fb52e6dc669e87c0b1fb854bbb7f1412f95b2661b3968eac48d057d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "421a065354488e1b49f729c41b11b2a9c27e55e72f236ffb7a1030810135e28d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "fba94cff96a784c6bfcc5c49979ec3577f3a62ba01a0063319cdf85575a92d93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "89578cc4e9f5ca65db848024b8ec1ae828c57920a3912a5e0d471eebe00c99de"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240709.1.1/x86_64/fedora-coreos-40.20240709.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0a0b3f16d6597eed201126d4e193c7216e78b67c9f9796260c91fdcb0c146a3a",
-                                "uncompressed-sha256": "b9a1326be00e2cbe754e27115ed91703165871f292d4ce3cb4151c41d5d44cf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "47cb2fd1c5c66ceaaf377e71d93fb2605f2ee7a6214b615a887349704db76dfb",
+                                "uncompressed-sha256": "16db7d50240bf695bc52a2a1c7a040137f1856f8156a3c3e0bfc9f89095dd899"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0e829ad8ebc9b6949"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-02b0b8e7a6aabd1bb"
                         },
                         "ap-east-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-083b09503c2e03e24"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-053770967d540ed85"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-030bc21a7579b352a"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0f84fd9854ef872a7"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0e3e5372b862a431a"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0de3c3dd2a152b15c"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0ce88d7625f2e69b0"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0ee92f897806c3e1b"
                         },
                         "ap-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0e11af9e165305335"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0c06287c784d02981"
                         },
                         "ap-south-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-04c575114ae955b25"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0da886c30c56e58ef"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-09817942da9868a39"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0c3a4458729493cf5"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-06ec9b5811fd0e1f3"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0768d63c5b254e6a6"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-06a2a935f2dc84f4a"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0956e40f2b0c1c3e4"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-03120937d39b5b2cc"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-07e979ce70fbdf9e7"
                         },
                         "ca-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0f3af4ac0ef95b210"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0e3f15b49e62e98ad"
                         },
                         "ca-west-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0e1ebac3e9b08c949"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-05a17e70c54e32208"
                         },
                         "eu-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-033f698c3a4cbc13e"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-07ba9328f8bed2506"
                         },
                         "eu-central-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-01790e2e93a0d2e27"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-031211daba9c7874d"
                         },
                         "eu-north-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0ae59bc88c104a00d"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0f6ed566916eae02d"
                         },
                         "eu-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0fa7df45123c88680"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-01d11c03aa89de097"
                         },
                         "eu-south-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-044d5138f8a0ce759"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-07f499b90970f77c4"
                         },
                         "eu-west-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0283482aaccc9bd29"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0864b81ffd107c0c7"
                         },
                         "eu-west-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-06d14daf8fdc191ab"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0893847f23f5e15e5"
                         },
                         "eu-west-3": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-014bb98cfbbbb2248"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0fb65ab86e1fd65b3"
                         },
                         "il-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-06180bc7deb7d0f59"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-06cba0f155eb91bf2"
                         },
                         "me-central-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-098b3c95fba95697d"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0a7a2126755616921"
                         },
                         "me-south-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0b924c075d6393cc1"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-056d1c27b7f6f3a76"
                         },
                         "sa-east-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0362b0b58fc629abd"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-06363f85623c18e91"
                         },
                         "us-east-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0f9eff2d3c9c441a6"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-007e0dbe3938cd72d"
                         },
                         "us-east-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-0c2958772e276abff"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0126b3b398e08deb5"
                         },
                         "us-west-1": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-06ee150f27c772177"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0be01a65a36f2ecf0"
                         },
                         "us-west-2": {
-                            "release": "40.20240709.1.1",
-                            "image": "ami-08a60e829864a60ad"
+                            "release": "40.20240728.1.1",
+                            "image": "ami-0710323d7df561551"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240709-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240728-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240709.1.1",
+                    "release": "40.20240728.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f4ca1f8a8ff44505d11f5dd63f1bdcd7c32236a89b4efa33156d3863e4152a24"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b47292f96187baa426d213b83834f4e3702699e2a52a73dfee1b816e953425c6"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-07-17T15:37:12Z",
+        "last-modified": "2024-07-30T21:17:00Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ac97a07cf528b23c3d7fced7982ac387fc10008e671cab45fcbcd5711a1c48d9",
-                                "uncompressed-sha256": "6a98615f24ea7bb00d99ec5013f5a9fc0209d5f6898988ada2ac93e1a08930d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "de521fac4059094dac837754fa010573176ab0292cfc7e54c6cf9fb4b8b9ab4f",
+                                "uncompressed-sha256": "cb004dfed9f6e9ecd5f14bfe733d7b15efd8585b4b76e66d03462377c0172af5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "90f097487d5a0b037a3161a4972ce267f580ca659686c18ec221127cd693cfe7",
-                                "uncompressed-sha256": "cbd06aab80dedd103a94e8e5fa5f2aa7585ca13aef3c6fc021f0b631702ef9ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "6b84d2487cfecae4fd588a0e4a000691ecf6865839f3beaa08c9b1b47a9f0c3d",
+                                "uncompressed-sha256": "0c04370a5680323802df23d58fbf41b3f5c4e39c92da3b8e5edd9ab235912ca6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "43fb63f189ef69218b2f9abe4a05f962b7591b512f8e7df1043785fd3a5711ea",
-                                "uncompressed-sha256": "48766186f8a66b6bf8fbbb1717496abfaa8b4c742858b8971eab2f8e19a1c89e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a94cce686a02ed39661d785aafcbcaab1203c9c0c01cd732aacbcd31b15253d2",
+                                "uncompressed-sha256": "1916c60b61f59bef41dc870162cab8459fffe1a5db9a7509316cf03cd0220a73"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "553dbf5e367f1cf26cf1b572fbf4400ade36b83a5d47afd720cfe78558df4e6f",
-                                "uncompressed-sha256": "19a69a6585f704d6bce96dc2934a774947b1bff09bb7567b8805a7ade03e2648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "84d5e8f3eb8311a30ff3f3823f0b9d5a1d488608b68395e13d132686bbf6f390",
+                                "uncompressed-sha256": "16222f5376b178edd48817e28e0eed3b799f8d70e3e555c2002e3967e2e4d98c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1ded4d053db17d202ab5f7853fa5edbf478e3796080c59753e7cf3361710475e",
-                                "uncompressed-sha256": "773d2698ed1eae1820bdee1e871aad1087fd15f49cb02841f950b3d1c00a0c63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "702eccc19ecbe775b5baf4c175f4d1419bc243321dd788925e4304a5e3ab3289",
+                                "uncompressed-sha256": "9f04485445102367f596259932ad1b0c7f4c7cf74948aa0f0eb3fbc885e2ed6c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "51a7b0e8d8c544c05994f28d217b01bddbd15347f8f58dbaeb2173601301ba9e",
-                                "uncompressed-sha256": "eb6460c3b46e355bb200818c8e7cb2672d0633cd3c8768d17c128002bdb44c68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a707fc34f99d3e0b8a26e0f941132e290992b21e204891351b4bf0693255023f",
+                                "uncompressed-sha256": "248796b9d8855171597cfa7c7d54424fcbcfda3285010c77319631f9a821db23"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live.aarch64.iso.sig",
-                                "sha256": "40a8a8e5dad7194e263d6b823f4615c9acf63637350ff6079e6164caf89ddb54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live.aarch64.iso.sig",
+                                "sha256": "6ed44fcb1cb527726f9899fbbed6aa8a77e05a7b51a0c087b3f37a1535d46ff9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-kernel-aarch64.sig",
-                                "sha256": "0f746a07a5eee4c49907beded60b81cd771c4ddf85fcf1762c8bc8e4fbdf889b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-kernel-aarch64.sig",
+                                "sha256": "57983a9642bee5a62c26c9d3b441733d4755462c1cd3cc5e278953b12a3232f5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e369656572804cab6820a7f71c07d21b7619339bbbcd0eb60a40b8a501c526e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "c00a8a16466c8ca7cfa03f06c85c93827356ed07092432bf6b67042fc8060bb3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "89d8778486a1d5a54fb3bd865353c442a152f856a5e2a49df516cc68a0b69e2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "cbf946eda0d4fb390843c059421f99bbbeb075dc2ab3a7ac36cb1d164eb34869"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5d0eeae7f96e0bc6ef560f82d6a9dedc482792560ae703fb0c82009970a0f7e6",
-                                "uncompressed-sha256": "20b5b7bb3fe3dea10c9f9f051bca885ebfc767f8efd9cdaffb100e1c52081f09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "2a2461dd9d2b1fe7c781e7cfc7c8795da7352187a4efc15a6937473f437b3692",
+                                "uncompressed-sha256": "5c67b75bca8d3433b3d43cbc7a658d6ff0a5324ff92aa18a3da62097cd01d276"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4e1ff03552a2f06684c1b4ab6e92ab5addb8222c998b40535d391a39ed3b0394",
-                                "uncompressed-sha256": "adce565bf1f46bb87248a497c77a48fe4f853e22eeccd97f326734e798dc7b61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d1faccb3b73afb448a354ff1e0f02caedaadf4584ea0d45e1f68c1a445e0f25f",
+                                "uncompressed-sha256": "1d7b3612b1db749645eba882bb1d5d7dc9553f5e272b42507db60f6291014c22"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/aarch64/fedora-coreos-40.20240701.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2b12d3bcec98c8d8c41d9daa2dc0a80552f3d9a0d19e1ee016789c809eb03385",
-                                "uncompressed-sha256": "7d6af192c726f53d088f9184696cde15de6b5bb86a6415ba9278d95e6251972c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9847a445bf343a4e182f0226911c4b781488050dcc15ef84b97fe175485375c8",
+                                "uncompressed-sha256": "5615cf185b6f624f484533d36b13f0f350c77c41573a419cc0e9c02a439fdd98"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0ecee247c510e382f"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-03e5659512a7c3b44"
                         },
                         "ap-east-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0decb9d0f0f82c55e"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0386e9766de609e8e"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-05fd85e98eaf0052e"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0587c1afa030eb7ad"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0f9301febe369da1d"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-05025057e9fea1715"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0f450d708060e7d0b"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0e49fc125956c9f0b"
                         },
                         "ap-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-080140206975df558"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-044d3b59ea49b4810"
                         },
                         "ap-south-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0ba4ae617b90b53bf"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0c71aa120c05c0696"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-025f8dd009e681b78"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0f0af848d3e794a5b"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-07828f251096b52fb"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-07b268e17cab4af15"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0cea7c980dd58c205"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0c5ab376dfc50d200"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0779cae86c180f114"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-01ef89f86b19f09ab"
                         },
                         "ca-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-049b221eac541b577"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-00c9743539140fe95"
                         },
                         "ca-west-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0b84b4926d4b8dfc2"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0b2a52aaada1268ec"
                         },
                         "eu-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-06552155933f852c8"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-00444a4004eafbf74"
                         },
                         "eu-central-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-08eb8276843c8ca50"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-07845a09b1250bb5b"
                         },
                         "eu-north-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0bbf31f747123d1fb"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-045e06aab112a429f"
                         },
                         "eu-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-06b756d0d85651f3c"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0d5e8a0d5340a25ef"
                         },
                         "eu-south-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-062e77c86c130d074"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-00b503589b3a2c2cd"
                         },
                         "eu-west-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0b9bfdc89c4d0f4ba"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-00bea8557c1a3391e"
                         },
                         "eu-west-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0ab31dd3817b92ebe"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0e6bc438eb70bd6b9"
                         },
                         "eu-west-3": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-035e0b0be15699ace"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0f26992fb5799bec5"
                         },
                         "il-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0c8ed668ee220fad2"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0f07908a7590d965b"
                         },
                         "me-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0bd45e899bc8fba71"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-068a6d0e9d761cc83"
                         },
                         "me-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-07f4988838f7deac8"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0f51e28dc6d2e980b"
                         },
                         "sa-east-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0089819df99abe311"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-01ca11e15421cab47"
                         },
                         "us-east-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0a67e652b4e367892"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-01cc6c45582ac099d"
                         },
                         "us-east-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0f1e5870309501e2e"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-046d1b51de473fbce"
                         },
                         "us-west-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-093ff83af3cdfdf18"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0db6966fa680a8de2"
                         },
                         "us-west-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-02ab90b95d47a151b"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0836f4f273754d763"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240701-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240709-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "298c8fee1df2e1ffc2af3fac0c7ab79d2b85c976724a005fdfa567d2adf61295",
-                                "uncompressed-sha256": "6d744b50e35bae2398f9ef65bdf448f066b33bf7dfbc504256a04a273df32fb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a9ff4d51ee1ef16889a4753fe79576226d5d914c784ccb1aeeff041b03078ccf",
+                                "uncompressed-sha256": "b09d75fcada05191b7256e10c82d0367ce68e65226e0eca956c0b1ddf3601259"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live.ppc64le.iso.sig",
-                                "sha256": "608ed8c22a5c56a7c4163910fc65f9a7f8de5be6e3a4978afeb3949225e9b45c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live.ppc64le.iso.sig",
+                                "sha256": "add3b0a9f4e452a9635dd34184e58fbbc0fd187965b84b0aa594257cddea45ff"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "198c364afe8faf8bbbbe7af955ce708f173c52517733cb84f201ff2df6b89810"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-kernel-ppc64le.sig",
+                                "sha256": "0a49db68d0a6618c4cbfc20a64c8227d12e4316b0342395fceb984379784c5b8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "c7820c61bfcffe9ba6639af142c5366d6db92f4c30badad0344c0cb76780821a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "513b65898dadc425e141fde773d0a50a9711ccc8daed38b705c83a5bf2541bd0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3c9153c52662a937a58857bfd15b1905594e20a2141c12792aee8017668a1c05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d56da35f7bf450c92041f3a9f1c661018324a44ae54136162b00b6a15e592169"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "643aca23443236b229084873fe03242200ff9503bd78e41e8bd75dad60109566",
-                                "uncompressed-sha256": "9d4c615d1aadabfe720a0a24737540242e80aefef8638013e340499434450451"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b006315d2a183e4015bbd1b23aaab24ae826e080358508611d6359573d7c018c",
+                                "uncompressed-sha256": "a09f70fde077463972de4311b29b1548c4e2b139372aeb617e7040676c4517b2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1aeaad551b090569939996ffd022810a570cec5a96f8af05f3bc1caf939e78b2",
-                                "uncompressed-sha256": "4fa548f5dad29ad78061a2ff13a8f7d13fa7a4fd4ccc6d35f10903c6de6afcb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "550d69fef659350dd0c62cfb4a3585fe2c7eb43569b5814279e42ada9059237e",
+                                "uncompressed-sha256": "62cb21fd0237f61c38e6faf62c232d72bc4dbbab1284033bb596bb0748146b65"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "6002e1d5ba31531108a47c6898177bfc558a119b50f10c4061278a29b706d046",
-                                "uncompressed-sha256": "b20aedc6a78dd29ad61eeffcbfbf435f569e717a929fe939e946e7abd1c966dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "082c0b422136155f65fae6574c393011b42a2a780631c4c9cee5aae3bfb73c1d",
+                                "uncompressed-sha256": "a62f2b1ef12bcfdbe65ceb41cd2d5e729c94566e8a72ef78fcecc26e588571db"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/ppc64le/fedora-coreos-40.20240701.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "0016299f852b8172f63569acf630c94726c3c81c55f9dce874620d23ef0513a6",
-                                "uncompressed-sha256": "ffa9d5719baa7859a2212c08b90f65593f14f80f6704c653a0370d05e3676642"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "22401303dd847477270552a58b740aa0fbf0f69318a4f3f64328d6aff81b0c69",
+                                "uncompressed-sha256": "ef92392c86b727a7b02fd6186ec8123612a16efdac7daa4ca02a4d413063d667"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2decedf185c66fe3e5adab16d13ab203d3a5c296ffb74f8fd565234c2d645fb5",
-                                "uncompressed-sha256": "32a88c9ad92862d23f4549b5800264f6da7359063880b2b1a35e35857abea707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6e02b013bf6f550c5f25d8cb09c542b9cfae4ba96e6432a56b6cc82d27dede31",
+                                "uncompressed-sha256": "7b22a8c5c7d0329be65f272378d62554ecbcacdbd540150a363a8fda0f969bdc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f025b67f65a57fb2a57879b3aa36eaec6a260388392525451b65730e919e9c6e",
-                                "uncompressed-sha256": "c05e1e1b3442171d89455941afdbfa52983f65292fee8a8ff02c9796bbc2a9a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d3a36c0315e35bcfe6d69ea2afa42a7993d88403a3166df7f0323a9886ea883c",
+                                "uncompressed-sha256": "e13a1bc9f41adab675167b0aa19c092fdb04e276306d138d3c54527e16115986"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live.s390x.iso.sig",
-                                "sha256": "12ecfbbd356ca9fedd2c54618f11b55a1c7d8f49c9fedf298c2d17d4636a223f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live.s390x.iso.sig",
+                                "sha256": "b29270a3ed116ab1e496bf5c6066596f68a2b14f78a7ba679a544cc0800166fd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-kernel-s390x.sig",
-                                "sha256": "baae3454b2abe43c05545f75bbeff8044cc60333b4b32862756ece1665352387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-kernel-s390x.sig",
+                                "sha256": "ffd9104defb17c4e0699ceacc8c1a468d8b74f5b310ffbee37e0aa1391a3f293"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "24ff5b783dc9cb0e949f67fe4db7f4e13d854e35466b22c6a28c5f19cdb678d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "6dcc0bfa8dd8370af8b7817879a2a53a823c578f7ddbd941270797b5bfc0f20d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "94c2e8c70a347174690da5959023d9598ec42215f46bef6e62165e677f397bfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "22aeb0118e6d09b7418e0d524972d781cf623460f5f1c354d4ab8df00aefcf0b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "aa66f8c4ac3b5938fa3749e86838992e6d4de7bf49a56bb1a46a0dc4e20f07fe",
-                                "uncompressed-sha256": "02ff3f358cd2b7b4ea3014bc43c3f7f825e427d3ea5d4784e566a54123e5e0b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "8af7fe81c5c257f7173f0410c7a57821d80a08768a72e418a9ebe68cfe448fc7",
+                                "uncompressed-sha256": "9d7743fb567d3d8c53c5e303ac28aba6eaae2453ac47bdbdec6934fdf7d3657c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9f2189edbac542b75385a30bf60365eb617503d0b5132a909354f8c0451d9361",
-                                "uncompressed-sha256": "37a18d0b2d339457f5796cf8c4d9599554ed0e155c5afcbcba0f870bb60f579b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "d7060255ac658878413207ab784c9079c341b0da070bb79d89f3baf2fab9672f",
+                                "uncompressed-sha256": "59f889174c876bd1cc0a927239a6e4c4dae5067a6d447c4a8ebb88e696ab5195"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/s390x/fedora-coreos-40.20240701.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b10d7e2ca56658dae02666c75f039160942405990831e77a56aaa45e2aec9219",
-                                "uncompressed-sha256": "b1c7f56450e7f0f9c8f7c25556f74dbd6eee91a92e1149cf1b37d64a7107d026"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "23802f71d57630bb08b588ebb7cf1540725b995000f8ecef409bdb3989159f19",
+                                "uncompressed-sha256": "df9ac29cd7b36fc59b4f5a65c74d0e714c9924b9bd854118ce29253e6a8d0cbf"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4a587380b95d2a9d923fef136c33908e29cdcd7bbdc088ccaff0ef0765ad4dcc",
-                                "uncompressed-sha256": "4abfda8d2fb3598af6a70d82fb21a2c3ed36df6a04e98e78acf94ad111721c43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "920dab5c358f09bddfbc9d77fcd03a12df571d4bfe1b6831ecb1065ebb1b74f0",
+                                "uncompressed-sha256": "dc8c08a870347b39fe88495c1b69197f7a6bc945c4fe9750e63e4638eafb9f01"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "82bcf95d7a835793caaf0d6c866d92bbf8c784600fa29c82dc1670fcbf468e11",
-                                "uncompressed-sha256": "d410bed7fb5458a4db8f58ab6f7afe5cd61baf5cc0c9e0aa01d9e4f4e4fc19d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "a7f4237e6b2fe2234977d3eafbb16b02f5a526643dd4b145bec15ec5f42445b0",
+                                "uncompressed-sha256": "025c4094c6c2af8c0fb7447b55e2f8f458486bf4b1c151ba27118a40baa99865"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0a7bb34ec113f9b6d6357c53428b58d156ccd6934538afe5978ad65a1929b9ca",
-                                "uncompressed-sha256": "f9c7ee3e552d67f52fc930f034fdfc50055e7db744309e577a04445e7562f864"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "30074cc38c188879a6d0d302344bd2d3bd0f8dac8b5214d222afc454fef4659c",
+                                "uncompressed-sha256": "f0302c9315a23a72d037012e7ccc68ea459755e7ec98b06586892a94adaa5906"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c1121de49407f0a4e226d3b09aa2ccf55adf102b49fa9214d02a5e8bbdc8923d",
-                                "uncompressed-sha256": "453bf53713deb77faedcb56464be9f8963d579385efb4095a7c8fd0f70e79df6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ba6161c80dbe59f3418fb82f1a1312f21be6a7bd4625165a0dccb4a0a30059d6",
+                                "uncompressed-sha256": "38be2743338f414cef503830e52954f895fce2c4150395a1a3ca6d2c828ca911"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f62c52fe8609aa8448970650c4285dda96ce51b8deea39beee6af97c181026c3",
-                                "uncompressed-sha256": "6be18d7211977745a9d02f1be9bfdc32ff3b9447d017d939ad1bd25e34441aa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0dd65a35ef06a429d4a515166fc1f74e462487f54f9b0d8fbf88169414b13e19",
+                                "uncompressed-sha256": "1e7890d5095fecaa7cfffcce9fefc29c1b8a314ff1c7db2a08406d2baedb8963"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "62c73492630a9c7e42c35edbe83950c6e94dcca1e07ad86503baed32c554c240",
-                                "uncompressed-sha256": "ec7bfd7e68dbed6c3d93d729fb8abdaa2fb00a3dacb19f3fb92c86aa6da283f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3f7d1a8a746654f3e7484bb77d4d29f53d33112a838b9d97f2c33a7f1b30f988",
+                                "uncompressed-sha256": "9a09b1af8d36d3a3ca89a8da7165025841557650238aabcabde4f0ca31394d50"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "941ad7db3eeb5c0225d77a81dadc3306ba12e1152e46ff73c2f3bd1eda0536dd",
-                                "uncompressed-sha256": "4800b21d0c8049cc5b646ff578a937d5487665590dab163d210d3825770911aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3fd705714a98e83100258022b3dd93d4062c434fa07e4fa296aa48ff91417d70",
+                                "uncompressed-sha256": "e096810e9bd7e471b4001263f62252f3c3408aaf60412bbe37d9afaa43fd9268"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9d85ccf595a64fdca35e446fad37c9a244d2cc3dd466abf7181a2b5cba54df4e",
-                                "uncompressed-sha256": "1b2353461a62282a4abf8f4207f8195547554c727f3071ebcda51c87a327dc41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "81b612bc34b91a5f845b4eef59abd577967d360dd78f7ffe4efe03dde0af8385",
+                                "uncompressed-sha256": "5ac5fd456d5bddd713616d0aa30f162f676d346388c0c35bf41e7416d330d1bc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2e64703f500cfb690a01c22bd9ef1746d01a764eb8b2bbe06edc0ddbc05ca18d",
-                                "uncompressed-sha256": "fa4b638df376f960822d4842e855cb7d9dd08eb5581d3354de73556289e6ceba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "9dab19a0203d809fc2618fe3ec8fc7e266ff3ae429fb07ba4d26e0ea1160a9b6",
+                                "uncompressed-sha256": "7638da2e74657c0b045e7cfa7ac2db5064db78e23c3f04b89ec8e63d0e33d8a5"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "12be915243f2daa1d6c978b8fbe42777fa41390d3436a2e79744106beb755979",
-                                "uncompressed-sha256": "b279dfb7684676f8e10821573e3ec390e1e6e89bdf76ab06a25f74219d2dbe8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "da80892d5d161fdf75291bf4d7b19ee354669bf4fd6f5b514410c851dd2ea96d",
+                                "uncompressed-sha256": "55250e75f5391372ebeb2f6e88725c7f8a825d195532c03a3c1ec85092dd00ac"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "9e0f4250c12b18912d733960a06ee1bab7f13c3f23129ac81e57a5d1fad8110e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "66764b9d84cb324306d1e39b188f23f447bae5fe71c99657e54f447d23dcbf72"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "58acb45eedbfa0a52ee607698d223b6b42c31e0883427f072190a721e9b6cbdd",
-                                "uncompressed-sha256": "5f6d7a87175f9d70e6eea8e48f0f0e1638eed292ac54acfa3e573e9091f4da4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d57fd960063e3a4317dbe51aef6fc0ca7bb3635f4e18721dcea6a0c2f7706cd6",
+                                "uncompressed-sha256": "e68acd31ea266e41cacf1454935ed56d5d00963c0ca6c3f429ee549ce25969cb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live.x86_64.iso.sig",
-                                "sha256": "8021d12231ab454fc1b24be4b30841ea62bb5cd1f710ea03916b76ee902875cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live.x86_64.iso.sig",
+                                "sha256": "41ffed9cf051d793caa1fece0a0e4412f130092ecc99d323bd20be51568b7c78"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-kernel-x86_64.sig",
-                                "sha256": "07018e6f6ef057124673acf27e0713d25d6e92b71c26d6c47b874dccd516c16b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-kernel-x86_64.sig",
+                                "sha256": "17b1696ec6d7184205501409abb5c242d6ad0b14b4a5e78aee62c64b325ed4cc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "68178043b935357a18983b3e731104252f1b2f22412af756a5f072211d7a924f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "1ff2a15a3205b147d6b46c61bfa7b862c04cb1353640e043a28976df19494148"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5ee737322135be305a08f5dd0914dfeaf395fff0b4decac7bd65cd19f73235b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "663a206ef6860ffadb68ebbd0cf744c5ab4ec148393117a89a2f84fa5543790d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "af99abeec23f238caeae923dfee7085567efe599ff489aaab18920e0160d166d",
-                                "uncompressed-sha256": "6abe90a6a199df9aa1eecad5b6f07cbce0c8b5043fada4a0063dd115521f4e0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "332eee8283f0ef80605f96d5ae9353c1899872793b0127ada175c4fd53bb992b",
+                                "uncompressed-sha256": "6d1033d096cb98bb38d0e0c26b073325cd06cb17b30aefc09cf1c271c81cc6e2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "34e2ced90dd468d871f6bb2b1a0a8c5f40c9cfa9637346b19cf8182449787d51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c037d5fc74901f24134845b344910ab3f4d8b5cd59555d4fe1366d84e6f613b1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ac6b2cea29e34d11e3076d04e34d307e444c5eae8fa3ee835fadfe0daadac222",
-                                "uncompressed-sha256": "b356a1e1bdb4edecde543bf1566b2151465edba3e1f3069397e3b9703ac73fa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3389775d8e625c27df56f999d51f512981471bfff61944d67d6a8130eb7c6d04",
+                                "uncompressed-sha256": "6d8856a37a48a2e76bf97385730756117d0aa612428ef22da3998dd6018491e2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "97575d133ab9fe7b88ea99d0ae5548ac3cc0432dfb5f0cbbdc89de7bf994f63d",
-                                "uncompressed-sha256": "cd410deb8a6aac66323dd8b3b67e9dea52b3d59e596f899efb63710037c8bcbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0c014b59d3030ff536f90f39af16e75ab519ee66b0de766989d5ffc40e1809d3",
+                                "uncompressed-sha256": "5aeaee0d719ef9cedb12a63ce1b351076f469a7dfd36c76c7fc4339dfd66d792"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b65bc4a56bf97291247f6f5b212e9fa4412a5429bea5f9d5fca959fb2103a1ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "de1f5670a30c8d9eccac27945c29635f4c7e74ae88e579352740d04588681944"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "d2532c5369ee22e31ee1e38940ba0343070d3f73f2e589f4f378878b7fde207f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "bc2bd6a174d28eb20ddcb0f2a7317ec4045ca4a5f1b7d758b8ac71b747fa08d0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240701.3.0/x86_64/fedora-coreos-40.20240701.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "cffe1acdd05a3e901b74d0142d9feab208d0f15991bbe8ea4923571d87a5f228",
-                                "uncompressed-sha256": "3b012638e0aa108d4a147633f91115153dc927b8c2ea7433ddeea37ecb0d8bfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "69d8d0c7f62143458b3144b2d7b0d10405c8212c25d6dc1b2f1886e4668bcd83",
+                                "uncompressed-sha256": "d7742be6d4f7b05a8f67eb2198d940ebeac4537475a56631ae3d7cc693992fce"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0659689cc0caa0d64"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0fffb90f87fd8a62c"
                         },
                         "ap-east-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0759ec8b8fbf21696"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-003087c91f98b8388"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0046110f45e4e056e"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-045ea1aec81dc84e3"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0f871fd7839ec7685"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-02986c2699a0b1442"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0f386d465f5a9986a"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0555c00e420c9babc"
                         },
                         "ap-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-066e380de7aeb3adf"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-097a91d2010d2fcf4"
                         },
                         "ap-south-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0cca7abd8c17c56a2"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-038abab04bd23a485"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-01fa3bacf28b0df05"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-09757ba26748630b9"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-06efd3128336c3bb7"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0bebfd1617be041ea"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-028fea5b0029541a2"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-06947dd25bffc63f2"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-014adb8aa1eebf00e"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0ad1c714cde7c767d"
                         },
                         "ca-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-069aa43d8d6f9bd1c"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-07a399fd39ebd64bb"
                         },
                         "ca-west-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-057a8b6959cb03a13"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-06f0089fd0045cd12"
                         },
                         "eu-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0fc80d02f73ec2adb"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0484ae18abc932b67"
                         },
                         "eu-central-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0089b449cb3a32856"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0c1dbb2f9f5dac603"
                         },
                         "eu-north-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-07daa39363096b5e7"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0a369a9bea84f79f1"
                         },
                         "eu-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0cd0c670705167457"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-08b45f6bb8d22cf4b"
                         },
                         "eu-south-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-093ba8e8ab1cb09d0"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-063f8940012868ec3"
                         },
                         "eu-west-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0572b8bc59d03e4cc"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-09676327950b422a2"
                         },
                         "eu-west-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0646aa0a742bc953f"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-03fa1ffb8b60be01d"
                         },
                         "eu-west-3": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-004c7763585b023f0"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0d4d9c52dc128c88d"
                         },
                         "il-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0ac61891a6ef5833a"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0d33d65ca8fd3d82c"
                         },
                         "me-central-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-039b2e0ef177b400a"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0cd4ece398f201a7c"
                         },
                         "me-south-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0174696365beb4cc0"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0d53736fde5895013"
                         },
                         "sa-east-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-069a2aee38def4c51"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-01110ea46dd668c99"
                         },
                         "us-east-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0b78c87ffaa1015be"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-05937ddf5eec95099"
                         },
                         "us-east-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-04af9187073a3bcc4"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0ead7edb98b23e731"
                         },
                         "us-west-1": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-0d71bf3247419c5b1"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0a39085fb3fa17bcf"
                         },
                         "us-west-2": {
-                            "release": "40.20240701.3.0",
-                            "image": "ami-077382a4d20277841"
+                            "release": "40.20240709.3.1",
+                            "image": "ami-0c2a6e81dd837c3c2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240701-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240709-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240701.3.0",
+                    "release": "40.20240709.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:66b23715dda6924833652638b3939dc81d5479c909a6d5d912cce5bcf17a3cd5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:31086ffbd6f869cef2bdf8ace5a40d43bbe66089b1b07c640eb31a18ecfdce2c"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-07-17T15:37:13Z",
+        "last-modified": "2024-07-30T21:17:02Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "788e7cc3e1a36ae09e1a7633caabff39d84f81571dd07a01937ec290d150c5c3",
-                                "uncompressed-sha256": "893f6e708bb070909e60ba5a6eae4bde6303cf696a58b08873f6e7a88d58c951"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "4ab9b7ba9c4bd46e2bd21e85ff0b0711a768a00b30582b7226b82d69b022a8ff",
+                                "uncompressed-sha256": "b873d862a35657d39a4e8844e25fa42a2ff65d11f61c9a92ecb88fcdf153d080"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b480cdece792a0319ec0f54032b09f079f6def1605c0d02fdb53a871bb46e3c9",
-                                "uncompressed-sha256": "49cd2d8578b5d71a0ac6cab5443d423e9ca3a7eadce5cfa9fc5eaa6e86fd2bfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f800d32ec69a1b011775b15446c3fe55664d6c3734e01c547725c4883213793a",
+                                "uncompressed-sha256": "413d9e70c16ee74454fbe282619fc927782d45f9961313ea55834c118b789447"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d137bbe67642c9eaff86dc949793c55b6c084f46c3b87c9481ea8ba78a79b010",
-                                "uncompressed-sha256": "9e5a161e8ec13713ec9487d938fd0579bd3990475497bebac0b76be0c8fcca5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "921d6776134093cd61bf7e0f324040e9bb8cddf18b90375ecf573eda2aceaf0a",
+                                "uncompressed-sha256": "add0a9aa5a06db38ad3431a65505e727562d9e4b287f326ffc8a2625ebc8d764"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "4adad3e8992474ecd3d4b24f8519b521a59db1e2bae170ae6de0726bbfe3fb18",
-                                "uncompressed-sha256": "d9ec03237637e07fc14941a015a9ba01146d599637cc0566f0159a24d2961272"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f7ed9ee39ade909b34dd9d23129f6c1e871bfdff390edbb90994cf727e33f308",
+                                "uncompressed-sha256": "c42c4b385cfe47facbbf614a3b823246717fe4383824790ef73aa03df4c45f63"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "66a800359078a83c469ec29f992ae7061c2d1d4e9abd466ff6a717b042e54ac3",
-                                "uncompressed-sha256": "815e126247a260159121b9838b81210a54fb9d6f7c0d0304d4a48a953e81c7c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "83956e3761d7eef4d41d2e227cd1447a0a03a2f9947d1d1b58add5667cde349c",
+                                "uncompressed-sha256": "238a068ce9034bcc8b8b5866c1330722beccc0d62ae7441417956cece09547cd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4c2a4c60835bb3139a87128ce6c8f85a7749409d020f2a722d8cf3fd9f979b6b",
-                                "uncompressed-sha256": "da9ce4404f2d146c60bd7f7443d3c71dbedad06852041665c4675703790bcff4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b236eb9730a73da597179696badc1a7c0c388834e5ac5ac9bdfc01d503fb2c46",
+                                "uncompressed-sha256": "0db8445d7f0f59bcdb896141ce9784c44e93295d7d636a44b797563472cb32c9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live.aarch64.iso.sig",
-                                "sha256": "29f0fca8c7da4522c8f5163432b11dc527f226d82b3f3c38d5df9441a86d1e68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live.aarch64.iso.sig",
+                                "sha256": "b47a08ef754bb4a6ff5bbbd0cb33fcab83de36107cd0fc342738f5f16a01f94d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-kernel-aarch64.sig",
-                                "sha256": "57983a9642bee5a62c26c9d3b441733d4755462c1cd3cc5e278953b12a3232f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-kernel-aarch64.sig",
+                                "sha256": "c346e94ccbbdce6450144add99eabf90f14b20176a6e401a912b642d6ef702af"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "4b2a08c924f2ba40a72deaa1d9675c6ea8d1659b459e8adbb5ee871aae68139b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "0f411ca7d132f5774d62a02a92de72e2a6c3a51aa6c0eb00efc5a1c095aa7494"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ea95c06a12f64547adeb667fead8de3023b49996f1eb76f90a82c355ac244841"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "7faed70d8028076d58976347a34a7943b5b4dd5dfd8285aa0e3ac6c0b9af987d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5bf57fb0f8504921787f2049ffebc2c8ce1017302db4af9a4f2790d2ceee9b43",
-                                "uncompressed-sha256": "a537c27bb56984ce7cde0394bcda6c471060960d4761e74dabefca1b2f9262b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "62688c7746c1ad890d1436ef721586226da418365fcde9776eef55e0bd204e14",
+                                "uncompressed-sha256": "c9f408008d0ae7f422a0eb595c2c997f5c2ffbf12928f8867982b905af26ba14"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "399280bcf7775fdcd3ebbc2e259240505b573b5dcfc45d00377e1f7ed5207798",
-                                "uncompressed-sha256": "793c1ff718f357d186ffe661ee77d50f4fca20ee12929beb934ac7eac56d8f83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c71fe66b4683b3ac1b3b5bf9052edb4fe7d065563d1a7781a4ee7da98bb183a0",
+                                "uncompressed-sha256": "ae3b5d64ec488bdb77a32e1da8f482ca40555626eb55ff7f85749e023f88a6ed"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/aarch64/fedora-coreos-40.20240709.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "54ab6b3468dd27597978f5ad850f837cbcff7ca7c738a0d9807fe792192148e0",
-                                "uncompressed-sha256": "5ddf73835abe5c42d5373cd4c461f15353572e626b6c2a3c0ab40cd52445ff6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7ae0e92c70ed61f919dd0f5bba3f0907ab2e4b575bf88d7f65d873c8e0ec79d4",
+                                "uncompressed-sha256": "72dc65c4974582c436bccf1b76909f849f8b4ac97b401499e743ab52066a60c4"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0974fd4ce7b9e4bb9"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0f8956770fb270ded"
                         },
                         "ap-east-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-07c07fdf6c9ea1d2a"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0fcf5e0cbce4d71c4"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-03efe50a9b1cc869e"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0a042d1b2e19d3dc0"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-04f39453c623c5830"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0642d8c9ebdf1aaa1"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-06b4434e1cc5a4a73"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-080a1cbf1fecd7eb3"
                         },
                         "ap-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0aae0fcc921311a1d"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-020b4a8f1ef25f22b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-06158551bf33951e5"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0805c0511f8bd732d"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-02cda90cc23424fff"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0f7b934138cbeb65d"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0e30896ca6c7cab01"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0bf99843c124139b4"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-049528e82c17616af"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-08af3124f7a88e4df"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-02625a31dffe949e9"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-063cef5f6eb2e9037"
                         },
                         "ca-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-04f24ad7a18173806"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-093b101531631ccd0"
                         },
                         "ca-west-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0968f6d40f211ed32"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0e65ed7291a617a3d"
                         },
                         "eu-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0e1a98c5be7569a8b"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-025c7ba86c78ee278"
                         },
                         "eu-central-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-064048f2fddc84ac5"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0fa42ff34688ca2a4"
                         },
                         "eu-north-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0b45b5f4c8d929519"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0c48bce93c09635c2"
                         },
                         "eu-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0c59c9d57e74a81d3"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0c7bda77630d65b5f"
                         },
                         "eu-south-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-08dd71f19bf33c93e"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0d3bd357f96743c9d"
                         },
                         "eu-west-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-072abb62496785d9c"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0150a1df31d1b5082"
                         },
                         "eu-west-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-01aa0799f2ce54d00"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0600df03113a75a4b"
                         },
                         "eu-west-3": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0f2ee4c3fde6c31a4"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0927edc00d2968997"
                         },
                         "il-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-06cd7b471d4a37eab"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-00055465ce9231a02"
                         },
                         "me-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-04433141fd97e6723"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0d9d6c19769994724"
                         },
                         "me-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0a6bf5d011585bda6"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0abdef45d071839f9"
                         },
                         "sa-east-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0b739e6bdb5376c7f"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-02ae6bc7e24d14c07"
                         },
                         "us-east-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0aaec4358a8b6b658"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0ba958042be20ad4f"
                         },
                         "us-east-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-07179c31914d42c11"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0262e98594da02e64"
                         },
                         "us-west-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0cc11c40a7398ac94"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0a40cf79f87d210ad"
                         },
                         "us-west-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-00117edc14ba908b4"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0c3c0c5798dc8b37a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240709-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240728-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c5823029be5d5293fe4c8e2a547b3e22e8d588be37dc228e06988cbbef94f8be",
-                                "uncompressed-sha256": "a726454e131eec2cdcaa4b92685f7d8103eef3c41bdd7ec0ad95a53a40fa3400"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "ede7c740e9e8bc2ed7e247f36c1906c68a9b2f307a7aed4c1f31f07daca1abfe",
+                                "uncompressed-sha256": "528c9ce44598afa178e1ea3b1204a92c8bab05b9d6eecb2ab0e4cb30a7797d2e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live.ppc64le.iso.sig",
-                                "sha256": "1cc14169ceb9eb6353cb0867d7a47b358b8864796781c124f6549b317a18455a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live.ppc64le.iso.sig",
+                                "sha256": "06ac2921c26007f4a3830c659dc2202c8e2aec495c62c817d13f10c47b8097df"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "0a49db68d0a6618c4cbfc20a64c8227d12e4316b0342395fceb984379784c5b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-kernel-ppc64le.sig",
+                                "sha256": "b9f76fc0668f1d6919f8691b9fc6bf0daf4d4f562229d40150fbcdad92cbfd62"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "56acd3477db215c5503347c33a126985e3860e8ff7051e30ce6a959390a50ffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "352da9d62de8594b210b37b1c41041f585c99f1b1d34df73e1754b550b18006d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "154f4f708e1401f1519bee2d9d8f94c793ad56b975ae2bb0576687ab981aac82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a2c5a14208bc48c763314302e5e9f88c958469694b70e3bf384da77f4abac10d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "74eb66a46e7e630d7de43299cf6c784ae3a50500785049a47ea5978641ff55a9",
-                                "uncompressed-sha256": "0a0eb2a54ae8bcc333e3f1aab23f89bc050f89c110d05b0a8d272f0a0469de81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "7590c7e776e6b7885ca069542ce50fb577bfea011fa7626d9f2406e95b8ec088",
+                                "uncompressed-sha256": "b770a61772360f1ca4fbfc8776fe878b1938b70491092ca5f80be1e963743fba"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "27dfd648bd3b74356e8458fb0f11c4a45c658f28afcf010add46877227759b9b",
-                                "uncompressed-sha256": "101fde96a597ea37e68e3bf7d04025f1206921ff86038f528a7c4f6f30768dfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "791650ccec5fe0c3f7b3a7b2fbf9686335d7c096ee16998e17fe31c845451d94",
+                                "uncompressed-sha256": "6cce0bcee86de01a158b2d4dc466bbdf60482a6d00ff90cdb5df156421986553"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "36e5534241a22ddb7110207b7506855f7b98ab92736185e3fad9660d7d8a23cd",
-                                "uncompressed-sha256": "123ca0b8f2a3d89b8a732842d87eeb5fa6624b32e29eb27d9b18093f5e72e67f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "6a5c3d9f9a9405e66229f1ab429acefa79f455e7ed0b4f0089240eabfb158cad",
+                                "uncompressed-sha256": "67c770c9c64ebc061af08f8ee9e289319cddd252faba8b65dfeab4530ef8a849"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/ppc64le/fedora-coreos-40.20240709.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "1e4d078b78f1348f235390574d3b5142e997c41a89c3f1118698fbf13e4a245b",
-                                "uncompressed-sha256": "244b9471a323ece890c7a47e3c08a803b1527ad15456cb9960f0dae8321db3b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d4f541b87d5d98917089b32601cafd01fb3d40426506a7dc28d4d9805d522872",
+                                "uncompressed-sha256": "bb4dd9a10948bcdcfadf2476006d9a05ec36d7e0301a6f8935e7a132b6e31157"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e09ee3a87fe4ae178a198988270183874738526cd4dc83c6a0051b45e9c7a954",
-                                "uncompressed-sha256": "178e500f7afcbc4c9e21e928ee5bf4eb3019ba0fc2878e53d346de37229cdddb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "77a71faace26eeae45b96090661e5db64bf36986e86aa5120321e884ce2d5962",
+                                "uncompressed-sha256": "5e446d3342a56578a4ab54bd7772c27289eae9715925db33d3f85be81ef2a3cf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c5d7eb7239866ba38a487fbb733b91377b9808c0a9197f500ddbc4de5fbd9c0c",
-                                "uncompressed-sha256": "e5cda17f9f38842521ab5431211aa06f7372aafd22bdc8edff93409b72e94813"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ccb72712aab7592b779deb0674a37c52a94287a243fc809bc2b5ebf646012738",
+                                "uncompressed-sha256": "c31ce3fd52c55c23ee440a518b090978e1d1a72d97791edb236698008ff0139d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live.s390x.iso.sig",
-                                "sha256": "648780bc7bc219291732b74018e868f8d3c169b1b23753899715d27adeec2bd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live.s390x.iso.sig",
+                                "sha256": "0f932ca0a3121ece552ec56a52d35f71c73a54273366b6db78c50dfa48bcde88"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-kernel-s390x.sig",
-                                "sha256": "ffd9104defb17c4e0699ceacc8c1a468d8b74f5b310ffbee37e0aa1391a3f293"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-kernel-s390x.sig",
+                                "sha256": "41173681081a1d01c78df1a4f60e8480b0d0485cb7c49163154096dfc05f47ed"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "dc063304741b54aa0201cfc80ba426585d03feebb00b8c872124169bc67c1357"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "7ddbaa9e344eaa172387420916dd171787abaa28d28a2141c373328eb177b629"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "8c58f533b6c625da2ab7cc585374c664e12adec7c6ca91ca8b95f0cd4ed40bf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "7e020069f490b6d72a5ece98558c6a5023fb40193a1c4802afc81742746d273a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1832b6ca404bdac01595b4c21ae3ce8221f130eafc80c642a71a9dadc4da9cbc",
-                                "uncompressed-sha256": "f10dbc369ff56da3ba4d871b422b06f0f21fb116bcca05123f1a6baa57ecbfb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "6f7e92e9e64e4d2284ae1b880f63d106f49ea640e42207f184e229b25a2df2f7",
+                                "uncompressed-sha256": "689f43c6dfc890a497288a259fbd25c82601ee5a57a0b2b4ec166d7a42bdafcd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "7dc06b823693d31289e8c6f556bd6c23509d28cb9a6451afc61fda98684fb2be",
-                                "uncompressed-sha256": "aa8eba0a6eaf2821fb4618f57844319f5ae802ab1b4254b7f0a845c80133996a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8787192cb521b7fd056f1b9fe9a470a6b33ed3571981e71b3a66c77d145cc975",
+                                "uncompressed-sha256": "178bce4ad3a518266b0fa14f53b715dcd60ba3a47cdf22afd033b6665fdec1a3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/s390x/fedora-coreos-40.20240709.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "757bc2f59cb2d5fdb4acce3e6c09ad81ba2f51389fee7e18de0e068b9dd1d974",
-                                "uncompressed-sha256": "ef14646698dccdb6927ff2414ca1acbecfc5bedc726aeeaa2a6024559e421ebf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bdb81f7f5104dc5164d031166f7df5fed72a22d5606213b2866aaa4ea66dabc4",
+                                "uncompressed-sha256": "9a70a8c2209d099dfa5715574a54c78772aaa756f95a1ab08628c1974da52c37"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "954c06a6b7de0fbfecabdc5faa358fa78ce47828637f6901f140517f12bed89a",
-                                "uncompressed-sha256": "06c82ccfea3a2e53b48c21d1d9c01366fd2d3171445b2015f82b1d75dfe32efe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4967bbee5c926e54a88b4aadc22c89f24d526ced61c5144c01fd15dfc9e561de",
+                                "uncompressed-sha256": "72ef578f60a7d36c8380d8c9a22cc5cb399d8eaa7f0ea9b7b6e9da5d05a61ae5"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ca0f93828a7bcdf218017ae162ce8e1750c02b440d87d3984adc116480f8eb3c",
-                                "uncompressed-sha256": "1dc6c68951dd26020ec41ca83cabe90400695fbb2812ec52fef898fcdc245c19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "2ee8ccaeed642cc3d5cebe62a27aa61ad4d6391eaef38fe0ec222786b74470ec",
+                                "uncompressed-sha256": "7cdb6fcdbfc7af12cd6fa95ec47fddc558e8aca88a55a59cc4bb6297d6db4684"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a4f878a5a677d0aef3344922cd9f442e8eb9f74433be1eaba548fc4d469ec8f0",
-                                "uncompressed-sha256": "7f9ac7c509c8614a92623b224dc4188415ace3b9f48bb9ee0a850cd1000435ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3809a8b61c7b1368d3d362db663ef7aa4ca36149804da589a938bc988772a0d5",
+                                "uncompressed-sha256": "f468d855e2141f7fa697c5ebc82cc40ec0c0c01eb499c530bea114705b7fad07"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0ae904314e20bf9317785addbc1f933ee56a42126b542f5ce4605331bd4f906b",
-                                "uncompressed-sha256": "adbf5de489b3e604ed9c4be1c042517e73df1dc107e5d45676575730a3c3b3a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "580fc1d6c4125d14f5ae255c99b22dfede70b4fcfa6a8668901df847776a9a1b",
+                                "uncompressed-sha256": "4c4fb999d68508b56178ca0af00b70ada1d6318f50a43f5033a0f0f19b860a99"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5fdacd7ec0c46043d33edb35901fa14fa2607399732b2db348bbd2ebd6a20911",
-                                "uncompressed-sha256": "f430f6359932995d6c1ef2bd0d400f2a9426530fc28cfe39e647337da833cf22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ba4e7fd036b1c0af4b368fbd168fe94343801d769bde13e2ff0d45ba4884fe83",
+                                "uncompressed-sha256": "7c297ce84c2d4bee5d1e47a26cc9f86907b7d9b8323ce55cae9257330e01f8fd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "18273a3582c3157c46c674c59a4e6746eeb6e260967f40bba36adb62060b04c7",
-                                "uncompressed-sha256": "837010dfd750de40a18ee314aeb0b0db15036da02fb67897beb6bfd104262ace"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9fa558c7fdcc14fccd3ba4797044c13a66d0ef84a7b8e45da2ef445a81e318b7",
+                                "uncompressed-sha256": "5bd309b2c5682a6639bf2db0604b91dfd6662321eed758e7ff7a30080ac9eb5e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2fd4f2c4667c9fda607a01f7df0f908a81970cd05509a1cbf0e753246da5961e",
-                                "uncompressed-sha256": "0d8a1d97df06419d7566f959abbe30d6c2de63294ec26ee6ebc18f08ae6ff63f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d369f48413ed3568192d6d76f594b6e22dcfc370b7beaa6887a77a8aec4ddbc5",
+                                "uncompressed-sha256": "dd9926c8fb600de3382dfb9a00dbd0a40990a8e6ecfac09ec97dc9887338f88b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "eabfb0251aff53a34fec1aa0f01220d55ffa78ea252ff95b60692d977176a2d3",
-                                "uncompressed-sha256": "2868307db5b3c5288e6df278471691f01b414f40cdb547816e010fc34a55b3e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "122283ff7291ac841651c8223bca81430abdffc502ab37b8dea5228ba72c6148",
+                                "uncompressed-sha256": "63b581cb941c33238ed20675d1d7e8d039a505e34c7a74f8b6e2412caa7f0f6f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2dfabefd14e059101d618c6e019e74a84a34004e0936cf59959178212873a237",
-                                "uncompressed-sha256": "094871b5f511b307803c4b476f2517bd2d8eb9b484d0e99f36cd970eb14f3b72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "a0d66d21af50b6dcef8cd261a960acb5783866771a4154d1816cc2a3b5cddf77",
+                                "uncompressed-sha256": "109dafd7cb41540a5cca659129df46ce19673de519905fad1fa2f40ebef1dc75"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "747ebe3f6247d57e31f142dd84fcca160263f02932d21002d5f6e44b1047b5a9",
-                                "uncompressed-sha256": "fabf988cbcf25a4e667bd029965c1be2d682f946b8f6b11d5f5685d4f322fb83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "97b3b4b868f351ae74f9d035a247578c2dcd0e9ca43a0d7d448c6eb97a39c304",
+                                "uncompressed-sha256": "42be540aefbfade8b5e0b6484386cce1ecd2318dd0aa6b7491eafdd4f3449b83"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "1a108a85517429c375345139de11630cc13ae7ef728c4c4d8ae65af1f56a139b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c9ebb37b1643219d236df169a2f35c83de1bc2a559b16a2b7657c362e6f87499"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "dbba3760f1f379290f2479b01fd9149c1f235916dda300cd1a897bc329a2ee1f",
-                                "uncompressed-sha256": "bf07004587ce291a5f15be0ac6b6b01edbe8b92ea47918f0ea9a06ce09b0cf20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "85d1841292ee2c2eb577b1cf9b32b9daea5188b37b956ce11f9cce5d3af08ce4",
+                                "uncompressed-sha256": "a46a0f2d04d688cb3b00707c7389d3721f1dbadbb1ba38da10c43cc0a721221d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live.x86_64.iso.sig",
-                                "sha256": "1de8df412b4fb05fdd5bf3c559126719660d61c348af979ac851fda5e8bfdfac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live.x86_64.iso.sig",
+                                "sha256": "ef52c1fdf1daf48209e1ad28d31af8a4baa231a3c67138b5db35a443654ac5ab"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-kernel-x86_64.sig",
-                                "sha256": "17b1696ec6d7184205501409abb5c242d6ad0b14b4a5e78aee62c64b325ed4cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-kernel-x86_64.sig",
+                                "sha256": "559b86e867a743956204d1f17e492c3273c6ef288accf3aa0c4356e16a9aa439"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ba2e601ad08dd5ed0ae7f554750056337ad6405309f474dda37e382c38a9ed43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "4000b00914307b31eeab5b469098045e26e67e6115fea6998f0beb482001022f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f15ff790d8790e8763de68a412edb5892679914582451149a9849837e0aa89a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "915eeb34253caa3f226ed71dbf4d7ae51dfcd42742a7a81ccad1041c7e11c544"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c5b9d8b4ad4e2f262b4d8e6533e85666a2541ee32d3ea8c5a38aa65bc0cda64b",
-                                "uncompressed-sha256": "82944cbde34285d534a53935166793334069dde175a14c345f5c3755882ec37c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "5a2906d36a0692fe1ddd385f250a5f6e54022ef5af14133f46a62d6cef049a6e",
+                                "uncompressed-sha256": "ea3bbcd6475e9d828a6fba3226b78c5475d774596cdce99bf77dd0308881c67a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "62da48b26ae9d260c2b717f9c2a0849cd368b939d8ecb510877596749a34dc1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4f5827b7810ea47f48d74c3bc09c6d70995a229d80edbb04bf395c08ef30d648"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c1db42b1384619812ffcb619fb2d3bab499656eafeefb3a07c6b5dc3276613f1",
-                                "uncompressed-sha256": "896b7c257ffbd63804e57bdccf52c8b91d161803305c97e11556000642f145fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7d0ea00a0734d0635d9ce33afe6b7d5393a14db6768c0b97cbc44fa2f434681b",
+                                "uncompressed-sha256": "b300cd2b96a00f05304d2f1cd43cf7b4d9aa55729478360162f6fa519545747c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "af89414ea325c62534c3b12fc274ef406cd05a716f9c04fb3457e6fe271be3ea",
-                                "uncompressed-sha256": "ce1d8392ab001cfd010bfb9dcbc22966892cb4a61cfec9111b7f3ea7870ef61a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d8685cef39ef9919866612c0d8d9ba52bc15c9a9c081dc371ae8926db15e650d",
+                                "uncompressed-sha256": "340e842b981a743859baf74bc4a589f972b7d22e0f9d9b257325dee3a09f08fc"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f809ee03303ab3ff27ecdf8ce60821964ee9f138ea178e876ea5b9d7db26386f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "dd17f52ebac1626d814f8fd671a5a2a80c880c90f1a60701275252f59629b100"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "22724890974f926df895208fe3aaeaa0ffd873b0b1a7396d3a1edd496824c85a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "69966d7007c859127e989ba7e18256ed9037928adebe0ab561516451c59f0372"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240709.2.0/x86_64/fedora-coreos-40.20240709.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "305334a8bd6e50c7bc8d14cff2918f3e44c4e664c39ad5a096ceeec7fd482c2e",
-                                "uncompressed-sha256": "332d2b569eddbc3e0a2cb13d92c47c7b3e9255af5a5161e49602c53d6aa976a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "73b444ab4298cb504cb986e72d694c8459c8ac8e7eea6cc0f8de5b84016e0b76",
+                                "uncompressed-sha256": "2fe41b1ce8ad45cdca0e0df425e027d4c2bf3c3832d4ae87ff2d2630427fe7b8"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-00665e50df1e4da14"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0fb21f54f6e2a7c15"
                         },
                         "ap-east-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-036c0c597ad3315e2"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0ddb9a2cf5bd596ab"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-08df37b5df85cbc79"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0ac828e26f4fa0191"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-007c872481e7cb32f"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-07ca5758c1440ba12"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-04075282a6a73b2ab"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-04df5d3bae5583e4a"
                         },
                         "ap-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-005e014576197f002"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0b3e19f000c420f5a"
                         },
                         "ap-south-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-087933e8dbc916799"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0886ba78a687d131f"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-06a890adda9892396"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0f47f8958656c0f94"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-047758b150b4d939d"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0ef6b855401ad40c1"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-091a99bdecd56c7fa"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0ef68bb4bbff128e5"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0e7ca52b3bbecd96d"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-058abbd382790eac4"
                         },
                         "ca-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-064acf457543ab422"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-05b2ade8aa72db841"
                         },
                         "ca-west-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-047abdd627777a26e"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0da4345435b6823d6"
                         },
                         "eu-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0e0efb14cf077aab5"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0cc6377b220ba530e"
                         },
                         "eu-central-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0dba1d8d511a4344e"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0f264611ea18eb8f5"
                         },
                         "eu-north-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0b7c3d5a8e3a78498"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-03df2540063acd14f"
                         },
                         "eu-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0bbfc72eaf06acfa8"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-07b957a1e4bc796e0"
                         },
                         "eu-south-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0a5ec09736ab9b013"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-05c18622ca687a8d2"
                         },
                         "eu-west-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0068b9c9c4fea2430"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-05c47b6cd3650980b"
                         },
                         "eu-west-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0e5d98400c9969b88"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-06102c7971010b886"
                         },
                         "eu-west-3": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-08240c35d875a3a0e"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-09f945baa4d9e2085"
                         },
                         "il-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0e3b6da637c1d7076"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0faffb3e5ea106ed1"
                         },
                         "me-central-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0934232303f9c6637"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0a3aac5e3227ea9b1"
                         },
                         "me-south-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-04fa70c5a35a98a87"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-058fe61506ed5fc04"
                         },
                         "sa-east-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0bf6a1dd8ba9973d3"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0407be689a402d808"
                         },
                         "us-east-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0f2d53490f0f95e40"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-05357a685abadc317"
                         },
                         "us-east-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-034d54fdea7ab2cef"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-003017766a900c380"
                         },
                         "us-west-1": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-037ef368973e063d6"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-0be5c9773eb5dce0d"
                         },
                         "us-west-2": {
-                            "release": "40.20240709.2.0",
-                            "image": "ami-0ce37c23182487533"
+                            "release": "40.20240728.2.1",
+                            "image": "ami-09cf068540a841474"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240709-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240728-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240709.2.0",
+                    "release": "40.20240728.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4e741f9bfc009d582685bf050311df43a1a4f813ff0c398ddae06f2c6da3b6fa"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f44987a618dedfd755dd13a490d1c36d613d0fcf3eabc40116722e9719c214b3"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-07-17T15:37:14Z"
+    "last-modified": "2024-07-30T21:17:03Z"
   },
   "releases": [
     {
@@ -113,9 +113,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -123,8 +120,16 @@
       "version": "40.20240709.1.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1721232000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "40.20240728.1.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1440,
+          "start_epoch": 1722434400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-07-17T15:37:12Z"
+    "last-modified": "2024-07-30T21:17:02Z"
   },
   "releases": [
     {
@@ -101,22 +101,22 @@
       }
     },
     {
-      "version": "40.20240616.3.0",
+      "version": "40.20240701.3.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
+        },
         "rollout": {
           "start_percentage": 1.0
         }
       }
     },
     {
-      "version": "40.20240701.3.0",
+      "version": "40.20240709.3.1",
       "metadata": {
-        "barrier": {
-           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
-         },
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1721232000,
+          "duration_minutes": 1440,
+          "start_epoch": 1722434400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-07-17T15:37:13Z"
+    "last-modified": "2024-07-30T21:17:02Z"
   },
   "releases": [
     {
@@ -121,9 +121,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -131,8 +128,16 @@
       "version": "40.20240709.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1721232000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "40.20240728.2.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1440,
+          "start_epoch": 1722434400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).