### PR TITLE
release-notes: updates for last 3 release cycles

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,10 @@
 releases:
+  40.20240825.1.0:
+    issues: []
+  40.20240808.1.0:
+    issues: []
+  40.20240728.1.1:
+    issues: []
   40.20240709.1.1:
     issues:
       - text: "No serial console login after update to 40.20240616.3.0"

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,10 @@
 releases:
+  40.20240808.3.0:
+    issues: []
+  40.20240728.3.0:
+    issues: []
+  40.20240709.3.1:
+    issues: []
   40.20240701.3.0:
     issues:
       - text: "CVE-2024-6387: OpenSSH 9.8: regreSSHion: RCE in OpenSSH's server, on glibc-based Linux systems"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,10 @@
 releases:
+  40.20240825.2.0:
+    issues: []
+  40.20240808.2.0:
+    issues: []
+  40.20240728.2.1:
+    issues: []
   40.20240709.2.0:
     issues:
       - text: "No serial console login after update to 40.20240616.3.0"


### PR DESCRIPTION
Updates for the following release cycles:
- 2024-07-29
- 2024-08-12
- 2024-08-26

No noteworthy changes over those releases:

```
$ git shortlog --no-merges 6e188d56..8ee4035c


Adam Piasecki (1):
      overrides: unpin selinux-policy-40.20-1.fc40

Code (1):
      overrides: fast-track selinux-policy-40.27-1.fc40

CoreOS Bot (17):
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: drop graduated overrides 🎓
      overrides: fast-track rust-coreos-installer-0.22.1-1.fc40
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: drop graduated overrides 🎓
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest

Jonathan Lebon (1):
      tests/kernel-replace: use `dnf repoquery` to get kernel version

Michael Armijo (6):
      tests/podman/rootless-systemd: use the FCOS defined fedora.repo to set up container
      denylist: snooze ssh.key until new afterburn release
      workflows/openshift-os: add rhcos-4.17
      denylist: branched: add kola-iso tests failing due to SELinux denials
      denylist: rawhide: add kola-iso tests failing due to SELinux denials
      tests/files/validate-symlinks: add bootc/storage symlink to allowlist

Timothée Ravier (1):
      coreos-ignition-setup-user: Remount before writing to /usr

gursewak1997 (1):
      manifests/user-experience: Add which package

jbtrystram (2):
      Revert "denylist: add kdump.crash.ssh for aarch64"
      Revert "denylist: add kdump.crash for aarch64"
```