### PR TITLE
Roll out stable 40.20240808.3.0, testing 40.20240825.2.0, next 40.20240825.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-08-15T00:33:27Z",
+        "last-modified": "2024-08-28T20:39:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f5c38d661c9a0249237a28ce9b1a138558d54c1ceca0fc7c8675d06a5d011aaf",
-                                "uncompressed-sha256": "9c470246f17938164c5650afee686cf5d806d82b4d37811185cbafc68700ecee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "5e084eef5e86dd782f565ba2070f0e5943cf356ec45e60578e7c5054d0b4dde5",
+                                "uncompressed-sha256": "863a2fe461c35b825aff96edbeb9ca3fd72abdde421e2831faa5ee12e465abc9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e2debe38ca40ff1fd1e120fd8d2e47b9382aa7feca4a0f0c478581e1d69e0e28",
-                                "uncompressed-sha256": "a20f86986c27ad9d81a5871e99775a4f52de6d380b452aa72513b44bf340ec47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "028d6ec80b14c7c45301506c2b4022546f83ccf939ae8914ead0916606113e2c",
+                                "uncompressed-sha256": "a222db2fe5713d553e164475d49932e348c433fd1a82a81bb6063c68913fa989"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8423e277f5b24db80c1088a4011bd041f66e0725a15a1d6e088b3df7c3570d3c",
-                                "uncompressed-sha256": "67e40c74db2b4c5c750d0588d19d842bc4a69ea3ac8e54860798caf33e23923d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ef0f00374fa20709a4dd417d1a7be47e37d08c5597a78f19b16e8cfee118f1f2",
+                                "uncompressed-sha256": "a034296e8c253925449a04d4023a8f3246e552c634107c6719454b834ef8231e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "626c4b1ca469e04ba531febb6d3aeea4a771b4b4d772cacc900a857dc6f91459",
-                                "uncompressed-sha256": "1846a27e1f4bc70fb9e2febddd87799c0f2c972eb2c19017801ca1c45d10efe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "aa2ec9acaa36ad84c5e0f4929cbaf69d2ca0d4b99e4954c5c9be2d6d6f9df51f",
+                                "uncompressed-sha256": "caa4dbad282a20db936555aa70fd7e139c30c2eac57f9ab2f3bcc464e1534c6b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1ca8fd9c6912007c8c6183d97a6bb00c6273949850ce83863609a7860b8ababf",
-                                "uncompressed-sha256": "831a206f97be04df6c3a078556ee85a4c5e1833905b87504836a58b24c55f96c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "652d7d87b9ccbb456d69a1f7ea97932d1d1da48b9778fcdd9a8be8370cf495e2",
+                                "uncompressed-sha256": "3206449c2bd199882bb281f73a5ff5f20c1369e08595d92e12732a75e3ccf31c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6d334bf8b16d6d6a0933d6087e4a94411d36d2ae8aaec80ca6472e657ecca02f",
-                                "uncompressed-sha256": "81991b8aaa8a78bdcb0287a8874e07e484dd4bf4c5b2971be1a2cef673ab7ee1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d628fc87f6bb04654750152a6255d45b200014b02c24ac4f9f989ce4a144b477",
+                                "uncompressed-sha256": "47b667c4583545e657957a6422bacebcffa382cdf507dae54ae022150136a406"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live.aarch64.iso.sig",
-                                "sha256": "a9e584937dc56e9544291b02fff06a6d4f01a9c78e1ae560eefe338d43ff1f04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live.aarch64.iso.sig",
+                                "sha256": "a05143733ae32a0478e9e91455c46fe965ea94904b4475f79ee5c5f08af89c2e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-kernel-aarch64.sig",
-                                "sha256": "cb0b0862cd36bb3accca36434076086a1a72059498c1fd320361c08d8255c7dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-kernel-aarch64.sig",
+                                "sha256": "8ed95915e2d2bb8f683e3a17256fe2dd2826dd7e8cdcaf9194bf6813ad0f125a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2f06b8df6443ed7b0a923b1466076c122fa29d2592f191e8f14286e6857b886b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "45d0e35b83fe9c1eb7e15cbd336937c57fe12ba1b8644e3ef1b6f3e311e81add"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "901df33fd3aab32c0bdf4dbd9da36edf91160e24845674f0d424df24adea24ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4a8a2612e2f6684c4ad7dc717ea7e132c249367b6d4ecc0ba650482b7d1c078b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "123a613e516b5c749a92471cc6d63f9d1f5a20a8f1dc83d4f95fce33a6a29804",
-                                "uncompressed-sha256": "0dc5a1c588b5bdf96e2bbefeb34d7e57626ba5635b61ebeee1b85e889d50a15e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "fb54c854f7b42d1283b097cfe39a623abf395c7a9fa8e22a767486892f2ce044",
+                                "uncompressed-sha256": "bb38e7ad829eb77c87fee429d3024c820e2548b6ad7418d4d33e9b2d2007426b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6701fde949677d6a5173b1e134f994c9c3f179002a152bb4bfb9bfb4968fde2e",
-                                "uncompressed-sha256": "0ae6c3fe4894766d685333163b3434a069a72a9b28a00c4c39dcb2716ea38932"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a4f6153021376517efc5aa62b153a36c61d40e78984bdad8ef1e86e10aa7f913",
+                                "uncompressed-sha256": "8d981472cf97a0b30921b3cb8e1d7c114797b6f38f140a3f948ad9d256ac18dc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/aarch64/fedora-coreos-40.20240808.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2cb6bdcb5c6b78ddf85449bd399156ec8c6605b8eee5fae33c78aeb63144451c",
-                                "uncompressed-sha256": "390b324bc808c5d4be0cf7928f42b50591e9758be70b23ff013f1eca2b993cb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "df8e8a2aaa3a2dc96aa52f33c6e0e05186833412d159c413d65dd69109ef2c89",
+                                "uncompressed-sha256": "6d64947396e52a1c143a400bc36eef51b4a61ab69f2bdf16332ea8b8d3bc1847"
                             }
                         }
                     }
@@ -148,213 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-09b60426b853b5b0a"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0478aa0e208e39f97"
                         },
                         "ap-east-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0f99fb68fe3877a1b"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0001e0a3911a24919"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-085e0d5f85e21b912"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-093bbab90596690a9"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0d0abf2e0a3ffcaf5"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-03cfa3aa2463dfdbf"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-08ac5a17332cd1c75"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0ab4494c3385d86bd"
                         },
                         "ap-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0a33dea0d053d45c0"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-07374ba9eb05726fb"
                         },
                         "ap-south-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0074fa1fe0798fb20"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0b01b83648c86f873"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0f2718f653c5714e2"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0fb6931421aca9a84"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-019f2588f4dd29977"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0c7a99afe9d795363"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0ffb741e5ee2eeba2"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0ca3a1327b03a84c1"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-00b0344bcac848ec9"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-09cdf010d6fa5440c"
+                        },
+                        "ap-southeast-5": {
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0fe6723475e3b065c"
                         },
                         "ca-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-005292a62b438b623"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0e69c5859cf5caa75"
                         },
                         "ca-west-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0207f657da0f1da71"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-065954a240146beb7"
                         },
                         "eu-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0cea8713794886afd"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0a2e4bde53b720786"
                         },
                         "eu-central-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-02906a43e9568def9"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0d88a5fccd1481d8b"
                         },
                         "eu-north-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-03513fc216cea4491"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-070bd379ea6387c88"
                         },
                         "eu-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-090bd7a4dd0692121"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-00e5eaa42b92a0205"
                         },
                         "eu-south-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-03dc8c171ea10a92d"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0ddf2ce8008428756"
                         },
                         "eu-west-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-07f5cc9d165e44b1a"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0a0cd9e2ca75114fd"
                         },
                         "eu-west-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0d773619c7ac118da"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-00858be030164a7f7"
                         },
                         "eu-west-3": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-019ea313d46ef8299"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0ccfb710b6f0a153c"
                         },
                         "il-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0b2581dfecb6d90a3"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0dddcf30fdf6b66ce"
                         },
                         "me-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-00c02c0ca987dcf11"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-050fd34e58d8d9503"
                         },
                         "me-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0cf06b6664f2d604f"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0b433fa1a4b75762b"
                         },
                         "sa-east-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-073c23a34ad061b3a"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-06464b75b716f7ae8"
                         },
                         "us-east-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-07d517522eaa378bd"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-04b95c1df02865157"
                         },
                         "us-east-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0742710ff63e3a161"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0af39360bc865567c"
                         },
                         "us-west-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0628fba2c8b408354"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-02a7c9a46faea56bd"
                         },
                         "us-west-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0268fac848ab25bc9"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-085e8fecee6d78d4d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240808-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240825-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "081cf40bcf3d588abcfdde34e75ec104c835e7b0d5d67f62335a9881eedf4fc4",
-                                "uncompressed-sha256": "c2d2d4de58c876d0b5ec49153e16412c0bbc13aa66452ea198981f0f98deaaea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a8ba517ac83809e22f30a22cf1b2f58e07a6a629b2ae8759087434078bdc8e3a",
+                                "uncompressed-sha256": "4575e2aad0959d5a242a744281c4a7cf4bb08a2b70550fad0cb31fb239f80e64"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live.ppc64le.iso.sig",
-                                "sha256": "15e4578bb35924379e1322a2c16bc5ca8eb0ab42976904d285a0198e1f9a3188"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live.ppc64le.iso.sig",
+                                "sha256": "a039fab1ced46f73644c4d353171f8b66ea8e73f771ec04224169b40e5458e58"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "c9e2f1cb0a59a1d1b74e256e4f74078eb099e998df7c48b2e15cefc63944f92a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "f46688f208e600397c0d194a81b78885ee65cdc060af8ca2769c9ad02fd39b09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "0f5468354ff29176f6e617cfc139e538b12f90994574c54539ecbb545cde3c9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b8f736d743de7186464740d4eda48229604937c47377df95614e075dc34f0d48"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "200787cb559ba80452d91bf9b933e5036df15fd5ba02020d31fcb61200779ebf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "70ad7b639200fa58db7dd46693429c0eebfaef25fb9d02eae119730e591296b7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "4f026d0ee49cd75f66fcb057725d17d5fbe2da5dd419997bc2328abd13f4c24d",
-                                "uncompressed-sha256": "f40a1383f7ad78e0c306dbe06470df0659fe8fd6db507cd284db9b205c457790"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "195c30feb6c6f4c6e7d7eccc12cadeec9f4cd0592699a8f1481a53c66a90ad2b",
+                                "uncompressed-sha256": "868a6a8a3780de76af632392131a704334e81ed5d13ebc49f9b0898b2ded43a5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "03bcc27eee9848713362aafb7d5fe2756569247fb80b948a9e958bfbfbf334aa",
-                                "uncompressed-sha256": "ba94c019c7072020ced94582b634d296429f116d11fc5cab78a0b9c9919fdaab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "bdb1111d2cbc26bd82f22e2d70fe18ca4b375efe524091a91d4066c886b01f82",
+                                "uncompressed-sha256": "cbb1e3b7098aff9d5497e3b6d142a86ca82ca029bcf84025d81651db6dd50fab"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "966f68883ab168dd73b935560cf6bca6c16bcd3883b4363269d4926524d5d20f",
-                                "uncompressed-sha256": "f6d6271b335a6494b9ef42c0511d4066d989c0a48033a72900d2a522d9ec7bf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "60fd44183a8ba16dbeadb8553bcf7cbf5c250f1167b1c6e8a68029757ed04d37",
+                                "uncompressed-sha256": "5e288821bd995bca7518ead7dd91166b3641bd757b4b9c27a9e5cea31bb0855d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/ppc64le/fedora-coreos-40.20240808.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "30f476e597d518b96eb65570cb52f6ad7030c56fa28959cd6c3e944ca1349ab9",
-                                "uncompressed-sha256": "b01e9d808abaf3155ae43be2f9f0202ffee2f86e73083476a6a701e412b263a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b76c9240e51b65ddcb4118791dda16d2e20b6791aada890c8f1bff351680bd47",
+                                "uncompressed-sha256": "abd84a395f7dafaccda9248f17f70b76b0c6889917b652e19b67809c3b8ef08a"
                             }
                         }
                     }
