### PR TITLE
Roll out stable 40.20240825.3.0, testing 40.20240906.2.0, next 40.20240906.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-08-28T20:39:03Z",
+        "last-modified": "2024-09-10T23:15:35Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "5e084eef5e86dd782f565ba2070f0e5943cf356ec45e60578e7c5054d0b4dde5",
-                                "uncompressed-sha256": "863a2fe461c35b825aff96edbeb9ca3fd72abdde421e2831faa5ee12e465abc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "265627088a268336c026ee71bcc64cd19c8fb2035834efe3362cec221abfa2c3",
+                                "uncompressed-sha256": "2b0a605d589fa6a5bd4ebb0c142156bd41552ff840f686a8ba4bb777629dbc8a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "028d6ec80b14c7c45301506c2b4022546f83ccf939ae8914ead0916606113e2c",
-                                "uncompressed-sha256": "a222db2fe5713d553e164475d49932e348c433fd1a82a81bb6063c68913fa989"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a007c0ede30ad909b692c76928683a9c4bfebf6236bbd96ee90e78c19ea2b54a",
+                                "uncompressed-sha256": "c3066eb4c121af7e642225cbcadd01ace8ea6476cc0bc40b2257a82a123c28cd"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ef0f00374fa20709a4dd417d1a7be47e37d08c5597a78f19b16e8cfee118f1f2",
-                                "uncompressed-sha256": "a034296e8c253925449a04d4023a8f3246e552c634107c6719454b834ef8231e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9f6becb767254d2d0e2a4accaf87b5f5782df0cdfbea24bccb144e29739a19d0",
+                                "uncompressed-sha256": "4bda1cefc17f78318763318217e60de5b1f39cd63bf0bf7a229a508858205186"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "aa2ec9acaa36ad84c5e0f4929cbaf69d2ca0d4b99e4954c5c9be2d6d6f9df51f",
-                                "uncompressed-sha256": "caa4dbad282a20db936555aa70fd7e139c30c2eac57f9ab2f3bcc464e1534c6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "fa6d9984970181bc34e3b438af24e58d460d799ebb7be474bc52ad42befa3d20",
+                                "uncompressed-sha256": "d9f773ce100cb9f6af8fd51ddf24749e0d00b485f47458f7f7b864cfa227dfd0"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "652d7d87b9ccbb456d69a1f7ea97932d1d1da48b9778fcdd9a8be8370cf495e2",
-                                "uncompressed-sha256": "3206449c2bd199882bb281f73a5ff5f20c1369e08595d92e12732a75e3ccf31c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "8c10f4b9797430b5a2ee3574e975cec4b41718b758f27a04aed461a277eec17f",
+                                "uncompressed-sha256": "ff3b3b3a7d1de47febbdbd2bc405b5a090938900fbb261c24791cf5fa0cc27d6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d628fc87f6bb04654750152a6255d45b200014b02c24ac4f9f989ce4a144b477",
-                                "uncompressed-sha256": "47b667c4583545e657957a6422bacebcffa382cdf507dae54ae022150136a406"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "36e3474a126c71edff3023f0d5196dc33ea78af91b9e393b3a0ad43671cc8739",
+                                "uncompressed-sha256": "5c6f03ecc10fb24014e82d400d80c3025ed5537e590e7419981c6fb64d8974a6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live.aarch64.iso.sig",
-                                "sha256": "a05143733ae32a0478e9e91455c46fe965ea94904b4475f79ee5c5f08af89c2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live.aarch64.iso.sig",
+                                "sha256": "b02a57b3736a5658eebf9d97e0440af4c10f8668633b0438d35143620fb88d5c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-kernel-aarch64.sig",
-                                "sha256": "8ed95915e2d2bb8f683e3a17256fe2dd2826dd7e8cdcaf9194bf6813ad0f125a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live-kernel-aarch64.sig",
+                                "sha256": "09855c0c691c8d13f8a7216bc45366ba83f627884c35c755fab01e4da0c19761"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "45d0e35b83fe9c1eb7e15cbd336937c57fe12ba1b8644e3ef1b6f3e311e81add"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "54c8f4faf3841b64b1a6ce6bf38618985cea28db974904ff162e8c7eb2afa1b8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "4a8a2612e2f6684c4ad7dc717ea7e132c249367b6d4ecc0ba650482b7d1c078b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "aa664027459a1332d61313ef5cba3134496a60e9f79ed34c040eb2d2f1874ec8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "fb54c854f7b42d1283b097cfe39a623abf395c7a9fa8e22a767486892f2ce044",
-                                "uncompressed-sha256": "bb38e7ad829eb77c87fee429d3024c820e2548b6ad7418d4d33e9b2d2007426b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6454e560be2bc0c3140f1312b3afe76ca8feaf287e95e83baedb881e37d89823",
+                                "uncompressed-sha256": "6bad3d64e0cbec13881708e3070c30026a2b79e599a5ce0b5ca3b913000fd954"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a4f6153021376517efc5aa62b153a36c61d40e78984bdad8ef1e86e10aa7f913",
-                                "uncompressed-sha256": "8d981472cf97a0b30921b3cb8e1d7c114797b6f38f140a3f948ad9d256ac18dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b272cf493d321a8099592e295b13c1f8b4dfe1407d888b6d89b668884e7148f6",
+                                "uncompressed-sha256": "bfd4ac28ffc4ee412589967a5559a24ce95f468bc16451d8aaa9a3f34899d57e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/aarch64/fedora-coreos-40.20240825.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "df8e8a2aaa3a2dc96aa52f33c6e0e05186833412d159c413d65dd69109ef2c89",
-                                "uncompressed-sha256": "6d64947396e52a1c143a400bc36eef51b4a61ab69f2bdf16332ea8b8d3bc1847"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/aarch64/fedora-coreos-40.20240906.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "abc9437f32f7e457934809efd550999bdbfeedf688b082d3d19f7c0e88d6b9cd",
+                                "uncompressed-sha256": "0648ca12555d29e34c1f073a0a2d4c7e6fa95da1fbe85973dda1e3b831b170d4"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0478aa0e208e39f97"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-06ac61cdeb00684d0"
                         },
                         "ap-east-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0001e0a3911a24919"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-01e9110fcba595eb8"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-093bbab90596690a9"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-049e7f69e6c64a2e1"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-03cfa3aa2463dfdbf"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0b001e4eb3a866606"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0ab4494c3385d86bd"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0ee268b6c4e5cde63"
                         },
                         "ap-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-07374ba9eb05726fb"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-042976700ed0ae797"
                         },
                         "ap-south-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0b01b83648c86f873"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0275275d655b8bef3"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0fb6931421aca9a84"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-011059e4a1a0cf055"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0c7a99afe9d795363"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-07ad75f4e48b56100"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0ca3a1327b03a84c1"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0addc54947d54218e"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-09cdf010d6fa5440c"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-041f04c07512b62dc"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0fe6723475e3b065c"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0767f4ca0f3ebb799"
                         },
                         "ca-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0e69c5859cf5caa75"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-05031b1110be35041"
                         },
                         "ca-west-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-065954a240146beb7"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-04ca7598f9197b4a4"
                         },
                         "eu-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0a2e4bde53b720786"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0efaac62bb0e25e81"
                         },
                         "eu-central-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0d88a5fccd1481d8b"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-03cc3069a71b4f11a"
                         },
                         "eu-north-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-070bd379ea6387c88"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-07001cdfbec93a43b"
                         },
                         "eu-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-00e5eaa42b92a0205"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0654cbef25770ff20"
                         },
                         "eu-south-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0ddf2ce8008428756"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0812839956c27040e"
                         },
                         "eu-west-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0a0cd9e2ca75114fd"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-057c17a4aeaf45b5d"
                         },
                         "eu-west-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-00858be030164a7f7"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-06bb0ec7dd5d300ed"
                         },
                         "eu-west-3": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0ccfb710b6f0a153c"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0bec62b085a4eadee"
                         },
                         "il-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0dddcf30fdf6b66ce"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0421089c614df196e"
                         },
                         "me-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-050fd34e58d8d9503"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0fc187f78e58c3926"
                         },
                         "me-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0b433fa1a4b75762b"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-072e3c462b7aa1281"
                         },
                         "sa-east-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-06464b75b716f7ae8"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-04297aa521d64b3bd"
                         },
                         "us-east-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-04b95c1df02865157"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-052eccfb4246922d0"
                         },
                         "us-east-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0af39360bc865567c"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-02ce876996cf73c27"
                         },
                         "us-west-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-02a7c9a46faea56bd"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-024aca9e3a7da5774"
                         },
                         "us-west-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-085e8fecee6d78d4d"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-02abd83b1f4bef7ad"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-40-20240825-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240906-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a8ba517ac83809e22f30a22cf1b2f58e07a6a629b2ae8759087434078bdc8e3a",
