### PR TITLE
Roll out stable 40.20240728.3.0, testing 40.20240808.2.0, next 40.20240808.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-07-30T21:17:03Z",
+        "last-modified": "2024-08-15T00:33:27Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "facb45d339a3cf822e62e262f7127617476521bc102df3f2b582f743b9a2eb2f",
-                                "uncompressed-sha256": "8b82de451d0d6bb7e264ca43bb6b8e9d249c30f542b0675ef1758307a363df4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f5c38d661c9a0249237a28ce9b1a138558d54c1ceca0fc7c8675d06a5d011aaf",
+                                "uncompressed-sha256": "9c470246f17938164c5650afee686cf5d806d82b4d37811185cbafc68700ecee"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a42936b17085f15663e5c9432ea8fb244ebb47da933884e0a988c932e941a4a9",
-                                "uncompressed-sha256": "f1fd32f39241af766b9ded3ed34a69e1f1ae64dcde6de58c5cede1363b235842"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e2debe38ca40ff1fd1e120fd8d2e47b9382aa7feca4a0f0c478581e1d69e0e28",
+                                "uncompressed-sha256": "a20f86986c27ad9d81a5871e99775a4f52de6d380b452aa72513b44bf340ec47"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "392b0b52364129aeef46689a370576ab09cc184e94c732ee3c373fb696cc465e",
-                                "uncompressed-sha256": "efcc91763988d893be56ddc789b3bdfaaf0d28a89866febc50d41606ff0a9c1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8423e277f5b24db80c1088a4011bd041f66e0725a15a1d6e088b3df7c3570d3c",
+                                "uncompressed-sha256": "67e40c74db2b4c5c750d0588d19d842bc4a69ea3ac8e54860798caf33e23923d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d5ae7f5f51f2e1d6993c08f221a8d4ba5b6e04c583503ead8d2f4712b76a88f9",
-                                "uncompressed-sha256": "7d18c1a3263f419b271cb334af71972a025ea0233a036e7564242ae421ee9029"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "626c4b1ca469e04ba531febb6d3aeea4a771b4b4d772cacc900a857dc6f91459",
+                                "uncompressed-sha256": "1846a27e1f4bc70fb9e2febddd87799c0f2c972eb2c19017801ca1c45d10efe5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "674a02030a84a4e211b18e19f24e68cd04565cdaeb0ef774de0971afdea94038",
-                                "uncompressed-sha256": "dca183911c4d7d5f00fe5d52d2e410d13aeaedb2fc36875142af3a8d701c1e8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1ca8fd9c6912007c8c6183d97a6bb00c6273949850ce83863609a7860b8ababf",
+                                "uncompressed-sha256": "831a206f97be04df6c3a078556ee85a4c5e1833905b87504836a58b24c55f96c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "de4f6b76f4d0e2eb6291dd4db973fcacf31b28ff7a838b2dfb54deeb2b3d45d1",
-                                "uncompressed-sha256": "d1e9a94a495ee4618931498ce93e4a7230f7670683716a7f01d96f60795d3f3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6d334bf8b16d6d6a0933d6087e4a94411d36d2ae8aaec80ca6472e657ecca02f",
+                                "uncompressed-sha256": "81991b8aaa8a78bdcb0287a8874e07e484dd4bf4c5b2971be1a2cef673ab7ee1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live.aarch64.iso.sig",
-                                "sha256": "bf8e9b791eed78d407bc98559d75eb8d4ffbbb0668c9b15e94de930687560081"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live.aarch64.iso.sig",
+                                "sha256": "a9e584937dc56e9544291b02fff06a6d4f01a9c78e1ae560eefe338d43ff1f04"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-kernel-aarch64.sig",
-                                "sha256": "c346e94ccbbdce6450144add99eabf90f14b20176a6e401a912b642d6ef702af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-kernel-aarch64.sig",
+                                "sha256": "cb0b0862cd36bb3accca36434076086a1a72059498c1fd320361c08d8255c7dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "7fb858acf8e5b11808e6643b9b24a8ce061a0d5bb6eafabe082784307688886d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2f06b8df6443ed7b0a923b1466076c122fa29d2592f191e8f14286e6857b886b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "1f204f2446de14c6fdbff39e2f47ff80a5fdc653cbab7eda8a522e828e4fe157"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "901df33fd3aab32c0bdf4dbd9da36edf91160e24845674f0d424df24adea24ed"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "f637bcd513c118212fe76a6a020fb4b24a3199681913aef25958c08f865396ed",
-                                "uncompressed-sha256": "9f0f198637c70f38bae47bd9ec7aa5261b6b702da7aaa48f77df6a09aea13bf3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "123a613e516b5c749a92471cc6d63f9d1f5a20a8f1dc83d4f95fce33a6a29804",
+                                "uncompressed-sha256": "0dc5a1c588b5bdf96e2bbefeb34d7e57626ba5635b61ebeee1b85e889d50a15e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2d59ce7f96a4d2ea6269dea8588247571c01cd721def2c0adc7ef019158dfb57",
-                                "uncompressed-sha256": "de2796045143f72211b00d9318fbd7a291a05c2f7e653dce4b8568b6cc419278"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6701fde949677d6a5173b1e134f994c9c3f179002a152bb4bfb9bfb4968fde2e",
+                                "uncompressed-sha256": "0ae6c3fe4894766d685333163b3434a069a72a9b28a00c4c39dcb2716ea38932"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/aarch64/fedora-coreos-40.20240728.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7e8bee325c775a52c110dea969c7c2d9163b089e9481cc8083505d3299d264e9",
-                                "uncompressed-sha256": "5790f51ed658d310ce56aaa7c5ac17b0c7c04c4340756a2d9d1f1b5172e210f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2cb6bdcb5c6b78ddf85449bd399156ec8c6605b8eee5fae33c78aeb63144451c",
+                                "uncompressed-sha256": "390b324bc808c5d4be0cf7928f42b50591e9758be70b23ff013f1eca2b993cb8"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0594e411d6de6ba1d"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-09b60426b853b5b0a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0199f0a3669be5f53"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0f99fb68fe3877a1b"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-044134edf82c9b54b"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-085e0d5f85e21b912"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0b850c2888493103e"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0d0abf2e0a3ffcaf5"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-02813059e5b968c81"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-08ac5a17332cd1c75"
                         },
                         "ap-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-04c85310c9b10863b"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0a33dea0d053d45c0"
                         },
                         "ap-south-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0af66fca5a5ea121e"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0074fa1fe0798fb20"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-03f5bfaad0ca74178"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0f2718f653c5714e2"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-064210105a4aa7a6c"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-019f2588f4dd29977"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0406520c2b0206f7e"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0ffb741e5ee2eeba2"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0f046df81fb38bf45"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-00b0344bcac848ec9"
                         },
                         "ca-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0e6cb8fa8f570f646"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-005292a62b438b623"
                         },
                         "ca-west-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0550a2b203b34b209"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0207f657da0f1da71"
                         },
                         "eu-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0b07430d85a6d6b71"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0cea8713794886afd"
                         },
                         "eu-central-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-00d343d546904ac16"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-02906a43e9568def9"
                         },
                         "eu-north-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0cb8b7af1c3b5826e"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-03513fc216cea4491"
                         },
                         "eu-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0f4d58256f8f2880a"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-090bd7a4dd0692121"
                         },
                         "eu-south-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0e71e3aca6e58be81"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-03dc8c171ea10a92d"
                         },
                         "eu-west-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-01bca6b38631254aa"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-07f5cc9d165e44b1a"
                         },
                         "eu-west-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-08df3c9c5a6beec83"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0d773619c7ac118da"
                         },
                         "eu-west-3": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0e3476682413d26c6"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-019ea313d46ef8299"
                         },
                         "il-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-07b616313b87a27a7"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0b2581dfecb6d90a3"
                         },
                         "me-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-01c147aee5e0b7b59"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-00c02c0ca987dcf11"
                         },
                         "me-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-00d568b3b78ed2fba"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0cf06b6664f2d604f"
                         },
                         "sa-east-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-01a112ac981b5f366"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-073c23a34ad061b3a"
                         },
                         "us-east-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-01020169579d28307"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-07d517522eaa378bd"
                         },
                         "us-east-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-05ef3fc3207207c26"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0742710ff63e3a161"
                         },
                         "us-west-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0d3b2b8c1f786a214"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0628fba2c8b408354"
                         },
                         "us-west-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0eeb9b7cae17377b3"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0268fac848ab25bc9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240728-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240808-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b6a1d398122d7c0636e6aec7ba227b927cc3af72346bf7061631388733c4105d",