@@ -365,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "941e51a78640340a21413ef05d42975507f8cc87de89d53f33bca85a6be3c734",
-                                "uncompressed-sha256": "aef42eecd9cb084c078023f26eee10debde0442046a6809fb09d4bfa9ef1933f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "eb3ea91be9f7f77b0b7eaa4597f027355b7046807ec1abfc7ae5bcef9fa1a247",
+                                "uncompressed-sha256": "6057e96624a3143520a2f35fda1e951ec9438f62c1cd4320eec4329293cf80cd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "aea8a38c49817dfabcd6efc681434e30707363ecf8b61a3642713f25acedbb78",
-                                "uncompressed-sha256": "8c8dad09ad391d832a0ee2270875bc6fd9ad323fed995da5af7dd74a312636b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7e7ad84bcd0694decf31e2d8a0383529f51cb3dd77838137a61d78a5c1ff4ca4",
+                                "uncompressed-sha256": "66606714511926ad0a61f1a9b2fb0e2a7f449b32da4ae3c91a989f409d174243"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live.s390x.iso.sig",
-                                "sha256": "d4267f9ed99d71fdc8adba84018ac4d528ae1079c01c8d86a5bf73c121d976f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live.s390x.iso.sig",
+                                "sha256": "2b0983775fb53ee1e2d8e36217abd161334a90d3f834586ce687f57729f862e2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-kernel-s390x.sig",
-                                "sha256": "cd0ccb133703f0b51afea4a2bb0c1e76111a442745137e866f0945f808191a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-kernel-s390x.sig",
+                                "sha256": "c3c314b436e4e93d8f96c773189fff652fabd9145f34f9eef851e65754e0461d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "e0eb5b9f4bf9fec51c1379b4d5c03691d5a9cda943afc652a9a42b8801113a69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8c659355b6c61773cd876c1076e6593eea62296969ca96e7d3d9f28ace50c4e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "77c8d315def8b8446d10c53c2294c8784d924ae0c5bfe65dd1cb0d3e7b1b763a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "15aef58ca43920bc6cb9e9ea09829980df80d865621865994ef34519365fe73c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d40ea9a950c2d80117c05b751a6cd3135dced74e2a6cd5d0cabee13998112f5a",
-                                "uncompressed-sha256": "5642f8b4d3bc0af7c242261412040ab1429f4378e686b587d918f9d0f9d7b2a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "dc46fc217d69b0635d7130cdd8a4f4c0ed8f19501112a41a26edf29560501e10",
+                                "uncompressed-sha256": "164389632daddae1a9aa2e35524a8740d039797f7905ca445e98e84c433eb430"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "4874cd017914ebc8466b01502bec801b55b5f44c7344894ac66f3f6c244cc1b3",
-                                "uncompressed-sha256": "9d8b59da2729a3b9f03b49086585821325008b73c47ac4fb8bbe91e3205f36c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "de28a6737b0c0b99967f1e659b0ffd54954e9f750a0a9dc28a0f714fc998e10c",
+                                "uncompressed-sha256": "43254d165c5cd981ed8044bb16b6f6a700144afba967985ec63d1ed483a970a1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/s390x/fedora-coreos-40.20240808.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3044309acc991a48bb8192b6effde193b1837e57fd48eaafa2b2198daab006d2",
-                                "uncompressed-sha256": "482e0c2ec60888722d2b195b9c0aceebc0da8abdd11b6258adde6eedc95c8ebc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "352c02d833ca848244bc2b4154ee6994dd9c4b35e0de24cea89e2093017ec83a",
+                                "uncompressed-sha256": "741f397c177d85e790ba45fa1772baedc419347528f1b275c65b9a43f18c7aef"
                             }
                         }
                     }
@@ -454,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5606b33b4687baaf8ade31b77d2cbe191f8a624239e453bf3fccd098ded9169c",
-                                "uncompressed-sha256": "95e42181e7d08b3e05e40c5fa9284c1c74d950c8bfc6250079958452afb5b300"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "06be8919dae6f9658d698f23e64108321c780ba5c56653628b5a893fd0851333",
+                                "uncompressed-sha256": "1c85c65e1f8bd7a7e8d960500128bfffdb64b68cbd3340fc4959a85695975fa4"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "7da4df0a83e4880f21cc30782966917103ca2b51a78f959f4acab8e2b9ed799a",
-                                "uncompressed-sha256": "2fe6abe2ca6a629a1100de372ab730d040986286f38d37f3044033c47108cb43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "a13a9c358eb0fb547487fb046a45efd7256514a72d4b77db07dcdaf7f6f285d0",
+                                "uncompressed-sha256": "1968d7fdcbb1d10665363ac2b032a0d32bde03ac4287f28cadd870e074f2285c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4ddfa2aaa6aa623798c69b3772788de64005d33f9840b3072efe9e24af4f30e4",
-                                "uncompressed-sha256": "3a4dff25d12702f6d3813c2f822f0df0e402d0cb0e0714c516c0db8f9fb2f02d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1dd3a5b5e912b2621aa2f8318bf4944b894db65ea6228cdc3a8369ae5fec48f4",
+                                "uncompressed-sha256": "7717529b52deff766686f45b35f208c028cf24add1ee43e7e56bbaca07d831b0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "62174ef36de9110bdeefd80675b4dc54d729d0ec82620b02cc28b8b56f49a301",
-                                "uncompressed-sha256": "bb8e8ad6f8ae6f10d70cb92b698e828f0e42985ba2e748cbdaf1252edaa31a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1d16208c499288fd23b89658ddad19f86bdba0c99ca6810ab2c25b5595726e38",
+                                "uncompressed-sha256": "a975bdf6e06904c2d73449d3a91296e7217a2354bbbf3002bd162e09c2d3a185"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a0dd1a4b8e81cd352775f447e9c61b5d3f5396d5a22f6ba5893a6c7ee3196068",
-                                "uncompressed-sha256": "70b79613f0133fb10daa4fba08ba30eada9024b50f7df0a29a74569b4e99354d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a700fabcac5905c41ba3e1ce4128174c8a650ad23ecc8a58cc44f0aa7c2ec9c3",
+                                "uncompressed-sha256": "252463bb848719e8d77016b0b564378a48feca3b621110eaa91e31553f0ba317"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1b0a16945b2a0166a9a7c289d216aba2cc1239e120ff3adb86b50ab355c7fbf3",
-                                "uncompressed-sha256": "151caa0f99140ab0b27288b2e0e7743511dcfc22c5482c1a44e0e90a0076fbf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "81b25a803181620eeb6f10fe13aaa4b13c135728457b85e64f956a108ab9e646",
+                                "uncompressed-sha256": "ef11f7f26c10af13cd250a543a65916d97f4df467748ec96204b15a91f78c424"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6c2300368880814068777d5a0ef33bc44a734dcbff1eebc20a0b989c2151007d",
-                                "uncompressed-sha256": "bb00774d310cfe5c82feca3a82d284ac399c4882b7dee1867851c490be33eaf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "30738ccac1cb39824601ca68cd8a04c1af2e89c70415aa9be3f64d4c7bca1c91",
+                                "uncompressed-sha256": "f5c17e74db86473b34b6788c07c4b550115fb73385f984a0c75aec0e35eb3aec"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "57c117ad77b091da13fa7af9c24427939c409b5823ea6a90abf45040c8c397b1",
-                                "uncompressed-sha256": "22e67881971c890780046ed2b02871c26dcdeca8947d39db2b9a4b58032532dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f3b9afa66a173c4f9583a128e6d4c0dab19977cfa1bf4b7a835270b344bcc5a8",
+                                "uncompressed-sha256": "b5ff686c04a55872a4127588a1a056270acbad28181a12d8c30fdc74757dfb63"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "c068ab71738f2cb855fef0cb3a932f2108c2becaa25621032ec5c375b99cfb24",
-                                "uncompressed-sha256": "d6b86b2dbcd86ca1f4805628fc37f5d00ef067362ffb8bb7f131f52ff78d30b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2a6d7496bd473fad54eb0ffb24ff078aa718de38a4b61d57bc70326a4f71a059",
+                                "uncompressed-sha256": "e1f0a31bcd6350975cd195d41e692d9ffc38be00a4e5349224724817840d6da6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "46fb973e324c3f7dae74155e8f2cd9e7171715edeb010cdcf4117829a86b537c",
-                                "uncompressed-sha256": "0e081d291862ce3e84a18a49cf77893dfb7bf6ca290b0399120c45c6fa771924"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3143d72391c8d81f6cd486f678449debe5a291a89f41cd5644c45b01888d38c6",
+                                "uncompressed-sha256": "1e460c825f0b2283a9507c4a0ecd40c7d56677800f3ea389cc538542899e793c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b81a8c16471c72abf60e7fa66fe69e482db6f0effa4c1b27e6f62707ee04f9cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ea37b90205629731110a6e1489c398166d62a6369b287ebf02b1efba11218283"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0068a4774c3a25a41cc90c9e7edaee994aa69a851252bd9a9c070d0780780efb",
-                                "uncompressed-sha256": "ff994ceff1281133c460933a96e86deb5798414c722060aa3b3b3f1b506824f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "251ccd7cef0f08da133792f3b181ba39e3233e62886692a252b9504f97c2198e",
+                                "uncompressed-sha256": "6671d44a5c651f72d2bb117d1eec42edac6baee6346ae7366e5654d0cae04fa6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live.x86_64.iso.sig",
-                                "sha256": "7cf84e0e4de57b7a43169318288725b277be803baf48f37085db3d6960c1759f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live.x86_64.iso.sig",
+                                "sha256": "12f1f5c6fa80871129ca748f83699b1ccef5fb482bb4de8b66223749c1079c4b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-kernel-x86_64.sig",
-                                "sha256": "36eac90bbc9b6c594515fa36e2dfd4e15b769bbb5015f3b024d7bde4c4f50abf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-kernel-x86_64.sig",
+                                "sha256": "241a166c730747365b85b5f391f15a5f8325242b79f52cb39c943ae9665f7a02"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3600e5f79d0ecd85f0809094e9443166e1599f86924781583a15060ba58840bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "85e85db81190303e7624b617f188d4808ad4a7768708aa74e819b9c89c9ff5f7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "25f6dfd17195ebe204fcecac4abf3af4b1e72a025d29f9d64f0483bdb088a203"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "fc3e851994f063b40c889c3ab49aa809ee9e9dd7c222aadd83cb33be6d4bb0b1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a8956b340af03d54664b022f2c994bbc7d82e352aa1b9300d9831344a4aed08e",
-                                "uncompressed-sha256": "ed86f37ff91e7b5f833b9dd972dddd415a25d6141acc56346dd360b8e524a19f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "11a7ff17a3fa4b38891e0129504920ba1f3df7af91ab18f4958fe0aafdf2d2da",
+                                "uncompressed-sha256": "5a9ba8bf73687e400078a8bcad989e33fcb448fa1cd90ec842ff46b450ab1b23"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f6c8be3dbcc8ab4fff87656eac6d30058802e5dcd9ab73380b355678aabb57ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ec0370ea3473d26ae80f256745a0b13ad577c2c9356533e00e07c41fcb0be3ca"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7ef1a1fb3e0fc320ff2bb7791b08d9412ec04e79c5e057d03570bca00569eef9",
-                                "uncompressed-sha256": "ec6e58a53e0f27e12cefcf8a55bc4241568621290821b81c6961c6607e1b96c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8d288560cf9b6d06e8249e28c5823194ce9a696beca6e59d2a435184f58e3d4b",
+                                "uncompressed-sha256": "07e641c560da8a9d7ed637fda41c9802ffd16edb985451927c03aa91659431a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d201818cb45058d6e54de057ec82d042bc99769eeb6ab13614ebcf9a180a2a10",
-                                "uncompressed-sha256": "5cbcb4ff26dd48c92e8a395803391ab91aadf487463560cc611508c69d29f3d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "41b9596ab25ced5a248ce1d9110bd743425972cd63e590683be2c6ed9730c3f2",
+                                "uncompressed-sha256": "9498acbaf0f6ffc4daf3a0fae6ec58ebe767dda5515b05e29a63fe974801ecd9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "da5073de02a4dfadf2fb23ef88c1fbb2f6a949976d1fba17d8b63d7a15922aef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "1cf90cc82ba5cc28d74f590d957ebe17cc3a3cfce28a11e806b319d63367a602"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "d11bcbb035d2f8e7e888718c3b3ec1cc8f825a39ab602b714ccf6969698cb337"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "e8a56b2dbbdef19855e6ddb0a5ce5566ec9f18958fc73e28c88b6aac0f424f07"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240808.1.0/x86_64/fedora-coreos-40.20240808.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "430bf3ba5fd7e5cd573102f323d1483f1ba81a37e7c6d4a88b85b03576f9ca63",
-                                "uncompressed-sha256": "4bf7e48b44284274ee57bb2980513982662b3bdbac8b2c270172ff066f5e2004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8fafc664fc0a12de26f6546b7efcc7056867cb0d01e5b6752a788fe8f7bed51f",
+                                "uncompressed-sha256": "31c1ee5cfaff2edcf47ec3cfcc6983d25b66f4901b933d2c6bc9f943b8d2aca6"
                             }
                         }
                     }