-                                "uncompressed-sha256": "4575e2aad0959d5a242a744281c4a7cf4bb08a2b70550fad0cb31fb239f80e64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "67d7d09f2e06b6f3b922cf223efb7ac0a0e56633d56c830420c906804f8b3df0",
+                                "uncompressed-sha256": "72ddbf2e62e48fd4b9ef92ca91b5757893c97f0b05dec86c1e75a5e70ce018df"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live.ppc64le.iso.sig",
-                                "sha256": "a039fab1ced46f73644c4d353171f8b66ea8e73f771ec04224169b40e5458e58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live.ppc64le.iso.sig",
+                                "sha256": "afd18180568b47327175e2757b5ccdf40f969111c08c17c640d40fa8ae02663e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "f46688f208e600397c0d194a81b78885ee65cdc060af8ca2769c9ad02fd39b09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "8f74ba2c9942315b677986a78ce529d61aa5edddce2c6675b0d797cba280eecd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b8f736d743de7186464740d4eda48229604937c47377df95614e075dc34f0d48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "77b2da0dd236d5ea35051c38be35c3d49e1f2eb40e3aa5366ef69b5bff96dcb9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "70ad7b639200fa58db7dd46693429c0eebfaef25fb9d02eae119730e591296b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "80320e074092a912b0bca02fef0f0d774cc270d1062023675ced6c26db5137a6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "195c30feb6c6f4c6e7d7eccc12cadeec9f4cd0592699a8f1481a53c66a90ad2b",
-                                "uncompressed-sha256": "868a6a8a3780de76af632392131a704334e81ed5d13ebc49f9b0898b2ded43a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a67ab45a52ff64ff9d30820794fb6c908f7b0cb3c44684932ab3b38ffc7ccbd6",
+                                "uncompressed-sha256": "f5f77ea2c8f6de8c9075983a9b4e8ac2e63c2248f95cf8d0c4f89ed1f9cd7dd4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "bdb1111d2cbc26bd82f22e2d70fe18ca4b375efe524091a91d4066c886b01f82",
-                                "uncompressed-sha256": "cbb1e3b7098aff9d5497e3b6d142a86ca82ca029bcf84025d81651db6dd50fab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2221095e64d302a242501a8fa5e445b4e4ad36e4edcb9b38beaef9fcd5b56460",
+                                "uncompressed-sha256": "8aa07142f2845d1bff5982ab10658b704c3fbf1e8dbcf1129a5ebf1ee70ab600"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "60fd44183a8ba16dbeadb8553bcf7cbf5c250f1167b1c6e8a68029757ed04d37",
-                                "uncompressed-sha256": "5e288821bd995bca7518ead7dd91166b3641bd757b4b9c27a9e5cea31bb0855d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "8d3713acb7ea7326708398221a8add3c32dbbc0d55b65cce3d18fe4a4aba5fe8",
+                                "uncompressed-sha256": "da65ed534fe5f603b60fe3c744b6f72392c8ff5d6566fef152193220f9ca03e5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/ppc64le/fedora-coreos-40.20240825.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b76c9240e51b65ddcb4118791dda16d2e20b6791aada890c8f1bff351680bd47",
-                                "uncompressed-sha256": "abd84a395f7dafaccda9248f17f70b76b0c6889917b652e19b67809c3b8ef08a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/ppc64le/fedora-coreos-40.20240906.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "eab2aae7c6d9c8da129ed22830f3da74a6c413620e2a2c85e719c2873da769ae",
+                                "uncompressed-sha256": "ad460723057f8fe7d9feea18b05665c50aaf881032b3e7ee0bba647beac36777"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "eb3ea91be9f7f77b0b7eaa4597f027355b7046807ec1abfc7ae5bcef9fa1a247",
-                                "uncompressed-sha256": "6057e96624a3143520a2f35fda1e951ec9438f62c1cd4320eec4329293cf80cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5353a45ef5886c18ff43a326ef9a5958d2d88df9bec07ef46b5cc0bca99dff15",
+                                "uncompressed-sha256": "a7a6ef816db74085576421ec1948cd484930e3231433c0a30ee58bdf94fb4994"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7e7ad84bcd0694decf31e2d8a0383529f51cb3dd77838137a61d78a5c1ff4ca4",
-                                "uncompressed-sha256": "66606714511926ad0a61f1a9b2fb0e2a7f449b32da4ae3c91a989f409d174243"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "889436a43e909f4719c4eb1a2c64e4b89712e8f15532cba04ae975770a17a313",
+                                "uncompressed-sha256": "ed081d8f439a07f2716759d92d10b8928864acbc67a0d5083b440763172889ff"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live.s390x.iso.sig",
-                                "sha256": "2b0983775fb53ee1e2d8e36217abd161334a90d3f834586ce687f57729f862e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live.s390x.iso.sig",
+                                "sha256": "0db8dfcf81348b2ed235e216b77a69cd35d4f182778ace8cce5d452c97d090e0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-kernel-s390x.sig",
-                                "sha256": "c3c314b436e4e93d8f96c773189fff652fabd9145f34f9eef851e65754e0461d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live-kernel-s390x.sig",
+                                "sha256": "94e52beccbd2c3840e93c4dc5f078767f617bd350534460fb4fefaa40d8f6130"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "8c659355b6c61773cd876c1076e6593eea62296969ca96e7d3d9f28ace50c4e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "9d5201ecd82b7e058ca6a6096e3c7b0d6afbe2a6edf2b83d967bb80b89ad692e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "15aef58ca43920bc6cb9e9ea09829980df80d865621865994ef34519365fe73c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ca3d22d998c31a68083cac3efc24d5c951385db14298220743d41b1f3a2e161c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "dc46fc217d69b0635d7130cdd8a4f4c0ed8f19501112a41a26edf29560501e10",
-                                "uncompressed-sha256": "164389632daddae1a9aa2e35524a8740d039797f7905ca445e98e84c433eb430"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e7eddaa1475136fe3fdadcc106ddba8023810b950e8ecb7b937c38d7815b553c",
+                                "uncompressed-sha256": "fbffebaf49a67083e04a8dcc76e41234ee4b292dd2cad8e22c5b1d8581bd92f8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "de28a6737b0c0b99967f1e659b0ffd54954e9f750a0a9dc28a0f714fc998e10c",
-                                "uncompressed-sha256": "43254d165c5cd981ed8044bb16b6f6a700144afba967985ec63d1ed483a970a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6b94a45ccc70a0dd26210933d77063d75ef62735365964b5208186b7a74a6908",
+                                "uncompressed-sha256": "8fec3a8ec3c4afe2c20e62ca55f6541ab6a8ca14a22e9fe6a8d55bbecea0042b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/s390x/fedora-coreos-40.20240825.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "352c02d833ca848244bc2b4154ee6994dd9c4b35e0de24cea89e2093017ec83a",
-                                "uncompressed-sha256": "741f397c177d85e790ba45fa1772baedc419347528f1b275c65b9a43f18c7aef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/s390x/fedora-coreos-40.20240906.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c42e0dfb6181635d55106197eebe21c40fca8c5bdb3d9f1dad2a29fb93e0c331",
+                                "uncompressed-sha256": "d9d0932c2b4a881294b5fb4ac88901d29b533ec1d9418e936b85ce532a5ebb75"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "06be8919dae6f9658d698f23e64108321c780ba5c56653628b5a893fd0851333",
-                                "uncompressed-sha256": "1c85c65e1f8bd7a7e8d960500128bfffdb64b68cbd3340fc4959a85695975fa4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7db757a90007a68a0bdcbc76292094465ff3f8286f83174f732a79bfb996a806",
+                                "uncompressed-sha256": "4e147e751295a7316d53f023a0aa2b815e94addedc0d9333e964fe8ac688a345"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a13a9c358eb0fb547487fb046a45efd7256514a72d4b77db07dcdaf7f6f285d0",
-                                "uncompressed-sha256": "1968d7fdcbb1d10665363ac2b032a0d32bde03ac4287f28cadd870e074f2285c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "0921d69eb6a847d09a44cb55599a5cfc26461460a2e5f9da4040ffd75d858204",
+                                "uncompressed-sha256": "ffcfc6fc6b0eb8430eb82d195990dc1eb88efe7fdca371f0c158adb4458494b9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1dd3a5b5e912b2621aa2f8318bf4944b894db65ea6228cdc3a8369ae5fec48f4",
-                                "uncompressed-sha256": "7717529b52deff766686f45b35f208c028cf24add1ee43e7e56bbaca07d831b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "41ee6df35fe984b798d430b1ae26ee6988c5e6c37124bd945de0284108f5d98f",
+                                "uncompressed-sha256": "f01e6aca872234f0fbbeb9ae3125aa76ea980f717003eb29a5f60100ed3890ff"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1d16208c499288fd23b89658ddad19f86bdba0c99ca6810ab2c25b5595726e38",
-                                "uncompressed-sha256": "a975bdf6e06904c2d73449d3a91296e7217a2354bbbf3002bd162e09c2d3a185"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "888b8f63f270411d88ea11417331365c452e61a1b0f129a06e0490a612bc681b",
+                                "uncompressed-sha256": "9cbc1828362866737e86b8a11b878a49af14187d55f4a1fa844124184d6c4ce8"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a700fabcac5905c41ba3e1ce4128174c8a650ad23ecc8a58cc44f0aa7c2ec9c3",
-                                "uncompressed-sha256": "252463bb848719e8d77016b0b564378a48feca3b621110eaa91e31553f0ba317"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8d02aaf1aa4ee54e2a9f8ceedbe40c9bedded2422ae6d44584ececf184d2ce24",
+                                "uncompressed-sha256": "7acac1acab0673c7e7165dc9abdf3707e1b58d6ae91225527e5349eb09a9f351"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "81b25a803181620eeb6f10fe13aaa4b13c135728457b85e64f956a108ab9e646",
-                                "uncompressed-sha256": "ef11f7f26c10af13cd250a543a65916d97f4df467748ec96204b15a91f78c424"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "536f9dd8c3202f8186eaf7bac702c3b8d150e7359fa03407b5acff6c5d612b38",
+                                "uncompressed-sha256": "186993654d28f3d47ed56dd312fa310ac0829d014fbf6bcd6d194ae2d6e802a6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "30738ccac1cb39824601ca68cd8a04c1af2e89c70415aa9be3f64d4c7bca1c91",
-                                "uncompressed-sha256": "f5c17e74db86473b34b6788c07c4b550115fb73385f984a0c75aec0e35eb3aec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ace7062550d46b043cad3bfe5924d8ee11394ee4ec13bc5a31af0dd05273d66a",
+                                "uncompressed-sha256": "fbe98e0fc7e44b4e57f923584f3b9441f6f0273357ebed5f3bd2e8e19c78e8dd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f3b9afa66a173c4f9583a128e6d4c0dab19977cfa1bf4b7a835270b344bcc5a8",
-                                "uncompressed-sha256": "b5ff686c04a55872a4127588a1a056270acbad28181a12d8c30fdc74757dfb63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e0f09b26de9cd610850c3cb1f9475e3d2290838a8081a06913b71cafb7489a98",
+                                "uncompressed-sha256": "aac496b49f31fdec19298fbd235da25f0ad5c9cd22059e39cddfba37967dd0f3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2a6d7496bd473fad54eb0ffb24ff078aa718de38a4b61d57bc70326a4f71a059",
-                                "uncompressed-sha256": "e1f0a31bcd6350975cd195d41e692d9ffc38be00a4e5349224724817840d6da6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "15037893d37399fd0542f4fab8cee679eb4e0d578c2361e5222ff9d644312b86",
+                                "uncompressed-sha256": "cc856a3af169ae05b575690c248cf56a6e2bc9ab25ac9504028731891f6d343d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3143d72391c8d81f6cd486f678449debe5a291a89f41cd5644c45b01888d38c6",
-                                "uncompressed-sha256": "1e460c825f0b2283a9507c4a0ecd40c7d56677800f3ea389cc538542899e793c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9ef0d87a1a783e9abc9e00a6f4fa1dc311ddd3973471d036acac4598d34f1d9b",
+                                "uncompressed-sha256": "a90417cd1f41222f7932cc30bb6d43f17a04160bf29e713bdc2de2507a1ff2b1"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ea37b90205629731110a6e1489c398166d62a6369b287ebf02b1efba11218283"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "3fc353fe2a70bc3035ee271159c9ed293c65f86e665df167208c777f521105cf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "251ccd7cef0f08da133792f3b181ba39e3233e62886692a252b9504f97c2198e",
-                                "uncompressed-sha256": "6671d44a5c651f72d2bb117d1eec42edac6baee6346ae7366e5654d0cae04fa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c4ef64b421c6accb2503fc01928fac6abd1c2ea8319c54ab00ed6df2cc8551cb",
+                                "uncompressed-sha256": "9c883d09f42c0c6473f0f0f2fc3e9e8141b3fe18d9c4aece2f2ec0bc5c7fd217"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live.x86_64.iso.sig",
-                                "sha256": "12f1f5c6fa80871129ca748f83699b1ccef5fb482bb4de8b66223749c1079c4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live.x86_64.iso.sig",
+                                "sha256": "e625d3c1270379950e08176f352f0977b9911544a5a7fe0d3540e3ff12520257"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-kernel-x86_64.sig",
-                                "sha256": "241a166c730747365b85b5f391f15a5f8325242b79f52cb39c943ae9665f7a02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live-kernel-x86_64.sig",
+                                "sha256": "f99eabaaf7523e47b50b1e14c5fae53432c9de2d0fc842bf6af2d7926f9cec01"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "85e85db81190303e7624b617f188d4808ad4a7768708aa74e819b9c89c9ff5f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "86ccec6266fc82d7a571f5c7c3995e9bb5da54213cd31965af793f1f4155ee58"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fc3e851994f063b40c889c3ab49aa809ee9e9dd7c222aadd83cb33be6d4bb0b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "16fcf957cde8b64654aa827faaca7cd908a7f563b1c63238cd3415822687ca66"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "11a7ff17a3fa4b38891e0129504920ba1f3df7af91ab18f4958fe0aafdf2d2da",
-                                "uncompressed-sha256": "5a9ba8bf73687e400078a8bcad989e33fcb448fa1cd90ec842ff46b450ab1b23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "da133ba954cbf5c365f6b88011c24048fb658ace631d0a32fca7f7d04fe87805",
+                                "uncompressed-sha256": "d64d48516d1ca9d042d862a9eba6b6e652acf90751f06a70ba7851e02b6483a8"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ec0370ea3473d26ae80f256745a0b13ad577c2c9356533e00e07c41fcb0be3ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ab1afdebfbc2f2832bfb4ec259da7d89458a626da1e3e869f9091af12be441bc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8d288560cf9b6d06e8249e28c5823194ce9a696beca6e59d2a435184f58e3d4b",
-                                "uncompressed-sha256": "07e641c560da8a9d7ed637fda41c9802ffd16edb985451927c03aa91659431a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "850f143dd530afc6aa29d0c5024758084d83d561a79c36ac09e460b3aac8770f",
+                                "uncompressed-sha256": "7b4cc4a9b04430a68aaf02aa22eec84016b0b8d2f42d873a8a82c8c7b54c0941"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "41b9596ab25ced5a248ce1d9110bd743425972cd63e590683be2c6ed9730c3f2",
-                                "uncompressed-sha256": "9498acbaf0f6ffc4daf3a0fae6ec58ebe767dda5515b05e29a63fe974801ecd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "79dbba5c211c3203394512c664eae632a05587c2cad5ad00ae039af26d7f4d0e",
+                                "uncompressed-sha256": "70c7832e33cd7e53f512d292e7791ab845577586cc3ca02a538cf470271c3521"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "1cf90cc82ba5cc28d74f590d957ebe17cc3a3cfce28a11e806b319d63367a602"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "799de2e0ee9fe6d989f60e6ff10c9a4821fc31dcbfb27fa22e13a865c3658b68"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "e8a56b2dbbdef19855e6ddb0a5ce5566ec9f18958fc73e28c88b6aac0f424f07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "b733db7d23f3d1ef842dbf61c57cf60a5d60a36fc061430431f9fec0600702c7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240825.1.0/x86_64/fedora-coreos-40.20240825.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8fafc664fc0a12de26f6546b7efcc7056867cb0d01e5b6752a788fe8f7bed51f",
-                                "uncompressed-sha256": "31c1ee5cfaff2edcf47ec3cfcc6983d25b66f4901b933d2c6bc9f943b8d2aca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/40.20240906.1.0/x86_64/fedora-coreos-40.20240906.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1f9ee4c575e147f04e22d216e7fe0cc9a95861f0f718eadafe2deb479873b9be",
+                                "uncompressed-sha256": "42865f80ce78b9e5fb2a7ecee997d897c17a9a5d60500a682613a6436fc80f17"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0adea858a2c111a44"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-02ac1a4bfe0aeaa5f"
                         },
                         "ap-east-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-02a9f70d24fd3b218"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-044d38940441144f3"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0d793202a568e2a3f"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-08a8c4d1d5551bc4d"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-08e583f3b1c97ffad"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-022a18a849cd9d47b"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0d73a4a70a840fadb"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-09e7e66571bc28fa6"
                         },
                         "ap-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-02fa215c3d01823ae"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-06a1fb98ae1f34fd7"
                         },
                         "ap-south-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-00cda3fabbedb1f28"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-071a44067c2a8a0be"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-08b54c0c0b7e471bb"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0f2e05b95fcd1c6aa"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0ef543b68319853dc"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0ca1d1bbd4e7d749c"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-07bacecd4bde9a4a8"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-099e081a1142ac885"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0b04eb41eb2135e4b"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0c864fd8094a6fb9a"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0aae7baeb2ee45bb1"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-05124ca95442f4950"
                         },
                         "ca-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0b0a032eba72aaaac"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-003a74ba8ab698d0c"
                         },
                         "ca-west-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-079424ecd8a18088b"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0a9b91bb9dd125628"
                         },
                         "eu-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0af4145d2e6cb7571"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-05f61c2117f52f64a"
                         },
                         "eu-central-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0850913bd01bdc874"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-08ddcc546fdc9ae8b"
                         },
                         "eu-north-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0455f6a9452ccd0cf"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0d8cd02c08d459969"
                         },
                         "eu-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-009bb3ed8e6cd6075"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-05c5ceec1994fe228"
                         },
                         "eu-south-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-05256832a2a7552aa"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-00784724cf7184a8f"
                         },
                         "eu-west-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-05a281cad4c6bcca1"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0e3e883d43bc53337"
                         },
                         "eu-west-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-07016fcbceeaab6b5"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0311f0443ba8afa29"
                         },
                         "eu-west-3": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0e3c2a7c5b03744e6"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-02700ea554e524117"
                         },
                         "il-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0e2fa556cba73c8e4"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-032cd49678e214517"
                         },
                         "me-central-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-004653d4a3ed4f46a"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0f6f6344e46f56051"
                         },
                         "me-south-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0fc1b03ffd6c676cc"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0584d2ced1780336b"
                         },
                         "sa-east-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-05f7104411f02eae3"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0860cbf4d3694458c"
                         },
                         "us-east-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-05175de406a27d1e9"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-042cbb85136a140aa"
                         },
                         "us-east-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-06d54e89a0b4411bb"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-09caaa3f8787af740"
                         },
                         "us-west-1": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-0de864de8adf247f1"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-01d87e8fdf90614be"
                         },
                         "us-west-2": {
-                            "release": "40.20240825.1.0",
-                            "image": "ami-01d150bf191b6c78c"
+                            "release": "40.20240906.1.0",
+                            "image": "ami-0c7bb20a9537ba1d7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-40-20240825-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240906-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240825.1.0",
+                    "release": "40.20240906.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:89f351c7ff1282f1a3ee29faffdb38a425bec034bb9c6400139ce25f6786b7ce"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2082023db0f18ac8440b1288fb3d2056e3fe25999497d462cbe98475c991c239"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-08-28T20:38:58Z",
+        "last-modified": "2024-09-10T23:15:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "da315071b32ee882b3f12bd2176757f065bcab8b3a746f746023c6a68c5a7185",
-                                "uncompressed-sha256": "254f427ff7fe6ff0e584e14907e87d3e05e4b90a0a6e097349502dbc2861a62b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "40ebd1e52a061253f617e3650737e97ee66d2f0612998508abdaf4d4cc5d22c6",
+                                "uncompressed-sha256": "27936e1d78e207a9f2045d6404c361f35d1774e83f1e709cab9b1b86ef230b42"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "318afe72a8e8e50cfd047d80087c9092ec6d38f3b91cbc177d7f615cbcddaf97",
-                                "uncompressed-sha256": "814356b034a25359a7775132b9c8cab51c248e5d121faf4383c9cf723232385b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "050afb4546bdb3ad2f8171cf5beb64ab9d2e64c88c3218bb96c617d43b7eef1e",
+                                "uncompressed-sha256": "d8b6c90a1acd85b7745cac1a7ed80ef1c8445cf2c01288c21fa99f5b1585932b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "43880d7f4af97c2cfb5f805d825eaef3bc8b5db2a30e5375938b5e01d5fb5df5",
-                                "uncompressed-sha256": "81ae85d095992297f4ec859f6e1f00b765522142d1f2f10d91b98d8d462f43ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "003ffabe733dddf7928cd8745ebe562c8b1f15c15fb14ae917a63814dcfbf1eb",
+                                "uncompressed-sha256": "16dae7380dacb382d455a995d29f73d68a21078247ae0af3ff13409bd2756e4b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "4b1861abfb0a9e7826efaf5f70dcbf36574b45ee8eb5ffa8e777144fdb778dc5",
-                                "uncompressed-sha256": "e180e3b8441e945ed5a04b2ae33d9b48062a718c9f08d98572386e5e8f7b94ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "754b3928c4bf5c385abd36c8b78bdde68b2fd7d139273b77a262666c9402e933",
+                                "uncompressed-sha256": "7c0ec23d611034a04870ca698390ab71406b4bee99b64843a404a6f393f878d3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "23fd0397069ece08787baae003e8aaecf16989d6e3fa930b734fa4ef5ebb3887",
-                                "uncompressed-sha256": "ab83b6b6c67506fed6711244b9704e50846d9dccfdb070c34cc71dd79f88a54f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "9cd7dbf22d9b16e2dc8041d8bd1d79504a6d77dbe8aecf24039d0b89e2f8ee9a",
+                                "uncompressed-sha256": "2f0d53a0dee903a49149ad0f5a7565117eed83dabd1a75647f7bd3d2f6830f13"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6e17b3c1416be05b3a58a67d2eb38bedc0a4f3337949152ae5b8b868892ef6e3",
-                                "uncompressed-sha256": "465ebd084cc29b479925236213fe3ac1d05223ccb15993afd4e598564a45c9d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "06906391180885abf04af360c4863d6da6715e0bcc26e2e03e37ace63bfb1774",
+                                "uncompressed-sha256": "08a0e2027f0070514eea2b3cfb9bbc99cc53d03b6263494ff342e39828071cb2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live.aarch64.iso.sig",
-                                "sha256": "23f4c3e9cca747088c1dd8db84c4bfb93a9e74e364d36a7bc7847b9025109471"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live.aarch64.iso.sig",
+                                "sha256": "8af33ca9f09555ba61f01db7e1d2f47e096b0f331a141f21f897de0f4382e6eb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-kernel-aarch64.sig",
-                                "sha256": "cb0b0862cd36bb3accca36434076086a1a72059498c1fd320361c08d8255c7dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-kernel-aarch64.sig",
+                                "sha256": "8ed95915e2d2bb8f683e3a17256fe2dd2826dd7e8cdcaf9194bf6813ad0f125a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d03f6dd23a7ced520b9b04f727fc48536373c0e8d4c3c989ee734fa6c706d415"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8789bc01550ab35952140215500d187b71522a78a4b9f9026cb30fb353cffea2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "31bcd0fa98456745141c2dd419e08c151898d685de5bfcdcf3d02552289e9656"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6c7595d9f6acbc0091cc8ac6406ec57dcdf8e0bdfd5916b0d10f3108fc683b43"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2a4874322f83b174fa45ddc06bc8113cec3b696b04f6e511cff744884c7e8258",
-                                "uncompressed-sha256": "eb40d9aa4bbc7bb4569f185c7234eb696e4c58f7c9a07f5bea2a20389ddf8618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "56d25ff75f6b2cad60ef1c16fa3962b17edf9c80c5cce611bd97100d1870cd1f",
+                                "uncompressed-sha256": "e9ba6a0235ca9eeffc7c4802c6c0b2c10f33d3af03dc5750a9dc65bcd6d8638d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3e0bb53471951f51da0066c2d0d68a61404b688ec6961a618769377cb17646a1",
-                                "uncompressed-sha256": "cc816c6a61e8dac9064fedd22d97282f284e1def5404b696c23d5c045d15c48e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "547819cbce0cc4028785210d8bfda070bb87244b79e01f4cfc43d0940921cdf3",
+                                "uncompressed-sha256": "17a49a1b2f8d19f02d93b0cab99d5e466e8ba17f80694957333711c8bb3b5730"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/aarch64/fedora-coreos-40.20240808.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d426264e8c8b10365184a33614f039e5f88380303f0c48f6106c53b735e2cf2b",
-                                "uncompressed-sha256": "1e67c8baddb5b27977c5750e8274c1f2846ee5e756b60db5108e4a66195b22bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6cbb72311ff3ef95cc68a2aa84d863934a2ef3e3acf0af77cf857e3802bfb658",
+                                "uncompressed-sha256": "674e64325b118b653f7bf7db3661e53cda52211637dfd3355a12dc4a9ca2e2ea"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-00158c832e2c4401c"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0efaed3f9fbdd2ff9"
                         },
                         "ap-east-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0256498dd4f8c8b95"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-05e686de7a6cdc332"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0a9262679181ea8d0"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-07e35bf8a166450c9"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-07605e1cae40052c3"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0e182ddc6e7cce101"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0c5b2cd525d1d9a15"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-09fdbfd10417155f5"
                         },
                         "ap-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-087b0f89679585852"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0efce531260a08b3e"
                         },
                         "ap-south-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-061f2c213967e311b"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d07e2b4cccb4e8e6"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0c1485d59c76cff77"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-00804b2c06ce46131"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-08d6cf9a6077f7c0f"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0a60ac9b6932b7a72"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-04821c8b83c2248d5"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0eb62592f766f49c6"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-05c43327a16167731"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0c84c4cfe82204137"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0e91b8ece2b5077fe"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-08adf32d04ec59d2c"
                         },
                         "ca-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-03c0332bfbee2948f"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-01ef92d21a517e9da"
                         },
                         "ca-west-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0317df7fced4187fa"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-070bf5a6ef7f8c458"
                         },
                         "eu-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-04cea1c1942423800"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0366a4f758fc33f35"
                         },
                         "eu-central-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0d355a4a20f85fc55"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0e218a19f82868c66"
                         },
                         "eu-north-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0dd5b03978e3f5d4c"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0a768c30da01d0559"
                         },
                         "eu-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0dc239cdb014526ed"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0becd0fc05e5e9471"
                         },
                         "eu-south-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0e8ee23cad93108c7"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-079fbe044fd108315"
                         },
                         "eu-west-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0a98bead057df4d5c"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-052cb563d2a81dc12"
                         },
                         "eu-west-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-052941468e27755a1"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0dbd6d5410e3a697c"
                         },
                         "eu-west-3": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0bd091956b6667d5e"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0a365a808402562a2"
                         },
                         "il-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0d5c79ac7da470045"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-07af62d0fa44e67f8"
                         },
                         "me-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0ad529ea5b631cdf6"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-07fcf22af4c197eab"
                         },
                         "me-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-01ab80fb97e379c6c"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0a98142768d63da6e"
                         },
                         "sa-east-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-03a0d48cdaa345dc1"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0ce63ddb651b657c1"
                         },
                         "us-east-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-06d09490c12433148"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-097639dd63538e166"
                         },
                         "us-east-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-096f3633970cb2e2e"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-06094918de11f3ede"
                         },
                         "us-west-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0f0d14583c9548910"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-01e71c4525f290607"
                         },
                         "us-west-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-090bddf91a0f94ee6"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d3b86775a035afc0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240808-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240825-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "72d1dbbd6cb5e33c24c24a21d45c46faeafbc915147d729ed4058e8dcfcbb395",