-                                "uncompressed-sha256": "a36ecf7c89d5d09d36e7294f44b0d45e3525bb0f634f7a74dcff49e7f82d8a04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "081cf40bcf3d588abcfdde34e75ec104c835e7b0d5d67f62335a9881eedf4fc4",
+                                "uncompressed-sha256": "c2d2d4de58c876d0b5ec49153e16412c0bbc13aa66452ea198981f0f98deaaea"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live.ppc64le.iso.sig",
-                                "sha256": "d1252fbb3312f4d9ac4ecd9958edc08d6701f258e5e92c87a036f8f715dc781a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live.ppc64le.iso.sig",
+                                "sha256": "15e4578bb35924379e1322a2c16bc5ca8eb0ab42976904d285a0198e1f9a3188"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "b9f76fc0668f1d6919f8691b9fc6bf0daf4d4f562229d40150fbcdad92cbfd62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "c9e2f1cb0a59a1d1b74e256e4f74078eb099e998df7c48b2e15cefc63944f92a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e9f367b6d5beb6ba399cd63ab770499d34b4e15e6673a769a1d15de535e02958"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0f5468354ff29176f6e617cfc139e538b12f90994574c54539ecbb545cde3c9a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "848a24c1abc71ea4cc4ee1f91b1576451645be3b24a8903bec9b2dccab24dede"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "200787cb559ba80452d91bf9b933e5036df15fd5ba02020d31fcb61200779ebf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "56ae7b82611f82d796b04c0ab2939b9c69a40be35579fc8df2b97b4487b6aa3c",
-                                "uncompressed-sha256": "f8b4c8dc845e2d6d4a74438e2e03133ba8ae5057203660cc447f9e2c27969640"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "4f026d0ee49cd75f66fcb057725d17d5fbe2da5dd419997bc2328abd13f4c24d",
+                                "uncompressed-sha256": "f40a1383f7ad78e0c306dbe06470df0659fe8fd6db507cd284db9b205c457790"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a662cb72d52eb37506d1993623e578fee5b06d6ba257b68f608d7a54b0482aa7",
-                                "uncompressed-sha256": "1f62d553b75fbb2bc67ffce74dd8f6667fb3f0e6e42255f4a7235c2161ac2d62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "03bcc27eee9848713362aafb7d5fe2756569247fb80b948a9e958bfbfbf334aa",
+                                "uncompressed-sha256": "ba94c019c7072020ced94582b634d296429f116d11fc5cab78a0b9c9919fdaab"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "17cf160988cba88c44f1aa512877ff7f5e9236a062c5a5b33892c34b9529fe2a",
-                                "uncompressed-sha256": "1bd0366ec0f86c47257307d4734f5311012a35752ddbea7eadfc0e8c1226943e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "966f68883ab168dd73b935560cf6bca6c16bcd3883b4363269d4926524d5d20f",
+                                "uncompressed-sha256": "f6d6271b335a6494b9ef42c0511d4066d989c0a48033a72900d2a522d9ec7bf0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/ppc64le/fedora-coreos-40.20240728.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2d14706daf47a4cfb5d1b49d5e7a1158059d630ef75cd538e273b39fac607791",
-                                "uncompressed-sha256": "ddd5c01820dd242e88a437e80f125a130036f3d3238ba38385504c1b6bcca507"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "30f476e597d518b96eb65570cb52f6ad7030c56fa28959cd6c3e944ca1349ab9",
+                                "uncompressed-sha256": "b01e9d808abaf3155ae43be2f9f0202ffee2f86e73083476a6a701e412b263a6"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8205a95f65210f8320bb0b36fb749fbade240921e204ee2c1197b4517de1a92e",
-                                "uncompressed-sha256": "f74826fd5b8311decb762668d1fa064bf4dbddd9b9b52cb6df2aa1aacfad8f12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "941e51a78640340a21413ef05d42975507f8cc87de89d53f33bca85a6be3c734",
+                                "uncompressed-sha256": "aef42eecd9cb084c078023f26eee10debde0442046a6809fb09d4bfa9ef1933f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "779bd7a938420c516eba98acf7b3080740ac732b27cd8f80a64d5165fc21722e",
-                                "uncompressed-sha256": "b2c9f81300222173fa90cd566989d0675d938ba5e03b6828559c152568513a1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "aea8a38c49817dfabcd6efc681434e30707363ecf8b61a3642713f25acedbb78",
+                                "uncompressed-sha256": "8c8dad09ad391d832a0ee2270875bc6fd9ad323fed995da5af7dd74a312636b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live.s390x.iso.sig",
-                                "sha256": "10fd8e00aa9ce87544e2a637e078437ad1e861742dbe12ad5ae63c929878ac55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live.s390x.iso.sig",
+                                "sha256": "d4267f9ed99d71fdc8adba84018ac4d528ae1079c01c8d86a5bf73c121d976f1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-kernel-s390x.sig",
-                                "sha256": "41173681081a1d01c78df1a4f60e8480b0d0485cb7c49163154096dfc05f47ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-kernel-s390x.sig",
+                                "sha256": "cd0ccb133703f0b51afea4a2bb0c1e76111a442745137e866f0945f808191a7f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "e65bb2c99d8522a890218e6b5cf59c265b3400570e406b66fa2cf91f40f18d50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "e0eb5b9f4bf9fec51c1379b4d5c03691d5a9cda943afc652a9a42b8801113a69"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "ad49d3f94ca269ab42481177b835cce67ba81c70202da7deb58be3a83efaca74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "77c8d315def8b8446d10c53c2294c8784d924ae0c5bfe65dd1cb0d3e7b1b763a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "f0fe67063d2d780719eb30af5a72b67a1bbdc1a253e0bc1c548cb6adedb075f6",
-                                "uncompressed-sha256": "246f34702a394bd5d164dc1d1124c3a729bdb58db4f44eff2df8c172caad314e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d40ea9a950c2d80117c05b751a6cd3135dced74e2a6cd5d0cabee13998112f5a",
+                                "uncompressed-sha256": "5642f8b4d3bc0af7c242261412040ab1429f4378e686b587d918f9d0f9d7b2a8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4462e128b6814d1abfb8e0d072fb7b9c8545cc49821634a3b79f062cf6f442e8",
-                                "uncompressed-sha256": "c4fc186ae4be8291327672d837f321dda7e0f93fc4bec61c79178d3d149fd41e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4874cd017914ebc8466b01502bec801b55b5f44c7344894ac66f3f6c244cc1b3",
+                                "uncompressed-sha256": "9d8b59da2729a3b9f03b49086585821325008b73c47ac4fb8bbe91e3205f36c1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/s390x/fedora-coreos-40.20240728.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d6bbd46896e320464982c657c1e195eeb65b5dbaf778d381ba1943e7eb7ea3b9",
-                                "uncompressed-sha256": "9a86fab918edd8b9f1cc89898fdee4fff555c29012e00bf96534a55d98f0fb4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3044309acc991a48bb8192b6effde193b1837e57fd48eaafa2b2198daab006d2",
+                                "uncompressed-sha256": "482e0c2ec60888722d2b195b9c0aceebc0da8abdd11b6258adde6eedc95c8ebc"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c5de822aff1c50ad13e320fd8b65affd131245109e5f103546b65828a8922eb0",
-                                "uncompressed-sha256": "2938d41635dde2b8b72693da5505799fd2d18840e7f4fcc9d0bc00506bc7c1f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5606b33b4687baaf8ade31b77d2cbe191f8a624239e453bf3fccd098ded9169c",
+                                "uncompressed-sha256": "95e42181e7d08b3e05e40c5fa9284c1c74d950c8bfc6250079958452afb5b300"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "bd89fc2429b4f55707ba0b8fd4612779eae57d4f7cff3e837a5b52821fec531a",
-                                "uncompressed-sha256": "67c7bab55a9fab29dab37e9b4d18c8ec716270cbfa0db0e4982e1f048fa11d9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "7da4df0a83e4880f21cc30782966917103ca2b51a78f959f4acab8e2b9ed799a",
+                                "uncompressed-sha256": "2fe6abe2ca6a629a1100de372ab730d040986286f38d37f3044033c47108cb43"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4380ceb6b10a6c7aeefb0a02392d3be0848dbd05cc0cefa9512d6e2c49858a3e",
-                                "uncompressed-sha256": "30250d7a11616e2a4a6b017db91d485e08312a4ceca9412d64fc71c1426d3053"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4ddfa2aaa6aa623798c69b3772788de64005d33f9840b3072efe9e24af4f30e4",
+                                "uncompressed-sha256": "3a4dff25d12702f6d3813c2f822f0df0e402d0cb0e0714c516c0db8f9fb2f02d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "230a32dff7854e899091ff6208c1e7b5126750f25011999be4968d25fbaff4cb",
-                                "uncompressed-sha256": "10e613a4f034b0ce77c2d0e13fa55220f810c4f42881dbfb818fe1414e9f3024"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "62174ef36de9110bdeefd80675b4dc54d729d0ec82620b02cc28b8b56f49a301",
+                                "uncompressed-sha256": "bb8e8ad6f8ae6f10d70cb92b698e828f0e42985ba2e748cbdaf1252edaa31a8b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cf1b029a6217deed91aa31023842e3b4440648903366b75add10d7031316a37f",
-                                "uncompressed-sha256": "a7cb656184a8fff37c09bd394a1e61af8dfb97c2a1122d612572b5c374e8095f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a0dd1a4b8e81cd352775f447e9c61b5d3f5396d5a22f6ba5893a6c7ee3196068",
+                                "uncompressed-sha256": "70b79613f0133fb10daa4fba08ba30eada9024b50f7df0a29a74569b4e99354d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0c0225a51df713f5f75afde15671f94c68ed233540df7965e5f4476ff7396851",
-                                "uncompressed-sha256": "a9ce18ef6256c710d14c00af0cbc27806840c857e991134cbc843db826e7355d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1b0a16945b2a0166a9a7c289d216aba2cc1239e120ff3adb86b50ab355c7fbf3",
+                                "uncompressed-sha256": "151caa0f99140ab0b27288b2e0e7743511dcfc22c5482c1a44e0e90a0076fbf2"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a6ec65bd1107de8c29422763a3a3a18ef8b0fe723857227cb0cd6777ac91ae9b",
-                                "uncompressed-sha256": "f61649dd63b6e2b48bcbc5e6429453337acc7e6540f94886a437a2f85b8432bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6c2300368880814068777d5a0ef33bc44a734dcbff1eebc20a0b989c2151007d",
+                                "uncompressed-sha256": "bb00774d310cfe5c82feca3a82d284ac399c4882b7dee1867851c490be33eaf5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "d9a1b5271af698966431c7da772dc8a991a791b89bc3c537f043557cde3f7678",
-                                "uncompressed-sha256": "1abe70e60004eefc9f42afc824aec42c7727a58e2fd423e1dfbc2b483a349327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "57c117ad77b091da13fa7af9c24427939c409b5823ea6a90abf45040c8c397b1",
+                                "uncompressed-sha256": "22e67881971c890780046ed2b02871c26dcdeca8947d39db2b9a4b58032532dd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7f873cd9a1b096c30f8e3daaf53a2d5b03cab5341013f0d091bf6414f9d06786",
-                                "uncompressed-sha256": "5b7fae50b1569a28be9b729765dc1f8e7f6fc343059f015edd79ef6a8acb152b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c068ab71738f2cb855fef0cb3a932f2108c2becaa25621032ec5c375b99cfb24",
+                                "uncompressed-sha256": "d6b86b2dbcd86ca1f4805628fc37f5d00ef067362ffb8bb7f131f52ff78d30b3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "520a342d3e2f9f866320f0d09307c9ac1b6f306de74f6c50826a2b0b07203d5b",
-                                "uncompressed-sha256": "4692b27559a4fc5d9bfa4356370eae761bb7be3796d433d864e015f92feebfd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "46fb973e324c3f7dae74155e8f2cd9e7171715edeb010cdcf4117829a86b537c",
+                                "uncompressed-sha256": "0e081d291862ce3e84a18a49cf77893dfb7bf6ca290b0399120c45c6fa771924"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "05e20a0408011f85c3ec3503d464b03af62d23d7d3c97c680702068d3edd9067"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b81a8c16471c72abf60e7fa66fe69e482db6f0effa4c1b27e6f62707ee04f9cf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "08ade7f9bdb3fbe05293e5d2463be1619700ab4139970c4853ee22ea84717b99",
-                                "uncompressed-sha256": "b7dfbe453773d6e32a299edd7d6356f9e34d9f13debbcb045760a52055f5adc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0068a4774c3a25a41cc90c9e7edaee994aa69a851252bd9a9c070d0780780efb",
+                                "uncompressed-sha256": "ff994ceff1281133c460933a96e86deb5798414c722060aa3b3b3f1b506824f2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live.x86_64.iso.sig",
-                                "sha256": "9a23e05c8e53d4b0e7fea7ad517f05ba02a1ebac33b2d9d06bcd4bb4d78b724a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live.x86_64.iso.sig",
+                                "sha256": "7cf84e0e4de57b7a43169318288725b277be803baf48f37085db3d6960c1759f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-kernel-x86_64.sig",
-                                "sha256": "559b86e867a743956204d1f17e492c3273c6ef288accf3aa0c4356e16a9aa439"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-kernel-x86_64.sig",
+                                "sha256": "36eac90bbc9b6c594515fa36e2dfd4e15b769bbb5015f3b024d7bde4c4f50abf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "2849468e2ea992838bf7f4c28f1bd3d97a5eebd930b67ad7250dff785d4927bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3600e5f79d0ecd85f0809094e9443166e1599f86924781583a15060ba58840bb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "1128c4956a3b392d1396a8c4eda53b1d7164194920b9872f909e3a60ce0e7822"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "25f6dfd17195ebe204fcecac4abf3af4b1e72a025d29f9d64f0483bdb088a203"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "fce59adb40948538f42f350c4dd81204085de1ae8ed81c7326b0820c07d92357",
-                                "uncompressed-sha256": "2e29d8cd7d73fa311fece39a7b81d31ec0a428fed723e12db79e10b48bf5ae58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a8956b340af03d54664b022f2c994bbc7d82e352aa1b9300d9831344a4aed08e",
+                                "uncompressed-sha256": "ed86f37ff91e7b5f833b9dd972dddd415a25d6141acc56346dd360b8e524a19f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "432cf05d50f106a2708cb72596ce7764f802e407f94fee72ebc84840efd2bfe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f6c8be3dbcc8ab4fff87656eac6d30058802e5dcd9ab73380b355678aabb57ed"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3678bb8d8a38c4423b2e0b93e097a31cc0691757dd5435723be0589500376999",
-                                "uncompressed-sha256": "0f673299e8511e86072b1189d000c9b27a5f2b007392eeda6145f2e23269fb92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7ef1a1fb3e0fc320ff2bb7791b08d9412ec04e79c5e057d03570bca00569eef9",
+                                "uncompressed-sha256": "ec6e58a53e0f27e12cefcf8a55bc4241568621290821b81c6961c6607e1b96c7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "df7f2e05baa090b3dfcebc1b4ba3945eae11fe6e072ae3d7cc65ae651069a82e",
-                                "uncompressed-sha256": "212a167e3c42f5b05ea8bb64a72bc41ddac45d79ff60a0304a89f901542adaa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d201818cb45058d6e54de057ec82d042bc99769eeb6ab13614ebcf9a180a2a10",
+                                "uncompressed-sha256": "5cbcb4ff26dd48c92e8a395803391ab91aadf487463560cc611508c69d29f3d0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "421a065354488e1b49f729c41b11b2a9c27e55e72f236ffb7a1030810135e28d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "da5073de02a4dfadf2fb23ef88c1fbb2f6a949976d1fba17d8b63d7a15922aef"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "89578cc4e9f5ca65db848024b8ec1ae828c57920a3912a5e0d471eebe00c99de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "d11bcbb035d2f8e7e888718c3b3ec1cc8f825a39ab602b714ccf6969698cb337"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240728.1.1/x86_64/fedora-coreos-40.20240728.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "47cb2fd1c5c66ceaaf377e71d93fb2605f2ee7a6214b615a887349704db76dfb",
-                                "uncompressed-sha256": "16db7d50240bf695bc52a2a1c7a040137f1856f8156a3c3e0bfc9f89095dd899"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "430bf3ba5fd7e5cd573102f323d1483f1ba81a37e7c6d4a88b85b03576f9ca63",
+                                "uncompressed-sha256": "4bf7e48b44284274ee57bb2980513982662b3bdbac8b2c270172ff066f5e2004"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-02b0b8e7a6aabd1bb"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0c37351545a26e594"
                         },
                         "ap-east-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-053770967d540ed85"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0332889c59b90caaa"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0f84fd9854ef872a7"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-06e9287962afc82a0"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0de3c3dd2a152b15c"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0726ed173c506c08a"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0ee92f897806c3e1b"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-02c38d4417da699e8"
                         },
                         "ap-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0c06287c784d02981"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-07e5f83bc2ef7880b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0da886c30c56e58ef"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0febe6d1898204d4b"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0c3a4458729493cf5"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0af42c45a75efea40"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0768d63c5b254e6a6"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-09086704ec19d6504"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0956e40f2b0c1c3e4"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0c6d895d10f992f66"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-07e979ce70fbdf9e7"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-021f7ce1437df79ef"
                         },
                         "ca-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0e3f15b49e62e98ad"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0d9418e82af2dae52"
                         },
                         "ca-west-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-05a17e70c54e32208"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0fbdc3e069f98493b"
                         },
                         "eu-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-07ba9328f8bed2506"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-04e39fc3020dbf1d0"
                         },
                         "eu-central-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-031211daba9c7874d"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-00df9bacde3994e71"
                         },
                         "eu-north-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0f6ed566916eae02d"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-02baab6f9ec90f7be"
                         },
                         "eu-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-01d11c03aa89de097"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0c66af539926177fa"
                         },
                         "eu-south-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-07f499b90970f77c4"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-06651947a1ea798de"
                         },
                         "eu-west-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0864b81ffd107c0c7"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-00318732602461031"
                         },
                         "eu-west-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0893847f23f5e15e5"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0c1d66e80ce47c5b4"
                         },
                         "eu-west-3": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0fb65ab86e1fd65b3"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-043ee58a85e625876"
                         },
                         "il-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-06cba0f155eb91bf2"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-01a2c3de209e4b229"
                         },
                         "me-central-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0a7a2126755616921"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0612aa2614ee64565"
                         },
                         "me-south-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-056d1c27b7f6f3a76"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-08f58076f39bbecf7"
                         },
                         "sa-east-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-06363f85623c18e91"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-05b73d9b7e0fbc948"
                         },
                         "us-east-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-007e0dbe3938cd72d"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-06aab3ef1aa8b3c91"
                         },
                         "us-east-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0126b3b398e08deb5"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-0c9b5cd2edc926e6f"
                         },
                         "us-west-1": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0be01a65a36f2ecf0"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-09b33548d49bce164"
                         },
                         "us-west-2": {
-                            "release": "40.20240728.1.1",
-                            "image": "ami-0710323d7df561551"
+                            "release": "40.20240808.1.0",
+                            "image": "ami-08360e076590d2795"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240728-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240808-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240728.1.1",
+                    "release": "40.20240808.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b47292f96187baa426d213b83834f4e3702699e2a52a73dfee1b816e953425c6"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c5fc15906df2f41e3c169b2ea0ff6d373292c46e25d597c585cb0cbf6e4990cc"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-07-30T21:17:00Z",
+        "last-modified": "2024-08-15T00:33:25Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "de521fac4059094dac837754fa010573176ab0292cfc7e54c6cf9fb4b8b9ab4f",
-                                "uncompressed-sha256": "cb004dfed9f6e9ecd5f14bfe733d7b15efd8585b4b76e66d03462377c0172af5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "0e35754f66640550a1b6da0aec01c6d8c2bf73d44097a01b861d686049e7ff4a",
+                                "uncompressed-sha256": "6cdd43be7c1cad47d7160aa8d9f186580c2e88bf9d2a84cd6f15282b706da377"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "6b84d2487cfecae4fd588a0e4a000691ecf6865839f3beaa08c9b1b47a9f0c3d",
-                                "uncompressed-sha256": "0c04370a5680323802df23d58fbf41b3f5c4e39c92da3b8e5edd9ab235912ca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f68fa565dfd17998bc53b986e11471264b0b28e964c27d4d769d0dbd12a1806d",
+                                "uncompressed-sha256": "f95300ed918d3f8f29ad666ce6e5fb8b3ddcf786122408520f0159fd5d6c89f8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a94cce686a02ed39661d785aafcbcaab1203c9c0c01cd732aacbcd31b15253d2",
-                                "uncompressed-sha256": "1916c60b61f59bef41dc870162cab8459fffe1a5db9a7509316cf03cd0220a73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "2f07c080c3a5658850ec788f497ff496f995e3d111a453d00b56f861da1481e6",
+                                "uncompressed-sha256": "5618a10359bae6359dc5a10e9fc7025417c2698a6aca2ec2efe286cfc7c43f5c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "84d5e8f3eb8311a30ff3f3823f0b9d5a1d488608b68395e13d132686bbf6f390",
-                                "uncompressed-sha256": "16222f5376b178edd48817e28e0eed3b799f8d70e3e555c2002e3967e2e4d98c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "ad444a500954a89672d8b74994d2f8241c8550717fdd7a8c743cfba7b71a2e6c",
+                                "uncompressed-sha256": "9247075d0a75de0c83fe3c8dc8b33b75c4ac4c87e363a98069b92f8cc8a284b5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "702eccc19ecbe775b5baf4c175f4d1419bc243321dd788925e4304a5e3ab3289",
-                                "uncompressed-sha256": "9f04485445102367f596259932ad1b0c7f4c7cf74948aa0f0eb3fbc885e2ed6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0bfd91d9203b392c3908044e78b15cef1b406a759636487670b227b543e43b90",
+                                "uncompressed-sha256": "387ad5803db16700b24e171850b88d31407634b849322cb338d9486636c740f9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a707fc34f99d3e0b8a26e0f941132e290992b21e204891351b4bf0693255023f",
-                                "uncompressed-sha256": "248796b9d8855171597cfa7c7d54424fcbcfda3285010c77319631f9a821db23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "45213a80e5d637516c11adbd11d573ddf89fb64528c91d6ea50470cd7f09e554",
+                                "uncompressed-sha256": "d99917c1733f4ef9a17150ca86f45513a3e74007ef5e21c28f7ee0cd7e569383"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live.aarch64.iso.sig",
-                                "sha256": "6ed44fcb1cb527726f9899fbbed6aa8a77e05a7b51a0c087b3f37a1535d46ff9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live.aarch64.iso.sig",
+                                "sha256": "01c4d1718f985fbb1c66ab7970bf1ab573f6a7273767186ad9952d5b2be63eb2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-kernel-aarch64.sig",
-                                "sha256": "57983a9642bee5a62c26c9d3b441733d4755462c1cd3cc5e278953b12a3232f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-kernel-aarch64.sig",
+                                "sha256": "c346e94ccbbdce6450144add99eabf90f14b20176a6e401a912b642d6ef702af"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "c00a8a16466c8ca7cfa03f06c85c93827356ed07092432bf6b67042fc8060bb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a7967f95108846a5cd0159c045d2a562ad4a3715fcbaed153e50090549601065"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "cbf946eda0d4fb390843c059421f99bbbeb075dc2ab3a7ac36cb1d164eb34869"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0fffad80d9717deb323c74ce8caa39d50826a5943c02bd2213bda9cbad9e7ab1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "2a2461dd9d2b1fe7c781e7cfc7c8795da7352187a4efc15a6937473f437b3692",
-                                "uncompressed-sha256": "5c67b75bca8d3433b3d43cbc7a658d6ff0a5324ff92aa18a3da62097cd01d276"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c9f3b25df7ba8b62e5da7f1ede1f58c1db1be9b18eecb014e88a687dd9c26ecb",
+                                "uncompressed-sha256": "8d89fc7d202437f8d8b168a2720a61c5bfa602464e4263364217497bd48f51e5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d1faccb3b73afb448a354ff1e0f02caedaadf4584ea0d45e1f68c1a445e0f25f",
-                                "uncompressed-sha256": "1d7b3612b1db749645eba882bb1d5d7dc9553f5e272b42507db60f6291014c22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7580b7fae27f532178459c45945064961aba7cdde34417a490a626bed9113a4b",
+                                "uncompressed-sha256": "fd3a9a13d055e153bcf7f60c1274a83c34e8bb5d6f13f1d168dbd2b8e69eba78"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/aarch64/fedora-coreos-40.20240709.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9847a445bf343a4e182f0226911c4b781488050dcc15ef84b97fe175485375c8",
-                                "uncompressed-sha256": "5615cf185b6f624f484533d36b13f0f350c77c41573a419cc0e9c02a439fdd98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a1d5ffa57f9ec42b2a4f21241b0b90df03b6c4775e901f47f1c11ab5c8f07f0e",
+                                "uncompressed-sha256": "277cc039fdf9ef9b600b88c11eed5f47c47c2993e4229cd0945e092aaffa605f"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-03e5659512a7c3b44"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-00e18d1612ffc0f5a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0386e9766de609e8e"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0a1a581a4889284ce"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0587c1afa030eb7ad"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-095ccc03ed2a0dce8"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-05025057e9fea1715"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0a48e1638039e4b68"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0e49fc125956c9f0b"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-076c6eafc9f6419af"
                         },
                         "ap-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-044d3b59ea49b4810"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0fc8f8674953000b4"
                         },
                         "ap-south-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0c71aa120c05c0696"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-00ad976f18b539949"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0f0af848d3e794a5b"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-02e5737d17860020e"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-07b268e17cab4af15"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-03abfce59be44f244"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0c5ab376dfc50d200"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-090210632cbbc7c66"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-01ef89f86b19f09ab"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-02005c035657d3e8b"
                         },
                         "ca-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-00c9743539140fe95"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-03e0f32467190a1a9"
                         },
                         "ca-west-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0b2a52aaada1268ec"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0a4d3507d31e97af2"
                         },
                         "eu-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-00444a4004eafbf74"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-05e32a7ce89ccc2b7"
                         },
                         "eu-central-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-07845a09b1250bb5b"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0bbe7ba8581d741e2"
                         },
                         "eu-north-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-045e06aab112a429f"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-058d4c1dba2c0f594"
                         },
                         "eu-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0d5e8a0d5340a25ef"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-06d8df1b290b5aaa6"
                         },
                         "eu-south-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-00b503589b3a2c2cd"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0e0290a470f7da2ed"
                         },
                         "eu-west-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-00bea8557c1a3391e"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0a68466a361749c40"
                         },
                         "eu-west-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0e6bc438eb70bd6b9"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-07e401fe7197bedac"
                         },
                         "eu-west-3": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0f26992fb5799bec5"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-08637403f5dcf3de3"
                         },
                         "il-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0f07908a7590d965b"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-01a3cc89dcd134221"
                         },
                         "me-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-068a6d0e9d761cc83"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-09ba995a64d136463"
                         },
                         "me-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0f51e28dc6d2e980b"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0a13553519512ab83"
                         },
                         "sa-east-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-01ca11e15421cab47"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-07f4f42860083a84b"
                         },
                         "us-east-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-01cc6c45582ac099d"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-027746658553ff214"
                         },
                         "us-east-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-046d1b51de473fbce"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-094c56731598618c3"
                         },
                         "us-west-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0db6966fa680a8de2"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0b77a08c72e342e88"
                         },
                         "us-west-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0836f4f273754d763"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0db87bed84d360095"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240709-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240728-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a9ff4d51ee1ef16889a4753fe79576226d5d914c784ccb1aeeff041b03078ccf",