@@ -720,133 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0c37351545a26e594"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0adea858a2c111a44"
                         },
                         "ap-east-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0332889c59b90caaa"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-02a9f70d24fd3b218"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-06e9287962afc82a0"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0d793202a568e2a3f"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0726ed173c506c08a"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-08e583f3b1c97ffad"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-02c38d4417da699e8"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0d73a4a70a840fadb"
                         },
                         "ap-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-07e5f83bc2ef7880b"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-02fa215c3d01823ae"
                         },
                         "ap-south-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0febe6d1898204d4b"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-00cda3fabbedb1f28"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0af42c45a75efea40"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-08b54c0c0b7e471bb"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-09086704ec19d6504"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0ef543b68319853dc"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0c6d895d10f992f66"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-07bacecd4bde9a4a8"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-021f7ce1437df79ef"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0b04eb41eb2135e4b"
+                        },
+                        "ap-southeast-5": {
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0aae7baeb2ee45bb1"
                         },
                         "ca-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0d9418e82af2dae52"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0b0a032eba72aaaac"
                         },
                         "ca-west-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0fbdc3e069f98493b"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-079424ecd8a18088b"
                         },
                         "eu-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-04e39fc3020dbf1d0"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0af4145d2e6cb7571"
                         },
                         "eu-central-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-00df9bacde3994e71"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0850913bd01bdc874"
                         },
                         "eu-north-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-02baab6f9ec90f7be"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0455f6a9452ccd0cf"
                         },
                         "eu-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0c66af539926177fa"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-009bb3ed8e6cd6075"
                         },
                         "eu-south-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-06651947a1ea798de"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-05256832a2a7552aa"
                         },
                         "eu-west-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-00318732602461031"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-05a281cad4c6bcca1"
                         },
                         "eu-west-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0c1d66e80ce47c5b4"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-07016fcbceeaab6b5"
                         },
                         "eu-west-3": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-043ee58a85e625876"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0e3c2a7c5b03744e6"
                         },
                         "il-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-01a2c3de209e4b229"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0e2fa556cba73c8e4"
                         },
                         "me-central-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0612aa2614ee64565"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-004653d4a3ed4f46a"
                         },
                         "me-south-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-08f58076f39bbecf7"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0fc1b03ffd6c676cc"
                         },
                         "sa-east-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-05b73d9b7e0fbc948"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-05f7104411f02eae3"
                         },
                         "us-east-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-06aab3ef1aa8b3c91"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-05175de406a27d1e9"
                         },
                         "us-east-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-0c9b5cd2edc926e6f"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-06d54e89a0b4411bb"
                         },
                         "us-west-1": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-09b33548d49bce164"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-0de864de8adf247f1"
                         },
                         "us-west-2": {
-                            "release": "40.20240808.1.0",
-                            "image": "ami-08360e076590d2795"
+                            "release": "40.20240825.1.0",
+                            "image": "ami-01d150bf191b6c78c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240808-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240825-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240808.1.0",
+                    "release": "40.20240825.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c5fc15906df2f41e3c169b2ea0ff6d373292c46e25d597c585cb0cbf6e4990cc"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:89f351c7ff1282f1a3ee29faffdb38a425bec034bb9c6400139ce25f6786b7ce"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-08-15T00:33:25Z",
+        "last-modified": "2024-08-28T20:38:58Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "0e35754f66640550a1b6da0aec01c6d8c2bf73d44097a01b861d686049e7ff4a",
-                                "uncompressed-sha256": "6cdd43be7c1cad47d7160aa8d9f186580c2e88bf9d2a84cd6f15282b706da377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "da315071b32ee882b3f12bd2176757f065bcab8b3a746f746023c6a68c5a7185",
+                                "uncompressed-sha256": "254f427ff7fe6ff0e584e14907e87d3e05e4b90a0a6e097349502dbc2861a62b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "f68fa565dfd17998bc53b986e11471264b0b28e964c27d4d769d0dbd12a1806d",
-                                "uncompressed-sha256": "f95300ed918d3f8f29ad666ce6e5fb8b3ddcf786122408520f0159fd5d6c89f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "318afe72a8e8e50cfd047d80087c9092ec6d38f3b91cbc177d7f615cbcddaf97",
+                                "uncompressed-sha256": "814356b034a25359a7775132b9c8cab51c248e5d121faf4383c9cf723232385b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2f07c080c3a5658850ec788f497ff496f995e3d111a453d00b56f861da1481e6",
-                                "uncompressed-sha256": "5618a10359bae6359dc5a10e9fc7025417c2698a6aca2ec2efe286cfc7c43f5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "43880d7f4af97c2cfb5f805d825eaef3bc8b5db2a30e5375938b5e01d5fb5df5",
+                                "uncompressed-sha256": "81ae85d095992297f4ec859f6e1f00b765522142d1f2f10d91b98d8d462f43ac"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ad444a500954a89672d8b74994d2f8241c8550717fdd7a8c743cfba7b71a2e6c",
-                                "uncompressed-sha256": "9247075d0a75de0c83fe3c8dc8b33b75c4ac4c87e363a98069b92f8cc8a284b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "4b1861abfb0a9e7826efaf5f70dcbf36574b45ee8eb5ffa8e777144fdb778dc5",
+                                "uncompressed-sha256": "e180e3b8441e945ed5a04b2ae33d9b48062a718c9f08d98572386e5e8f7b94ac"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "0bfd91d9203b392c3908044e78b15cef1b406a759636487670b227b543e43b90",
-                                "uncompressed-sha256": "387ad5803db16700b24e171850b88d31407634b849322cb338d9486636c740f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "23fd0397069ece08787baae003e8aaecf16989d6e3fa930b734fa4ef5ebb3887",
+                                "uncompressed-sha256": "ab83b6b6c67506fed6711244b9704e50846d9dccfdb070c34cc71dd79f88a54f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "45213a80e5d637516c11adbd11d573ddf89fb64528c91d6ea50470cd7f09e554",
-                                "uncompressed-sha256": "d99917c1733f4ef9a17150ca86f45513a3e74007ef5e21c28f7ee0cd7e569383"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6e17b3c1416be05b3a58a67d2eb38bedc0a4f3337949152ae5b8b868892ef6e3",
+                                "uncompressed-sha256": "465ebd084cc29b479925236213fe3ac1d05223ccb15993afd4e598564a45c9d3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live.aarch64.iso.sig",
-                                "sha256": "01c4d1718f985fbb1c66ab7970bf1ab573f6a7273767186ad9952d5b2be63eb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live.aarch64.iso.sig",
+                                "sha256": "23f4c3e9cca747088c1dd8db84c4bfb93a9e74e364d36a7bc7847b9025109471"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-kernel-aarch64.sig",
-                                "sha256": "c346e94ccbbdce6450144add99eabf90f14b20176a6e401a912b642d6ef702af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-kernel-aarch64.sig",
+                                "sha256": "cb0b0862cd36bb3accca36434076086a1a72059498c1fd320361c08d8255c7dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a7967f95108846a5cd0159c045d2a562ad4a3715fcbaed153e50090549601065"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d03f6dd23a7ced520b9b04f727fc48536373c0e8d4c3c989ee734fa6c706d415"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0fffad80d9717deb323c74ce8caa39d50826a5943c02bd2213bda9cbad9e7ab1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "31bcd0fa98456745141c2dd419e08c151898d685de5bfcdcf3d02552289e9656"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c9f3b25df7ba8b62e5da7f1ede1f58c1db1be9b18eecb014e88a687dd9c26ecb",
-                                "uncompressed-sha256": "8d89fc7d202437f8d8b168a2720a61c5bfa602464e4263364217497bd48f51e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2a4874322f83b174fa45ddc06bc8113cec3b696b04f6e511cff744884c7e8258",
+                                "uncompressed-sha256": "eb40d9aa4bbc7bb4569f185c7234eb696e4c58f7c9a07f5bea2a20389ddf8618"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7580b7fae27f532178459c45945064961aba7cdde34417a490a626bed9113a4b",
-                                "uncompressed-sha256": "fd3a9a13d055e153bcf7f60c1274a83c34e8bb5d6f13f1d168dbd2b8e69eba78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3e0bb53471951f51da0066c2d0d68a61404b688ec6961a618769377cb17646a1",
+                                "uncompressed-sha256": "cc816c6a61e8dac9064fedd22d97282f284e1def5404b696c23d5c045d15c48e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/aarch64/fedora-coreos-40.20240728.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a1d5ffa57f9ec42b2a4f21241b0b90df03b6c4775e901f47f1c11ab5c8f07f0e",
-                                "uncompressed-sha256": "277cc039fdf9ef9b600b88c11eed5f47c47c2993e4229cd0945e092aaffa605f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d426264e8c8b10365184a33614f039e5f88380303f0c48f6106c53b735e2cf2b",
+                                "uncompressed-sha256": "1e67c8baddb5b27977c5750e8274c1f2846ee5e756b60db5108e4a66195b22bf"
                             }
                         }
                     }