-                                "uncompressed-sha256": "c89ef7bda91bf088fee5e7a3fef3a2cedc2e3e234881de26959fc48579557041"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a58aff88474fc7c20302c1ab4092c52aa51c899aedb5d8ecc0ec04e449913b1e",
+                                "uncompressed-sha256": "04c833d9c2ce4970290c54365b7a6551a06c2e2c8ce8326fba9fa250c231384d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live.ppc64le.iso.sig",
-                                "sha256": "12a4f18b4f88580e5524b8be119b246c145f212baf7d0777c1b8560afdf29097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live.ppc64le.iso.sig",
+                                "sha256": "abc4fd4919e595f3c4872db4557c2dcf3ca132df793af61ce7d0a10ae5ccfb4d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "c9e2f1cb0a59a1d1b74e256e4f74078eb099e998df7c48b2e15cefc63944f92a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "f46688f208e600397c0d194a81b78885ee65cdc060af8ca2769c9ad02fd39b09"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b283a26cd7861e990b7bc5a6bee4e62b1f85b2d888c16117f72c4da9f3e45885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9caff4fc300f9f596d025417268ea8d5ec2ac5383a7ceb1847586beab9ddfbae"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "108b63ea55548c91146750bbc1c5c49bce4e1fa22e9019d2f72f74cffca4eac6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "bfdbd000140d2921c9a802f683d6d6e9bb654faff45cddb0f119696794992f2a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "64dfcd13b5f42b2ee6e595b59f321eec3357e0e2f1d429cf839103707e60880e",
-                                "uncompressed-sha256": "cc57f147ef80b43804af8a64cccd7189b4eeceb4161715ff7cd1de063841bf48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "eb782f37e1094db75fc7c3540e45390444dccea5a93cf79a373995b31905f704",
+                                "uncompressed-sha256": "0128b5e1ef91f63d47946e9a7928ede88a85e5596b62987838610db14c0c60a7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "25d181233cf5828202babac5369ee44e99c3de04396354f411fd5859dfeb482e",
-                                "uncompressed-sha256": "ca69f8874daabf0bc96e86fc6a34ac4512e437c7c0248a4ed2cd29c50017c204"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6518b83c9287e1cc02a5c9945074cd1a5d19cbf348899ae634a364d9dda9fce8",
+                                "uncompressed-sha256": "d467f8504de2c1ed38f85e399540fac39fb07ac00922f9ba9b6cc441132da202"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4032e55ad1ab944361018009bdf8399ee92e11875c9b318f5900218f42c8b1ee",
-                                "uncompressed-sha256": "a5398cd3315d171c81163032083a61367eb4469aa3c758452c1c42bee029cfe2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2201ed634291d0555a11e12e4b0facd36e7c571c6c041893c5016cfae1a9430f",
+                                "uncompressed-sha256": "0c0dd3ed61642ba17cb59e7fa8fcd874b07fe6fb2aea3b96b8a3d22b06a239c4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/ppc64le/fedora-coreos-40.20240808.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b8d0a781eda93716cfb4772ddb9567dff8d424cbc530722434ea1a5a7657ae2c",
-                                "uncompressed-sha256": "95e6d7d25c7c6cff4d91b0e1e1c065d597b6d6e03b4e571cf76e9ce451f12727"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5d3c9bf6d4b051e934e7f903f06a8b0762ef724ad1d049616a420e594e3e75a9",
+                                "uncompressed-sha256": "124616b5c468f46a9e3c6a855a42781409485c45a3cbe1bebcc4adf51455afc7"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "76db78cffdc7f757ebdca71f0d1d026c67523ce878ddd0de48d09c6598a3cc6a",
-                                "uncompressed-sha256": "158c82089cea6b5000f7b0384d12c14cddb1686ed2e60d61433adfd07ae04dca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "370eafe2352561602f3fdf5069135d1097e710f1ccf4fcc89da229fd5d03e6a7",
+                                "uncompressed-sha256": "fd9a9bc327ae7ecd3a50f2b985bba992806646b06b474ce0ff542457a0bd0848"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "dfafc7a00987b6522099a737f7c8c8a9588212ed60c8ef6a43f89ba50e08e1c9",
-                                "uncompressed-sha256": "6d71b66471ae18b14f0d7972aa909159cc4f0f1fc617ca5ace16c37d48ad9f49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "096a8280a10b6d9afa5d58e15b952f3a805f0aeeb105c2609a1ac073a4fa7f4a",
+                                "uncompressed-sha256": "c3a5962aa7722aec5b8f44f4941d246475a112cb8bd49a2f6d421eea9e76a159"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live.s390x.iso.sig",
-                                "sha256": "8b65ef626a95ab66c8a2c0b8dd22a2ab6efff7eca6880c35465c842c60dd6e6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live.s390x.iso.sig",
+                                "sha256": "316fc5126a5635ea3f9e678914ab2ab7a0c70a6d6f56041d16a75bb1967accd2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-kernel-s390x.sig",
-                                "sha256": "cd0ccb133703f0b51afea4a2bb0c1e76111a442745137e866f0945f808191a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-kernel-s390x.sig",
+                                "sha256": "c3c314b436e4e93d8f96c773189fff652fabd9145f34f9eef851e65754e0461d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "1a26f4eb46c994350573bda051e7fba0000cb5c1d9cec2a69ca7b3f35e3d6df8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4c557028d0c0920ef4ed7ced05971de622ff4d460c7ea54cd2689971fb593dca"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b3831e79f738f913eb98739153321c181b1ffe19ee97a2e85460813f4e550b7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "27674ab8bb41d49f3334aab5d705a49202796fcbcd17b6d7ebddbe8837d6e177"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "bf9cdecac02f9e5c1e9edca7a8a8ca6b8f64b7cf45440ee41a85031a005e5001",
-                                "uncompressed-sha256": "4e767562ab2bf5f4fe49a4a1ac1f101419b6436ab134da36e5546de74f75682e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "980c959308b126c2198db344fd9e8bc4e8fce68c55dcd7a63c2bd8a467f4b24e",
+                                "uncompressed-sha256": "04c47938ced17a8def2261464087c0297ed5c1706fb9c3c89016ca86ffca07c6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c18eb2fb07256a804cc3d499b33f42285e730995b75851f0094e197cef60dfbf",
-                                "uncompressed-sha256": "4cc8922b80fc001f6db984288afdbf8fda8e52fd121c6e67a11c4300d8b617a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "74e15630ae91ff04870b3234f418e355a85b95693a6dc74668211077b4068358",
+                                "uncompressed-sha256": "ee0cf438884aa8f497a214cc550906f0048937e1d4469a0ae5ff4333db431b08"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/s390x/fedora-coreos-40.20240808.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ae4ea22c52edb14471a1fe89befd07626234f9191de41039ec4220d152deae15",
-                                "uncompressed-sha256": "faa160c7b08517b9fcde0b2bb3ebfffa938d767ddf05371ea6eaf877d48afeb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "10c05bdba8c25a4581571ddf989ebc383d92ed37c7d9e0667ccef598015037ac",
+                                "uncompressed-sha256": "3dbcdf2de69fec9966534a7ddad1e6c7c6ef215682df8f2c12e45da5599e65f8"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "df4c6dfd92aa3376c02c1f455358175ab6c4ee59be61a69e16414be309fd7d9b",
-                                "uncompressed-sha256": "8d140804db226bd51360d43b0d7980705da44f7ddc5556b644eca35a786f02ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8b6676f0a252f45730fe5188ad21903067c9f1fdc43b82936b7ac2470baa5567",
+                                "uncompressed-sha256": "562ee94c8f6e50c255d2bef216f852f21bd3049772597895ebb00f8ef436888b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "dd0e8b5348c907ee42a40762caabf0e220e0ae23718289f4f6c21b0cadf280d2",
-                                "uncompressed-sha256": "4807aaa63b92cd21a4c516a8bebe9d44ee8d7a56f4c1d3b172e26b959ce98915"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "68ad3821af161c4dbcad5d4125c93e7ecbb97e93831477b1fc78f5bf81d7933e",
+                                "uncompressed-sha256": "9d9c81cab34f8be5d83c730e219a5294120dc1ad2e34ba9d9f859be2dc8a79ac"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a852e689259ffc9f56abf3510adbe8240492a2df35164d4dde2cfcd987a9ab15",
-                                "uncompressed-sha256": "95b4c89bf01da947409742fd98f7d27254b74e001649acfdb57f44a3f017771b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "beeda76d171da262ff092eed96b924a5a86c51901ce9efa009b6af50c93dcdb0",
+                                "uncompressed-sha256": "cbd7780dc029f71c851c513c371e4c46b82e8fa8fde70a55005fb9f563f2d247"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4487fd6b81ea8be138a9109a959bdacfc506ed76ede75b918aeb1b0c7ef9499f",
-                                "uncompressed-sha256": "3b7bbe70b0d006315fe0c32d6ab82aa8beb8cd62763e7ac56e2e894fa7f0c01d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7287e4a46b602976123539fa9738eceaac1d457a00cb09a740827b6b4ff815e0",
+                                "uncompressed-sha256": "793bde75060c14f6ff8f4cd748b1b74925eb3a51921a3f487023c462e4c65adf"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "dd7e18014f9251193e4887f861a42a95864ed48f12ec1f7db703f047fbce9b2c",
-                                "uncompressed-sha256": "87bb41e365637260f96994d889e2f2469677e40597e494460f5657aabc564871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a9379e0f5f7faea3f6e2681229191a8e6c55119b8cb3d3641b2422252bc6f2fd",
+                                "uncompressed-sha256": "f2b29f9fc8b86f6c4f6c215408ff98151d2987b58718f035b3578d404dfecb38"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d3e858c4882a834e6048314691034b698a54cc5eddcfb0a7ce1949209344e24e",
-                                "uncompressed-sha256": "16b3282a6b9d1064ca216610b7f17bf827a9fc1a06e1b17a9f0c57d12afea07b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8a441527693408e39244a2624c754a021f84c99aa0a4102004bdb120b3821696",
+                                "uncompressed-sha256": "d03075410a7de0230d26a0165e64868d4e5514e1b85d96256be405d406533ab8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "83ed2bb484044be5070ee009f1fde6abe61e9f487e654021776b0ee49be58ab7",
-                                "uncompressed-sha256": "4429500e2f6d77a9cdf4ac6c397a1507a46e764c8c481d602f731ad17c6c9e48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6f8f3dcd1cf1ce89aa23cf328adbb2390e1f389e18df328519bb8d4523ede470",
+                                "uncompressed-sha256": "d51f811c7975c8ca411cb0c14bf51f90b96c34b767230cb702e922b84367e9e9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2ef6212f9fcfacb8a6acfe2a3726f89dc19372adc3bb891a44f385e9b28230ad",
-                                "uncompressed-sha256": "1c56018f58e0918ff0e6532fb07c7e5a63def936350deba0689ed1bc9e93c410"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c86ce370fc3cb70af913758682fe57a74ac1e61147f33f1113e5a3e7f6764da0",
+                                "uncompressed-sha256": "4761c404d22869d6d3e01bf8723941902de01d01ff26092f7231c76fac241162"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0d49dc66f7347d28fb13028c052ef219309410f3473a0f853a860929b75a8abd",
-                                "uncompressed-sha256": "505ca3c1e3ad338f7b07f2e0dbf8a4873390ce0eedca91b7ad4005e7f6480d52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "abe70a21e27d67b7a888d2c232664496c4a49170ec831a83b625f31b2d42646f",
+                                "uncompressed-sha256": "7bd6aa2a67fcb1f42af13b91cde83b252112738320722d683c36960ea1557a7c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "23b28a036e64fb98bccd4661347ed47b5635bf79c4e782d92131a351b99593db",
-                                "uncompressed-sha256": "7145e53a7ca0abbe1ba4276666fbfcf61cd4835db5abcc4c3200ac001b44a02d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4ec9200406a3b7d8198ba3845b3bbbc1e534e7dd398b582191680e9e2bfb0602",
+                                "uncompressed-sha256": "f44cb7b56b30795eee29aed34a2c5d75370b083b90d28113b28d114628f5ed84"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "be290e789ba10482fdadc06eb612edaf296e6d5449aac57334bd301e0e1ead3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "917494ceaea056eaa322b105ba569670dd985645fc98c4684baf8e992a994702"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "83842a076c21b9f2d81d024cae35d8bf641ab19117a04eac099ffec580cbebe2",
-                                "uncompressed-sha256": "7c9593b9d735f0175be1e728800fb8fc3f76b15d5d90860d85bfb19c83bfb749"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7b56cefee0f712b1a9b00247c71bcce73ed227226145b8870dba91fccf4b7196",
+                                "uncompressed-sha256": "0474d2042ecf317c00fc4b26b6c7c481743bd8255a65035e5066b5a5b8d5b8a0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live.x86_64.iso.sig",
-                                "sha256": "09529395854807a38fd6720c418b80fab49e073d47acf290f677b453770bc781"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live.x86_64.iso.sig",
+                                "sha256": "1a8ace5c2ff81747321e51c120c49bb421f22d1bf8ed2b1571b00e69d62d5911"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-kernel-x86_64.sig",
-                                "sha256": "36eac90bbc9b6c594515fa36e2dfd4e15b769bbb5015f3b024d7bde4c4f50abf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-kernel-x86_64.sig",
+                                "sha256": "241a166c730747365b85b5f391f15a5f8325242b79f52cb39c943ae9665f7a02"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4280a9c2e29e9e59758709d40b17a05359802bd6b52d6286bf6fa0bac2c2aa45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "399debdeea17746dd35da60d03bf8508f625ce6e40fe9e11f968b2c6f884a63e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "556acc04b82349228b2428cd9a7a4806f9f66be151e1f413f1b75681fc8286c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e170090ebe41527d757e419aee9cdb2a7c50555cdc9430a103faaf1c24538c4c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1f9b0cfa2a12175324b8463430c6f6f602027f121179b265a22436b861e7daff",
-                                "uncompressed-sha256": "f9f69587af33bf676bd8764fd6e78575f0ff8e83b412baf93c1a02dd15f57b9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "38483be2efb70a51f0c43fdffa08e2311cee0bac8a64fd2d120c62d9861a13ca",
+                                "uncompressed-sha256": "fd62f24adafef4d0ce0f9e02a99d347bb4337f0500290847eb226264618beace"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0c0b53e8bffb9d4aee3689576a67aad82368875f770750593d4f9427bfefb0c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "cee115c6d89ac143fe1a0037c32979656cc167e1b0c09851ce3f2c19689d98ea"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a1e9e774763456fd2cf9ac689ad86f4710b66def3e563471d6b3c902d143ebd7",
-                                "uncompressed-sha256": "d2f714e06d714f83a3f3f1af1c739c5a11d3a6a412fbf314414f32b5db9a9fac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "24e3f8e7311d5ce11eb732ae70be595e0c9ef7ab777bd57146f8bcf557023572",
+                                "uncompressed-sha256": "5b01c202b9fa304b1fec4b8e069dd32d1a848e598eb1a1836353d50fe13180b3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3404b874090c95fc4bc8e7661a26d491d51ba019e278cb174843b5fcda2b429c",
-                                "uncompressed-sha256": "f7cdd87266c4d9c08f18458734a5482774ddba7facad16a6ecc9dfae643126c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "c4a6dc838e766a57f47ca82877e547e95b011bc766a5eef4478fc74090631ac4",
+                                "uncompressed-sha256": "c62b3fa46a9b1bffb42994b5de1e2d2841f468b3336fbab33b52fa5225348d10"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5336a4efb06cf912a9ad9790b6eba67465d1bea46d701b26bb369df622b107c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c54aec3a22114da7c8526fc2d7318f7ffc61057c8925b6089cb3d13382d81d7d"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "a8e18dc16d32874d69564c20f7a16a94e8435ab779a5086730aa7e2b1fa6aaee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "70d0d1336a16aa78efa85032fae2c563cfd8848938a2693abab29f57a4fa7394"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240808.3.0/x86_64/fedora-coreos-40.20240808.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9cdac4f1efd5a4d7f23941573ea10d9c1d01c21ca3c9684ad3123c5b11522d82",
-                                "uncompressed-sha256": "b33319603fe8fae893b103779c7f49f54cfa7d8f5de58b8c19420b905cf007a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "179a4065c36984b5fa64a623933a6565110a17269bfd94f9d51ee961958d6f3b",
+                                "uncompressed-sha256": "fed3e01202dab35280152f272e47fc21b3bc2261a1338e853a9fc37bae599885"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-032561396a0f33eb5"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-090db5a9766d84ac0"
                         },
                         "ap-east-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0b5489977772628d3"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-03b1fd80b5a652633"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-089f993432a8ef9a7"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0952ec91a65e49582"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-05e883b5c299d597f"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0329aa9853eb6bfdc"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0066545fc60815a0a"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0512ca1a77f8cde69"
                         },
                         "ap-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-01993f2db485c4e3b"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-08c0438b5ecb1fd12"
                         },
                         "ap-south-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0708cb1783b07de29"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-09ab7b9ae18fcb944"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0b91b5465d06dcfcc"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d5deb94d7ccdd9b7"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0d32b3efba94bf5f7"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-032da4f815b94215a"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0f24efc55769cb2d7"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-07ae7944d29e7d1fc"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0ba0e6dc3ac181d5c"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-08f2105688c3caa82"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0880473596aeba8c6"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d5ec5cf10447fec7"
                         },
                         "ca-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0014c37871214c46a"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-00bf6634758bdbd42"
                         },
                         "ca-west-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-095ca4651b27479f8"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-022e1c0847b9a8b40"
                         },
                         "eu-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-01e740ca2bf2cb17e"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-06d99f83f85694ef9"
                         },
                         "eu-central-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-047ffb9fb997fd9b1"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0845a089809d85714"
                         },
                         "eu-north-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-07d4c5e00d828fa73"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-05d36aed063c7f5db"
                         },
                         "eu-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0f58a0677a73150e2"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0af151f580717c867"
                         },
                         "eu-south-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-06ef1cf8293cdc2f8"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-08ea477b13168ff7e"
                         },
                         "eu-west-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-07648f553708a8d4a"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0a016f7874e0ebb36"
                         },
                         "eu-west-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-057d43873ae066064"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d470b68ff0dbfe01"
                         },
                         "eu-west-3": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-08f514f9a9d3357f1"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-05b03e7e5677c82b9"
                         },
                         "il-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0219e31a8cb9bef39"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0a1411a203cba8d64"
                         },
                         "me-central-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0ef3bc454caf77f9c"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-01be89d82e4ac30c2"
                         },
                         "me-south-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0afcf731348464e4b"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0745079b1d172c0ee"
                         },
                         "sa-east-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-03a440141d47ec2a8"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d3f076cbaf4a9c01"
                         },
                         "us-east-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-084d189f8811844c4"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0993e354ed68d6a51"
                         },
                         "us-east-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-0cb8768900dd576e4"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-05e132da293699986"
                         },
                         "us-west-1": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-03530adbc1e7d3bcc"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-07b44f3c5d1995374"
                         },
                         "us-west-2": {
-                            "release": "40.20240808.3.0",
-                            "image": "ami-06b7f026f48cd3c6b"
+                            "release": "40.20240825.3.0",
+                            "image": "ami-0d8b0bae570eb6d85"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240808-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240825-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240808.3.0",
+                    "release": "40.20240825.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8696c82174ee0ae9919371dd4c88138e3febe064c9bda2434ffec9e053ba0a44"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3ff2ff2a25b0c9f408d464f752d23318cdb40e617aaff8e97739217ebbb8484c"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-08-28T20:39:01Z",
+        "last-modified": "2024-09-10T23:15:34Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d180f1ebf182358635f999f3532c0e086949a1e8d1e01a874650be876018791d",
-                                "uncompressed-sha256": "e97e203b81d17366b5624b6b67c40bdb7c824187e35b8c099a5bb1dc5e9bfd8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "36f5a7bb3faec57efa492753adf8fe5786c130ebfe215f3ad34773c6323ffd67",
+                                "uncompressed-sha256": "fbf5e76b44425daad88a4dc83222549d30ad96a184c6c9df0219f167fa39262a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "383afee7e7c9c422e6e3c02e9a587d3c7ca1aeb45157691cbec6d2f56836825c",
-                                "uncompressed-sha256": "86a5b6bd8f83bb203fcc8038251fd6cf11dc07f6a05585dd02d43fd80f916d54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "99b3c77c4af9072b5727b7f8448c689e642dc51dd250e22036a0139072c3dd76",
+                                "uncompressed-sha256": "b6a0a0c43777e87ef9784a696def4fe9a06221cf234cfd4b708324ad607b8a0b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "d167f995e8db0c7e3894335682515373ce51b607d816a4b3c380082ab28e9d89",
-                                "uncompressed-sha256": "b93a6c016481e863dbc0fe908a55b22fef721351be12ab0cc3a01e0f715bff14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "f3636355714e02bbf5ab4b800967b6cbb3dc75383fd6764f7cd82e7c8e1a9a17",
+                                "uncompressed-sha256": "ecf0acf7573e2ade5961312ded1aae87fd0bbaadea61327cf241a61b5b3a13d6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "abdc79a8b997892040a52cd1461a8f174c97539735ecc8a3c3f99f6367edd82c",
-                                "uncompressed-sha256": "45b468d669dc870cdd4b95f9d8301046242f84d9a820833a02116ca994fea0e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2c43f5288ba8213e98ccc9eae435a093f4d4ebb3df67a195b114b936c15600cc",
+                                "uncompressed-sha256": "c9538ed35e8152cab9c49fab862b28d8ca31677c932114f5c8453cd8b1cfa06d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "50b214673db683e94414170056291c4d4bbe41a35c7818fbd225597c6f5bd0f7",
-                                "uncompressed-sha256": "aa18974980d176bc856f51a236991cd696ff4d0cbecf27e9f1a84f8a2c095be0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "bdec0ecb98831a9ccc474d1a3c6d232794895824f76a5c10d44420094c917fa4",
+                                "uncompressed-sha256": "dfd17d424ee3e5ed0b2ab350943eaf66e575beaffa6648dadb65bac64a7a115b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "49c7b6a2bb49f856bd533379098cb4a70658e4e8aed843a04e41bc4f7313969a",
-                                "uncompressed-sha256": "8e0c4d02e5f8fd3ec6b14deb82169961a052da74d536b2262a12800c0c1858b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0498fa7c15868f11a814e08fcd9b9229104ba2bdda78fde9345ff1fd6782a97c",
+                                "uncompressed-sha256": "947f52242cd959897b04467bc427d1b73ae8ae1f8240d922ef9422316817ada1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live.aarch64.iso.sig",
-                                "sha256": "bb3510a27d49891a6fcd7009f73a774f9511da3f43b38cd9fef0d0420f62559c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live.aarch64.iso.sig",
+                                "sha256": "b7f5c5c2711cb3cb751504cc946d887bf0b09fce2976e4f0c68faae241c39844"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-kernel-aarch64.sig",
-                                "sha256": "8ed95915e2d2bb8f683e3a17256fe2dd2826dd7e8cdcaf9194bf6813ad0f125a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-kernel-aarch64.sig",
+                                "sha256": "09855c0c691c8d13f8a7216bc45366ba83f627884c35c755fab01e4da0c19761"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "cd6ea18a2c490ba1a9a4715f82651f112d0e6cb6b7271901a1055702f9336b62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d7421f336e1b942ebd9257b472de34e2c865c4f768ad901f5c4fa60ec1500cfb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "40f1abf44c2206d4bdaafe7d4168cfc5ff2b798bcf8ff1f57a951892042d4bb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6ad3c298c6d2e9ccf8c0695e5d944718e7beaa035f036f4d1d90fb6c6bc67446"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "df0ad28eaf70f8af14c6ab388b371d1bbbaeb3ee45703a9e0e21ae47be3c75d0",
-                                "uncompressed-sha256": "62ac55aaeb04fa7f385a544b9b18234e30ef95e4a69061a8b5ae6f8e4e3daa68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "154a4c6dbd1652047841a6d578c87a1697b3654d6e9e73e510fd3717e846c4dd",
+                                "uncompressed-sha256": "d9c40ad25c09d4b6f230b1ea3c9bf11c4a4c90feecd3233d664b901d296b5fe1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fb3501722879bfcaeab5121140b6ea0ba68665ff58eaebb6dcf13ac7cecbddf7",
-                                "uncompressed-sha256": "058997587cc195a4f2a5910c20e3d4c432a04394695ee98c0243250018c6c7d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "fc3f1c1fdbf9ca0183409cb3f291b1a4d25c3dcec57446343622de5f9a6e784a",
+                                "uncompressed-sha256": "3f72d86ea23be55a0d9e7825eb6c614a97b85249808ddcc1b45e6b1e528e3145"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/aarch64/fedora-coreos-40.20240825.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cfcee74defe497c63d4239a5c96bb94d5b122cb5cb1502d4c429a36e4bac684a",
-                                "uncompressed-sha256": "743135dca0f61ea8c87623f6f5bd8aefd36a4b2885924742f06e863fc4d9390b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a2f7debb14805a886e474f755c2446004c45e4d5b6bd230b58fc74539c535247",
+                                "uncompressed-sha256": "67bc1e4535157f70f8daf8c9fa7a1aaa76dfcd9a24246f4dfd9aed4c141d5132"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-09d697060c0e8ac6f"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0913ac37e800c7ba6"
                         },
                         "ap-east-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-074862814fd1c39c9"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-060d1e4217694ea17"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03c95567e8acb18f8"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-06ccde999a404cb07"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0bee3c6fede287785"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-09b02ecc09e8a50a8"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03ae68058268d9e47"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-06daec6ef437b66d3"
                         },
                         "ap-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-04457613eb0f212d5"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-04e737505eadd2275"
                         },
                         "ap-south-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0faa5eb9a261def7a"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0655d100c35c3a501"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-05cb9421257c5fc17"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-081d7d0eb87553f73"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0f5668105757108e3"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-02dc36dccc365edbe"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-047142bc385295cb9"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0f0220b57e12fda64"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0bb0800ece8e36867"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0b7c39f9fc6956e81"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0981d18ae7c4ae916"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0d68d90d75ab847ac"
                         },
                         "ca-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0a3b6ee3665a5b768"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0492fc93331aa8aa0"
                         },
                         "ca-west-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0df7c6ea4db341dd2"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0ff46a6061f7dcedd"
                         },
                         "eu-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0bf0d714515b17b7d"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a4ccdc0731d5f1db"
                         },
                         "eu-central-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0bd6c6fe014263dac"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0706d1f0e6dbac2d6"
                         },
                         "eu-north-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-06b566113e0b2769e"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0c88b2f4c5ed132f3"
                         },
                         "eu-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-00f605b90d6c752e1"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-005d067297c017674"
                         },
                         "eu-south-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0df2dd5f2f3614b57"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-034dd9ffc5206c83a"
                         },
                         "eu-west-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0f9324c7d5527532c"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-024e2dc9c90dc2657"
                         },
                         "eu-west-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0fbd6671d995c418b"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0fe67a61145841e4e"
                         },
                         "eu-west-3": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-09972e325dd9789bb"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0045ddd8c9cc9a98f"
                         },
                         "il-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03d221afbc06da352"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-02b5932a17f15d36e"
                         },
                         "me-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03f2ee9805b20d693"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a095bb326a6f9fa1"
                         },
                         "me-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0bb383195804dfe75"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0b9b754b88518c605"
                         },
                         "sa-east-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0173289a1713c41f1"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-05737f2c0619e7656"
                         },
                         "us-east-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-02aae8cfe237e032f"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0d00ea1d44977bb67"
                         },
                         "us-east-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0a4c33419f055a850"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0eafd4d6cf4822181"
                         },
                         "us-west-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0efbf5e29ccda47a6"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0c95b70057b0f60db"
                         },
                         "us-west-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-09b5170d4d85e6051"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-07d4c95758d6695e0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240825-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240906-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "588692860fd15f24665a288f8e82b62cf965ad51f32ea69cf8c14594dab0bb8e",