-                                "uncompressed-sha256": "b09d75fcada05191b7256e10c82d0367ce68e65226e0eca956c0b1ddf3601259"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "d8007a032be150471990f73afb2174c4ceae5411d77d96252e876d0d46734d95",
+                                "uncompressed-sha256": "69ddc6cff844d36b5c47bcf039640fd958c6631d175258e2061d1aaee524440e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live.ppc64le.iso.sig",
-                                "sha256": "add3b0a9f4e452a9635dd34184e58fbbc0fd187965b84b0aa594257cddea45ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live.ppc64le.iso.sig",
+                                "sha256": "132cf748130e29806262398ac68454a2224840ee1ce0501ab1d2bf053a655685"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-kernel-ppc64le.sig",
-                                "sha256": "0a49db68d0a6618c4cbfc20a64c8227d12e4316b0342395fceb984379784c5b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "b9f76fc0668f1d6919f8691b9fc6bf0daf4d4f562229d40150fbcdad92cbfd62"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "513b65898dadc425e141fde773d0a50a9711ccc8daed38b705c83a5bf2541bd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "38ef2de6454c5884343146dc400d8a7ec66ccf68c4b955ed4c797d4a4c69c993"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d56da35f7bf450c92041f3a9f1c661018324a44ae54136162b00b6a15e592169"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d7afb05bc19278113cff9adcc70194ec31f45e5ae7aa506e9537b50a7e5a520e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b006315d2a183e4015bbd1b23aaab24ae826e080358508611d6359573d7c018c",
-                                "uncompressed-sha256": "a09f70fde077463972de4311b29b1548c4e2b139372aeb617e7040676c4517b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "c00585f48b920ebaeb870413d22eeea854217942cfcfdbec3390db572c989bbc",
+                                "uncompressed-sha256": "b0103cc13903a549a790b553765df5eadadb58a221370fd8312a859b017b2399"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "550d69fef659350dd0c62cfb4a3585fe2c7eb43569b5814279e42ada9059237e",
-                                "uncompressed-sha256": "62cb21fd0237f61c38e6faf62c232d72bc4dbbab1284033bb596bb0748146b65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9a84bbbca1068732f8cff39df771a314aa1ea995e66811c3c510f58988d14aee",
+                                "uncompressed-sha256": "663575f39f573cc84c4754912343f839ea5c7776ca16c1262640ce8d5d14391a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "082c0b422136155f65fae6574c393011b42a2a780631c4c9cee5aae3bfb73c1d",
-                                "uncompressed-sha256": "a62f2b1ef12bcfdbe65ceb41cd2d5e729c94566e8a72ef78fcecc26e588571db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5542688c9c967ef081ee15b3496ae1e1d93d5c42a42681d183047563cc2838a4",
+                                "uncompressed-sha256": "eaafb028f734b95e585eaef0a4296372f689153b2a8236ae94136f52446e3c2b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/ppc64le/fedora-coreos-40.20240709.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "22401303dd847477270552a58b740aa0fbf0f69318a4f3f64328d6aff81b0c69",
-                                "uncompressed-sha256": "ef92392c86b727a7b02fd6186ec8123612a16efdac7daa4ca02a4d413063d667"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e23c01b5c13e07ccf7707d07ca5ff52c5ad436ea1081222627163b36e9c66fdf",
+                                "uncompressed-sha256": "ecb4548f9e481ba3cb0e7c0c2a80be13d2294bf561b16a1b502578b8d003d463"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6e02b013bf6f550c5f25d8cb09c542b9cfae4ba96e6432a56b6cc82d27dede31",
-                                "uncompressed-sha256": "7b22a8c5c7d0329be65f272378d62554ecbcacdbd540150a363a8fda0f969bdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "30fd2960fc5971225b396ad41714d8e237a27098670f80a7d97b9ce2898d5408",
+                                "uncompressed-sha256": "b8924588c4bb2882f9205404ae4923fa4ed86c980c69bb6dc2e839103c002ceb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d3a36c0315e35bcfe6d69ea2afa42a7993d88403a3166df7f0323a9886ea883c",
-                                "uncompressed-sha256": "e13a1bc9f41adab675167b0aa19c092fdb04e276306d138d3c54527e16115986"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7dc2739f9a24ebb490d2f267b8b0080900022a2d30ace6a4b4a3a73657464da5",
+                                "uncompressed-sha256": "684fca3f972d2841786c73999b35d156c2d2ea120ca7521143c9d50c65cf7cad"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live.s390x.iso.sig",
-                                "sha256": "b29270a3ed116ab1e496bf5c6066596f68a2b14f78a7ba679a544cc0800166fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live.s390x.iso.sig",
+                                "sha256": "a966bb5a84b771784da9036e95554604cb93d30ce9d3866c62d84c6310aa38cc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-kernel-s390x.sig",
-                                "sha256": "ffd9104defb17c4e0699ceacc8c1a468d8b74f5b310ffbee37e0aa1391a3f293"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-kernel-s390x.sig",
+                                "sha256": "41173681081a1d01c78df1a4f60e8480b0d0485cb7c49163154096dfc05f47ed"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "6dcc0bfa8dd8370af8b7817879a2a53a823c578f7ddbd941270797b5bfc0f20d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "21a4c0f928a69b45e6f72901eb9a3ae12f2c4dab1aa54af6d093e184bfe22b8a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "22aeb0118e6d09b7418e0d524972d781cf623460f5f1c354d4ab8df00aefcf0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "38d49662971a1d773d80e95168fec81c6ddeb683933937bfe6f06e9a3d9027e8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "8af7fe81c5c257f7173f0410c7a57821d80a08768a72e418a9ebe68cfe448fc7",
-                                "uncompressed-sha256": "9d7743fb567d3d8c53c5e303ac28aba6eaae2453ac47bdbdec6934fdf7d3657c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "16cf2646ea7f7cceb08743c5e2ba42f243418062dd2e77155310fe2d0fcdafd4",
+                                "uncompressed-sha256": "3ba191d6f897465dadff939fda283a225995cbb900a5af5f430a0155dffa5461"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d7060255ac658878413207ab784c9079c341b0da070bb79d89f3baf2fab9672f",
-                                "uncompressed-sha256": "59f889174c876bd1cc0a927239a6e4c4dae5067a6d447c4a8ebb88e696ab5195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5bc1dc1b56258ffca88c20276c124542645aa9a1099138d9b9d16091f947c12b",
+                                "uncompressed-sha256": "2334140e31672752ca8ade28823908915e493a98271fd9f5ddc86b4a57a185da"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/s390x/fedora-coreos-40.20240709.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "23802f71d57630bb08b588ebb7cf1540725b995000f8ecef409bdb3989159f19",
-                                "uncompressed-sha256": "df9ac29cd7b36fc59b4f5a65c74d0e714c9924b9bd854118ce29253e6a8d0cbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "fe0df1ac6d2c719ef29933402514bf44bdb856e1e0797fa8b092de6da5d7d5e2",
+                                "uncompressed-sha256": "b8eb9beb6bc4d50d9a3a7ae097512869b024f3a3211d2512b997ddb331a6e1ef"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "920dab5c358f09bddfbc9d77fcd03a12df571d4bfe1b6831ecb1065ebb1b74f0",
-                                "uncompressed-sha256": "dc8c08a870347b39fe88495c1b69197f7a6bc945c4fe9750e63e4638eafb9f01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4b9f2a0eb7ec99854c96708e1d0c115cc4bf2ec102e185a08e5e3f2b8205102b",
+                                "uncompressed-sha256": "a83813ffd7fa02f450a9a21d9eaaed4425d8a473a1068c309020c1000dfffcb2"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a7f4237e6b2fe2234977d3eafbb16b02f5a526643dd4b145bec15ec5f42445b0",
-                                "uncompressed-sha256": "025c4094c6c2af8c0fb7447b55e2f8f458486bf4b1c151ba27118a40baa99865"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ed699e28296c418cad81874003ceee03e858ce23f043067a734439e8056d0ded",
+                                "uncompressed-sha256": "85999eadfd8a4c9a8cdc1812f60d4d25af1f35b3902876d26d9fef95c4df64d6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "30074cc38c188879a6d0d302344bd2d3bd0f8dac8b5214d222afc454fef4659c",
-                                "uncompressed-sha256": "f0302c9315a23a72d037012e7ccc68ea459755e7ec98b06586892a94adaa5906"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0d239b2a85beb52b4c3a0519406ae284fce169576878ca86606cea9ce023d628",
+                                "uncompressed-sha256": "7ff73a5d55bb4c4d4e124fb56d73c0b71901ffa0de7fcec7fab50f448e0bc380"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ba6161c80dbe59f3418fb82f1a1312f21be6a7bd4625165a0dccb4a0a30059d6",
-                                "uncompressed-sha256": "38be2743338f414cef503830e52954f895fce2c4150395a1a3ca6d2c828ca911"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9c9f238e2ac3ee01fbdbacf16f1aaa02973ebba9958fddafa7bb0c594507682f",
+                                "uncompressed-sha256": "d2833f9a255f989dc0094ca0dc6eccb6a7c20f8ce2b0cb6b6bd8e43cb5b2c452"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0dd65a35ef06a429d4a515166fc1f74e462487f54f9b0d8fbf88169414b13e19",
-                                "uncompressed-sha256": "1e7890d5095fecaa7cfffcce9fefc29c1b8a314ff1c7db2a08406d2baedb8963"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "120a9cca1b9755d555ed630069a137af5045fe0ce1d351a497cd7894741fac95",
+                                "uncompressed-sha256": "b11064ad6b61996d0612b700723dc548ee48d8dc319a3c74b54a03f1ea7f514e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3f7d1a8a746654f3e7484bb77d4d29f53d33112a838b9d97f2c33a7f1b30f988",
-                                "uncompressed-sha256": "9a09b1af8d36d3a3ca89a8da7165025841557650238aabcabde4f0ca31394d50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "aa66df96b47f21316c1dbf9e7e95b608c5338afb95735c844c2536050e0e8e04",
+                                "uncompressed-sha256": "d21446fa3e8bebcc536d9cfc2367145cf09ecf009dd21f5959761892668d325f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3fd705714a98e83100258022b3dd93d4062c434fa07e4fa296aa48ff91417d70",
-                                "uncompressed-sha256": "e096810e9bd7e471b4001263f62252f3c3408aaf60412bbe37d9afaa43fd9268"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8c0a6ee178961c48583aedad51b0f5ef2b10e6505a5bff00e999d43bb6a74ca8",
+                                "uncompressed-sha256": "df051fba21145c4b80d651b716b3a4be47cdb0392c91fd536a69329a4d58bc13"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "81b612bc34b91a5f845b4eef59abd577967d360dd78f7ffe4efe03dde0af8385",
-                                "uncompressed-sha256": "5ac5fd456d5bddd713616d0aa30f162f676d346388c0c35bf41e7416d330d1bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9551bd3c49f43dada1e6507853cd4c0a68c3d20d5e95022eaa33bf73e5aff373",
+                                "uncompressed-sha256": "dc8a47c811a09149c6b251984d854aacc270a707fe5ba6938b8d857668049a75"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9dab19a0203d809fc2618fe3ec8fc7e266ff3ae429fb07ba4d26e0ea1160a9b6",
-                                "uncompressed-sha256": "7638da2e74657c0b045e7cfa7ac2db5064db78e23c3f04b89ec8e63d0e33d8a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "f371fa365792db9a4384d5b8b98ab34375c8b227e7e6acbdaadeb901715d6ea5",
+                                "uncompressed-sha256": "4b5c3f9a32cdbdf29a9aa4cad9eb0b026e8a2ac340058d2edbcf78600977544c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "da80892d5d161fdf75291bf4d7b19ee354669bf4fd6f5b514410c851dd2ea96d",
-                                "uncompressed-sha256": "55250e75f5391372ebeb2f6e88725c7f8a825d195532c03a3c1ec85092dd00ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0e250845e7de92ab30335f7527dd9ea21741211c324b5daa749cb5ac088c451a",
+                                "uncompressed-sha256": "6eefb4786f5a6180d5e2c5a9ec2bd5bf03603d0d01e6201c22b7efe16a35f9af"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "66764b9d84cb324306d1e39b188f23f447bae5fe71c99657e54f447d23dcbf72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "975552c7ec074e10b7c660d8775e09a952d26af72acf54b6d48bdae3e31fb57e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d57fd960063e3a4317dbe51aef6fc0ca7bb3635f4e18721dcea6a0c2f7706cd6",
-                                "uncompressed-sha256": "e68acd31ea266e41cacf1454935ed56d5d00963c0ca6c3f429ee549ce25969cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e2124402a2ba69eb4c3201240fdb99c03d34fba09017de970cda5d4a2f5ad209",
+                                "uncompressed-sha256": "ef8d1c5aaa940d245a88a0e0edce2af90b7639103e11792aec7702f83a7e78b8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live.x86_64.iso.sig",
-                                "sha256": "41ffed9cf051d793caa1fece0a0e4412f130092ecc99d323bd20be51568b7c78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live.x86_64.iso.sig",
+                                "sha256": "ccfb5729f6e86ed54c28884dbf1d1554305dd43040d757928204fceb1ec09be0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-kernel-x86_64.sig",
-                                "sha256": "17b1696ec6d7184205501409abb5c242d6ad0b14b4a5e78aee62c64b325ed4cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-kernel-x86_64.sig",
+                                "sha256": "559b86e867a743956204d1f17e492c3273c6ef288accf3aa0c4356e16a9aa439"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "1ff2a15a3205b147d6b46c61bfa7b862c04cb1353640e043a28976df19494148"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9e7911cd5a129f3ef83c646afd06149745ecb60ef9d8b1223fea61a5615b86b5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "663a206ef6860ffadb68ebbd0cf744c5ab4ec148393117a89a2f84fa5543790d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ef014785149ebf9fd88c13aa23ff24486161e422e4f702ce8a7691b569e1d117"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "332eee8283f0ef80605f96d5ae9353c1899872793b0127ada175c4fd53bb992b",
-                                "uncompressed-sha256": "6d1033d096cb98bb38d0e0c26b073325cd06cb17b30aefc09cf1c271c81cc6e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "730038d168bc942e4643e2c32e78535004d6a286ef70176c1c0f5889f12a126b",
+                                "uncompressed-sha256": "8b90e0fee8b30cb4ff6a3e54000f4cd91af31aba3837641e5141a363b1a2b1ad"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c037d5fc74901f24134845b344910ab3f4d8b5cd59555d4fe1366d84e6f613b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "fa7447f846dc7dccb8881b1d52e63174a991374608be79003ed7845203e5fad0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3389775d8e625c27df56f999d51f512981471bfff61944d67d6a8130eb7c6d04",
-                                "uncompressed-sha256": "6d8856a37a48a2e76bf97385730756117d0aa612428ef22da3998dd6018491e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c15be065adbc3fc1f3e534ee58879d2edb7055513e1bc441911f531d36bdbca5",
+                                "uncompressed-sha256": "b4f8edeb72e467d6d3524c5ae833c3cf1b96faff6ac80457d16b07bd8d97e61e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0c014b59d3030ff536f90f39af16e75ab519ee66b0de766989d5ffc40e1809d3",
-                                "uncompressed-sha256": "5aeaee0d719ef9cedb12a63ce1b351076f469a7dfd36c76c7fc4339dfd66d792"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "75ef6401fa3509999db3e48298020b2921388cb4bf043f62f531f5cd1bb052df",
+                                "uncompressed-sha256": "224a0dbb79043db73b1d1a05274085a42d6bbdc9c6714eafe641750edc6e27ee"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "de1f5670a30c8d9eccac27945c29635f4c7e74ae88e579352740d04588681944"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "56f1994f77d2fb024379b117add74c666b3da0f9b25486bcbe837d9d63b77675"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "bc2bd6a174d28eb20ddcb0f2a7317ec4045ca4a5f1b7d758b8ac71b747fa08d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "09cdb878b17e8be9b6db10b07403f5c2d0312064ac75b3cc1f592a7326d1c23d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240709.3.1/x86_64/fedora-coreos-40.20240709.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "69d8d0c7f62143458b3144b2d7b0d10405c8212c25d6dc1b2f1886e4668bcd83",
-                                "uncompressed-sha256": "d7742be6d4f7b05a8f67eb2198d940ebeac4537475a56631ae3d7cc693992fce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c087be17976926ff1a232c3997ac2b050aeec3b03f3908d795ae63d8776b97ce",
+                                "uncompressed-sha256": "1d38d0ded361e6253f57e9d6285fa35783c5a5b488c75f185d8df3bdedb123cc"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0fffb90f87fd8a62c"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-05c6bb254507c43cc"
                         },
                         "ap-east-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-003087c91f98b8388"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-042f13df88f3d7ac0"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-045ea1aec81dc84e3"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-027e66de13705c799"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-02986c2699a0b1442"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0df0fd9bfbb806bff"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0555c00e420c9babc"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-03cb0c294b782b36c"
                         },
                         "ap-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-097a91d2010d2fcf4"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-041fa0f53688cdb70"
                         },
                         "ap-south-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-038abab04bd23a485"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-07a48583a85680dbc"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-09757ba26748630b9"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0e229135699755b96"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0bebfd1617be041ea"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-00ccc5c0f223f9c36"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-06947dd25bffc63f2"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0b66025ed56725949"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0ad1c714cde7c767d"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0d6eccdd0d837e91b"
                         },
                         "ca-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-07a399fd39ebd64bb"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0c69949cd7033aa27"
                         },
                         "ca-west-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-06f0089fd0045cd12"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0f159092e6c9aae95"
                         },
                         "eu-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0484ae18abc932b67"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0818d11fe91521f88"
                         },
                         "eu-central-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0c1dbb2f9f5dac603"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0ea44594da95d080f"
                         },
                         "eu-north-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0a369a9bea84f79f1"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-00f9e0f85f3b48966"
                         },
                         "eu-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-08b45f6bb8d22cf4b"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-00f14d4a88fb40494"
                         },
                         "eu-south-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-063f8940012868ec3"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-05b4548551fee760b"
                         },
                         "eu-west-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-09676327950b422a2"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-09a64a7f5429b4f9e"
                         },
                         "eu-west-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-03fa1ffb8b60be01d"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-043dc6dbfd3df3cfc"
                         },
                         "eu-west-3": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0d4d9c52dc128c88d"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0efa1a4515fb346c3"
                         },
                         "il-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0d33d65ca8fd3d82c"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-03c024974e531c89a"
                         },
                         "me-central-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0cd4ece398f201a7c"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0e75df18492801651"
                         },
                         "me-south-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0d53736fde5895013"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0f574903f37448354"
                         },
                         "sa-east-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-01110ea46dd668c99"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-072ce7c2f0da61e4d"
                         },
                         "us-east-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-05937ddf5eec95099"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-03f543464cf460674"
                         },
                         "us-east-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0ead7edb98b23e731"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0191ee134962b0906"
                         },
                         "us-west-1": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0a39085fb3fa17bcf"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0ee2ae1570d15ed19"
                         },
                         "us-west-2": {
-                            "release": "40.20240709.3.1",
-                            "image": "ami-0c2a6e81dd837c3c2"
+                            "release": "40.20240728.3.0",
+                            "image": "ami-0d775ffee25006fff"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240709-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240728-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240709.3.1",
+                    "release": "40.20240728.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:31086ffbd6f869cef2bdf8ace5a40d43bbe66089b1b07c640eb31a18ecfdce2c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fb4c720d15bbe5023899da388a608cd7a290db4bc5e6d412c6023e3f00302e78"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-07-30T21:17:02Z",
+        "last-modified": "2024-08-15T00:33:27Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "4ab9b7ba9c4bd46e2bd21e85ff0b0711a768a00b30582b7226b82d69b022a8ff",
-                                "uncompressed-sha256": "b873d862a35657d39a4e8844e25fa42a2ff65d11f61c9a92ecb88fcdf153d080"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "31d529369b586f2ae252c30210c72a50db46a5211c6e7b10fe829738afe015d8",
+                                "uncompressed-sha256": "6e7d86672e38d4abc8a20dc0e0ab1ce9b49ae74a6eda3efcddde0b488f51772f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f800d32ec69a1b011775b15446c3fe55664d6c3734e01c547725c4883213793a",
-                                "uncompressed-sha256": "413d9e70c16ee74454fbe282619fc927782d45f9961313ea55834c118b789447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a00b7f314223af92e24074b4bdf0406deb93645c7c18c47f5612383c68909d2e",
+                                "uncompressed-sha256": "fbbb0f24d685ba2ef6cabcf17b757b3d33d669f32d9dbd8cb24606e1f233558a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "921d6776134093cd61bf7e0f324040e9bb8cddf18b90375ecf573eda2aceaf0a",
-                                "uncompressed-sha256": "add0a9aa5a06db38ad3431a65505e727562d9e4b287f326ffc8a2625ebc8d764"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "f8fe0ce168522d8456dc208bd2c0c29324ffbf40b1e6fbd6cec5c041c173b584",
+                                "uncompressed-sha256": "59302f4e16c987ed4d9f1b8c9aaf81506a7066790e7663575f98293c95edc66e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f7ed9ee39ade909b34dd9d23129f6c1e871bfdff390edbb90994cf727e33f308",
-                                "uncompressed-sha256": "c42c4b385cfe47facbbf614a3b823246717fe4383824790ef73aa03df4c45f63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "52012c5bde22f3996fa86d12f600432031aad96de3449931c5ffd8cea4ace00c",
+                                "uncompressed-sha256": "89d63ea9b21603bea0689576a1b4ac1c7878bf147867805d804b96b38120fb84"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "83956e3761d7eef4d41d2e227cd1447a0a03a2f9947d1d1b58add5667cde349c",
-                                "uncompressed-sha256": "238a068ce9034bcc8b8b5866c1330722beccc0d62ae7441417956cece09547cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "5f97ab247f1d7143fb214030ce7f91aca99b8d160db645ea804a6403bc909f9b",
+                                "uncompressed-sha256": "0c8e086e572f7bbe89adbee9777e3363db00e51a217bef6fbccc7bfdc098cc54"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b236eb9730a73da597179696badc1a7c0c388834e5ac5ac9bdfc01d503fb2c46",
-                                "uncompressed-sha256": "0db8445d7f0f59bcdb896141ce9784c44e93295d7d636a44b797563472cb32c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c895def6e8986fc91eef5a1447c862e30fdb7631ea9129adc7885139d64d7338",
+                                "uncompressed-sha256": "411767afe1b280be7aa952fbe77007f82b82bf9ebe8a4c69539ddae9f4f53a12"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live.aarch64.iso.sig",
-                                "sha256": "b47a08ef754bb4a6ff5bbbd0cb33fcab83de36107cd0fc342738f5f16a01f94d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live.aarch64.iso.sig",
+                                "sha256": "5ecc7d0eb1bad0a3fda3989648ce69b06c729558f252ba928b4daec601901794"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-kernel-aarch64.sig",
-                                "sha256": "c346e94ccbbdce6450144add99eabf90f14b20176a6e401a912b642d6ef702af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-kernel-aarch64.sig",
+                                "sha256": "cb0b0862cd36bb3accca36434076086a1a72059498c1fd320361c08d8255c7dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "0f411ca7d132f5774d62a02a92de72e2a6c3a51aa6c0eb00efc5a1c095aa7494"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "65202423a21139374a3c277aea800f91ddb68145947c1b3e7fa254c4c0ad5284"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "7faed70d8028076d58976347a34a7943b5b4dd5dfd8285aa0e3ac6c0b9af987d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ebaa3791bbfc26fbd6d0d3991a74bdab449b00e9301445db8e9083caa66063c1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "62688c7746c1ad890d1436ef721586226da418365fcde9776eef55e0bd204e14",
-                                "uncompressed-sha256": "c9f408008d0ae7f422a0eb595c2c997f5c2ffbf12928f8867982b905af26ba14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "31fbeef8c1d85f2e3e8a844f26b3dcd1298873fd8f647a7ea9b6e41c50a2abce",
+                                "uncompressed-sha256": "bbcd1beebca8d01ae7e2916598e4e7b61f8de720ddaeb7616da9cea7556e5f26"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c71fe66b4683b3ac1b3b5bf9052edb4fe7d065563d1a7781a4ee7da98bb183a0",
-                                "uncompressed-sha256": "ae3b5d64ec488bdb77a32e1da8f482ca40555626eb55ff7f85749e023f88a6ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4711a7f2d8bb8400f92bda374b0ee4524c0bd85a507b511b47e154511667450f",
+                                "uncompressed-sha256": "6a89933906743c37ea4f1de0bc40d75f28c092dc3f863b5853aee59bea3760cd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/aarch64/fedora-coreos-40.20240728.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7ae0e92c70ed61f919dd0f5bba3f0907ab2e4b575bf88d7f65d873c8e0ec79d4",
-                                "uncompressed-sha256": "72dc65c4974582c436bccf1b76909f849f8b4ac97b401499e743ab52066a60c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "34ed0e5a26edb7ef468b105b711668e41a18d62d4f7daa1bffad2bc79ec9eb5e",
+                                "uncompressed-sha256": "9a6cf817e1bccb5ed9fa259dbb3412815ba4bb3328a660c258cb190addb99469"
                             }
                         }
                     }