@@ -148,213 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-00e18d1612ffc0f5a"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-00158c832e2c4401c"
                         },
                         "ap-east-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0a1a581a4889284ce"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0256498dd4f8c8b95"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-095ccc03ed2a0dce8"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0a9262679181ea8d0"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0a48e1638039e4b68"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-07605e1cae40052c3"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-076c6eafc9f6419af"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0c5b2cd525d1d9a15"
                         },
                         "ap-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0fc8f8674953000b4"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-087b0f89679585852"
                         },
                         "ap-south-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-00ad976f18b539949"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-061f2c213967e311b"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-02e5737d17860020e"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0c1485d59c76cff77"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-03abfce59be44f244"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-08d6cf9a6077f7c0f"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-090210632cbbc7c66"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-04821c8b83c2248d5"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-02005c035657d3e8b"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-05c43327a16167731"
+                        },
+                        "ap-southeast-5": {
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0e91b8ece2b5077fe"
                         },
                         "ca-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-03e0f32467190a1a9"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-03c0332bfbee2948f"
                         },
                         "ca-west-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0a4d3507d31e97af2"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0317df7fced4187fa"
                         },
                         "eu-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-05e32a7ce89ccc2b7"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-04cea1c1942423800"
                         },
                         "eu-central-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0bbe7ba8581d741e2"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0d355a4a20f85fc55"
                         },
                         "eu-north-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-058d4c1dba2c0f594"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0dd5b03978e3f5d4c"
                         },
                         "eu-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-06d8df1b290b5aaa6"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0dc239cdb014526ed"
                         },
                         "eu-south-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0e0290a470f7da2ed"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0e8ee23cad93108c7"
                         },
                         "eu-west-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0a68466a361749c40"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0a98bead057df4d5c"
                         },
                         "eu-west-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-07e401fe7197bedac"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-052941468e27755a1"
                         },
                         "eu-west-3": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-08637403f5dcf3de3"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0bd091956b6667d5e"
                         },
                         "il-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-01a3cc89dcd134221"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0d5c79ac7da470045"
                         },
                         "me-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-09ba995a64d136463"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0ad529ea5b631cdf6"
                         },
                         "me-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0a13553519512ab83"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-01ab80fb97e379c6c"
                         },
                         "sa-east-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-07f4f42860083a84b"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-03a0d48cdaa345dc1"
                         },
                         "us-east-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-027746658553ff214"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-06d09490c12433148"
                         },
                         "us-east-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-094c56731598618c3"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-096f3633970cb2e2e"
                         },
                         "us-west-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0b77a08c72e342e88"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0f0d14583c9548910"
                         },
                         "us-west-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0db87bed84d360095"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-090bddf91a0f94ee6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240728-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240808-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "d8007a032be150471990f73afb2174c4ceae5411d77d96252e876d0d46734d95",
-                                "uncompressed-sha256": "69ddc6cff844d36b5c47bcf039640fd958c6631d175258e2061d1aaee524440e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "72d1dbbd6cb5e33c24c24a21d45c46faeafbc915147d729ed4058e8dcfcbb395",
+                                "uncompressed-sha256": "c89ef7bda91bf088fee5e7a3fef3a2cedc2e3e234881de26959fc48579557041"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live.ppc64le.iso.sig",
-                                "sha256": "132cf748130e29806262398ac68454a2224840ee1ce0501ab1d2bf053a655685"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live.ppc64le.iso.sig",
+                                "sha256": "12a4f18b4f88580e5524b8be119b246c145f212baf7d0777c1b8560afdf29097"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "b9f76fc0668f1d6919f8691b9fc6bf0daf4d4f562229d40150fbcdad92cbfd62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "c9e2f1cb0a59a1d1b74e256e4f74078eb099e998df7c48b2e15cefc63944f92a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "38ef2de6454c5884343146dc400d8a7ec66ccf68c4b955ed4c797d4a4c69c993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b283a26cd7861e990b7bc5a6bee4e62b1f85b2d888c16117f72c4da9f3e45885"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d7afb05bc19278113cff9adcc70194ec31f45e5ae7aa506e9537b50a7e5a520e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "108b63ea55548c91146750bbc1c5c49bce4e1fa22e9019d2f72f74cffca4eac6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "c00585f48b920ebaeb870413d22eeea854217942cfcfdbec3390db572c989bbc",
-                                "uncompressed-sha256": "b0103cc13903a549a790b553765df5eadadb58a221370fd8312a859b017b2399"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "64dfcd13b5f42b2ee6e595b59f321eec3357e0e2f1d429cf839103707e60880e",
+                                "uncompressed-sha256": "cc57f147ef80b43804af8a64cccd7189b4eeceb4161715ff7cd1de063841bf48"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9a84bbbca1068732f8cff39df771a314aa1ea995e66811c3c510f58988d14aee",
-                                "uncompressed-sha256": "663575f39f573cc84c4754912343f839ea5c7776ca16c1262640ce8d5d14391a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "25d181233cf5828202babac5369ee44e99c3de04396354f411fd5859dfeb482e",
+                                "uncompressed-sha256": "ca69f8874daabf0bc96e86fc6a34ac4512e437c7c0248a4ed2cd29c50017c204"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5542688c9c967ef081ee15b3496ae1e1d93d5c42a42681d183047563cc2838a4",
-                                "uncompressed-sha256": "eaafb028f734b95e585eaef0a4296372f689153b2a8236ae94136f52446e3c2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "4032e55ad1ab944361018009bdf8399ee92e11875c9b318f5900218f42c8b1ee",
+                                "uncompressed-sha256": "a5398cd3315d171c81163032083a61367eb4469aa3c758452c1c42bee029cfe2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/ppc64le/fedora-coreos-40.20240728.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e23c01b5c13e07ccf7707d07ca5ff52c5ad436ea1081222627163b36e9c66fdf",
-                                "uncompressed-sha256": "ecb4548f9e481ba3cb0e7c0c2a80be13d2294bf561b16a1b502578b8d003d463"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b8d0a781eda93716cfb4772ddb9567dff8d424cbc530722434ea1a5a7657ae2c",
+                                "uncompressed-sha256": "95e6d7d25c7c6cff4d91b0e1e1c065d597b6d6e03b4e571cf76e9ce451f12727"
                             }
                         }
                     }
@@ -365,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "30fd2960fc5971225b396ad41714d8e237a27098670f80a7d97b9ce2898d5408",
-                                "uncompressed-sha256": "b8924588c4bb2882f9205404ae4923fa4ed86c980c69bb6dc2e839103c002ceb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "76db78cffdc7f757ebdca71f0d1d026c67523ce878ddd0de48d09c6598a3cc6a",
+                                "uncompressed-sha256": "158c82089cea6b5000f7b0384d12c14cddb1686ed2e60d61433adfd07ae04dca"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7dc2739f9a24ebb490d2f267b8b0080900022a2d30ace6a4b4a3a73657464da5",
-                                "uncompressed-sha256": "684fca3f972d2841786c73999b35d156c2d2ea120ca7521143c9d50c65cf7cad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "dfafc7a00987b6522099a737f7c8c8a9588212ed60c8ef6a43f89ba50e08e1c9",
+                                "uncompressed-sha256": "6d71b66471ae18b14f0d7972aa909159cc4f0f1fc617ca5ace16c37d48ad9f49"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live.s390x.iso.sig",
-                                "sha256": "a966bb5a84b771784da9036e95554604cb93d30ce9d3866c62d84c6310aa38cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live.s390x.iso.sig",
+                                "sha256": "8b65ef626a95ab66c8a2c0b8dd22a2ab6efff7eca6880c35465c842c60dd6e6c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-kernel-s390x.sig",
-                                "sha256": "41173681081a1d01c78df1a4f60e8480b0d0485cb7c49163154096dfc05f47ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-kernel-s390x.sig",
+                                "sha256": "cd0ccb133703f0b51afea4a2bb0c1e76111a442745137e866f0945f808191a7f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "21a4c0f928a69b45e6f72901eb9a3ae12f2c4dab1aa54af6d093e184bfe22b8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "1a26f4eb46c994350573bda051e7fba0000cb5c1d9cec2a69ca7b3f35e3d6df8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "38d49662971a1d773d80e95168fec81c6ddeb683933937bfe6f06e9a3d9027e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b3831e79f738f913eb98739153321c181b1ffe19ee97a2e85460813f4e550b7a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "16cf2646ea7f7cceb08743c5e2ba42f243418062dd2e77155310fe2d0fcdafd4",
-                                "uncompressed-sha256": "3ba191d6f897465dadff939fda283a225995cbb900a5af5f430a0155dffa5461"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "bf9cdecac02f9e5c1e9edca7a8a8ca6b8f64b7cf45440ee41a85031a005e5001",
+                                "uncompressed-sha256": "4e767562ab2bf5f4fe49a4a1ac1f101419b6436ab134da36e5546de74f75682e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5bc1dc1b56258ffca88c20276c124542645aa9a1099138d9b9d16091f947c12b",
-                                "uncompressed-sha256": "2334140e31672752ca8ade28823908915e493a98271fd9f5ddc86b4a57a185da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c18eb2fb07256a804cc3d499b33f42285e730995b75851f0094e197cef60dfbf",
+                                "uncompressed-sha256": "4cc8922b80fc001f6db984288afdbf8fda8e52fd121c6e67a11c4300d8b617a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/s390x/fedora-coreos-40.20240728.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "fe0df1ac6d2c719ef29933402514bf44bdb856e1e0797fa8b092de6da5d7d5e2",
-                                "uncompressed-sha256": "b8eb9beb6bc4d50d9a3a7ae097512869b024f3a3211d2512b997ddb331a6e1ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ae4ea22c52edb14471a1fe89befd07626234f9191de41039ec4220d152deae15",
+                                "uncompressed-sha256": "faa160c7b08517b9fcde0b2bb3ebfffa938d767ddf05371ea6eaf877d48afeb8"
                             }
                         }
                     }
