### PR TITLE
next: add release barrier for n-1 of first F41 release

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -121,6 +121,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },


### PR DESCRIPTION
With the rollout of F41, set the n-1 build to be a release barrier.

https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/