@@ -148,213 +148,213 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0f8956770fb270ded"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0235ecea7315513ae"
                         },
                         "ap-east-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0fcf5e0cbce4d71c4"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0d17a7767c47218be"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0a042d1b2e19d3dc0"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-08a232b3b79041a46"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0642d8c9ebdf1aaa1"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-02525b4ab5bd5b6ee"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-080a1cbf1fecd7eb3"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-00d39518415e0f34e"
                         },
                         "ap-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-020b4a8f1ef25f22b"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0f623175c6e477234"
                         },
                         "ap-south-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0805c0511f8bd732d"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0ade711d850730f51"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0f7b934138cbeb65d"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0a91c5df48b29c7f1"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0bf99843c124139b4"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-09aef5259f1d07880"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-08af3124f7a88e4df"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-007a11ef365d574c5"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-063cef5f6eb2e9037"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-072acc6026b7b7049"
                         },
                         "ca-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-093b101531631ccd0"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-003142fbfac0858d4"
                         },
                         "ca-west-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0e65ed7291a617a3d"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0a80d5489a6442419"
                         },
                         "eu-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-025c7ba86c78ee278"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0408e01a1d66b89ec"
                         },
                         "eu-central-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0fa42ff34688ca2a4"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0e912795a8b925444"
                         },
                         "eu-north-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0c48bce93c09635c2"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0a4adab3a363580ac"
                         },
                         "eu-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0c7bda77630d65b5f"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-064a416bd451efefa"
                         },
                         "eu-south-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0d3bd357f96743c9d"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0a17412b4e21b7874"
                         },
                         "eu-west-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0150a1df31d1b5082"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0e29d901d953e7542"
                         },
                         "eu-west-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0600df03113a75a4b"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-01fb7edb095326c9d"
                         },
                         "eu-west-3": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0927edc00d2968997"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-056b115cd4b923430"
                         },
                         "il-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-00055465ce9231a02"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-07b94d2b8a8370f15"
                         },
                         "me-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0d9d6c19769994724"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0e1784ebc4ecd143f"
                         },
                         "me-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0abdef45d071839f9"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-01f1d550e997e27d1"
                         },
                         "sa-east-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-02ae6bc7e24d14c07"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-09b65838ab1ebdec3"
                         },
                         "us-east-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0ba958042be20ad4f"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0ee95765fb7f39970"
                         },
                         "us-east-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0262e98594da02e64"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-013811bcde8acb900"
                         },
                         "us-west-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0a40cf79f87d210ad"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-04d227ce052e22e0a"
                         },
                         "us-west-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0c3c0c5798dc8b37a"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-01026412d389d4cb4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240728-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240808-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ede7c740e9e8bc2ed7e247f36c1906c68a9b2f307a7aed4c1f31f07daca1abfe",