@@ -454,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4b9f2a0eb7ec99854c96708e1d0c115cc4bf2ec102e185a08e5e3f2b8205102b",
-                                "uncompressed-sha256": "a83813ffd7fa02f450a9a21d9eaaed4425d8a473a1068c309020c1000dfffcb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "df4c6dfd92aa3376c02c1f455358175ab6c4ee59be61a69e16414be309fd7d9b",
+                                "uncompressed-sha256": "8d140804db226bd51360d43b0d7980705da44f7ddc5556b644eca35a786f02ef"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ed699e28296c418cad81874003ceee03e858ce23f043067a734439e8056d0ded",
-                                "uncompressed-sha256": "85999eadfd8a4c9a8cdc1812f60d4d25af1f35b3902876d26d9fef95c4df64d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "dd0e8b5348c907ee42a40762caabf0e220e0ae23718289f4f6c21b0cadf280d2",
+                                "uncompressed-sha256": "4807aaa63b92cd21a4c516a8bebe9d44ee8d7a56f4c1d3b172e26b959ce98915"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0d239b2a85beb52b4c3a0519406ae284fce169576878ca86606cea9ce023d628",
-                                "uncompressed-sha256": "7ff73a5d55bb4c4d4e124fb56d73c0b71901ffa0de7fcec7fab50f448e0bc380"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a852e689259ffc9f56abf3510adbe8240492a2df35164d4dde2cfcd987a9ab15",
+                                "uncompressed-sha256": "95b4c89bf01da947409742fd98f7d27254b74e001649acfdb57f44a3f017771b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9c9f238e2ac3ee01fbdbacf16f1aaa02973ebba9958fddafa7bb0c594507682f",
-                                "uncompressed-sha256": "d2833f9a255f989dc0094ca0dc6eccb6a7c20f8ce2b0cb6b6bd8e43cb5b2c452"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4487fd6b81ea8be138a9109a959bdacfc506ed76ede75b918aeb1b0c7ef9499f",
+                                "uncompressed-sha256": "3b7bbe70b0d006315fe0c32d6ab82aa8beb8cd62763e7ac56e2e894fa7f0c01d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "120a9cca1b9755d555ed630069a137af5045fe0ce1d351a497cd7894741fac95",
-                                "uncompressed-sha256": "b11064ad6b61996d0612b700723dc548ee48d8dc319a3c74b54a03f1ea7f514e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "dd7e18014f9251193e4887f861a42a95864ed48f12ec1f7db703f047fbce9b2c",
+                                "uncompressed-sha256": "87bb41e365637260f96994d889e2f2469677e40597e494460f5657aabc564871"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "aa66df96b47f21316c1dbf9e7e95b608c5338afb95735c844c2536050e0e8e04",
-                                "uncompressed-sha256": "d21446fa3e8bebcc536d9cfc2367145cf09ecf009dd21f5959761892668d325f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d3e858c4882a834e6048314691034b698a54cc5eddcfb0a7ce1949209344e24e",
+                                "uncompressed-sha256": "16b3282a6b9d1064ca216610b7f17bf827a9fc1a06e1b17a9f0c57d12afea07b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8c0a6ee178961c48583aedad51b0f5ef2b10e6505a5bff00e999d43bb6a74ca8",
-                                "uncompressed-sha256": "df051fba21145c4b80d651b716b3a4be47cdb0392c91fd536a69329a4d58bc13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "83ed2bb484044be5070ee009f1fde6abe61e9f487e654021776b0ee49be58ab7",
+                                "uncompressed-sha256": "4429500e2f6d77a9cdf4ac6c397a1507a46e764c8c481d602f731ad17c6c9e48"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9551bd3c49f43dada1e6507853cd4c0a68c3d20d5e95022eaa33bf73e5aff373",
-                                "uncompressed-sha256": "dc8a47c811a09149c6b251984d854aacc270a707fe5ba6938b8d857668049a75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2ef6212f9fcfacb8a6acfe2a3726f89dc19372adc3bb891a44f385e9b28230ad",
+                                "uncompressed-sha256": "1c56018f58e0918ff0e6532fb07c7e5a63def936350deba0689ed1bc9e93c410"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "f371fa365792db9a4384d5b8b98ab34375c8b227e7e6acbdaadeb901715d6ea5",
-                                "uncompressed-sha256": "4b5c3f9a32cdbdf29a9aa4cad9eb0b026e8a2ac340058d2edbcf78600977544c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0d49dc66f7347d28fb13028c052ef219309410f3473a0f853a860929b75a8abd",
+                                "uncompressed-sha256": "505ca3c1e3ad338f7b07f2e0dbf8a4873390ce0eedca91b7ad4005e7f6480d52"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0e250845e7de92ab30335f7527dd9ea21741211c324b5daa749cb5ac088c451a",
-                                "uncompressed-sha256": "6eefb4786f5a6180d5e2c5a9ec2bd5bf03603d0d01e6201c22b7efe16a35f9af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "23b28a036e64fb98bccd4661347ed47b5635bf79c4e782d92131a351b99593db",
+                                "uncompressed-sha256": "7145e53a7ca0abbe1ba4276666fbfcf61cd4835db5abcc4c3200ac001b44a02d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "975552c7ec074e10b7c660d8775e09a952d26af72acf54b6d48bdae3e31fb57e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "be290e789ba10482fdadc06eb612edaf296e6d5449aac57334bd301e0e1ead3a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e2124402a2ba69eb4c3201240fdb99c03d34fba09017de970cda5d4a2f5ad209",
-                                "uncompressed-sha256": "ef8d1c5aaa940d245a88a0e0edce2af90b7639103e11792aec7702f83a7e78b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "83842a076c21b9f2d81d024cae35d8bf641ab19117a04eac099ffec580cbebe2",
+                                "uncompressed-sha256": "7c9593b9d735f0175be1e728800fb8fc3f76b15d5d90860d85bfb19c83bfb749"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live.x86_64.iso.sig",
-                                "sha256": "ccfb5729f6e86ed54c28884dbf1d1554305dd43040d757928204fceb1ec09be0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live.x86_64.iso.sig",
+                                "sha256": "09529395854807a38fd6720c418b80fab49e073d47acf290f677b453770bc781"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-kernel-x86_64.sig",
-                                "sha256": "559b86e867a743956204d1f17e492c3273c6ef288accf3aa0c4356e16a9aa439"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-kernel-x86_64.sig",
+                                "sha256": "36eac90bbc9b6c594515fa36e2dfd4e15b769bbb5015f3b024d7bde4c4f50abf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9e7911cd5a129f3ef83c646afd06149745ecb60ef9d8b1223fea61a5615b86b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "4280a9c2e29e9e59758709d40b17a05359802bd6b52d6286bf6fa0bac2c2aa45"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ef014785149ebf9fd88c13aa23ff24486161e422e4f702ce8a7691b569e1d117"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "556acc04b82349228b2428cd9a7a4806f9f66be151e1f413f1b75681fc8286c0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "730038d168bc942e4643e2c32e78535004d6a286ef70176c1c0f5889f12a126b",
-                                "uncompressed-sha256": "8b90e0fee8b30cb4ff6a3e54000f4cd91af31aba3837641e5141a363b1a2b1ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1f9b0cfa2a12175324b8463430c6f6f602027f121179b265a22436b861e7daff",
+                                "uncompressed-sha256": "f9f69587af33bf676bd8764fd6e78575f0ff8e83b412baf93c1a02dd15f57b9c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fa7447f846dc7dccb8881b1d52e63174a991374608be79003ed7845203e5fad0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0c0b53e8bffb9d4aee3689576a67aad82368875f770750593d4f9427bfefb0c0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c15be065adbc3fc1f3e534ee58879d2edb7055513e1bc441911f531d36bdbca5",
-                                "uncompressed-sha256": "b4f8edeb72e467d6d3524c5ae833c3cf1b96faff6ac80457d16b07bd8d97e61e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a1e9e774763456fd2cf9ac689ad86f4710b66def3e563471d6b3c902d143ebd7",
+                                "uncompressed-sha256": "d2f714e06d714f83a3f3f1af1c739c5a11d3a6a412fbf314414f32b5db9a9fac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "75ef6401fa3509999db3e48298020b2921388cb4bf043f62f531f5cd1bb052df",
-                                "uncompressed-sha256": "224a0dbb79043db73b1d1a05274085a42d6bbdc9c6714eafe641750edc6e27ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3404b874090c95fc4bc8e7661a26d491d51ba019e278cb174843b5fcda2b429c",
+                                "uncompressed-sha256": "f7cdd87266c4d9c08f18458734a5482774ddba7facad16a6ecc9dfae643126c3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "56f1994f77d2fb024379b117add74c666b3da0f9b25486bcbe837d9d63b77675"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5336a4efb06cf912a9ad9790b6eba67465d1bea46d701b26bb369df622b107c7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "09cdb878b17e8be9b6db10b07403f5c2d0312064ac75b3cc1f592a7326d1c23d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "a8e18dc16d32874d69564c20f7a16a94e8435ab779a5086730aa7e2b1fa6aaee"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240728.3.0/x86_64/fedora-coreos-40.20240728.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c087be17976926ff1a232c3997ac2b050aeec3b03f3908d795ae63d8776b97ce",
-                                "uncompressed-sha256": "1d38d0ded361e6253f57e9d6285fa35783c5a5b488c75f185d8df3bdedb123cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9cdac4f1efd5a4d7f23941573ea10d9c1d01c21ca3c9684ad3123c5b11522d82",
+                                "uncompressed-sha256": "b33319603fe8fae893b103779c7f49f54cfa7d8f5de58b8c19420b905cf007a3"
                             }
                         }
                     }