-                                "uncompressed-sha256": "9c07ab0e966358ba7f7da2de8dbca857142df7230f6ab9a63536b86e4f7d12b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "cb94c9c53095e7d4d75853eaaab581827d60819b085dce48600a5bc8fb8cdc4d",
+                                "uncompressed-sha256": "085d2d4bf67d2dbb16dcdcbeae3631dfa1fa6ca0d313dd9e0adb5501f68e79ea"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live.ppc64le.iso.sig",
-                                "sha256": "4076a44d6e675fdf7a7556cc2aebed4706e842cd4385769c7f08e483c27b69ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live.ppc64le.iso.sig",
+                                "sha256": "caaefa76eeeb433d4f6517a61420d3eff00a34d9612c60bad485d7bb7ba9d69b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "f46688f208e600397c0d194a81b78885ee65cdc060af8ca2769c9ad02fd39b09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "8f74ba2c9942315b677986a78ce529d61aa5edddce2c6675b0d797cba280eecd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "4570cd93d98144dc81f10010988acc719a93e7e493f04cb67094da5249937ea0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "bb4d2c85a8e446a4667c9c04bfe48b0f41badd5922c0ee32c15e3d08b83a607f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c8b99c1806d26d6395b00c8419ffa20c39761bcf8850d65abdf36047819b857f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b48e2b7c8b83541428c1391c2ed71bac7bebd9b6ce6021376e84bc558fd11643"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1ff8ca66bc434ed82923f21906241539f23fe74567b4ea23a0b5ff7147204f99",
-                                "uncompressed-sha256": "ca53e327e6cd85ed13454383130c8da8975d9d536fba738dba2c922763e8c5df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "79faed11409ba9605ce0b62ce8504fc8df864a6eac5a621bee72ba7eb04375c2",
+                                "uncompressed-sha256": "4ebff3aeb713de7e7bd7d89056400ed2b233d952c5b6f4fcb4d9a72491718724"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6b30b43a4cf56d3c30d658034fb1989d6d78ca445da98fcf89322209407daa4f",
-                                "uncompressed-sha256": "34a244ccce1679bfc113b8f14ccb59ad03ea987e2f74a26ec9193e72985dfc85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9bca6aa980ef2915fac0bf22fe519bf4ffef4e13458e18b97710244139fee7dd",
+                                "uncompressed-sha256": "545be6a99d0442b4a3a5edf1b846841adf0afe6f1892d8b4a24ed851f876372b"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "15c8569c3d7c116cde620f9c42c893e0a81593a65a0d4d6b5b187ca63ec0a0c0",
-                                "uncompressed-sha256": "e4b87b81be0260654391871a745248402082d561d8ad63d690977a6bc47881de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1e567378fe0d296825a44614b11b9c609bb5993bdf57df4651dc9efb2015707f",
+                                "uncompressed-sha256": "33400e9842a9044bda9c6d4b3eb4effebbd45f42ee5d838c721a394bd6599f71"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/ppc64le/fedora-coreos-40.20240825.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "3b5e54cbbc4d80c58883c1130ef49b7ba4e89af5c2ad43b01d6ec08151d792bc",
-                                "uncompressed-sha256": "892d8c88c4c0d9fa36f6829ffedc9b14702b57f7c99dce065b0d898b72c0a16f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "70547b745cad15d072aee860d61940da2de5e2abfb91ef5a3e5aa2086c7eb5f9",
+                                "uncompressed-sha256": "4a638334c14195514119063fda188a17eda22213c2d39591ae484471d8e4d54e"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "20f9224b7054bf4aed679b55e17f1273a8ec7c2906257534c9bb43bbadad294b",
-                                "uncompressed-sha256": "3b4b4e5a27c781f651aec6cfb96d4e198c2bb157fb5d8134951c65d70e087554"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "2a75631ba4a0ef702298eb28570de54f939b2df3a1eb76eff9106509e3ece8be",
+                                "uncompressed-sha256": "e766d9032bc0590934657a7e452db0e8ab918ab7401423777d19674c6def86bc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2268d3d8fa13942f016da903f75bf6893d7813f38a962650f68e29c9472d4caf",
-                                "uncompressed-sha256": "62046f0861e46af2bcf78794ff2325f171531c96d13441ef0e0876c114e01bf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "cb69a04b757a195e7cc991ebb368bfa431957b0c52b6c1296c3e49ff04f31b0e",
+                                "uncompressed-sha256": "2104ac8186a205493ec74ea144e60a837ed426df66a028f6a28202fad8939f49"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live.s390x.iso.sig",
-                                "sha256": "c12f026a58ea203a5e4341f890cef4e2c71c9c2688b63226dc61de8dc95b090b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live.s390x.iso.sig",
+                                "sha256": "02acc6bf0db72e065e02408f0f35023fa91e9f87a126e8ef8258f83cfd312a21"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-kernel-s390x.sig",
-                                "sha256": "c3c314b436e4e93d8f96c773189fff652fabd9145f34f9eef851e65754e0461d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-kernel-s390x.sig",
+                                "sha256": "94e52beccbd2c3840e93c4dc5f078767f617bd350534460fb4fefaa40d8f6130"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "48efd4cb705c62c90cbadb5495eebe170e6b8324ca134b7d56d5348cfc7b8a10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "43661db3afdb1520bff8f4322191d9a01645dc7490fd65c9be8b946fe49d4900"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9b1bce2498f62d27909cbfde3253c4554cca66bb2e1cd73ef6f1befbad95a68d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "2d012905bad9b19a951e45e2b066e19224a3dafed3a336ee3a3c7808499f872b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6b62f871ec09c55b26cc2540b773dde8971b6b4e5af4e3fda75900ed6b6a25a2",
-                                "uncompressed-sha256": "ca8174fa1d28c3935c59e45f8ad5c38a06ce3eac8cff117d3df6cafdfb4203f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "64c950520fd33ad165dbba5c5309d6ec5d0478b5bfc0786463f9f2f06b82b6d7",
+                                "uncompressed-sha256": "75871a846852253ff4b6531df9fa42422e2e5cadabaec0ab54ebe6065c0690d5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e8b105027c2fabce8e700592f1e7dbc6b8583ca2f33d16b058cc5f84be5cfea8",
-                                "uncompressed-sha256": "d74c0b0499bf23dbd8b35f959a25269c84c9b452eaa207dd17575f733a1211c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "57dc143646700ea62c84123ec8c820a8361a7c38760e6d0d40880325fbf4c664",
+                                "uncompressed-sha256": "55e3363786d3f3ea1f1d302247809609f74d6d69f551e83b270149744e4832b3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/s390x/fedora-coreos-40.20240825.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "146a94ce8096746797a74bf269c4ae70c6b48d1d75e14fe49af6ef7d98288c19",
-                                "uncompressed-sha256": "88c34bd9a5e68f3bbf099333262c9ecbe19f466df567d978db723b8d68ffbdb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "cecdf386412fcbe25ab17ab367725e515b1c207516f5a1c8e937bf9b361d4148",
+                                "uncompressed-sha256": "cbdc12ae9a34ef7ee5126227042851680929ae6df29c083fd6390c2f156c67a1"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0d41776cef99387b0a5126230147e5fdcb594e53631fce09ad7c52888d14e1ba",
-                                "uncompressed-sha256": "437786e815e2b2019f3a6e7656b49f51c5de03ed702cdbc1f351301c23a7065e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "304f63049e48a753ab60085796440d0fbaa00061f8d1a832bb3eef64913b924e",
+                                "uncompressed-sha256": "042d7d58602d25d1011b620081e7ef18c83bdc06216c975277443b05f3ca2ec2"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3a2ce24665166a221b0065adffcdb1370538338a1127f9ba10e0b2047822f444",
-                                "uncompressed-sha256": "ed6930271b5d8b23cd3c712841c6287300c2ee50889772524350c60e661d1efc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6e8e2ba9f3249d365907617c38b2413d6c5d8489649588734d615f05bbf4f14e",
+                                "uncompressed-sha256": "c622523c16466da953f428a83ddac51b8a68ca9aa4b3717ef27d2343e7164487"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "257e0f8fd27a9a790978dc3233fe679828d2cb6aafb8a5b96818971b987485c9",
-                                "uncompressed-sha256": "7f9d59ac3264617b0bd04d08861cf6b3317215d1b2002115d8406f7c6cc38ea3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2551efb4ed37c780773c8dc98ed69a20f4053e90344a348526ef1746ca7e17ac",
+                                "uncompressed-sha256": "298e610732a6344c047099eae6f90b59bf797c17be37f94af80742016a3fb3ca"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6fae93f3d3ea632911bed98a25ef32f4dec16f1ec7ccbd1380627f57b2f63bef",
-                                "uncompressed-sha256": "677ff700313968d085cfebfb2b43372c7878df860a39a2e30fa8ba9690fc49f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1f749424029584ed9e2adc68e7e061bae4f49bc515d7948295971c5170d52533",
+                                "uncompressed-sha256": "d3bdea738cf2ea5f13a4113dc7c648d0dc4c9184bd6dde55baaf7b61d9f593d1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9c7dbab41ef3906895d9a1285426cc3ce6e81ec7e784654b41f2e9a867642976",
-                                "uncompressed-sha256": "88523bd5933f02af7d7535a226234a6a4239d4888ff07966974b76bcffb7961d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "512f78be03d98ad33aa9f757401ee4e70ae45265771636f76cefc0b55b60ab65",
+                                "uncompressed-sha256": "8708cce76e608d23e3205fe334cda84fe9fc21c7cd3fccba270209c515ecf872"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "fb708dcc1553b8f2a2f21e5252a2d94a6de13db0790139402e958c586e6db127",
-                                "uncompressed-sha256": "c619f3eaa841e520e30b62659b332af00eec1e68e5961de5bf32a1a65c8460db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f48b4ec8f6b97bc066eb73fbee82d61ecad7e4168c7ae4998a7a0d7c39a61b4e",
+                                "uncompressed-sha256": "dc7879def2fec4fd66eb15b3db99996194a5041d78dac198c815859234ca8098"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9e1cb9d081c15566d61951830a2eabb6308af47c01f288923b2a0a9fd930a933",
-                                "uncompressed-sha256": "a9723c8e8df953c33f972c4e65e93f8aee12d1f4d638fe5fc167867e18034469"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "29c2032845ab351b387b03b353e22ec7b8bac99f25895eb8a1805fec942262b1",
+                                "uncompressed-sha256": "8aab5bb992eb5ce2dc994850b12a0107333762c80bc5f7360ab145a4656ee442"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "87855455bc135d8d51eaaee9e6d23181b30c3c4dc48f7620b99ce1326ae65eb7",
-                                "uncompressed-sha256": "7ee4372e43fe2d1bdd1ba884b6c9826372dcff041b282c575de6f3803c9ac9b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "0b8a89bb714989223341e632a4d8d7b74845670fce94f8c01a09d5d37c9b38ed",
+                                "uncompressed-sha256": "6446c0e649ee1a28e607a2efb53704644baa7c26df58d669fac6ee199d2aa47c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e8f254b8eb753e2391aed03ca3e35ee32decb933df48222679f250c801ea5bb7",
-                                "uncompressed-sha256": "6e79a0db0aeb73e3063d7d3995095f4be3883596ff50766bc4518434cc228780"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "655f4abf59ac0a3d096fa09d8e3a2c774c3323d88c49dabecbfba4621825c5ae",
+                                "uncompressed-sha256": "1ac3757d3e9d4701063fdbb287b12b41421de0a6690b40bb36725df425f29145"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f54f9f0d316d6e1ac9287f0a1f439f5641e65ae2ed08d13df2239080f575a813",
-                                "uncompressed-sha256": "3f3851043d24dd3c7249a9f00755ba64dba72016601d4287da29f0ca1b3fb6b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "eb3eb94a1b7bf76e5a4d04c1c9e743526824d2a657f59fd2e46a16377eb5bb1d",
+                                "uncompressed-sha256": "f152296979ee8dc1f3990ed93e16cc5f16b837b0aaeed6141bb128139f892de2"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f7826f09e0e915dc9531ded3e32dbaa8d29b65c03d6c536a03168d8f2ad328ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b44b3ed4df7d73db834cd2846d26ebbe4c200d25d92002cd88c6fc3ac8481d36"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3dcec1a8730446aea02fd3598ec31d251450f6df7694098ade26568f44e6d760",
-                                "uncompressed-sha256": "0be607021cf8b82f84f9714ef9b1ba0f0c4dd85b900502e3a3d8fac9c0e8c7ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6a9da0f4161088e69dee7d2e8670305b116b84b403360dc039b6b72cfa8432e4",
+                                "uncompressed-sha256": "2f8e0c4685fc5c80e9d1d100d89d38409f3fa4da388099ef286d49256633b417"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live.x86_64.iso.sig",
-                                "sha256": "d7634fade6c7eaf3a261dfcf9fbc5d00768c9213e4a2b2b05e6d72fb022ad324"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live.x86_64.iso.sig",
+                                "sha256": "1ff5ae712aa1e75d19d8112abb694d63bd8b0090eb4434c145442dc465bd40cd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-kernel-x86_64.sig",
-                                "sha256": "241a166c730747365b85b5f391f15a5f8325242b79f52cb39c943ae9665f7a02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-kernel-x86_64.sig",
+                                "sha256": "f99eabaaf7523e47b50b1e14c5fae53432c9de2d0fc842bf6af2d7926f9cec01"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "58812f1b5125420de9ca2a0d4cd0a23589d9894180bdf8a0de87048c324b301e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3b22f64aa91fba706474b681b03fcb786e3be0479b1a8f53e7b4411b25f44d44"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "82d53550952968911ae505cc7a7b82d1aab611af5d8a7390bdfafec7ee72c922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "fe7f4423b4b704ce8f57f0b05a0f3bf3a41345fcef6db89630d2d66d7c0a64c5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7a254c25944f6aa62f2022fefbe9398d451a4a3acc5a8b2065b639c1e1c084e4",
-                                "uncompressed-sha256": "165b920fb677a264c0d17cd1483b62da3bbd40f2ffaff2fafcbb040c8ec2b84e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "78ffc83c0fdaf18f5c0c8b5026adb05c5e31193f9b6be1a0d3e1008f0a44931e",
+                                "uncompressed-sha256": "65e41b54448212a6479a0b0fb4525fa5712713c24da0cbed70f511db3096ce5d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c8119369d5b83f8ec6dfc05a93b36e12d4fdd4d06f98bfe5a935bd14eefabcaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "da5cb831f4024c0b01345deffa5b7e88b1eeede0d999d48d56a890796dae1426"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "01e40f80f16d4758b7690842c5ae70cbd28b440d9325815f942a456603626faa",
-                                "uncompressed-sha256": "398d31a150f1db770c6b86bfad8094ae7e9234ec7622a808e84f0d6b6e6ee884"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e833ff5106d356b1c3e063044fb2dc298096129ac60648a84be4738485b1a963",
+                                "uncompressed-sha256": "d6a84dc744a3d71a9a4648aee4b08716e70178ea0df04519ea6f6fc4059ef4c3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e6bb493fca5ea1248a82e86dabc09276c18cef08cbd136ac7057cc87bb3f4c52",
-                                "uncompressed-sha256": "046f92b2555eb339f5364c18255c857ccdbe77d9b5549371db0a08e95dec27f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "71cd5ead0c7dbbdfbc23eec22587eb69713037fff5a4e5291128726c27f6310c",
+                                "uncompressed-sha256": "6d2a1886ccf9d54c85df9d73c6ed198cea12a36605eba278f7b5706cdb3d64e9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "159f5758e4e0f8f7d52a40801b7b6d53c15599b1dae0b5c236b8ab3590459b57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "e2a7fd3bee6fa312118d13fbf8e39ee7b2d52bbea26ac1d47a9be5a27f72dbb5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "84df603e8b6ccbb5d7956361a130883d0ced66884a415ecca3957b8dd3f9ebdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "3618a19dcd80f637b6057dad6397126ecd5070a20d04b65774cf00aff3181ff5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240825.2.0/x86_64/fedora-coreos-40.20240825.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "93c4065d62c830cf222e0b5e22442e32c1b0a6d6c8a275bdd7e9ef5ad48751b0",
-                                "uncompressed-sha256": "c63263cc7ddb3eada1e10e8b8f037e8a5a336a36549726115d3724f87b0e1434"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "edf8b5f27688c194c7ac4853d385affc824ba233039f1652c7ea39c3d76cadfd",
+                                "uncompressed-sha256": "75e1b885b935ff919760258141b933b2f734cce690337620cb00d4cec33b4220"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0d90c4e989212e00c"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0838026a12f95e546"
                         },
                         "ap-east-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-09032e266489ab972"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-011f9ae4c94f90047"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-02cd270f1b421ed7e"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0c9e227b744d563ea"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-08599a88c0ebd614e"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-052475c7c73bef24a"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0a04ffad09535a459"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-075cfa74eeae216f7"
                         },
                         "ap-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-025141ff6a07d6b1b"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-01b261f8c6f0fba37"
                         },
                         "ap-south-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-080f1776623d42cae"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0efc82e4d68a6342f"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0fab2295e452cd350"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0d5f284c14e405ae5"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0e142214b1613bfdc"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0252499ea01516eeb"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-08765ebe629d66850"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0bde4f41cd553bb11"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0bc03e1cc8e93e969"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0d92b4e2b226b7dd1"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0c3880973da8610a6"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-08b384ae0064796fa"
                         },
                         "ca-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03fa2c75569f0b735"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-077b3e593dbf77071"
                         },
                         "ca-west-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-01334671f70ad4a1b"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a5ace3983542d10d"
                         },
                         "eu-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03679a771068df5dc"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a0213203e6f642c5"
                         },
                         "eu-central-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0d168cb67f7a00e85"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0164c92af551b8f4e"
                         },
                         "eu-north-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0683c1e87b38baf2a"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-08f760110042f2b90"
                         },
                         "eu-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0e8ea948badc65c60"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-034edcfc94a5681f6"
                         },
                         "eu-south-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0eb1876fd16d7dd59"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-02c14e97d47e6b296"
                         },
                         "eu-west-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0562cf5fe8de10384"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0dc081c772400882b"
                         },
                         "eu-west-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-083182e28c516bbe6"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0c5b6a73ea654cb32"
                         },
                         "eu-west-3": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0547287b4ea78bf8a"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a0c3855d363e185b"
                         },
                         "il-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0311d565645a106a9"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a24a51ff81a0591f"
                         },
                         "me-central-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0cd594fbf00c193d1"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-04722adb55f3bbef3"
                         },
                         "me-south-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0708d5f6130f2f5dd"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0515ea72f93ebccda"
                         },
                         "sa-east-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-03e8a5c22978852ce"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0a8b3cbc5f0b8e0f0"
                         },
                         "us-east-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0fb3fcbb279221b25"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0225bedf1c3241add"
                         },
                         "us-east-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0c8ba39c1c912d55c"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-02e3671274d42c120"
                         },
                         "us-west-1": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-07f0ea78a70fc054d"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-01b461d423bbcac5c"
                         },
                         "us-west-2": {
-                            "release": "40.20240825.2.0",
-                            "image": "ami-0cd1e02afc6177376"
+                            "release": "40.20240906.2.0",
+                            "image": "ami-0ecf5a288c91477e3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240825-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240906-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240825.2.0",
+                    "release": "40.20240906.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:38e1e589ba2f43470c57fcbff10d46dac3b32e9caa65ded5c99aa26ce5698345"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4df0d3741f4d411768927d61b87c9402f18bfca2dbc41f8cbcac5feaa37ca739"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-08-28T20:39:04Z"
+    "last-modified": "2024-09-10T23:15:35Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "40.20240808.1.0",
+      "version": "40.20240825.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "40.20240825.1.0",
+      "version": "40.20240906.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1724936400,
+          "start_epoch": 1726023600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-08-28T20:39:01Z"
+    "last-modified": "2024-09-10T23:15:34Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240728.3.0",
+      "version": "40.20240808.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240808.3.0",
+      "version": "40.20240825.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1724936400,
+          "start_epoch": 1726023600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-08-28T20:39:02Z"
+    "last-modified": "2024-09-10T23:15:34Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20240808.2.0",
+      "version": "40.20240825.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20240825.2.0",
+      "version": "40.20240906.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1724936400,
+          "start_epoch": 1726023600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).