-                                "uncompressed-sha256": "528c9ce44598afa178e1ea3b1204a92c8bab05b9d6eecb2ab0e4cb30a7797d2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e53fb08d0997921fb238ac499e546bf778952c2dfd715436da48701eb5dbd80c",
+                                "uncompressed-sha256": "708c24b01efa4463d717288d5223c7c7557951084512c44ffd0df165d5ebd24c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live.ppc64le.iso.sig",
-                                "sha256": "06ac2921c26007f4a3830c659dc2202c8e2aec495c62c817d13f10c47b8097df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live.ppc64le.iso.sig",
+                                "sha256": "c4e3dd6ed4efd00b09686c9e97b849afce80010137ec67b265ff29f4a2593318"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-kernel-ppc64le.sig",
-                                "sha256": "b9f76fc0668f1d6919f8691b9fc6bf0daf4d4f562229d40150fbcdad92cbfd62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "c9e2f1cb0a59a1d1b74e256e4f74078eb099e998df7c48b2e15cefc63944f92a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "352da9d62de8594b210b37b1c41041f585c99f1b1d34df73e1754b550b18006d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8015d49728f01e238f0c5d87af2d4fb9c7f9dca41248ca32973135322bcff192"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a2c5a14208bc48c763314302e5e9f88c958469694b70e3bf384da77f4abac10d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "8328fc560e4e8de938d759bde4ee9a86c4e384627ee488d735119e929b5c2545"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "7590c7e776e6b7885ca069542ce50fb577bfea011fa7626d9f2406e95b8ec088",
-                                "uncompressed-sha256": "b770a61772360f1ca4fbfc8776fe878b1938b70491092ca5f80be1e963743fba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "ac5cfbd885110431e2226ca68d2331e3c2e5e1b2885a9ae9a646eec94637aad5",
+                                "uncompressed-sha256": "e2044bc26d9fdee2890253ab815c08869a0b106e9fd5754feb32c19494515032"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "791650ccec5fe0c3f7b3a7b2fbf9686335d7c096ee16998e17fe31c845451d94",
-                                "uncompressed-sha256": "6cce0bcee86de01a158b2d4dc466bbdf60482a6d00ff90cdb5df156421986553"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "047b6e192bf2e57162b32a0c544ae27da28eeabaa71a7625a71600107b90f7c0",
+                                "uncompressed-sha256": "259b34100d8ba22cc114a10698bed7a1e29ba15f94280930c0a83b7e56ff7df0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "6a5c3d9f9a9405e66229f1ab429acefa79f455e7ed0b4f0089240eabfb158cad",
-                                "uncompressed-sha256": "67c770c9c64ebc061af08f8ee9e289319cddd252faba8b65dfeab4530ef8a849"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ca1f737b78f02ede54f12b46c1cc1af30e11b560f37f6977f8d8ed775836044d",
+                                "uncompressed-sha256": "83273377ed2351f3ed9aa323b9221bbe39585928068158b83bd8757f8517727a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/ppc64le/fedora-coreos-40.20240728.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d4f541b87d5d98917089b32601cafd01fb3d40426506a7dc28d4d9805d522872",
-                                "uncompressed-sha256": "bb4dd9a10948bcdcfadf2476006d9a05ec36d7e0301a6f8935e7a132b6e31157"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "0158ce64f1f44f793f9560761813ac753367f35aad2ddce53a9b5b3f190eeac5",
+                                "uncompressed-sha256": "5ac43f975a70f30a4c2fff61afa07123008f24e30eec65138685891207e05d67"
                             }
                         }
                     }