@@ -720,133 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-05c6bb254507c43cc"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-032561396a0f33eb5"
                         },
                         "ap-east-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-042f13df88f3d7ac0"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0b5489977772628d3"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-027e66de13705c799"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-089f993432a8ef9a7"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0df0fd9bfbb806bff"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-05e883b5c299d597f"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-03cb0c294b782b36c"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0066545fc60815a0a"
                         },
                         "ap-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-041fa0f53688cdb70"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-01993f2db485c4e3b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-07a48583a85680dbc"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0708cb1783b07de29"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0e229135699755b96"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0b91b5465d06dcfcc"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-00ccc5c0f223f9c36"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0d32b3efba94bf5f7"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0b66025ed56725949"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0f24efc55769cb2d7"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0d6eccdd0d837e91b"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0ba0e6dc3ac181d5c"
+                        },
+                        "ap-southeast-5": {
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0880473596aeba8c6"
                         },
                         "ca-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0c69949cd7033aa27"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0014c37871214c46a"
                         },
                         "ca-west-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0f159092e6c9aae95"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-095ca4651b27479f8"
                         },
                         "eu-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0818d11fe91521f88"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-01e740ca2bf2cb17e"
                         },
                         "eu-central-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0ea44594da95d080f"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-047ffb9fb997fd9b1"
                         },
                         "eu-north-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-00f9e0f85f3b48966"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-07d4c5e00d828fa73"
                         },
                         "eu-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-00f14d4a88fb40494"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0f58a0677a73150e2"
                         },
                         "eu-south-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-05b4548551fee760b"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-06ef1cf8293cdc2f8"
                         },
                         "eu-west-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-09a64a7f5429b4f9e"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-07648f553708a8d4a"
                         },
                         "eu-west-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-043dc6dbfd3df3cfc"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-057d43873ae066064"
                         },
                         "eu-west-3": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0efa1a4515fb346c3"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-08f514f9a9d3357f1"
                         },
                         "il-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-03c024974e531c89a"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0219e31a8cb9bef39"
                         },
                         "me-central-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0e75df18492801651"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0ef3bc454caf77f9c"
                         },
                         "me-south-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0f574903f37448354"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0afcf731348464e4b"
                         },
                         "sa-east-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-072ce7c2f0da61e4d"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-03a440141d47ec2a8"
                         },
                         "us-east-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-03f543464cf460674"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-084d189f8811844c4"
                         },
                         "us-east-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0191ee134962b0906"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-0cb8768900dd576e4"
                         },
                         "us-west-1": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0ee2ae1570d15ed19"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-03530adbc1e7d3bcc"
                         },
                         "us-west-2": {
-                            "release": "40.20240728.3.0",
-                            "image": "ami-0d775ffee25006fff"
+                            "release": "40.20240808.3.0",
+                            "image": "ami-06b7f026f48cd3c6b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240728-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240808-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240728.3.0",
+                    "release": "40.20240808.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fb4c720d15bbe5023899da388a608cd7a290db4bc5e6d412c6023e3f00302e78"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8696c82174ee0ae9919371dd4c88138e3febe064c9bda2434ffec9e053ba0a44"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-08-15T00:33:27Z",
+        "last-modified": "2024-08-28T20:39:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "31d529369b586f2ae252c30210c72a50db46a5211c6e7b10fe829738afe015d8",
-                                "uncompressed-sha256": "6e7d86672e38d4abc8a20dc0e0ab1ce9b49ae74a6eda3efcddde0b488f51772f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d180f1ebf182358635f999f3532c0e086949a1e8d1e01a874650be876018791d",
+                                "uncompressed-sha256": "e97e203b81d17366b5624b6b67c40bdb7c824187e35b8c099a5bb1dc5e9bfd8d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a00b7f314223af92e24074b4bdf0406deb93645c7c18c47f5612383c68909d2e",
-                                "uncompressed-sha256": "fbbb0f24d685ba2ef6cabcf17b757b3d33d669f32d9dbd8cb24606e1f233558a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "383afee7e7c9c422e6e3c02e9a587d3c7ca1aeb45157691cbec6d2f56836825c",
+                                "uncompressed-sha256": "86a5b6bd8f83bb203fcc8038251fd6cf11dc07f6a05585dd02d43fd80f916d54"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "f8fe0ce168522d8456dc208bd2c0c29324ffbf40b1e6fbd6cec5c041c173b584",
-                                "uncompressed-sha256": "59302f4e16c987ed4d9f1b8c9aaf81506a7066790e7663575f98293c95edc66e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d167f995e8db0c7e3894335682515373ce51b607d816a4b3c380082ab28e9d89",
+                                "uncompressed-sha256": "b93a6c016481e863dbc0fe908a55b22fef721351be12ab0cc3a01e0f715bff14"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "52012c5bde22f3996fa86d12f600432031aad96de3449931c5ffd8cea4ace00c",
-                                "uncompressed-sha256": "89d63ea9b21603bea0689576a1b4ac1c7878bf147867805d804b96b38120fb84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "abdc79a8b997892040a52cd1461a8f174c97539735ecc8a3c3f99f6367edd82c",
+                                "uncompressed-sha256": "45b468d669dc870cdd4b95f9d8301046242f84d9a820833a02116ca994fea0e6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "5f97ab247f1d7143fb214030ce7f91aca99b8d160db645ea804a6403bc909f9b",
-                                "uncompressed-sha256": "0c8e086e572f7bbe89adbee9777e3363db00e51a217bef6fbccc7bfdc098cc54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "50b214673db683e94414170056291c4d4bbe41a35c7818fbd225597c6f5bd0f7",
+                                "uncompressed-sha256": "aa18974980d176bc856f51a236991cd696ff4d0cbecf27e9f1a84f8a2c095be0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c895def6e8986fc91eef5a1447c862e30fdb7631ea9129adc7885139d64d7338",
-                                "uncompressed-sha256": "411767afe1b280be7aa952fbe77007f82b82bf9ebe8a4c69539ddae9f4f53a12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "49c7b6a2bb49f856bd533379098cb4a70658e4e8aed843a04e41bc4f7313969a",
+                                "uncompressed-sha256": "8e0c4d02e5f8fd3ec6b14deb82169961a052da74d536b2262a12800c0c1858b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live.aarch64.iso.sig",
-                                "sha256": "5ecc7d0eb1bad0a3fda3989648ce69b06c729558f252ba928b4daec601901794"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live.aarch64.iso.sig",
+                                "sha256": "bb3510a27d49891a6fcd7009f73a774f9511da3f43b38cd9fef0d0420f62559c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-kernel-aarch64.sig",
-                                "sha256": "cb0b0862cd36bb3accca36434076086a1a72059498c1fd320361c08d8255c7dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-kernel-aarch64.sig",
+                                "sha256": "8ed95915e2d2bb8f683e3a17256fe2dd2826dd7e8cdcaf9194bf6813ad0f125a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "65202423a21139374a3c277aea800f91ddb68145947c1b3e7fa254c4c0ad5284"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "cd6ea18a2c490ba1a9a4715f82651f112d0e6cb6b7271901a1055702f9336b62"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ebaa3791bbfc26fbd6d0d3991a74bdab449b00e9301445db8e9083caa66063c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "40f1abf44c2206d4bdaafe7d4168cfc5ff2b798bcf8ff1f57a951892042d4bb6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "31fbeef8c1d85f2e3e8a844f26b3dcd1298873fd8f647a7ea9b6e41c50a2abce",
-                                "uncompressed-sha256": "bbcd1beebca8d01ae7e2916598e4e7b61f8de720ddaeb7616da9cea7556e5f26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "df0ad28eaf70f8af14c6ab388b371d1bbbaeb3ee45703a9e0e21ae47be3c75d0",
+                                "uncompressed-sha256": "62ac55aaeb04fa7f385a544b9b18234e30ef95e4a69061a8b5ae6f8e4e3daa68"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4711a7f2d8bb8400f92bda374b0ee4524c0bd85a507b511b47e154511667450f",
-                                "uncompressed-sha256": "6a89933906743c37ea4f1de0bc40d75f28c092dc3f863b5853aee59bea3760cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "fb3501722879bfcaeab5121140b6ea0ba68665ff58eaebb6dcf13ac7cecbddf7",
+                                "uncompressed-sha256": "058997587cc195a4f2a5910c20e3d4c432a04394695ee98c0243250018c6c7d2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/aarch64/fedora-coreos-40.20240808.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "34ed0e5a26edb7ef468b105b711668e41a18d62d4f7daa1bffad2bc79ec9eb5e",
-                                "uncompressed-sha256": "9a6cf817e1bccb5ed9fa259dbb3412815ba4bb3328a660c258cb190addb99469"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cfcee74defe497c63d4239a5c96bb94d5b122cb5cb1502d4c429a36e4bac684a",
+                                "uncompressed-sha256": "743135dca0f61ea8c87623f6f5bd8aefd36a4b2885924742f06e863fc4d9390b"
                             }
                         }
                     }
@@ -148,213 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0235ecea7315513ae"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-09d697060c0e8ac6f"
                         },
                         "ap-east-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0d17a7767c47218be"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-074862814fd1c39c9"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-08a232b3b79041a46"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03c95567e8acb18f8"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-02525b4ab5bd5b6ee"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0bee3c6fede287785"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-00d39518415e0f34e"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03ae68058268d9e47"
                         },
                         "ap-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0f623175c6e477234"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-04457613eb0f212d5"
                         },
                         "ap-south-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0ade711d850730f51"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0faa5eb9a261def7a"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0a91c5df48b29c7f1"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-05cb9421257c5fc17"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-09aef5259f1d07880"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0f5668105757108e3"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-007a11ef365d574c5"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-047142bc385295cb9"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-072acc6026b7b7049"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0bb0800ece8e36867"
+                        },
+                        "ap-southeast-5": {
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0981d18ae7c4ae916"
                         },
                         "ca-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-003142fbfac0858d4"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0a3b6ee3665a5b768"
                         },
                         "ca-west-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0a80d5489a6442419"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0df7c6ea4db341dd2"
                         },
                         "eu-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0408e01a1d66b89ec"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0bf0d714515b17b7d"
                         },
                         "eu-central-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0e912795a8b925444"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0bd6c6fe014263dac"
                         },
                         "eu-north-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0a4adab3a363580ac"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-06b566113e0b2769e"
                         },
                         "eu-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-064a416bd451efefa"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-00f605b90d6c752e1"
                         },
                         "eu-south-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0a17412b4e21b7874"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0df2dd5f2f3614b57"
                         },
                         "eu-west-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0e29d901d953e7542"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0f9324c7d5527532c"
                         },
                         "eu-west-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-01fb7edb095326c9d"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0fbd6671d995c418b"
                         },
                         "eu-west-3": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-056b115cd4b923430"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-09972e325dd9789bb"
                         },
                         "il-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-07b94d2b8a8370f15"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03d221afbc06da352"
                         },
                         "me-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0e1784ebc4ecd143f"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03f2ee9805b20d693"
                         },
                         "me-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-01f1d550e997e27d1"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0bb383195804dfe75"
                         },
                         "sa-east-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-09b65838ab1ebdec3"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0173289a1713c41f1"
                         },
                         "us-east-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0ee95765fb7f39970"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-02aae8cfe237e032f"
                         },
                         "us-east-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-013811bcde8acb900"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0a4c33419f055a850"
                         },
                         "us-west-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-04d227ce052e22e0a"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0efbf5e29ccda47a6"
                         },
                         "us-west-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-01026412d389d4cb4"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-09b5170d4d85e6051"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240808-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240825-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "e53fb08d0997921fb238ac499e546bf778952c2dfd715436da48701eb5dbd80c",