@@ -365,85 +365,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "77a71faace26eeae45b96090661e5db64bf36986e86aa5120321e884ce2d5962",
-                                "uncompressed-sha256": "5e446d3342a56578a4ab54bd7772c27289eae9715925db33d3f85be81ef2a3cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "8cb2e0ccfe24df56148e8e12016e1d6d94b8a0c922522913a1b14b465bb96160",
+                                "uncompressed-sha256": "a43800a3436dab1450ae759882c873c29bac70d66bbe12b7d75e74b88d792136"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ccb72712aab7592b779deb0674a37c52a94287a243fc809bc2b5ebf646012738",
-                                "uncompressed-sha256": "c31ce3fd52c55c23ee440a518b090978e1d1a72d97791edb236698008ff0139d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "aa24ccd34e402ec09f88da705094eb291d7196cbfd1f750e410d1a98571f20f8",
+                                "uncompressed-sha256": "78d53f7e4957f500d53a52174c19fbff08afa1eb45a3d12847534907dcb65b0f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live.s390x.iso.sig",
-                                "sha256": "0f932ca0a3121ece552ec56a52d35f71c73a54273366b6db78c50dfa48bcde88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live.s390x.iso.sig",
+                                "sha256": "c72b41eda3519f217a488f2da3a63a9dfb9907c801a9b8349b0963a8b17229cf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-kernel-s390x.sig",
-                                "sha256": "41173681081a1d01c78df1a4f60e8480b0d0485cb7c49163154096dfc05f47ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-kernel-s390x.sig",
+                                "sha256": "cd0ccb133703f0b51afea4a2bb0c1e76111a442745137e866f0945f808191a7f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "7ddbaa9e344eaa172387420916dd171787abaa28d28a2141c373328eb177b629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "52d359ff76bfdd5350daa2a00156f9f88c26f3a7f2d3f0bac1b60002071c10d1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "7e020069f490b6d72a5ece98558c6a5023fb40193a1c4802afc81742746d273a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "17f2b79a5536cfcb321d5d4ea89e343f1968a7b501864f758c1c6eac3287be56"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "6f7e92e9e64e4d2284ae1b880f63d106f49ea640e42207f184e229b25a2df2f7",
-                                "uncompressed-sha256": "689f43c6dfc890a497288a259fbd25c82601ee5a57a0b2b4ec166d7a42bdafcd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4ece538f05d08e59eea66f837b0d805f421f29fc47be788effe040528d82ca5e",
+                                "uncompressed-sha256": "562b86755b4953a23fc82f8a0a07ca821dae1c3d2c9189242f978b3e1190adee"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8787192cb521b7fd056f1b9fe9a470a6b33ed3571981e71b3a66c77d145cc975",
-                                "uncompressed-sha256": "178bce4ad3a518266b0fa14f53b715dcd60ba3a47cdf22afd033b6665fdec1a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "63e4b63ea53c3ee6c5e2c77186ba411aec8f2b2be49fc9fdc21ab3015c890b48",
+                                "uncompressed-sha256": "35e191d9d0b223d68cbfb4654f6d2e9ae787ab020b140b053265aae791498fcf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/s390x/fedora-coreos-40.20240728.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bdb81f7f5104dc5164d031166f7df5fed72a22d5606213b2866aaa4ea66dabc4",
-                                "uncompressed-sha256": "9a70a8c2209d099dfa5715574a54c78772aaa756f95a1ab08628c1974da52c37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5f092e63b2b61d55edd5dbb40945fe60c158032fb8c2f1e5705d6b0a9913081e",
+                                "uncompressed-sha256": "e665e97cea45f64352d7a51d2442948e87989406e7514fc4f38979dd6c609369"
                             }
                         }
                     }