-                                "uncompressed-sha256": "708c24b01efa4463d717288d5223c7c7557951084512c44ffd0df165d5ebd24c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "588692860fd15f24665a288f8e82b62cf965ad51f32ea69cf8c14594dab0bb8e",
+                                "uncompressed-sha256": "9c07ab0e966358ba7f7da2de8dbca857142df7230f6ab9a63536b86e4f7d12b3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live.ppc64le.iso.sig",
-                                "sha256": "c4e3dd6ed4efd00b09686c9e97b849afce80010137ec67b265ff29f4a2593318"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live.ppc64le.iso.sig",
+                                "sha256": "4076a44d6e675fdf7a7556cc2aebed4706e842cd4385769c7f08e483c27b69ae"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "c9e2f1cb0a59a1d1b74e256e4f74078eb099e998df7c48b2e15cefc63944f92a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "f46688f208e600397c0d194a81b78885ee65cdc060af8ca2769c9ad02fd39b09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "8015d49728f01e238f0c5d87af2d4fb9c7f9dca41248ca32973135322bcff192"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "4570cd93d98144dc81f10010988acc719a93e7e493f04cb67094da5249937ea0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "8328fc560e4e8de938d759bde4ee9a86c4e384627ee488d735119e929b5c2545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c8b99c1806d26d6395b00c8419ffa20c39761bcf8850d65abdf36047819b857f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ac5cfbd885110431e2226ca68d2331e3c2e5e1b2885a9ae9a646eec94637aad5",
-                                "uncompressed-sha256": "e2044bc26d9fdee2890253ab815c08869a0b106e9fd5754feb32c19494515032"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1ff8ca66bc434ed82923f21906241539f23fe74567b4ea23a0b5ff7147204f99",
+                                "uncompressed-sha256": "ca53e327e6cd85ed13454383130c8da8975d9d536fba738dba2c922763e8c5df"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "047b6e192bf2e57162b32a0c544ae27da28eeabaa71a7625a71600107b90f7c0",
-                                "uncompressed-sha256": "259b34100d8ba22cc114a10698bed7a1e29ba15f94280930c0a83b7e56ff7df0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6b30b43a4cf56d3c30d658034fb1989d6d78ca445da98fcf89322209407daa4f",
+                                "uncompressed-sha256": "34a244ccce1679bfc113b8f14ccb59ad03ea987e2f74a26ec9193e72985dfc85"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ca1f737b78f02ede54f12b46c1cc1af30e11b560f37f6977f8d8ed775836044d",
-                                "uncompressed-sha256": "83273377ed2351f3ed9aa323b9221bbe39585928068158b83bd8757f8517727a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "15c8569c3d7c116cde620f9c42c893e0a81593a65a0d4d6b5b187ca63ec0a0c0",
+                                "uncompressed-sha256": "e4b87b81be0260654391871a745248402082d561d8ad63d690977a6bc47881de"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/ppc64le/fedora-coreos-40.20240808.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "0158ce64f1f44f793f9560761813ac753367f35aad2ddce53a9b5b3f190eeac5",
-                                "uncompressed-sha256": "5ac43f975a70f30a4c2fff61afa07123008f24e30eec65138685891207e05d67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "3b5e54cbbc4d80c58883c1130ef49b7ba4e89af5c2ad43b01d6ec08151d792bc",
+                                "uncompressed-sha256": "892d8c88c4c0d9fa36f6829ffedc9b14702b57f7c99dce065b0d898b72c0a16f"
                             }
                         }
                     }
@@ -365,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8cb2e0ccfe24df56148e8e12016e1d6d94b8a0c922522913a1b14b465bb96160",
-                                "uncompressed-sha256": "a43800a3436dab1450ae759882c873c29bac70d66bbe12b7d75e74b88d792136"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "20f9224b7054bf4aed679b55e17f1273a8ec7c2906257534c9bb43bbadad294b",
+                                "uncompressed-sha256": "3b4b4e5a27c781f651aec6cfb96d4e198c2bb157fb5d8134951c65d70e087554"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "aa24ccd34e402ec09f88da705094eb291d7196cbfd1f750e410d1a98571f20f8",
-                                "uncompressed-sha256": "78d53f7e4957f500d53a52174c19fbff08afa1eb45a3d12847534907dcb65b0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2268d3d8fa13942f016da903f75bf6893d7813f38a962650f68e29c9472d4caf",
+                                "uncompressed-sha256": "62046f0861e46af2bcf78794ff2325f171531c96d13441ef0e0876c114e01bf1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live.s390x.iso.sig",
-                                "sha256": "c72b41eda3519f217a488f2da3a63a9dfb9907c801a9b8349b0963a8b17229cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live.s390x.iso.sig",
+                                "sha256": "c12f026a58ea203a5e4341f890cef4e2c71c9c2688b63226dc61de8dc95b090b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-kernel-s390x.sig",
-                                "sha256": "cd0ccb133703f0b51afea4a2bb0c1e76111a442745137e866f0945f808191a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-kernel-s390x.sig",
+                                "sha256": "c3c314b436e4e93d8f96c773189fff652fabd9145f34f9eef851e65754e0461d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "52d359ff76bfdd5350daa2a00156f9f88c26f3a7f2d3f0bac1b60002071c10d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "48efd4cb705c62c90cbadb5495eebe170e6b8324ca134b7d56d5348cfc7b8a10"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "17f2b79a5536cfcb321d5d4ea89e343f1968a7b501864f758c1c6eac3287be56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9b1bce2498f62d27909cbfde3253c4554cca66bb2e1cd73ef6f1befbad95a68d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4ece538f05d08e59eea66f837b0d805f421f29fc47be788effe040528d82ca5e",
-                                "uncompressed-sha256": "562b86755b4953a23fc82f8a0a07ca821dae1c3d2c9189242f978b3e1190adee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6b62f871ec09c55b26cc2540b773dde8971b6b4e5af4e3fda75900ed6b6a25a2",
+                                "uncompressed-sha256": "ca8174fa1d28c3935c59e45f8ad5c38a06ce3eac8cff117d3df6cafdfb4203f1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "63e4b63ea53c3ee6c5e2c77186ba411aec8f2b2be49fc9fdc21ab3015c890b48",
-                                "uncompressed-sha256": "35e191d9d0b223d68cbfb4654f6d2e9ae787ab020b140b053265aae791498fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e8b105027c2fabce8e700592f1e7dbc6b8583ca2f33d16b058cc5f84be5cfea8",
+                                "uncompressed-sha256": "d74c0b0499bf23dbd8b35f959a25269c84c9b452eaa207dd17575f733a1211c7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/s390x/fedora-coreos-40.20240808.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5f092e63b2b61d55edd5dbb40945fe60c158032fb8c2f1e5705d6b0a9913081e",
-                                "uncompressed-sha256": "e665e97cea45f64352d7a51d2442948e87989406e7514fc4f38979dd6c609369"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "146a94ce8096746797a74bf269c4ae70c6b48d1d75e14fe49af6ef7d98288c19",
+                                "uncompressed-sha256": "88c34bd9a5e68f3bbf099333262c9ecbe19f466df567d978db723b8d68ffbdb2"
                             }
                         }
                     }
@@ -454,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a971592d2e250acbb412b5ae954aefb26dee667c04888bf772457880d1306732",
-                                "uncompressed-sha256": "20b4e8da4bc45786f363659240a0fd997285406bc567648712e56d8ba9a2ab31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0d41776cef99387b0a5126230147e5fdcb594e53631fce09ad7c52888d14e1ba",
+                                "uncompressed-sha256": "437786e815e2b2019f3a6e7656b49f51c5de03ed702cdbc1f351301c23a7065e"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6f484a7c2100e133a01b8e91ef1d4c259616f6b8d5292e3b92c7c7359b9bb9ec",
-                                "uncompressed-sha256": "a07301194688b06bf1fcf273c60e61206cb0795d7c88bbcdd761300af0521377"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3a2ce24665166a221b0065adffcdb1370538338a1127f9ba10e0b2047822f444",
+                                "uncompressed-sha256": "ed6930271b5d8b23cd3c712841c6287300c2ee50889772524350c60e661d1efc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "252f171f52009cc2ae58ef1285063932b87e1a0b18baa0f8214786b094f877bb",
-                                "uncompressed-sha256": "717a75687f0bdf438e01df06b19c40e2964b9bf7705188e2ae8c4aae8991070e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "257e0f8fd27a9a790978dc3233fe679828d2cb6aafb8a5b96818971b987485c9",
+                                "uncompressed-sha256": "7f9d59ac3264617b0bd04d08861cf6b3317215d1b2002115d8406f7c6cc38ea3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "07e578dd10293e314295f5a7fbd24075a4ee13fdf5727fe72b28567bc9e62ecb",
-                                "uncompressed-sha256": "5ef6ef2efaab057c1bc2b6cd622bafaa954315eaca9b5f95d04d2b157052ab9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6fae93f3d3ea632911bed98a25ef32f4dec16f1ec7ccbd1380627f57b2f63bef",
+                                "uncompressed-sha256": "677ff700313968d085cfebfb2b43372c7878df860a39a2e30fa8ba9690fc49f4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8dfa5cb7909b568bd3ccfefeba252e97f681403e7f746732a423a3563a23df08",
-                                "uncompressed-sha256": "a630dfbf02f60fa4e00627795a8b40fe72f974f58f0d53631b05dfa538cdbc56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "9c7dbab41ef3906895d9a1285426cc3ce6e81ec7e784654b41f2e9a867642976",
+                                "uncompressed-sha256": "88523bd5933f02af7d7535a226234a6a4239d4888ff07966974b76bcffb7961d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1e21d7756ef8e8c34df41ecb8a6b800dae8158739ceee24f0726beb6cacfaa4d",
-                                "uncompressed-sha256": "50687088c3561e4e719abc357592fab967fa89d289af898bba305ba15b4e19b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "fb708dcc1553b8f2a2f21e5252a2d94a6de13db0790139402e958c586e6db127",
+                                "uncompressed-sha256": "c619f3eaa841e520e30b62659b332af00eec1e68e5961de5bf32a1a65c8460db"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0b236c9a337823f97277a9770a82dd6abf221dccccbe6f7b88040a322eb0acee",
-                                "uncompressed-sha256": "90679664ec2617c609a8d71bf84307c51f9bd424346b8b206f651f2f55b2a192"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "9e1cb9d081c15566d61951830a2eabb6308af47c01f288923b2a0a9fd930a933",
+                                "uncompressed-sha256": "a9723c8e8df953c33f972c4e65e93f8aee12d1f4d638fe5fc167867e18034469"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f0eeb5bff3e6ac275652ba07b02cc319931a6c2d18f7cfb65be437ea0ccd953f",
-                                "uncompressed-sha256": "44dde027c5fc8723e6c494bbceaaabd17c7f33003ab6d21fd4d99cbc4a14eb99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "87855455bc135d8d51eaaee9e6d23181b30c3c4dc48f7620b99ce1326ae65eb7",
+                                "uncompressed-sha256": "7ee4372e43fe2d1bdd1ba884b6c9826372dcff041b282c575de6f3803c9ac9b9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7cc4b2f242f33d64e7f109a785b6644f3e0ecd428c90eceb4d0c7dbfcf02e3ea",
-                                "uncompressed-sha256": "92837474ac1841408bcca536d6d50cbba518275a174a018ef1946a27c2cc4773"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e8f254b8eb753e2391aed03ca3e35ee32decb933df48222679f250c801ea5bb7",
+                                "uncompressed-sha256": "6e79a0db0aeb73e3063d7d3995095f4be3883596ff50766bc4518434cc228780"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f8544c928cccfb8b60d66c135dd8ddbfdd599b0b5980e7428161b0cbd4e56399",
-                                "uncompressed-sha256": "4e01c4231fe04a72c8d6e305ecd88cf17b442b4b867f0e731a7235b342e9d1ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f54f9f0d316d6e1ac9287f0a1f439f5641e65ae2ed08d13df2239080f575a813",
+                                "uncompressed-sha256": "3f3851043d24dd3c7249a9f00755ba64dba72016601d4287da29f0ca1b3fb6b1"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "daff2064c2a55eccfb9842c0f690e5772b9162989548584d7a229f4bc47b5803"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f7826f09e0e915dc9531ded3e32dbaa8d29b65c03d6c536a03168d8f2ad328ea"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3153dfbe0881a0337b6a5de40df8d1196cb057bcc363e2390a2a03f80bb17389",
-                                "uncompressed-sha256": "a8b7e52d67cbb42977da9e01c08899464e5a53995fe49806a9c446871b718000"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3dcec1a8730446aea02fd3598ec31d251450f6df7694098ade26568f44e6d760",
+                                "uncompressed-sha256": "0be607021cf8b82f84f9714ef9b1ba0f0c4dd85b900502e3a3d8fac9c0e8c7ef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live.x86_64.iso.sig",
-                                "sha256": "da12f400915ee7be90bf32b6f6bdfff3bc017241c567c62626dc119324a5e76c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live.x86_64.iso.sig",
+                                "sha256": "d7634fade6c7eaf3a261dfcf9fbc5d00768c9213e4a2b2b05e6d72fb022ad324"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-kernel-x86_64.sig",
-                                "sha256": "36eac90bbc9b6c594515fa36e2dfd4e15b769bbb5015f3b024d7bde4c4f50abf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-kernel-x86_64.sig",
+                                "sha256": "241a166c730747365b85b5f391f15a5f8325242b79f52cb39c943ae9665f7a02"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "025a31f55f42104820b52f03aa94c5bc8b93631d071c1baee12f9a92d22b4d8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "58812f1b5125420de9ca2a0d4cd0a23589d9894180bdf8a0de87048c324b301e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ed69e1b45928ac260eddfbd280e037d1f18013445b96ea6f13f891bea94c7dca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "82d53550952968911ae505cc7a7b82d1aab611af5d8a7390bdfafec7ee72c922"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "07f74072332a94eeec383e80e142f5203be6bdabbf99ba37308c81ce86b4f8c5",
-                                "uncompressed-sha256": "0469fc42202708c507443826046b2c7610135228c26fcf5a5201d0f4ecd81846"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7a254c25944f6aa62f2022fefbe9398d451a4a3acc5a8b2065b639c1e1c084e4",
+                                "uncompressed-sha256": "165b920fb677a264c0d17cd1483b62da3bbd40f2ffaff2fafcbb040c8ec2b84e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6cd151c2c4c98e914816f952664cc465638bfcd2d904c2c93b448d8564c036ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c8119369d5b83f8ec6dfc05a93b36e12d4fdd4d06f98bfe5a935bd14eefabcaa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "10ccf57ff10708adc7137cfbeeafb4b2161f2a60ec7da583f8fd4b5526b09ca3",
-                                "uncompressed-sha256": "090f4a5c843d2f0ecd2d9a49475b49541f031976cb8e5f3080361fb0417f8bbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "01e40f80f16d4758b7690842c5ae70cbd28b440d9325815f942a456603626faa",
+                                "uncompressed-sha256": "398d31a150f1db770c6b86bfad8094ae7e9234ec7622a808e84f0d6b6e6ee884"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8f8d00cca189a30ee44f8df890108973045dd5072cdf71b9a19c5bbea857c58d",
-                                "uncompressed-sha256": "c2ff76e431125fadcb0a24c07169eb14cd3f02032413cd1f753d91122a8ec459"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e6bb493fca5ea1248a82e86dabc09276c18cef08cbd136ac7057cc87bb3f4c52",
+                                "uncompressed-sha256": "046f92b2555eb339f5364c18255c857ccdbe77d9b5549371db0a08e95dec27f3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "1db1799d4fb14f28bcb3a943874c82e3e6e22e8114e88a794769961c81e9d8cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "159f5758e4e0f8f7d52a40801b7b6d53c15599b1dae0b5c236b8ab3590459b57"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6ed4116982b834c9a8b9dd9df59880e4740e74778496fa61bfe6fe1be317e52d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "84df603e8b6ccbb5d7956361a130883d0ced66884a415ecca3957b8dd3f9ebdc"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240808.2.0/x86_64/fedora-coreos-40.20240808.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9f175631f5caaacd9da1bd523beeee42c4a593007d11ec53b050d2712034cbe1",
-                                "uncompressed-sha256": "0621f73262cd8db8de65ffd174dd93a3a3dc25ca24eed158f45eecdbfa8bd26d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "93c4065d62c830cf222e0b5e22442e32c1b0a6d6c8a275bdd7e9ef5ad48751b0",
+                                "uncompressed-sha256": "c63263cc7ddb3eada1e10e8b8f037e8a5a336a36549726115d3724f87b0e1434"
                             }
                         }
                     }
@@ -720,133 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0e6d62ec58ebcf44c"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0d90c4e989212e00c"
                         },
                         "ap-east-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-03a74fae4d7d2d6db"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-09032e266489ab972"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0cf88f93944708ee2"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-02cd270f1b421ed7e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0d04ea9acfea77762"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-08599a88c0ebd614e"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0ab401fad5dd51021"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0a04ffad09535a459"
                         },
                         "ap-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-08ca81f57079bc77c"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-025141ff6a07d6b1b"
                         },
                         "ap-south-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0609c579e3cebf80c"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-080f1776623d42cae"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0d16a899306bbdf1e"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0fab2295e452cd350"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-062dbf318f941753c"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0e142214b1613bfdc"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0fcf53514a56ffc86"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-08765ebe629d66850"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-03df541a2c64ee724"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0bc03e1cc8e93e969"
+                        },
+                        "ap-southeast-5": {
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0c3880973da8610a6"
                         },
                         "ca-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0f7766154d98932c8"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03fa2c75569f0b735"
                         },
                         "ca-west-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0352e5d46f11fe9d9"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-01334671f70ad4a1b"
                         },
                         "eu-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0e992d343a9150843"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03679a771068df5dc"
                         },
                         "eu-central-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0f9a7dc5915158e2a"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0d168cb67f7a00e85"
                         },
                         "eu-north-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0ac4062caa5373fbb"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0683c1e87b38baf2a"
                         },
                         "eu-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0b97b37a2907bb709"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0e8ea948badc65c60"
                         },
                         "eu-south-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-07d7657e8ac5f2bd9"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0eb1876fd16d7dd59"
                         },
                         "eu-west-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-02ffa330cc8752d74"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0562cf5fe8de10384"
                         },
                         "eu-west-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0fd6664c7351a3e64"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-083182e28c516bbe6"
                         },
                         "eu-west-3": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0b0d330dda9741b66"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0547287b4ea78bf8a"
                         },
                         "il-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-01b588f2389eedc6e"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0311d565645a106a9"
                         },
                         "me-central-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-02082b5eab4458c7b"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0cd594fbf00c193d1"
                         },
                         "me-south-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-03b6b3c5acea35420"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0708d5f6130f2f5dd"
                         },
                         "sa-east-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0f429966911dbd8c0"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-03e8a5c22978852ce"
                         },
                         "us-east-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-06236c4eb5a79c490"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0fb3fcbb279221b25"
                         },
                         "us-east-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0386df74800f2a2ac"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0c8ba39c1c912d55c"
                         },
                         "us-west-1": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-06eb5ad49649ba352"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-07f0ea78a70fc054d"
                         },
                         "us-west-2": {
-                            "release": "40.20240808.2.0",
-                            "image": "ami-0b5494c80dd1f2c49"
+                            "release": "40.20240825.2.0",
+                            "image": "ami-0cd1e02afc6177376"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240808-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240825-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240808.2.0",
+                    "release": "40.20240825.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:df52c54d561c7521f4d80a57d080f3c390d23513cf5f4d6531287c2d32a76986"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:38e1e589ba2f43470c57fcbff10d46dac3b32e9caa65ded5c99aa26ce5698345"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-08-15T00:33:28Z"
+    "last-modified": "2024-08-28T20:39:04Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "40.20240728.1.1",
+      "version": "40.20240808.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "40.20240808.1.0",
+      "version": "40.20240825.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1723701600,
+          "start_epoch": 1724936400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-08-15T00:33:26Z"
+    "last-modified": "2024-08-28T20:39:01Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240709.3.1",
+      "version": "40.20240728.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240728.3.0",
+      "version": "40.20240808.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1723701600,
+          "start_epoch": 1724936400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-08-15T00:33:27Z"
+    "last-modified": "2024-08-28T20:39:02Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20240728.2.1",
+      "version": "40.20240808.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20240808.2.0",
+      "version": "40.20240825.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1723701600,
+          "start_epoch": 1724936400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).