@@ -454,263 +454,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4967bbee5c926e54a88b4aadc22c89f24d526ced61c5144c01fd15dfc9e561de",
-                                "uncompressed-sha256": "72ef578f60a7d36c8380d8c9a22cc5cb399d8eaa7f0ea9b7b6e9da5d05a61ae5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a971592d2e250acbb412b5ae954aefb26dee667c04888bf772457880d1306732",
+                                "uncompressed-sha256": "20b4e8da4bc45786f363659240a0fd997285406bc567648712e56d8ba9a2ab31"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "2ee8ccaeed642cc3d5cebe62a27aa61ad4d6391eaef38fe0ec222786b74470ec",
-                                "uncompressed-sha256": "7cdb6fcdbfc7af12cd6fa95ec47fddc558e8aca88a55a59cc4bb6297d6db4684"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6f484a7c2100e133a01b8e91ef1d4c259616f6b8d5292e3b92c7c7359b9bb9ec",
+                                "uncompressed-sha256": "a07301194688b06bf1fcf273c60e61206cb0795d7c88bbcdd761300af0521377"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3809a8b61c7b1368d3d362db663ef7aa4ca36149804da589a938bc988772a0d5",
-                                "uncompressed-sha256": "f468d855e2141f7fa697c5ebc82cc40ec0c0c01eb499c530bea114705b7fad07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "252f171f52009cc2ae58ef1285063932b87e1a0b18baa0f8214786b094f877bb",
+                                "uncompressed-sha256": "717a75687f0bdf438e01df06b19c40e2964b9bf7705188e2ae8c4aae8991070e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "580fc1d6c4125d14f5ae255c99b22dfede70b4fcfa6a8668901df847776a9a1b",
-                                "uncompressed-sha256": "4c4fb999d68508b56178ca0af00b70ada1d6318f50a43f5033a0f0f19b860a99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "07e578dd10293e314295f5a7fbd24075a4ee13fdf5727fe72b28567bc9e62ecb",
+                                "uncompressed-sha256": "5ef6ef2efaab057c1bc2b6cd622bafaa954315eaca9b5f95d04d2b157052ab9c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ba4e7fd036b1c0af4b368fbd168fe94343801d769bde13e2ff0d45ba4884fe83",
-                                "uncompressed-sha256": "7c297ce84c2d4bee5d1e47a26cc9f86907b7d9b8323ce55cae9257330e01f8fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8dfa5cb7909b568bd3ccfefeba252e97f681403e7f746732a423a3563a23df08",
+                                "uncompressed-sha256": "a630dfbf02f60fa4e00627795a8b40fe72f974f58f0d53631b05dfa538cdbc56"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9fa558c7fdcc14fccd3ba4797044c13a66d0ef84a7b8e45da2ef445a81e318b7",
-                                "uncompressed-sha256": "5bd309b2c5682a6639bf2db0604b91dfd6662321eed758e7ff7a30080ac9eb5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1e21d7756ef8e8c34df41ecb8a6b800dae8158739ceee24f0726beb6cacfaa4d",
+                                "uncompressed-sha256": "50687088c3561e4e719abc357592fab967fa89d289af898bba305ba15b4e19b3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d369f48413ed3568192d6d76f594b6e22dcfc370b7beaa6887a77a8aec4ddbc5",
-                                "uncompressed-sha256": "dd9926c8fb600de3382dfb9a00dbd0a40990a8e6ecfac09ec97dc9887338f88b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0b236c9a337823f97277a9770a82dd6abf221dccccbe6f7b88040a322eb0acee",
+                                "uncompressed-sha256": "90679664ec2617c609a8d71bf84307c51f9bd424346b8b206f651f2f55b2a192"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "122283ff7291ac841651c8223bca81430abdffc502ab37b8dea5228ba72c6148",
-                                "uncompressed-sha256": "63b581cb941c33238ed20675d1d7e8d039a505e34c7a74f8b6e2412caa7f0f6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f0eeb5bff3e6ac275652ba07b02cc319931a6c2d18f7cfb65be437ea0ccd953f",
+                                "uncompressed-sha256": "44dde027c5fc8723e6c494bbceaaabd17c7f33003ab6d21fd4d99cbc4a14eb99"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "a0d66d21af50b6dcef8cd261a960acb5783866771a4154d1816cc2a3b5cddf77",
-                                "uncompressed-sha256": "109dafd7cb41540a5cca659129df46ce19673de519905fad1fa2f40ebef1dc75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7cc4b2f242f33d64e7f109a785b6644f3e0ecd428c90eceb4d0c7dbfcf02e3ea",
+                                "uncompressed-sha256": "92837474ac1841408bcca536d6d50cbba518275a174a018ef1946a27c2cc4773"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "97b3b4b868f351ae74f9d035a247578c2dcd0e9ca43a0d7d448c6eb97a39c304",
-                                "uncompressed-sha256": "42be540aefbfade8b5e0b6484386cce1ecd2318dd0aa6b7491eafdd4f3449b83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f8544c928cccfb8b60d66c135dd8ddbfdd599b0b5980e7428161b0cbd4e56399",
+                                "uncompressed-sha256": "4e01c4231fe04a72c8d6e305ecd88cf17b442b4b867f0e731a7235b342e9d1ee"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c9ebb37b1643219d236df169a2f35c83de1bc2a559b16a2b7657c362e6f87499"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "daff2064c2a55eccfb9842c0f690e5772b9162989548584d7a229f4bc47b5803"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "85d1841292ee2c2eb577b1cf9b32b9daea5188b37b956ce11f9cce5d3af08ce4",
-                                "uncompressed-sha256": "a46a0f2d04d688cb3b00707c7389d3721f1dbadbb1ba38da10c43cc0a721221d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3153dfbe0881a0337b6a5de40df8d1196cb057bcc363e2390a2a03f80bb17389",
+                                "uncompressed-sha256": "a8b7e52d67cbb42977da9e01c08899464e5a53995fe49806a9c446871b718000"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live.x86_64.iso.sig",
-                                "sha256": "ef52c1fdf1daf48209e1ad28d31af8a4baa231a3c67138b5db35a443654ac5ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live.x86_64.iso.sig",
+                                "sha256": "da12f400915ee7be90bf32b6f6bdfff3bc017241c567c62626dc119324a5e76c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-kernel-x86_64.sig",
-                                "sha256": "559b86e867a743956204d1f17e492c3273c6ef288accf3aa0c4356e16a9aa439"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-kernel-x86_64.sig",
+                                "sha256": "36eac90bbc9b6c594515fa36e2dfd4e15b769bbb5015f3b024d7bde4c4f50abf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "4000b00914307b31eeab5b469098045e26e67e6115fea6998f0beb482001022f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "025a31f55f42104820b52f03aa94c5bc8b93631d071c1baee12f9a92d22b4d8e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "915eeb34253caa3f226ed71dbf4d7ae51dfcd42742a7a81ccad1041c7e11c544"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ed69e1b45928ac260eddfbd280e037d1f18013445b96ea6f13f891bea94c7dca"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "5a2906d36a0692fe1ddd385f250a5f6e54022ef5af14133f46a62d6cef049a6e",
-                                "uncompressed-sha256": "ea3bbcd6475e9d828a6fba3226b78c5475d774596cdce99bf77dd0308881c67a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "07f74072332a94eeec383e80e142f5203be6bdabbf99ba37308c81ce86b4f8c5",
+                                "uncompressed-sha256": "0469fc42202708c507443826046b2c7610135228c26fcf5a5201d0f4ecd81846"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4f5827b7810ea47f48d74c3bc09c6d70995a229d80edbb04bf395c08ef30d648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6cd151c2c4c98e914816f952664cc465638bfcd2d904c2c93b448d8564c036ae"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7d0ea00a0734d0635d9ce33afe6b7d5393a14db6768c0b97cbc44fa2f434681b",
-                                "uncompressed-sha256": "b300cd2b96a00f05304d2f1cd43cf7b4d9aa55729478360162f6fa519545747c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "10ccf57ff10708adc7137cfbeeafb4b2161f2a60ec7da583f8fd4b5526b09ca3",
+                                "uncompressed-sha256": "090f4a5c843d2f0ecd2d9a49475b49541f031976cb8e5f3080361fb0417f8bbc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d8685cef39ef9919866612c0d8d9ba52bc15c9a9c081dc371ae8926db15e650d",
-                                "uncompressed-sha256": "340e842b981a743859baf74bc4a589f972b7d22e0f9d9b257325dee3a09f08fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8f8d00cca189a30ee44f8df890108973045dd5072cdf71b9a19c5bbea857c58d",
+                                "uncompressed-sha256": "c2ff76e431125fadcb0a24c07169eb14cd3f02032413cd1f753d91122a8ec459"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "dd17f52ebac1626d814f8fd671a5a2a80c880c90f1a60701275252f59629b100"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "1db1799d4fb14f28bcb3a943874c82e3e6e22e8114e88a794769961c81e9d8cf"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "69966d7007c859127e989ba7e18256ed9037928adebe0ab561516451c59f0372"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "6ed4116982b834c9a8b9dd9df59880e4740e74778496fa61bfe6fe1be317e52d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240728.2.1/x86_64/fedora-coreos-40.20240728.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "73b444ab4298cb504cb986e72d694c8459c8ac8e7eea6cc0f8de5b84016e0b76",
-                                "uncompressed-sha256": "2fe41b1ce8ad45cdca0e0df425e027d4c2bf3c3832d4ae87ff2d2630427fe7b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9f175631f5caaacd9da1bd523beeee42c4a593007d11ec53b050d2712034cbe1",
+                                "uncompressed-sha256": "0621f73262cd8db8de65ffd174dd93a3a3dc25ca24eed158f45eecdbfa8bd26d"
                             }
                         }
                     }
@@ -720,133 +720,133 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0fb21f54f6e2a7c15"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0e6d62ec58ebcf44c"
                         },
                         "ap-east-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0ddb9a2cf5bd596ab"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-03a74fae4d7d2d6db"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0ac828e26f4fa0191"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0cf88f93944708ee2"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-07ca5758c1440ba12"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0d04ea9acfea77762"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-04df5d3bae5583e4a"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0ab401fad5dd51021"
                         },
                         "ap-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0b3e19f000c420f5a"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-08ca81f57079bc77c"
                         },
                         "ap-south-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0886ba78a687d131f"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0609c579e3cebf80c"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0f47f8958656c0f94"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0d16a899306bbdf1e"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0ef6b855401ad40c1"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-062dbf318f941753c"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0ef68bb4bbff128e5"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0fcf53514a56ffc86"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-058abbd382790eac4"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-03df541a2c64ee724"
                         },
                         "ca-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-05b2ade8aa72db841"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0f7766154d98932c8"
                         },
                         "ca-west-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0da4345435b6823d6"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0352e5d46f11fe9d9"
                         },
                         "eu-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0cc6377b220ba530e"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0e992d343a9150843"
                         },
                         "eu-central-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0f264611ea18eb8f5"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0f9a7dc5915158e2a"
                         },
                         "eu-north-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-03df2540063acd14f"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0ac4062caa5373fbb"
                         },
                         "eu-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-07b957a1e4bc796e0"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0b97b37a2907bb709"
                         },
                         "eu-south-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-05c18622ca687a8d2"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-07d7657e8ac5f2bd9"
                         },
                         "eu-west-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-05c47b6cd3650980b"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-02ffa330cc8752d74"
                         },
                         "eu-west-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-06102c7971010b886"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0fd6664c7351a3e64"
                         },
                         "eu-west-3": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-09f945baa4d9e2085"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0b0d330dda9741b66"
                         },
                         "il-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0faffb3e5ea106ed1"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-01b588f2389eedc6e"
                         },
                         "me-central-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0a3aac5e3227ea9b1"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-02082b5eab4458c7b"
                         },
                         "me-south-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-058fe61506ed5fc04"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-03b6b3c5acea35420"
                         },
                         "sa-east-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0407be689a402d808"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0f429966911dbd8c0"
                         },
                         "us-east-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-05357a685abadc317"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-06236c4eb5a79c490"
                         },
                         "us-east-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-003017766a900c380"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0386df74800f2a2ac"
                         },
                         "us-west-1": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-0be5c9773eb5dce0d"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-06eb5ad49649ba352"
                         },
                         "us-west-2": {
-                            "release": "40.20240728.2.1",
-                            "image": "ami-09cf068540a841474"
+                            "release": "40.20240808.2.0",
+                            "image": "ami-0b5494c80dd1f2c49"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240728-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240808-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240728.2.1",
+                    "release": "40.20240808.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f44987a618dedfd755dd13a490d1c36d613d0fcf3eabc40116722e9719c214b3"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:df52c54d561c7521f4d80a57d080f3c390d23513cf5f4d6531287c2d32a76986"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-07-30T21:17:03Z"
+    "last-modified": "2024-08-15T00:33:28Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "40.20240709.1.1",
+      "version": "40.20240728.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "40.20240728.1.1",
+      "version": "40.20240808.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1722434400,
+          "duration_minutes": 2880,
+          "start_epoch": 1723701600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-07-30T21:17:02Z"
+    "last-modified": "2024-08-15T00:33:26Z"
   },
   "releases": [
     {
@@ -105,9 +105,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1752"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -115,8 +112,16 @@
       "version": "40.20240709.3.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1722434400,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "40.20240728.3.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1723701600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-07-30T21:17:02Z"
+    "last-modified": "2024-08-15T00:33:27Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20240709.2.0",
+      "version": "40.20240728.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20240728.2.1",
+      "version": "40.20240808.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1722434400,
+          "duration_minutes": 2880,
+          "start_epoch": 1723701600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).