### PR TITLE
Roll out stable 40.20240906.3.0, testing 40.20240920.2.0, next 41.20240922.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-09-16T21:49:17Z",
+        "last-modified": "2024-09-24T16:05:22Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "31cc10b8fe51a395ffaa0be0a6ac448f8e844d89f3c08b9842bb643c545e121a",
-                                "uncompressed-sha256": "663d6f40e2d285d91f6a19dfb09e841db3da3c3f01019c2b4d2826dba76b285f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "7248e26524e768c49642f7532687dabf93304bf886a7570d589397098a8ce56b",
+                                "uncompressed-sha256": "20d4ace4cad1a0579fdad7425801f42943cd3b21c3d6898f2eedb0a236d57c9c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "651faf9758451b02799c934b4324b49ca930eb18b79fb7e8171c1c0dc491ff63",
-                                "uncompressed-sha256": "ba27ce46b8243d7c772c71c1bf6e6ffaccd4cacf1186cf0c835d2b2bd1b785b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "266d1497e28e1b5477879d784edef37fa32e7eb392c7a6f7cac4f176f2dc268a",
+                                "uncompressed-sha256": "bbf5baaffe5532a25d2a720d53555cd894a49c6796bdfb7ff587c855299329e6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2dae60d0247082119b77a6a21e3b1c08c1b59fef5e638cefd28443241f2ff53f",
-                                "uncompressed-sha256": "ee00f3bafef9a5f41163ce245b2fed15b2d4a16d2254c39634ddfe3557472408"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "25bb80edf4e450741223c559d6c799129e6f366ab9f2c54fc6c3042ef7fbc3e5",
+                                "uncompressed-sha256": "b29710d4f3c1a9546fa0537f46b8be0aacc4f70a6a0af77ecaf81ceb7826c558"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "36c39f094a19c0ad1e464732da8dc5d3b36ea3a509f1f97f0ab664e8660232af",
-                                "uncompressed-sha256": "bfa18d780d2638f0bdcfc04680e870d701f1a36226bb462bd2a4b52027940584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "659f514a66f00bc8ac2fe69c105984f339f0237c7e21a30caeb69e3424904fdc",
+                                "uncompressed-sha256": "6e969c73263a617bc7f9030e38067130e3fd9a186a7cdb73cc5c53e59e7a6203"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "19763b150a55027d304b0177c15036dc6e05e9884e7b77fc5cd6a73e6df561f4",
-                                "uncompressed-sha256": "af1a5a51cfdf700048abbdda31a97642b6c35e5e3e3b48603936f97340103c7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "9725c871fb83ddc336142e254dd9a35c8d4abf9b0429091c63f59bb474a55e30",
+                                "uncompressed-sha256": "d24ff98f987fbbf5504c68e0e37b0884c8ac4a50b9af38a7ee0b114906b704fc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "90bc71e589535c0f457beb415c8544e3b3ef00d91aea1e3a5251f9ccfd1fe60e",
-                                "uncompressed-sha256": "0d683c3eb374b1541311692e750db8f01aa973b148f6076674e3ef511f82f9d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0a06952d315fe8767d456b35f8d6ca558fbe96e538d04ca56a6125c1f1d52ffe",
+                                "uncompressed-sha256": "1f984263f3df2eb616890fddfe27efac9cf85ea5d0b871387aa6be24d8a9e0ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live.aarch64.iso.sig",
-                                "sha256": "990198ce1b615432deae19a9100911270691c4899a2a974af860f09d02e61340"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live.aarch64.iso.sig",
+                                "sha256": "940873676a9be3c04fdbf1d0fea467fdd2fa1943676f34a07cbb8aee20fa2147"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live-kernel-aarch64.sig",
-                                "sha256": "0cfd19dad5b6c859d8f0a3b456981b75216584274fca2c4d13b3029c4e3a145a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-kernel-aarch64.sig",
+                                "sha256": "6c3f4ae2f25e9d8b5d9d005eb4376102d21a19cbdb8d9fd96ef43f17b106b9e9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8b7dead6fd9da148ac98f447b1c305c7081dcdeb31f97dae5056ffb790f612fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5d369b7c5b2c079473c9bf4b34e7f13b40bafc0abb714414aa74890e59bb72d4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "479dd39aa75cbd65d7ee485f26dc937808b9d084476850856957dc4e486a8208"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3b31cb63b703992e40552a53cace97d35b9deb873225bfb9e22d133313015462"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4e2732fb574ce92c3fb6d420effa48e6b97a622781b809b149a69ee9d16b9300",
-                                "uncompressed-sha256": "af23a889c2df00b81e3f18e82a3ff732818038dbbcc62d545a356da12b392cbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6cc099c3a427a3c9add5b445b2fc9fa40386c15fc5a0e46499e105919c4ec326",
+                                "uncompressed-sha256": "23ee9cdf3ea6f7fc6f310b7e0a01a4f39757a2d03e8d19f2271b9d181afee5a2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d5fe92c0c9092b23c81cc4468eae6cfaef1af38b3709f8153f0d1293c35aa721",
-                                "uncompressed-sha256": "243d0f24f74f9dec328fbc1023351d4b7aa8118a198496610fbb5620725470ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "478db23129e194f2eae730a6659b7a1fb76149f791cb8d98cb61b95d4d437962",
+                                "uncompressed-sha256": "b9707a266ca45f191ac11073e21b9e5535cddf5c7d164e475effce5d2bbbee7c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/aarch64/fedora-coreos-41.20240916.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d9c743ce174721bb6c03007f08eec6c3956e8229423dd48df8f73ba53f849394",
-                                "uncompressed-sha256": "eb422882b11b5e06ce36ce8a4f5031ee997063dc683ecfd4d61a296d80855263"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5fd19b84b5dc6cef51066e289c0fccad5402ab8bc225ae4bfbb3aaf64c8253da",
+                                "uncompressed-sha256": "2d93693f60ecf34e8d41bc294089a979809b8ee4607f41200e280ada5c037fe3"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0cd3843a992345b75"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0ebf6bb8533a3ce3a"
                         },
                         "ap-east-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0b534c4d0fea38735"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0aac3ef91bc881a98"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-000870cf6a81865e9"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-01465aa3f0acbf225"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-001e92ceec3adcd16"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0bb2401e168c72194"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-05864d38b35833a37"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-012da51892cfa2e5a"
                         },
                         "ap-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-08128021f35ee21c7"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-033912701c4133646"
                         },
                         "ap-south-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-07643282c502b8acf"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-05d6710843c5afc71"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-03b743e7d9ed8d433"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-06ebaa3a0beaab21d"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-024c7ab6678e50e6c"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0402a015d4311afc2"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-09cf920e693bb15c4"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-092e468c7944fb03e"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-06638e4bab4d7efda"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0cff666aae133a339"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-012c91c3977faaa9c"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-09c9cde6e1883ffca"
                         },
                         "ca-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-08a3698022738bb10"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0ca84ea30ec3c9637"
                         },
                         "ca-west-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-086d57be0eb06c8fe"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0007cdf44fb41d7ef"
                         },
                         "eu-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-03136f2f8ee318ecb"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0ca395256f6175ca3"
                         },
                         "eu-central-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-05c78ea6b7cf5de88"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0d8275a0ac0dcbfc5"
                         },
                         "eu-north-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0ae238b80b580d76c"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-068ab0c9b4b8991be"
                         },
                         "eu-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0563c2a0e9d51cfe5"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-014821fc4c91ef71c"
                         },
                         "eu-south-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-061af2fb1db0ab8f3"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-09e7c4942abb92ab6"
                         },
                         "eu-west-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0537dfebfc9ea4361"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-077b9102e7601871a"
                         },
                         "eu-west-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-06206e100a6e0fb64"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-08b3f4fa36ec11af6"
                         },
                         "eu-west-3": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-017b6295d39802cf1"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0d2208c3018a04ac7"
                         },
                         "il-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-02a43011efe77c8d3"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0c8bcec7601a1902f"
                         },
                         "me-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0832a0cdf3ed287e7"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-07921d7593ea03596"
                         },
                         "me-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0fbb09403fe0a9309"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0ea8a433afc2fd9c5"
                         },
                         "sa-east-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-02fb5cda6119b26c7"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-091e32f03b529e787"
                         },
                         "us-east-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0823a5f0b282e7061"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-05c7f9a99a2287c70"
                         },
                         "us-east-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0b5138d96cf6c6fa2"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0dc4e87d0780c83de"
                         },
                         "us-west-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0fed54121feebdfa4"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0dbcf7d531d38e967"
                         },
                         "us-west-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0f9c06a7d21a2dd1c"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0d25f07533dc4c18d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20240916-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20240922-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "441f30148dd83d0aec7b2469c576dc16741c42b778a5f00d29cfef13d69c038f",
-                                "uncompressed-sha256": "3f9645ad90137dbdb320a59f9229dd6cc3d926ee6d5a948928386c39f621aaee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "debf1609ca3c3c0eee9048fc5f8eaf0d972ced1863b1ab90ae284cbf76be0448",
+                                "uncompressed-sha256": "2e35803bf4bfa5e729fe24b1881d50c0c00d68c5fd470c58db8be589a4f1a260"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live.ppc64le.iso.sig",
-                                "sha256": "3cdaa0714c820f1c6f8f2b01ca73967ca60d4e77030ba311b8cf0c257c495572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live.ppc64le.iso.sig",
+                                "sha256": "1ccdc47a3459bb59737e41bec1f4e1bd513fdcdde084042f2c5df61f2c02fe79"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "c6c48282db22eef07ff3d91edba7f9747395e4cd4b424f8718ec0cae4b140fc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "259c2b1a34edf7d970afe1064733568edbee009acaa26a1c36e2fb215069c485"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "3af7104aa58e7c0b545ce1791771b87da786793105c71aaacde1919c393b3d01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "fe19a67c2d13fedc4b12cb080daab9c46f785079e0b1e14e7de37bb1b0f3f7ab"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "17b265ffaf4443b5c0b71f27d74ac679ddf125530a76feae6a59cada7ffb1254"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "3492eff39b963c4050ed783be21d93ff35273203663b3df5f4ccae80760b4462"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "deace97680b87920afce1f5a79816cab783c752028e63863fd43a6a0a2adeb35",
-                                "uncompressed-sha256": "dd859cdafe4daa0ad0cd4d144c90bdcd13cb412949249cdd56c6bdf3548bae7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6596e3ed17aa8930ee350399b7e57f5a24ce8f34d79cac8efab9902f82d24c5b",
+                                "uncompressed-sha256": "bc0294e6442858a989ff7629da65fc4bb50dc70207ec4a903e92e63929cc352f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "898827f27e01b3d24992d69e1ba41a637bbde3c5f20ee493b1ef7fa5a6c671fe",
-                                "uncompressed-sha256": "2d6b1a2ec74b0caf2f70e3b5383a246cf14541d2a02b51ee8218a55764c8504c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9f14d2414d013c2c98ea09fa8c17dbd21a07512dc5cedfc939807754438013b7",
+                                "uncompressed-sha256": "bafd39c18892d6e20a5c992de40a89f0fd79b9c7b1caf8d0f4527fbecb741e7b"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "a1d98f1332b8a353b5c47a3ef7df47532962dc71adaedf96255be75c473af993",
-                                "uncompressed-sha256": "4e5c2566112b8142aa0fbb54d38b8d26e91ca67c16662b2fcbd7a85a10ec6e25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "09ab5bf5c0a199ecd960c8e5a425b635e8c90e14a97dc509865a9bd50cb5e433",
+                                "uncompressed-sha256": "a9d0efa0217abfbeacae73b8061bf274d79d6c1bc2c6ca306bbd2cb99a39b0a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/ppc64le/fedora-coreos-41.20240916.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "582198e610f7b88e96983781e9ebe93bc64be96eeb7d42787a06ff3ea9acac82",
-                                "uncompressed-sha256": "a91d31358f7a572a9451b57e3d60ab87632e6294237370b569f1c47cf508f4c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4e54d0d8015d05124ec8ba624cf35664c9e615252359fc6e91b0d49b347104d2",
+                                "uncompressed-sha256": "550ea4d9514ff2caabfb06ad9b82c9009ebca6dec5e0faf5ff20166ba941d553"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8c3b43c09ca935e0ac6e40ee4e5fdc2fdc220f7c9f1b3db251f049187d424098",
-                                "uncompressed-sha256": "ec35033eabedb913b3b8671765b68c7e0bae200577a4dc594e3c0faece55eeea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "84999441e638be5dee074ad0f832f0ac9a2c29df68e06d490161aae3eb29130a",
+                                "uncompressed-sha256": "516a2e06f5a1996905400a770fc393e7762d38e54e943afa5a8eec4b1b808b21"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "9094007b84577c2051794a69a7428da6f9cc2da623394259be9b35769fe5e0c4",
-                                "uncompressed-sha256": "5b8271d192eb71cc37bd0bcfcd8383360cc13c911257a8174b1cc95c541e80d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8eefec34e16085226d3ae6165a11f2ce14b32514b06b9cc1eb553c5256009822",
+                                "uncompressed-sha256": "2b9911a74f85fd1d1f324b39b6e72935d65f72f1d721bbca25f7860bad8df7e1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live.s390x.iso.sig",
-                                "sha256": "1328a242e9a7a24a90ee6ce1e8c7f1f83da669ca779f360927e7c06c087632f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live.s390x.iso.sig",
+                                "sha256": "ecfe560ba193f9ac961b8434f234ad7e8c6c1bdb5d32cb672c945fb033d8dcb4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live-kernel-s390x.sig",
-                                "sha256": "6ccb86fd6b257ba7485f2e0e20315f456bd47482125fe80d92801455844b5d35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-kernel-s390x.sig",
+                                "sha256": "09f274db80438b62d9c77176d411f7fb0e49702512a35af09a6b9a1eb6b0c856"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "da865032ef8aa3eb6455557dfd89d4ca793ae71f1dabdfbaefdffc04e23b322b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4e0079699934cc0ad16bf75d10697812db214749a3a914510a0c2203aa16e977"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e55db337c2464300ce14f747881f1052d7beb4b3ca12a87393c908c19b7bf815"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9a80f4f94d3fb102425adc672dc1c38302e8c4973aa5f4a481f9ef4a1d33b948"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "5a36bb28c4356afbd73e2ac3fab71d83e6072877b2f76beba0a8426fbe0b2a41",
-                                "uncompressed-sha256": "21e2015b2980ee83370e9bc3b9d3a65e6bda52b1d36d11cc7ca268d741543f69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1d4b6aff80e1c0ffb2f6225dbd6a3998274c2d163dac2c419b795f0a4979db64",
+                                "uncompressed-sha256": "5a877a4f9f26dc7aa1e453245e55baad6a58328fd7ddbe778508c280b380cc93"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ae833c2cbad6f9e6d5d64533aa8ccf1e78d1a938cdb35fe073d40645c027a28c",
-                                "uncompressed-sha256": "0239ca58b06806a7b2976f7a8e161a269e3c89324e551dbccef2696e36a0b417"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "33e7bb044a27f06a91c565e65ee77288148a62d4c0ebf2f2200a3709dfc79d7f",
+                                "uncompressed-sha256": "dd289a74f3b915f94dd59e1685440944fad5402bf997eda61cd17088ddce7ce6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/s390x/fedora-coreos-41.20240916.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f854d712ede9920e19b15061f94edc6934c73dbb4a6c67378f7ebf8ce87ff7e2",
-                                "uncompressed-sha256": "0501ae8a8cfccc844af0ca6db7c6bb141a26d170328f738f84a0f29a20647ca5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b4ed31433c71a9d7d7cdaa4f3086ab837b0615e4407f08965dacbbd405a0c5ac",
+                                "uncompressed-sha256": "6fda029c65e49e0b519790af788f8c991c6c01ded07866afcdf4bcd0f2e0adbc"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a82effb1e7fa7d98a19e2deff3ad9fbeb1f29c4aa8511fc3bf36761c0524433e",
-                                "uncompressed-sha256": "c881b844845a6ca4ffe82a3106804d6ea3170d746ec7bf4dc25f3e0d217d1aed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "78bb24fe035a768264c348e95a88abb2086db5392dfa958895fda4982b040d7a",
+                                "uncompressed-sha256": "a90521a1e117dbbf1588b2e7faa2b3e31e50ba03e1cbdabaf4a23afe0133e32d"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "cddd63595588ef1d3819b42aa99780783bb1fcb3eec6e5a72defcbdd286eaca4",
-                                "uncompressed-sha256": "a908b70d646da5c4320d948999bb8569aab873cb9425692aad2c07b84cb76f92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "22b1f576921e7511b6c3348178d3f4a6cd1aab202bae0edbc87e6d0fb26be6d5",
+                                "uncompressed-sha256": "a45c16285a20f08bb89af60e4ca93cc64b0be09b329c892ae7e438888959f65f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "75219ddca751d0382d8f71b8c8e54dcb437e9633f3b40ac6f1c35824346e589b",
-                                "uncompressed-sha256": "87f0a634d8859700df5b2daa5459a82b02a59e3876fe828bf6f452cb6f35bff7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "747bbf89c773b8d9613732f96ae224f00a838c9f2e53b561bea64f31e8a736a1",
+                                "uncompressed-sha256": "9b36b4600803d210e03366267d6fce772bfd869bf0202c11da3e631566b7a878"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3e2ff23b8593b0b5ff16a9e7e9b0c9bc7ba81f7fd46609024eab089c31623fbc",
-                                "uncompressed-sha256": "96ef7ce845adb5b9e68bee7c38b41c86fc6df13501d9c5f9eefc9eea956b0a35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0f8da9641dd1e2f6a728faf68377ed44dd04e46c6a15890f486ea4afdaa201c7",
+                                "uncompressed-sha256": "a3d797beb723ec57a2fb2467522830be093f73bee6da9add2e0b77d85ab65f4b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b99c0682a535a34e358f8cbe7648a41ae4030fb09cedd30b72bfe5c7c30211f3",
-                                "uncompressed-sha256": "9b4f77eb8c5e1a52d092818133951af25d0e6f7c74d1e080ad4c426c816e7f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5a165bb1f2e00675b16b945643a2023748808e4d2cdb4cef52aee3cb770a2ed7",
+                                "uncompressed-sha256": "b51bb852d500bc0968acb1e4bf6ef6a8323865063e8bb0233d1dae1046787247"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "788f60116ae4790c0fefae1d9b91a0aae1d34bd41e156c6012a136346dbae022",
-                                "uncompressed-sha256": "63156e3fcee1a8a1793572df4562435c244c3e8892cc8703cec60a7adb7d087c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "eb443f7f33c6347033f36b845a319db862d47aeddbafafad7e941c2abe257fa9",
+                                "uncompressed-sha256": "5a679fc19cb7b2304f8aac7ac14744a6ed76f24a071cf8ec7fe33be2db53b519"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7004d041a7a0c0555812ab5e79263e2a0e1ab399dcaa8e8cb71f8d394b238017",
-                                "uncompressed-sha256": "1ca5fdcd953c0c33fb9b01424a2fb6c1dd8455a652c51c9a9127f6e24fef802a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "513d9dc934b6d78fd89c32da4b072e51a64c891d48a1a1448ae49ee93829cfc6",
+                                "uncompressed-sha256": "986125a5062f50a3226e2fb44c1ed754fb680d03dde13cea24cefa98dcb110d2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3114b503ff56c7963ec8935a8a79ca1eafbf1cde5c7c4b57fda66e2eb7d7fbec",
-                                "uncompressed-sha256": "70e39863db337e14fc7acaeffdf5c7eb69bf01895023062a576c631350814f9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f2feef5cbc52ce58ccb866eaa2d357a2ed91824d2e7bfdc9c80466cb2c1811fb",
+                                "uncompressed-sha256": "8efce421a7f4e93fbd65955e6990dac5459b3e848fe1f34a21c0d3a5e4840068"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "f7d06f8e4c0b030d9a422458217993d4717ba59693028d55144ed247602e2b95",
-                                "uncompressed-sha256": "eeeeb75edbab2319703cf29c45b17dca82a3f666e600c85c3e9f9f491c8108f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "689342f8863886e776d72b50c6f0383832670bf3fc0ab6411dc492e14f61a488",
+                                "uncompressed-sha256": "522dcb68177215766d207cce8fbe7ed0a999c7dabc0b0b078d4a514a8bfb5933"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "de488104deb8cd9ef334907918ca6d8ea16911185dbd0aff44cbc9de05123453",
-                                "uncompressed-sha256": "fcd215062bf0cb675741407e13a8cbb2c6bee9dbc0c0c9dab7a4e06c17748333"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c101cd276390e53afcea7b2bc833c81505bdc914b1626561d2d9508ac4bd656e",
+                                "uncompressed-sha256": "7f6ae36b2005981e678517e60a96a03d4a13958ecd7b6a3c2464705c73c804cf"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c1f882de5daba1a859ebd6d6524c5a8833bf08ccc7ba56e077b41c968b59c226"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "64b71d594720cbd0b4e9090c3c28fbca990f9d5b9d1cdc7eb71c0dc49b72ca42"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d1f6299d10641cab4d9732f52fceb68410227675158127e0a7b7f7d8a4290f36",
-                                "uncompressed-sha256": "d3cdb2d7f8298ba0fd8aaca54cac8bcb971fa195d594638ae54f0797268b1327"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "38abb96a1cdc389e9105d3d9adf689afcc45b2d989b92b218f3cb9b6824ee999",
+                                "uncompressed-sha256": "9a8bf1a92a3fb2d4f4daf515d1241032d17112dce55585d0ba1012271259a2c7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live.x86_64.iso.sig",
-                                "sha256": "12320a8baea2737bc4b380b117d99c7c183097285ece3c7903cd59581cf442fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live.x86_64.iso.sig",
+                                "sha256": "0a466bedbed970be9133283e3ad19c4a8a42e13bdbb30e177bc22c06089a57a4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live-kernel-x86_64.sig",
-                                "sha256": "eb04309378477d6be9a7f3807a28eb7f693318bf365b7f02d5440bfe802c0cae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-kernel-x86_64.sig",
+                                "sha256": "2dd814d42d3922d8d788c89b7da814733fd405d5e77c2dbe485883b76f014fde"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "40353d055341ceeede25768879bdcfb8112219e5ea0bf4b38bc1d3667a1e950a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0a3b58de522d486c09884a0daf528257f07ef0e764e1a3066b16cb2c8ce7daaa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "94fa88dd8d99cc88b4fc189c0d4e1e81a1c0e8d79aeb3882c8aa63bd8868c3d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "a6fe993fb5e0f4f67c0e7b80f4f6dfbe559299fe522393bd97673fab676eaa82"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b0131461015899bff1397d38e15490549728a27f88c997a39731a460719e917a",
-                                "uncompressed-sha256": "c55938f064ec900ec72b5322551e6fd7982bc25d2ddcbe39cbbd0004ad12a458"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "38059896aa5f78e8760b6a24f56fa637131c20f8c083156089f5b74d2980109a",
+                                "uncompressed-sha256": "ba5fa34b8302929f4cb940bb250d6c7b69a9f60b9eaa799e2f918cb329612276"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9cfc807cd79aa33f3a60520c5a55946407762f5010664fd22a2536a5cc56c1f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "acbd79fecfbffd08b225d9ed038c0aace93e61aae67272b27498efdea0f8ccff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e78a870575b765759f2ad058b316d0bee4f4d439b17715b0e793a0663701541c",
-                                "uncompressed-sha256": "ec151e9c66ecb92bc32a14beeb52bc76f4a0fd9ec3ea41f76ab85ae49961891a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "672cfe6a78ad64cabef41036d420fd1c43ac1af9af076214147a99a5e137f3c9",
+                                "uncompressed-sha256": "19bf931753e85bb05f91ea930a0ad1bdf47a0630842090a2e6aa077fb085064c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ab81877b309b8fcbcf439147209a9a705beb7bc8115807e69d061dd84d47ad94",
-                                "uncompressed-sha256": "fd75643ec96d1ed0cd37f6bf5713c4b78af273d2cf493b9efbacc8e2c1ac60f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a93e46feef1486d4c19267a8cb89ef667dcd4e459acd605d1a6c4672b28bc8cf",
+                                "uncompressed-sha256": "f41c5309ba771d91840f556c5823d8e4905eeea5f632e1c6f12ca31c85ebe66b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a3e73834687b84bc14c4699da3a95313de1845a8a2790d85c7f41542907efb3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "aaa51d8c1cea55289b68d99d940d3e21695bb6eb396c039b5b9ae495da667ed8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "fef129cd9eae27b38d510deeaa8b8de7094cab36b6f318415a6b34ad73928209"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "e7bafe56cdeef5e9697d7c90ee889df45bec134f2e09e497207bfd85f0e9f6ec"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240916.1.0/x86_64/fedora-coreos-41.20240916.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ce290b1039181212ede45b389fdd78974eaad5a44255d8588aca7fabd0f26e35",
-                                "uncompressed-sha256": "95e6083b9e491772882445791b48942ed88894d653682551ac3dae4dc90e5847"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "28e59715789e6c262c2c9aec025cc9b6a6f360ce3cc7f88a7d1bc5b5abb1e647",
+                                "uncompressed-sha256": "b8ff676cb5f8fb9692f1c1724a76a2bfc4dfca13ae31f122321663fb60004f95"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-096e70751cf3bdc95"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-03413207118873959"
                         },
                         "ap-east-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0d0da66848c33d614"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0c3dc01569d7a13eb"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0ccdbff8608238997"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0d15dd34f1462ddbd"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-08a3672d8f0b5b884"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-053ac2e065f20f981"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0eb593f26eb6d16a3"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0053da683f29a0357"
                         },
                         "ap-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-03d34c39bf25cfdb8"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0565519881c5d4ab3"
                         },
                         "ap-south-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0487a088f592065e6"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-091a5597d3aed8146"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0578c4cf1e0117274"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-02d32c185b448202a"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0ca8c2891a1909b77"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0bfbaf727ef7d2699"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0a26a7ae6c1e45865"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-029ccbaa287f12429"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0e5c0ce51d14eda27"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-028e8464c9f6771bb"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-04a89da130abb8b37"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-08cd3cf37a70250f8"
                         },
                         "ca-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-00216261399bfd789"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-00adf269935143522"
                         },
                         "ca-west-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0894418bd11a41b11"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0330d88a773e6147b"
                         },
                         "eu-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-04d93d921a93bcf8b"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0c706433ae8e46340"
                         },
                         "eu-central-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-009f532f40c6c953b"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0340d2e99794441aa"
                         },
                         "eu-north-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-03c71e689e49bb60a"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0533701ddaf7702ee"
                         },
                         "eu-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-04c879c85fbaf4d28"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-02b5aec6ff96ab49a"
                         },
                         "eu-south-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0bcc21bc4767c2e22"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-060b3ccc240c10a38"
                         },
                         "eu-west-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0e847ea68f55c9d0b"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0cb452c03b90d1434"
                         },
                         "eu-west-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0a9b7b4abe6579e65"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0703b9b02c5e28cf0"
                         },
                         "eu-west-3": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0e9576e2e8373360a"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-039f5e77766d3dc06"
                         },
                         "il-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0a2d811a9caca8e83"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0e8cbc12180411568"
                         },
                         "me-central-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0e7f53c9bc067bbf3"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-05518a863e56fb0a1"
                         },
                         "me-south-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0e044601749f5f0ba"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0e7bf507de10d0ba5"
                         },
                         "sa-east-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0da460203ac7ca615"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0892969c85ae7fd3c"
                         },
                         "us-east-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0cc9ce4ab94acc996"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0b49c88632d791ce4"
                         },
                         "us-east-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-00bfb7c2003e168a9"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0d1d369d0f60191d8"
                         },
                         "us-west-1": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-03e93866fbfdcb8a2"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-0c189991dd5a43974"
                         },
                         "us-west-2": {
-                            "release": "41.20240916.1.0",
-                            "image": "ami-0f848026e142ef2fe"
+                            "release": "41.20240922.1.0",
+                            "image": "ami-02df4f09c62395dd2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20240916-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20240922-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20240916.1.0",
+                    "release": "41.20240922.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9ce4503cdc8346338ba63b7c3871dd60dafaad1e58aa54b8801911fd23eb0a8d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dbd7f136d1d243d30477d3a22c3a76dd57a1033e595078f66bb03c01030235b7"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-09-10T23:15:33Z",
+        "last-modified": "2024-09-24T16:05:18Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "40ebd1e52a061253f617e3650737e97ee66d2f0612998508abdaf4d4cc5d22c6",
-                                "uncompressed-sha256": "27936e1d78e207a9f2045d6404c361f35d1774e83f1e709cab9b1b86ef230b42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c2b08ff68dfe5c4efbf9948aee899e712dc3dbf5f691459a0bfc3c7758e6fbdb",
+                                "uncompressed-sha256": "b32c5059fa0a8a95593373562e0791f55b7591b76e136616c95a11963e451711"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "050afb4546bdb3ad2f8171cf5beb64ab9d2e64c88c3218bb96c617d43b7eef1e",
-                                "uncompressed-sha256": "d8b6c90a1acd85b7745cac1a7ed80ef1c8445cf2c01288c21fa99f5b1585932b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4516b917f3bfd147d0490fab68008691bdb3be2f118908bbd3fb976990b2440b",
+                                "uncompressed-sha256": "08f03b0c87b4742b805d79ed39e0393fbc0ab7e807440704cd262b2bca7acae4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "003ffabe733dddf7928cd8745ebe562c8b1f15c15fb14ae917a63814dcfbf1eb",
-                                "uncompressed-sha256": "16dae7380dacb382d455a995d29f73d68a21078247ae0af3ff13409bd2756e4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "65c6079c246928ea21019fb9d3675ac7f021c9af18b28e1ad779761ea36b7d2f",
+                                "uncompressed-sha256": "04008d24166a09d9b76e5adfa334a3acbfb57e735dd4115f375f2a197ac63595"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "754b3928c4bf5c385abd36c8b78bdde68b2fd7d139273b77a262666c9402e933",
-                                "uncompressed-sha256": "7c0ec23d611034a04870ca698390ab71406b4bee99b64843a404a6f393f878d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "ba5d9cfed85a89d5ad292900f1c2cb5c0fbbdfd2b37cd2e3a366868f36c8d09b",
+                                "uncompressed-sha256": "3ce9bda64d65e3c5493a1b203e0254bf7474b45a39bcd2d909668725ba2be88c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "9cd7dbf22d9b16e2dc8041d8bd1d79504a6d77dbe8aecf24039d0b89e2f8ee9a",
-                                "uncompressed-sha256": "2f0d53a0dee903a49149ad0f5a7565117eed83dabd1a75647f7bd3d2f6830f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "3e93c16d17ea1a438b429aeeba4afce302882710210c4502428d058c9d146a20",
+                                "uncompressed-sha256": "4dd8b2b3eb0f7d91ff4f8fcf779dfe4155958f4758011f0decc7b52be3a6d25c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "06906391180885abf04af360c4863d6da6715e0bcc26e2e03e37ace63bfb1774",
-                                "uncompressed-sha256": "08a0e2027f0070514eea2b3cfb9bbc99cc53d03b6263494ff342e39828071cb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "22d79995fc1d404db4f8707c2237da8bdd00f84f0dfbacee9e12c4e96e33d8ac",
+                                "uncompressed-sha256": "11eb939f562a9edce8ccf91b5386a35d8e75d24abb9e4ee7ff8a211a47011245"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live.aarch64.iso.sig",
-                                "sha256": "8af33ca9f09555ba61f01db7e1d2f47e096b0f331a141f21f897de0f4382e6eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live.aarch64.iso.sig",
+                                "sha256": "c3a8ee006a235738ebbecbab27f3f7f5d844c62eea9b709b4e5ffe8a44cea64d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-kernel-aarch64.sig",
-                                "sha256": "8ed95915e2d2bb8f683e3a17256fe2dd2826dd7e8cdcaf9194bf6813ad0f125a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-kernel-aarch64.sig",
+                                "sha256": "09855c0c691c8d13f8a7216bc45366ba83f627884c35c755fab01e4da0c19761"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8789bc01550ab35952140215500d187b71522a78a4b9f9026cb30fb353cffea2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "84099bccac8db7b2988df11452c15958258afed7a11e2c5c5f7d199fb5d71a55"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6c7595d9f6acbc0091cc8ac6406ec57dcdf8e0bdfd5916b0d10f3108fc683b43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0d97a52c530a6bf945201b347bbf86a5eebdad52652a6554b74b9a805f611f9a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "56d25ff75f6b2cad60ef1c16fa3962b17edf9c80c5cce611bd97100d1870cd1f",
-                                "uncompressed-sha256": "e9ba6a0235ca9eeffc7c4802c6c0b2c10f33d3af03dc5750a9dc65bcd6d8638d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0978c82d4370e3f857f83586c10df99b3ad460ca6b4df2623aab0b45991ac624",
+                                "uncompressed-sha256": "30d0fe57daa85d6f34c1b07ce29aed63438eb726083bffcfd65570b9ccbf9909"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "547819cbce0cc4028785210d8bfda070bb87244b79e01f4cfc43d0940921cdf3",
-                                "uncompressed-sha256": "17a49a1b2f8d19f02d93b0cab99d5e466e8ba17f80694957333711c8bb3b5730"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8b187e7bb8acf18a160f0bc6bef2508c5feaac266ecbfd39e46c3a3b2a39a989",
+                                "uncompressed-sha256": "f093b66fc06a7d2f071de1a9ba8cd86202f10e1b81fa119f2d11dca9ed4876f2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/aarch64/fedora-coreos-40.20240825.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6cbb72311ff3ef95cc68a2aa84d863934a2ef3e3acf0af77cf857e3802bfb658",
-                                "uncompressed-sha256": "674e64325b118b653f7bf7db3661e53cda52211637dfd3355a12dc4a9ca2e2ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0beea26fd9baef60971fb83eb9ddf8b4c1991448540a5d6bf2fd91a64758d9fa",
+                                "uncompressed-sha256": "784ee26c47d5c3f38cfd300959a840ec12eb4081faf5e684cc8a79532f1e6819"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0efaed3f9fbdd2ff9"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-077b4143ea359c29a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-05e686de7a6cdc332"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0c9f5f057e438e9f9"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-07e35bf8a166450c9"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0537abcaa56968e2a"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0e182ddc6e7cce101"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-08482af66511a9213"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-09fdbfd10417155f5"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-03658d7e88ce8f0b2"
                         },
                         "ap-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0efce531260a08b3e"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0d667356c019a3653"
                         },
                         "ap-south-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d07e2b4cccb4e8e6"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0ec213b1dfb61ed0c"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-00804b2c06ce46131"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0565f3a673305cf44"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0a60ac9b6932b7a72"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-07532db9fa4ae3b3a"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0eb62592f766f49c6"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-01331a4c96262bc90"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0c84c4cfe82204137"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-01421b6f8663d5229"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-08adf32d04ec59d2c"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0dbb2cf8b189675a7"
                         },
                         "ca-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-01ef92d21a517e9da"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-01208def3a07175c7"
                         },
                         "ca-west-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-070bf5a6ef7f8c458"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0003dca6558ce8d38"
                         },
                         "eu-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0366a4f758fc33f35"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-03a7d31b82f8ade77"
                         },
                         "eu-central-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0e218a19f82868c66"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0201c27a9992f3a23"
                         },
                         "eu-north-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0a768c30da01d0559"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-02ba66daf850bfc87"
                         },
                         "eu-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0becd0fc05e5e9471"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-02aedb2e4caaf07ae"
                         },
                         "eu-south-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-079fbe044fd108315"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-09e096fc6c0bbcb38"
                         },
                         "eu-west-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-052cb563d2a81dc12"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-06fd9c6efdd622978"
                         },
                         "eu-west-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0dbd6d5410e3a697c"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-04c5ae4870417e0cb"
                         },
                         "eu-west-3": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0a365a808402562a2"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0cfc640372e90532d"
                         },
                         "il-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-07af62d0fa44e67f8"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-01e1f50020ce35abf"
                         },
                         "me-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-07fcf22af4c197eab"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0e1fd5f6c4138a720"
                         },
                         "me-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0a98142768d63da6e"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0f5518c40c325c0d3"
                         },
                         "sa-east-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0ce63ddb651b657c1"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-02030af2f45192e70"
                         },
                         "us-east-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-097639dd63538e166"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0f3330aaf83197342"
                         },
                         "us-east-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-06094918de11f3ede"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-092a236d1507291ee"
                         },
                         "us-west-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-01e71c4525f290607"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-06a7886f87e4931ff"
                         },
                         "us-west-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d3b86775a035afc0"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-074536ad21a0590e5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240825-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240906-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a58aff88474fc7c20302c1ab4092c52aa51c899aedb5d8ecc0ec04e449913b1e",
-                                "uncompressed-sha256": "04c833d9c2ce4970290c54365b7a6551a06c2e2c8ce8326fba9fa250c231384d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "5f649696a9203a5f2ea367dd298d95660cd873d1e6ceba295d1fe9be64b9f37b",
+                                "uncompressed-sha256": "dc8f597b68930352d5556ceb0382fd9bef42de8deb6dcdb863c4f4cc7703954b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live.ppc64le.iso.sig",
-                                "sha256": "abc4fd4919e595f3c4872db4557c2dcf3ca132df793af61ce7d0a10ae5ccfb4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live.ppc64le.iso.sig",
+                                "sha256": "c785925a45b28558cb5c32eb92c0968e658a3bc8368034125475cb69f406eb98"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "f46688f208e600397c0d194a81b78885ee65cdc060af8ca2769c9ad02fd39b09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "8f74ba2c9942315b677986a78ce529d61aa5edddce2c6675b0d797cba280eecd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "9caff4fc300f9f596d025417268ea8d5ec2ac5383a7ceb1847586beab9ddfbae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "85b331eb5381afc3589b98bf8a969f4138f0efecbd4f6f0f074a90d0d8b68194"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "bfdbd000140d2921c9a802f683d6d6e9bb654faff45cddb0f119696794992f2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "86d5b992e0a21ae2cf6177c71478fb054638aca87b6d9ccdb51e49eb20fc8c00"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "eb782f37e1094db75fc7c3540e45390444dccea5a93cf79a373995b31905f704",
-                                "uncompressed-sha256": "0128b5e1ef91f63d47946e9a7928ede88a85e5596b62987838610db14c0c60a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "9af286c1b237174131f6a2b41bb20c34fb9cdfc5c14709f1c03fa1435647c691",
+                                "uncompressed-sha256": "31ecf7aefebed8f815db343c0dc16fa816f8d4fbb887c70dd38d00d3bbe8f010"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6518b83c9287e1cc02a5c9945074cd1a5d19cbf348899ae634a364d9dda9fce8",
-                                "uncompressed-sha256": "d467f8504de2c1ed38f85e399540fac39fb07ac00922f9ba9b6cc441132da202"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2d038e27b927e889232b8a56b9d218e52b3a6a5e34d1a42f57569647bb89b284",
+                                "uncompressed-sha256": "bcd6dec8c5c16a9f13d4e15e7330068fc0d2c4e54a8d4c3efaf91ddab0604b8f"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2201ed634291d0555a11e12e4b0facd36e7c571c6c041893c5016cfae1a9430f",
-                                "uncompressed-sha256": "0c0dd3ed61642ba17cb59e7fa8fcd874b07fe6fb2aea3b96b8a3d22b06a239c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "0b0e306e3fa7aa9b9a035802f43466b69e4873894b4b94e2bf5788af31abbfd6",
+                                "uncompressed-sha256": "7155c464286e8ec98b82a0f4b2e186d2896ee921a3541f26b992f9f0f666547e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/ppc64le/fedora-coreos-40.20240825.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5d3c9bf6d4b051e934e7f903f06a8b0762ef724ad1d049616a420e594e3e75a9",
-                                "uncompressed-sha256": "124616b5c468f46a9e3c6a855a42781409485c45a3cbe1bebcc4adf51455afc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2259c4a368d1293419b9a9567ddba25d1461ecf0227cab1f09100dcacb039321",
+                                "uncompressed-sha256": "a5da0d133a0e0e4ea8ec58a704842fd8c16959a474000f20981daba64febb4ee"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "370eafe2352561602f3fdf5069135d1097e710f1ccf4fcc89da229fd5d03e6a7",
-                                "uncompressed-sha256": "fd9a9bc327ae7ecd3a50f2b985bba992806646b06b474ce0ff542457a0bd0848"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a5d0522a4d8147335dee35b424a795a6e625db13c746e49b9b35e859d302e976",
+                                "uncompressed-sha256": "9580664095bd9e9251d324a1c393dbd90c4d91e7458b9307a8fc7f7eebb5a3c2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "096a8280a10b6d9afa5d58e15b952f3a805f0aeeb105c2609a1ac073a4fa7f4a",
-                                "uncompressed-sha256": "c3a5962aa7722aec5b8f44f4941d246475a112cb8bd49a2f6d421eea9e76a159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "dea5d1d286687bb50c4f1f1f3544877d245f833a38562d939bb979af0e070d53",
+                                "uncompressed-sha256": "532466859de4cf99d385e6a576c797630853faf04d13abce15b8336789e25040"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live.s390x.iso.sig",
-                                "sha256": "316fc5126a5635ea3f9e678914ab2ab7a0c70a6d6f56041d16a75bb1967accd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live.s390x.iso.sig",
+                                "sha256": "8a59b891930993395158fa83ce5021841233352b0a5b20e1c91e9039794d9bd7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-kernel-s390x.sig",
-                                "sha256": "c3c314b436e4e93d8f96c773189fff652fabd9145f34f9eef851e65754e0461d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-kernel-s390x.sig",
+                                "sha256": "94e52beccbd2c3840e93c4dc5f078767f617bd350534460fb4fefaa40d8f6130"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4c557028d0c0920ef4ed7ced05971de622ff4d460c7ea54cd2689971fb593dca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c0f5c928da0696839c6c9dbc2d29e60ef10a472fd0d17f48b83a8fe90519202e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "27674ab8bb41d49f3334aab5d705a49202796fcbcd17b6d7ebddbe8837d6e177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9823bbb24929ded6a28a8be3dfc41cbd5a65771b8a043da09eb2bd09e71b3734"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "980c959308b126c2198db344fd9e8bc4e8fce68c55dcd7a63c2bd8a467f4b24e",
-                                "uncompressed-sha256": "04c47938ced17a8def2261464087c0297ed5c1706fb9c3c89016ca86ffca07c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "283d9dbba0a9a23d5653f959394ebd9d482c7571cf41b983089b39451473f14b",
+                                "uncompressed-sha256": "05a6b8b26a7e8aecc2d792b540dd2e277612e0d1f741b56e2af06f3dd9b203d2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "74e15630ae91ff04870b3234f418e355a85b95693a6dc74668211077b4068358",
-                                "uncompressed-sha256": "ee0cf438884aa8f497a214cc550906f0048937e1d4469a0ae5ff4333db431b08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c3e486f02e46f8a9173761280ad9d9a9f4748d68a094e2ea01f79bb497dfec6d",
+                                "uncompressed-sha256": "27233a2f053c1744393512564d17f924fe6ce58d1f0f7062f3bfd0c7ff8bf16f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/s390x/fedora-coreos-40.20240825.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "10c05bdba8c25a4581571ddf989ebc383d92ed37c7d9e0667ccef598015037ac",
-                                "uncompressed-sha256": "3dbcdf2de69fec9966534a7ddad1e6c7c6ef215682df8f2c12e45da5599e65f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "58b4e9d0ec6b90b33169985930939dc3e672beb51787a003de6246d05335e91b",
+                                "uncompressed-sha256": "f7982a6a7347178e7aef326fd4ef73c48dddbb85161dc2fafed86e7a066a465c"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8b6676f0a252f45730fe5188ad21903067c9f1fdc43b82936b7ac2470baa5567",
-                                "uncompressed-sha256": "562ee94c8f6e50c255d2bef216f852f21bd3049772597895ebb00f8ef436888b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "149fea70f06a3d57d741aaeb3170045b6fd4e4afc6fbad5a1d5c42b1aec9ccfa",
+                                "uncompressed-sha256": "ea8392d958a1aefbaa07422a83d365963172de4488181a58ad6113b0b194b321"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "68ad3821af161c4dbcad5d4125c93e7ecbb97e93831477b1fc78f5bf81d7933e",
-                                "uncompressed-sha256": "9d9c81cab34f8be5d83c730e219a5294120dc1ad2e34ba9d9f859be2dc8a79ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f0f2fa53d414522ba36e2d300183c68e8993cecc65ae79d287b7bb6a76e9b172",
+                                "uncompressed-sha256": "67a85c79adc0d63822d21444129fd5cc536e25a86a5b0a1ff2c64bf13c8c4b10"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "beeda76d171da262ff092eed96b924a5a86c51901ce9efa009b6af50c93dcdb0",
-                                "uncompressed-sha256": "cbd7780dc029f71c851c513c371e4c46b82e8fa8fde70a55005fb9f563f2d247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2d2f357781fc4148a9e3e0d4b63335a892e76a5fead9a1bd9fb62b54c87f516c",
+                                "uncompressed-sha256": "582b94eba72160ae9222d9b9d407010d5800a1733447bb996bcd458839053eca"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7287e4a46b602976123539fa9738eceaac1d457a00cb09a740827b6b4ff815e0",
-                                "uncompressed-sha256": "793bde75060c14f6ff8f4cd748b1b74925eb3a51921a3f487023c462e4c65adf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "54d94a9c4e523db8c3726f9f7310ed95521e42a8b832d73c92c30767ed1a6ac5",
+                                "uncompressed-sha256": "7ca6d68cd5af97fc2b989a7be94a4bece98312f4c9fb567749799dfa768d9662"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a9379e0f5f7faea3f6e2681229191a8e6c55119b8cb3d3641b2422252bc6f2fd",
-                                "uncompressed-sha256": "f2b29f9fc8b86f6c4f6c215408ff98151d2987b58718f035b3578d404dfecb38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "451e76aeca80fb40be4fe62227cb5214b22991aa76ed4b3b9659b9238dc57b5c",
+                                "uncompressed-sha256": "1227ff3eb56ed3015453a407775db7a45daaba0c8882733b4eeff7baa38b4e4d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8a441527693408e39244a2624c754a021f84c99aa0a4102004bdb120b3821696",
-                                "uncompressed-sha256": "d03075410a7de0230d26a0165e64868d4e5514e1b85d96256be405d406533ab8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2564673f536fd8bc4cefdfda37fdc0ab6d3e851437426cce281202abc2644899",
+                                "uncompressed-sha256": "5d90e85a4d9350a1865be7df7966d2b8d14bd3164bc1706f9e3d04f7ea52d62c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6f8f3dcd1cf1ce89aa23cf328adbb2390e1f389e18df328519bb8d4523ede470",
-                                "uncompressed-sha256": "d51f811c7975c8ca411cb0c14bf51f90b96c34b767230cb702e922b84367e9e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2e6ec7a69d68dcd5dc15665b9f93e734a08d9ea2f085aec4b65839a5e96016fa",
+                                "uncompressed-sha256": "aa00f294b5d9047c764409793f2947e87e71ba32cc5a099d317ab7be639c67fd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c86ce370fc3cb70af913758682fe57a74ac1e61147f33f1113e5a3e7f6764da0",
-                                "uncompressed-sha256": "4761c404d22869d6d3e01bf8723941902de01d01ff26092f7231c76fac241162"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7b50bb25f57a1efe8242fc3ccaa560f2bd1b26535d6fdf620e3d8caa104db62b",
+                                "uncompressed-sha256": "a6dbe2246922200a2d5dd45c61619d23a3c84d9b17785f7d0949cd405ab50751"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "abe70a21e27d67b7a888d2c232664496c4a49170ec831a83b625f31b2d42646f",
-                                "uncompressed-sha256": "7bd6aa2a67fcb1f42af13b91cde83b252112738320722d683c36960ea1557a7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "647f85ad90c9c66899f681363f4c36118cc1d2335aa44cdc598394381c3e6d71",
+                                "uncompressed-sha256": "59f19e8cd51124a28cec30484817eca781068d9596ebb8f2e24ec2e2259a20ce"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4ec9200406a3b7d8198ba3845b3bbbc1e534e7dd398b582191680e9e2bfb0602",
-                                "uncompressed-sha256": "f44cb7b56b30795eee29aed34a2c5d75370b083b90d28113b28d114628f5ed84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0b14a5fb09ae9872cd3f73966c703280e68583ae9e3f2c3016622d4077e20ff1",
+                                "uncompressed-sha256": "2ff49029aa698466cee07626956fc6bb19749d84fc9ba342c093a5ac66c9f45e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "917494ceaea056eaa322b105ba569670dd985645fc98c4684baf8e992a994702"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "eafa26d5c1a224c6b6873e00a4b5edaf686b489ed6e58b52f7ff4f15d3e85baa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7b56cefee0f712b1a9b00247c71bcce73ed227226145b8870dba91fccf4b7196",
-                                "uncompressed-sha256": "0474d2042ecf317c00fc4b26b6c7c481743bd8255a65035e5066b5a5b8d5b8a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b7353221ee88c4131d223b1e464ea0253e3c3f9e189eb68c47a3d1eb93933f63",
+                                "uncompressed-sha256": "8ad2fef33b17c235b33eb6454b6047f29a6ecd6378b559cac383a062b013f089"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live.x86_64.iso.sig",
-                                "sha256": "1a8ace5c2ff81747321e51c120c49bb421f22d1bf8ed2b1571b00e69d62d5911"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live.x86_64.iso.sig",
+                                "sha256": "5760135309cfcb2cb0ada13b65ac9b086ff85f485bb1a0ec72be1ee5033107d0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-kernel-x86_64.sig",
-                                "sha256": "241a166c730747365b85b5f391f15a5f8325242b79f52cb39c943ae9665f7a02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-kernel-x86_64.sig",
+                                "sha256": "f99eabaaf7523e47b50b1e14c5fae53432c9de2d0fc842bf6af2d7926f9cec01"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "399debdeea17746dd35da60d03bf8508f625ce6e40fe9e11f968b2c6f884a63e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9e97669dcac6ff79ba79c77f6f929df8fd5fc49f8762a7184f6274b1fc1aec1d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e170090ebe41527d757e419aee9cdb2a7c50555cdc9430a103faaf1c24538c4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1ddbad6a98540217f35ded7b0f0324a5877a4e4b93c1f8af01913b505062c08b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "38483be2efb70a51f0c43fdffa08e2311cee0bac8a64fd2d120c62d9861a13ca",
-                                "uncompressed-sha256": "fd62f24adafef4d0ce0f9e02a99d347bb4337f0500290847eb226264618beace"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f35e8b91457450f2e6df95ea7a3bcc374278d5f4e46b305efd941c34f1b60853",
+                                "uncompressed-sha256": "f30a7ab9f1a93014f87d7cb627952ca7dbe98e6bb96ce914c4b1e14fdb6b856c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "cee115c6d89ac143fe1a0037c32979656cc167e1b0c09851ce3f2c19689d98ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "849fdd38a3c5b6b5672208dd130c41e48e94a78bd26d1bdd8e902130737a2a1a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "24e3f8e7311d5ce11eb732ae70be595e0c9ef7ab777bd57146f8bcf557023572",
-                                "uncompressed-sha256": "5b01c202b9fa304b1fec4b8e069dd32d1a848e598eb1a1836353d50fe13180b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e00730191df38cdee9cf8a13d49d0a0244f71fc4e9f82741b88cca50e3531176",
+                                "uncompressed-sha256": "c8f15ee63a844d605f8bcdeaaea9b7d0fb518f3e7d3f4c59e8cb67459119c183"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "c4a6dc838e766a57f47ca82877e547e95b011bc766a5eef4478fc74090631ac4",
-                                "uncompressed-sha256": "c62b3fa46a9b1bffb42994b5de1e2d2841f468b3336fbab33b52fa5225348d10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "94d371b8b8ff878b1812690a7b0e0eede964fa2a05e178f5ca2f3537543f37cf",
+                                "uncompressed-sha256": "da378a384bff509850766e01405e9d665ab29362309d13ddcaf7b0a7a2ce299d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c54aec3a22114da7c8526fc2d7318f7ffc61057c8925b6089cb3d13382d81d7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "614502890cd0a30164b9f17f15e335965fc224d251d5e766ce9a5588086cd450"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "70d0d1336a16aa78efa85032fae2c563cfd8848938a2693abab29f57a4fa7394"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "61530b9617fd66f1e32185c171eca0e125431822077279c57a675c629d307a7b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240825.3.0/x86_64/fedora-coreos-40.20240825.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "179a4065c36984b5fa64a623933a6565110a17269bfd94f9d51ee961958d6f3b",
-                                "uncompressed-sha256": "fed3e01202dab35280152f272e47fc21b3bc2261a1338e853a9fc37bae599885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c282a7550145562c846dbf70db1b4c8192b36c0692d682823052de5c13c2070e",
+                                "uncompressed-sha256": "32632f4748e8a6a5999a037fbacabdca2e7dacfa6c69eb42dcc59f2517ad24bb"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-090db5a9766d84ac0"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-04b70cb2b62c5c3f8"
                         },
                         "ap-east-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-03b1fd80b5a652633"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-026a481e116e57331"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0952ec91a65e49582"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-042858d4462ac0f7c"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0329aa9853eb6bfdc"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0dc6d231737e2932e"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0512ca1a77f8cde69"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0fdc989a7d6715970"
                         },
                         "ap-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-08c0438b5ecb1fd12"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0842b0f4e9dd56633"
                         },
                         "ap-south-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-09ab7b9ae18fcb944"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-019acf3d2ee391bf1"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d5deb94d7ccdd9b7"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0d84d2ed79d4237f0"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-032da4f815b94215a"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-06b9a3be40b76fdb2"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-07ae7944d29e7d1fc"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-00684823413e31102"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-08f2105688c3caa82"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-010a834c242442380"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d5ec5cf10447fec7"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0d369dc8384734946"
                         },
                         "ca-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-00bf6634758bdbd42"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-085ad2bf09286eb7c"
                         },
                         "ca-west-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-022e1c0847b9a8b40"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0b6cc0ce67954f629"
                         },
                         "eu-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-06d99f83f85694ef9"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0424389e9756d216a"
                         },
                         "eu-central-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0845a089809d85714"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0d1482e2ecd9f3a83"
                         },
                         "eu-north-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-05d36aed063c7f5db"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0e1a8ac2b1ffc1e55"
                         },
                         "eu-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0af151f580717c867"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-073c3a2e45ddb8342"
                         },
                         "eu-south-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-08ea477b13168ff7e"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-07648e884c1e323df"
                         },
                         "eu-west-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0a016f7874e0ebb36"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0a5e4999ec9e1ad06"
                         },
                         "eu-west-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d470b68ff0dbfe01"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0766833335f4ab1dd"
                         },
                         "eu-west-3": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-05b03e7e5677c82b9"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0de2ffb91afa508bd"
                         },
                         "il-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0a1411a203cba8d64"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0e097c477167e4017"
                         },
                         "me-central-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-01be89d82e4ac30c2"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0aaf48076f7a7f129"
                         },
                         "me-south-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0745079b1d172c0ee"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0c346576e8e02aa60"
                         },
                         "sa-east-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d3f076cbaf4a9c01"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0f8c812c92064bd63"
                         },
                         "us-east-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0993e354ed68d6a51"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-0be1e1842ff557eb0"
                         },
                         "us-east-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-05e132da293699986"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-031249216d2ff012c"
                         },
                         "us-west-1": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-07b44f3c5d1995374"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-05a60c140bde387d1"
                         },
                         "us-west-2": {
-                            "release": "40.20240825.3.0",
-                            "image": "ami-0d8b0bae570eb6d85"
+                            "release": "40.20240906.3.0",
+                            "image": "ami-05af79112a5ccb661"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240825-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240906-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240825.3.0",
+                    "release": "40.20240906.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3ff2ff2a25b0c9f408d464f752d23318cdb40e617aaff8e97739217ebbb8484c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:36611de43a2d00b724e90855d05e5ce67fd443345d91437711cc73d3d3e99d13"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-09-10T23:15:34Z",
+        "last-modified": "2024-09-24T16:05:20Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "36f5a7bb3faec57efa492753adf8fe5786c130ebfe215f3ad34773c6323ffd67",
-                                "uncompressed-sha256": "fbf5e76b44425daad88a4dc83222549d30ad96a184c6c9df0219f167fa39262a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "4d62233247081a9444f419e09b23bcc9a99da8ab8f7737b1a06d819a485a2ebf",
+                                "uncompressed-sha256": "ec3fe25ba033aeb5b3d92c5d8f5b4dff49d32f155e5321915348cf7924667c9b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "99b3c77c4af9072b5727b7f8448c689e642dc51dd250e22036a0139072c3dd76",
-                                "uncompressed-sha256": "b6a0a0c43777e87ef9784a696def4fe9a06221cf234cfd4b708324ad607b8a0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "041b0e7842b7baf23e463d652e8409ca531851a13d7d2d3232975704fcf33a8e",
+                                "uncompressed-sha256": "751d134ca26852bce0fa798c7eeba3eb6544bb0cb4a4b808116bc58e39c3e00f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "f3636355714e02bbf5ab4b800967b6cbb3dc75383fd6764f7cd82e7c8e1a9a17",
-                                "uncompressed-sha256": "ecf0acf7573e2ade5961312ded1aae87fd0bbaadea61327cf241a61b5b3a13d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9d8d3f81865a2d4dd5da1807ca11642dbf44559cb1f8a9bc688248008f6d1e2e",
+                                "uncompressed-sha256": "d4bb44f187d8a7c29ce482a37f604ce8c44e23ade6bbb181e64cd1dac0a0f4bd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2c43f5288ba8213e98ccc9eae435a093f4d4ebb3df67a195b114b936c15600cc",
-                                "uncompressed-sha256": "c9538ed35e8152cab9c49fab862b28d8ca31677c932114f5c8453cd8b1cfa06d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d368f471a61d15c8d2e246b641912829d958e96fe06a927492af14e9dc8d62b3",
+                                "uncompressed-sha256": "e733dfd451d2e19e8116e1d203722d345df2acf1cee63b25c88fbc5d12436859"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "bdec0ecb98831a9ccc474d1a3c6d232794895824f76a5c10d44420094c917fa4",
-                                "uncompressed-sha256": "dfd17d424ee3e5ed0b2ab350943eaf66e575beaffa6648dadb65bac64a7a115b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "c31715f2e7abb9f41b2899badb2818dd22ac07e83036e737ded79e37dadd6018",
+                                "uncompressed-sha256": "4036c349324082b794972ec81019b00eebd3fea0c65d0c5757e452590675dd92"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0498fa7c15868f11a814e08fcd9b9229104ba2bdda78fde9345ff1fd6782a97c",
-                                "uncompressed-sha256": "947f52242cd959897b04467bc427d1b73ae8ae1f8240d922ef9422316817ada1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c45b68968f05c0ef0bd0bda13ca29e113ecb82e609e5b945ba6a2b85e05ddc42",
+                                "uncompressed-sha256": "075aff28e0c5bd966976f65ec2ba4045e07d5c4706d4c55e37d2b88a1803d58f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live.aarch64.iso.sig",
-                                "sha256": "b7f5c5c2711cb3cb751504cc946d887bf0b09fce2976e4f0c68faae241c39844"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live.aarch64.iso.sig",
+                                "sha256": "8df48c92341c998eb2a4daa21737e70314221da42c847866ef7ea9111da0444c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-kernel-aarch64.sig",
-                                "sha256": "09855c0c691c8d13f8a7216bc45366ba83f627884c35c755fab01e4da0c19761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-kernel-aarch64.sig",
+                                "sha256": "cba8ea5453c6dd2669ac9ae8c935e47bf5680a76bff0a4242fc6bd42f2479588"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d7421f336e1b942ebd9257b472de34e2c865c4f768ad901f5c4fa60ec1500cfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5be0a9ff617a4b6aad47eec0fbb351a3769adece0dcb24840efd1c3486e05a46"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6ad3c298c6d2e9ccf8c0695e5d944718e7beaa035f036f4d1d90fb6c6bc67446"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d949426a424f400867b93d8abda8ff4b6622f6aa8f406ad85efc9bcaf4ef71e7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "154a4c6dbd1652047841a6d578c87a1697b3654d6e9e73e510fd3717e846c4dd",
-                                "uncompressed-sha256": "d9c40ad25c09d4b6f230b1ea3c9bf11c4a4c90feecd3233d664b901d296b5fe1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "0bd07ab7e830e71dbd5c238f00fa8a89f66a6ff6d601bfa59fe13bd8e13a884a",
+                                "uncompressed-sha256": "0fab9f88a76ca146186923a570f43c97a2e505149e7f03b965d20b1abdeb855c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fc3f1c1fdbf9ca0183409cb3f291b1a4d25c3dcec57446343622de5f9a6e784a",
-                                "uncompressed-sha256": "3f72d86ea23be55a0d9e7825eb6c614a97b85249808ddcc1b45e6b1e528e3145"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2b899edbecec8d95355031f2685eb6f8237d8c55a6554d62f32ea6ed440af56d",
+                                "uncompressed-sha256": "fb60279ca41fb8fdad95009847c1fd54f45d198a9443826d6d3d280f19447b6b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/aarch64/fedora-coreos-40.20240906.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a2f7debb14805a886e474f755c2446004c45e4d5b6bd230b58fc74539c535247",
-                                "uncompressed-sha256": "67bc1e4535157f70f8daf8c9fa7a1aaa76dfcd9a24246f4dfd9aed4c141d5132"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "41725c6d3976969d5cf22f68b8c41689dce42ee3a41b317a8aa38bf9cf7db793",
+                                "uncompressed-sha256": "81116e0b9712a5cc7e6a76e02877da5bf17905d1a8fc2c3d4dfd780a6b7e2be5"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0913ac37e800c7ba6"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-01c99a6095272f77a"
                         },
                         "ap-east-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-060d1e4217694ea17"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-07e0ac2a28cbc3833"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-06ccde999a404cb07"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0aed18f7930518983"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-09b02ecc09e8a50a8"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0dde046be8efc4734"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-06daec6ef437b66d3"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0386d4f2ff06fa919"
                         },
                         "ap-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-04e737505eadd2275"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0f925ced27e59d51a"
                         },
                         "ap-south-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0655d100c35c3a501"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-090d3f4c5eb5b160c"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-081d7d0eb87553f73"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0b4fe1eb3e9b15d91"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-02dc36dccc365edbe"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-026827c4ee378eb40"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0f0220b57e12fda64"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0f01b4beee667129a"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0b7c39f9fc6956e81"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0edf606fbe1fa2895"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0d68d90d75ab847ac"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0b711ae7580834c9e"
                         },
                         "ca-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0492fc93331aa8aa0"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-00ef2529f7c2c234a"
                         },
                         "ca-west-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0ff46a6061f7dcedd"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-03807602a550479bf"
                         },
                         "eu-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a4ccdc0731d5f1db"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0145f58ca3fa4a3a7"
                         },
                         "eu-central-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0706d1f0e6dbac2d6"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0fedb07b8898bceb1"
                         },
                         "eu-north-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0c88b2f4c5ed132f3"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0e86e1c97bf14f583"
                         },
                         "eu-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-005d067297c017674"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0d087bbb964f512b0"
                         },
                         "eu-south-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-034dd9ffc5206c83a"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0c42c282f061bebb4"
                         },
                         "eu-west-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-024e2dc9c90dc2657"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-08c1721bd9a0da0f3"
                         },
                         "eu-west-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0fe67a61145841e4e"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0cf3771533c97abaf"
                         },
                         "eu-west-3": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0045ddd8c9cc9a98f"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-029a50e0105f13c3d"
                         },
                         "il-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-02b5932a17f15d36e"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0a44b4cf74a531226"
                         },
                         "me-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a095bb326a6f9fa1"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0806983b1625ac42e"
                         },
                         "me-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0b9b754b88518c605"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-051c4f2c3c1341dc9"
                         },
                         "sa-east-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-05737f2c0619e7656"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-00b899c22825e04bf"
                         },
                         "us-east-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0d00ea1d44977bb67"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-07847e982520399d8"
                         },
                         "us-east-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0eafd4d6cf4822181"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-07f7e53d773a496f0"
                         },
                         "us-west-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0c95b70057b0f60db"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-09b838d4c84639de3"
                         },
                         "us-west-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-07d4c95758d6695e0"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-055d491c9ae1bf33a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240906-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240920-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "cb94c9c53095e7d4d75853eaaab581827d60819b085dce48600a5bc8fb8cdc4d",
-                                "uncompressed-sha256": "085d2d4bf67d2dbb16dcdcbeae3631dfa1fa6ca0d313dd9e0adb5501f68e79ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "7155e94013c99922c8d47f124e4117def49e8c07ae3e036aa99e553b268f326d",
+                                "uncompressed-sha256": "17cc0ef44684224880ac39b924d12aa2bb7b5aad20f4417e71198ae36090a7ab"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live.ppc64le.iso.sig",
-                                "sha256": "caaefa76eeeb433d4f6517a61420d3eff00a34d9612c60bad485d7bb7ba9d69b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live.ppc64le.iso.sig",
+                                "sha256": "c14066f967f7a564d42bc9107aab2a55f26cd13f869368dc776f3fba476536da"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "8f74ba2c9942315b677986a78ce529d61aa5edddce2c6675b0d797cba280eecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "d46ee1013aaaf5ae268dec58b8ccf27d1691db19a770c5ace38f1ea9b6fc3244"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "bb4d2c85a8e446a4667c9c04bfe48b0f41badd5922c0ee32c15e3d08b83a607f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8785a1685f58b5594ea4a6ee5eb164a1d08b3f6a9c27afea1ec51d59dc2ab401"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b48e2b7c8b83541428c1391c2ed71bac7bebd9b6ce6021376e84bc558fd11643"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b4693f06e597b561241fab8dc8ac8cfc364a7d084f73f4483a61bccf3346dd8f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "79faed11409ba9605ce0b62ce8504fc8df864a6eac5a621bee72ba7eb04375c2",
-                                "uncompressed-sha256": "4ebff3aeb713de7e7bd7d89056400ed2b233d952c5b6f4fcb4d9a72491718724"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "58623a9cc7d0de0e521cb56d1e02c23d820cc6082f8044737676264c9cde0b78",
+                                "uncompressed-sha256": "92a5b27574cec67d3dfd4bfe3dd3ff68f760acac0d55b1db8f37c5d6f4a60a26"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9bca6aa980ef2915fac0bf22fe519bf4ffef4e13458e18b97710244139fee7dd",
-                                "uncompressed-sha256": "545be6a99d0442b4a3a5edf1b846841adf0afe6f1892d8b4a24ed851f876372b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "47d7fc76ea9c46e73b06b356f8da009c92fefb9a0c1d6add15988e50dbd75926",
+                                "uncompressed-sha256": "c467482e04c5e0c6f3f0751a38b528d4f18d4e9ed8e595afaac5edf4a7cfaeec"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "1e567378fe0d296825a44614b11b9c609bb5993bdf57df4651dc9efb2015707f",
-                                "uncompressed-sha256": "33400e9842a9044bda9c6d4b3eb4effebbd45f42ee5d838c721a394bd6599f71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "0809b79be534a2c516aca6bbd1ab568ca6358aa7d77cbdae7033491259435fda",
+                                "uncompressed-sha256": "7206749addc27ac9d4fd311d299142fc8bf2387e83ca82c8283f2ade2e5e0992"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/ppc64le/fedora-coreos-40.20240906.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "70547b745cad15d072aee860d61940da2de5e2abfb91ef5a3e5aa2086c7eb5f9",
-                                "uncompressed-sha256": "4a638334c14195514119063fda188a17eda22213c2d39591ae484471d8e4d54e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "ad8b5746f414c27f8839332ac8bea072a117168a2922159e98709e3d5673bc81",
+                                "uncompressed-sha256": "a052dc23658dfd3a5c12eda0f8f968e16705692035f14577c916069ccd9c7c7f"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2a75631ba4a0ef702298eb28570de54f939b2df3a1eb76eff9106509e3ece8be",
-                                "uncompressed-sha256": "e766d9032bc0590934657a7e452db0e8ab918ab7401423777d19674c6def86bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d0b2c1234877dd3e739fcdc9b3abe16091c446de8dba203173d63a85ec63eccb",
+                                "uncompressed-sha256": "6460d207c638a1134c4effa04fa25f16ae52e391be9d715895d58840cb394146"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "cb69a04b757a195e7cc991ebb368bfa431957b0c52b6c1296c3e49ff04f31b0e",
-                                "uncompressed-sha256": "2104ac8186a205493ec74ea144e60a837ed426df66a028f6a28202fad8939f49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7e9dbcdfb98ef4694335c3b3804bb4e844f556c43b7678d905e6ffa01a47e52b",
+                                "uncompressed-sha256": "bbedd880f3d0f848964dac299a1045d75adb4de95fdc3fd1abdde64f14533882"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live.s390x.iso.sig",
-                                "sha256": "02acc6bf0db72e065e02408f0f35023fa91e9f87a126e8ef8258f83cfd312a21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live.s390x.iso.sig",
+                                "sha256": "a794eebb5054fb7d69e88ad634ee4c2de35c67695468cc3d9507292f15cde103"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-kernel-s390x.sig",
-                                "sha256": "94e52beccbd2c3840e93c4dc5f078767f617bd350534460fb4fefaa40d8f6130"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-kernel-s390x.sig",
+                                "sha256": "319c73cd5ddfc00b861941bb7a2bf5b7cb04c2b728dc42e9c6095672f2169448"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "43661db3afdb1520bff8f4322191d9a01645dc7490fd65c9be8b946fe49d4900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "2046ee532b9461e17177e9c637661abe286813a172b0696433dbba02b6fc9a87"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "2d012905bad9b19a951e45e2b066e19224a3dafed3a336ee3a3c7808499f872b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ffde5500cc754f452951856f30eab964255b2442f94d22551943220726bc6fa6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "64c950520fd33ad165dbba5c5309d6ec5d0478b5bfc0786463f9f2f06b82b6d7",
-                                "uncompressed-sha256": "75871a846852253ff4b6531df9fa42422e2e5cadabaec0ab54ebe6065c0690d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c62db88e3fc6b2d12954ab615b8e1dcee821c63cf5991af4e28bed2626cf9f72",
+                                "uncompressed-sha256": "8a2ca3a18808ea557020130e15c1378b191f783af4a44a635723b2540f64795f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "57dc143646700ea62c84123ec8c820a8361a7c38760e6d0d40880325fbf4c664",
-                                "uncompressed-sha256": "55e3363786d3f3ea1f1d302247809609f74d6d69f551e83b270149744e4832b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "581bc2118e698ee1e787d8cd0ec691dd78a269ff08c77b8d85ca4c1ba10952d3",
+                                "uncompressed-sha256": "117181b49a89b5eeeb5c4f419bd787ee0a74d1edb03f7ac765b418387207517c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/s390x/fedora-coreos-40.20240906.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "cecdf386412fcbe25ab17ab367725e515b1c207516f5a1c8e937bf9b361d4148",
-                                "uncompressed-sha256": "cbdc12ae9a34ef7ee5126227042851680929ae6df29c083fd6390c2f156c67a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3aec7b993a935327cd201de170795d4cab896aaa5856bde845a1c5b33305ade7",
+                                "uncompressed-sha256": "713185f64088ade27e276850b42503af5f0ae4d6d76adce2574c60dafe24e125"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "304f63049e48a753ab60085796440d0fbaa00061f8d1a832bb3eef64913b924e",
-                                "uncompressed-sha256": "042d7d58602d25d1011b620081e7ef18c83bdc06216c975277443b05f3ca2ec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d223b44a3779bc4accd3e2b3a9354fa3f75cce1ea371e3a40a30a41ff39172f6",
+                                "uncompressed-sha256": "367434412870cb804f01e7547fb71212f08e0140995b262b3596c1c167123e1e"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6e8e2ba9f3249d365907617c38b2413d6c5d8489649588734d615f05bbf4f14e",
-                                "uncompressed-sha256": "c622523c16466da953f428a83ddac51b8a68ca9aa4b3717ef27d2343e7164487"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "cd07e852ecfdc475cc8be531af07d2d6577adbebf61fb30bdb5f298da86c2178",
+                                "uncompressed-sha256": "2f6af2a0431f579a3827cf74e121bd91bfe58f0e267ae19410c4279158135707"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2551efb4ed37c780773c8dc98ed69a20f4053e90344a348526ef1746ca7e17ac",
-                                "uncompressed-sha256": "298e610732a6344c047099eae6f90b59bf797c17be37f94af80742016a3fb3ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "33c58d7860d155b716e1b06378e93fab26c99c19af731422ad9972c62edd0520",
+                                "uncompressed-sha256": "e6b4e157b772c99914626d018859a22d063ebc85488eb4a16221c7bb51b08cd5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1f749424029584ed9e2adc68e7e061bae4f49bc515d7948295971c5170d52533",
-                                "uncompressed-sha256": "d3bdea738cf2ea5f13a4113dc7c648d0dc4c9184bd6dde55baaf7b61d9f593d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0d30acce04de1c310f13279ddd1f7136538cc2b4bd4336db381e28142a98a64c",
+                                "uncompressed-sha256": "2d8cdb4fbe7c1a75bc330ea8be23623d83ea1a483eb686130dacf239f002f22a"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "512f78be03d98ad33aa9f757401ee4e70ae45265771636f76cefc0b55b60ab65",
-                                "uncompressed-sha256": "8708cce76e608d23e3205fe334cda84fe9fc21c7cd3fccba270209c515ecf872"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bcd6e83ae4b8dc890ffbe1f4d6aec392154e3a5aa96c6c0cab2588ecab39eafc",
+                                "uncompressed-sha256": "c861ec6074f27765bb9730602890c87bf8ed4133feded0b2e5f13a1c1be58bee"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f48b4ec8f6b97bc066eb73fbee82d61ecad7e4168c7ae4998a7a0d7c39a61b4e",
-                                "uncompressed-sha256": "dc7879def2fec4fd66eb15b3db99996194a5041d78dac198c815859234ca8098"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "88ee04db542c869b0acbae3de8d32be00e3d06b5cb5b131474b760a48476d076",
+                                "uncompressed-sha256": "5e57448c50cf2d1326c783abd31e70ac402efebc0e0d1bb9c64943b895d14a1a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "29c2032845ab351b387b03b353e22ec7b8bac99f25895eb8a1805fec942262b1",
-                                "uncompressed-sha256": "8aab5bb992eb5ce2dc994850b12a0107333762c80bc5f7360ab145a4656ee442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "149eb632c820555609988b6897457d63b4c14e52888632ebb48841aaf2331ffe",
+                                "uncompressed-sha256": "ca3f3cd3927880249989f63e08718d322c9d935dc901765a6d428c7888bc51d8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0b8a89bb714989223341e632a4d8d7b74845670fce94f8c01a09d5d37c9b38ed",
-                                "uncompressed-sha256": "6446c0e649ee1a28e607a2efb53704644baa7c26df58d669fac6ee199d2aa47c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "0d2f721a14fe2090889ff6c0e2a128498880162c469d5a7a30450a767a9159dd",
+                                "uncompressed-sha256": "43371e0be41bead793a45271d1bb051eafdbd894aeadb485bbbe56e67d0afaed"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "655f4abf59ac0a3d096fa09d8e3a2c774c3323d88c49dabecbfba4621825c5ae",
-                                "uncompressed-sha256": "1ac3757d3e9d4701063fdbb287b12b41421de0a6690b40bb36725df425f29145"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6f698dd2351458430915302165d3ee9ddf68e72ce1ca0c880b69a4d9a33a0a24",
+                                "uncompressed-sha256": "a5d676568e4e7479936bcbd155b23f2701d39b7663dd02e3562c940183e8eaeb"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "eb3eb94a1b7bf76e5a4d04c1c9e743526824d2a657f59fd2e46a16377eb5bb1d",
-                                "uncompressed-sha256": "f152296979ee8dc1f3990ed93e16cc5f16b837b0aaeed6141bb128139f892de2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "09835d4c04897128ebe00fc6f68025a8b618caa28b607b628c91be126e09925b",
+                                "uncompressed-sha256": "1c944031cca971b4dc9af7d43210f9c84f0b58508e7dad7d65f075e49bf15379"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b44b3ed4df7d73db834cd2846d26ebbe4c200d25d92002cd88c6fc3ac8481d36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "218e0a8588e2a1c4483dcba466688a7183de7b1644d74e5b95269a72e007121b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6a9da0f4161088e69dee7d2e8670305b116b84b403360dc039b6b72cfa8432e4",
-                                "uncompressed-sha256": "2f8e0c4685fc5c80e9d1d100d89d38409f3fa4da388099ef286d49256633b417"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8f404cc3e94880350024d11aea0d0658f85ddff5001478394afc031538bbbbef",
+                                "uncompressed-sha256": "9518a08724b8f85bf5ac0f6e7b1929f9a62f55aa86ae19363fbdd2112be7e1bd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live.x86_64.iso.sig",
-                                "sha256": "1ff5ae712aa1e75d19d8112abb694d63bd8b0090eb4434c145442dc465bd40cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live.x86_64.iso.sig",
+                                "sha256": "163a46c39596d816768f587dd0eb3067d9b2d99bcea5e194cffe496309eb1fbd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-kernel-x86_64.sig",
-                                "sha256": "f99eabaaf7523e47b50b1e14c5fae53432c9de2d0fc842bf6af2d7926f9cec01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-kernel-x86_64.sig",
+                                "sha256": "76cae19de14b3957eaa9056a349a0fabe446dc668a437cd89a258952f515eb78"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3b22f64aa91fba706474b681b03fcb786e3be0479b1a8f53e7b4411b25f44d44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c9a64d863456585f04e067306bd93710f500665dda7fb8aea5dfc955843d63dd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fe7f4423b4b704ce8f57f0b05a0f3bf3a41345fcef6db89630d2d66d7c0a64c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c8d0d7a6f79445a19d9d6765ee4f3f4c06871a6e0ded0b628e1eb22b659b6444"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "78ffc83c0fdaf18f5c0c8b5026adb05c5e31193f9b6be1a0d3e1008f0a44931e",
-                                "uncompressed-sha256": "65e41b54448212a6479a0b0fb4525fa5712713c24da0cbed70f511db3096ce5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b41f057b0e783398f9360878383a77664ebd2ed4ed11559ddb949c33e75a95bb",
+                                "uncompressed-sha256": "b62ee000b16647643da7df50bc122516de4d4871a13d1c2f6caf9fb53fdc8072"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "da5cb831f4024c0b01345deffa5b7e88b1eeede0d999d48d56a890796dae1426"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8bb2a256a04276b671d0958750962415279402c3da14712c3b3ec2ea9b7d4424"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e833ff5106d356b1c3e063044fb2dc298096129ac60648a84be4738485b1a963",
-                                "uncompressed-sha256": "d6a84dc744a3d71a9a4648aee4b08716e70178ea0df04519ea6f6fc4059ef4c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d2db03cc0a5fb09bc456ef311b9ca54f358c94c9a796b6d2128b1d3aad0bfcce",
+                                "uncompressed-sha256": "73010fd4c7916aa55632f067fe49ab31122d21149fc398b9e445af94c7059e4b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "71cd5ead0c7dbbdfbc23eec22587eb69713037fff5a4e5291128726c27f6310c",
-                                "uncompressed-sha256": "6d2a1886ccf9d54c85df9d73c6ed198cea12a36605eba278f7b5706cdb3d64e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8d23d66088c654049866349048e3bcc65669d4adc8366179e7e66b983df661c8",
+                                "uncompressed-sha256": "cbf34098e4acf76e7be2f701ac910ae67a29580ae6e32b6ab3b358618d847972"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "e2a7fd3bee6fa312118d13fbf8e39ee7b2d52bbea26ac1d47a9be5a27f72dbb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0945ed4130fa5823dad2aad6b1698186a26ba7f6201020dfa3737b99a7a4b66f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "3618a19dcd80f637b6057dad6397126ecd5070a20d04b65774cf00aff3181ff5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "866a4f5286c7094572168b8a8f0f2fb22f25c6cd7110c750a59520880e5ea14f"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240906.2.0/x86_64/fedora-coreos-40.20240906.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "edf8b5f27688c194c7ac4853d385affc824ba233039f1652c7ea39c3d76cadfd",
-                                "uncompressed-sha256": "75e1b885b935ff919760258141b933b2f734cce690337620cb00d4cec33b4220"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9a75343efab5bf46e71e258e66f942307fb0e0359709cfad197d1e4b216a54e8",
+                                "uncompressed-sha256": "fbb4a80d523a120806c9fdf24dac52428df803aa0329ef04b81e82e44df56822"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0838026a12f95e546"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-08c7136e0183ef4fa"
                         },
                         "ap-east-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-011f9ae4c94f90047"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-04edb204556b8f21c"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0c9e227b744d563ea"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-03f7f041c541d6089"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-052475c7c73bef24a"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0b35cc9e33d108f85"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-075cfa74eeae216f7"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0b40ee87e15afc571"
                         },
                         "ap-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-01b261f8c6f0fba37"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0de2af8bf465a7d05"
                         },
                         "ap-south-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0efc82e4d68a6342f"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0747fc99c1541df43"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0d5f284c14e405ae5"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-06a37ebf086909708"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0252499ea01516eeb"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-06be7a3c2efd6ce30"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0bde4f41cd553bb11"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-095f4cebbcc3c21de"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0d92b4e2b226b7dd1"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-07f28549d9cab6d37"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-08b384ae0064796fa"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-09aad191d05b007c0"
                         },
                         "ca-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-077b3e593dbf77071"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-04e6ebb6004fd3423"
                         },
                         "ca-west-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a5ace3983542d10d"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-09f0073acf103034e"
                         },
                         "eu-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a0213203e6f642c5"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0cc97707e3c1f71ee"
                         },
                         "eu-central-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0164c92af551b8f4e"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0f281ea2b6e2eeeb3"
                         },
                         "eu-north-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-08f760110042f2b90"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-03448d8ef47f7c9f7"
                         },
                         "eu-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-034edcfc94a5681f6"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0368d5e6d732451cf"
                         },
                         "eu-south-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-02c14e97d47e6b296"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-005bcc7be14a5e28e"
                         },
                         "eu-west-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0dc081c772400882b"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0dcc1bbbc14ed5e1e"
                         },
                         "eu-west-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0c5b6a73ea654cb32"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-07a5c2046bc8eb1ac"
                         },
                         "eu-west-3": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a0c3855d363e185b"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-023691fe4b94608ab"
                         },
                         "il-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a24a51ff81a0591f"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-082a732027ef5aed5"
                         },
                         "me-central-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-04722adb55f3bbef3"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-06e27f9b5d5272f63"
                         },
                         "me-south-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0515ea72f93ebccda"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-037f078b11eaad7df"
                         },
                         "sa-east-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0a8b3cbc5f0b8e0f0"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0963bc449f7e62d03"
                         },
                         "us-east-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0225bedf1c3241add"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0073aa7222fd661e6"
                         },
                         "us-east-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-02e3671274d42c120"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-05136eaf0b0615e57"
                         },
                         "us-west-1": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-01b461d423bbcac5c"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-0820d6aae3729fa87"
                         },
                         "us-west-2": {
-                            "release": "40.20240906.2.0",
-                            "image": "ami-0ecf5a288c91477e3"
+                            "release": "40.20240920.2.0",
+                            "image": "ami-06c26c60938f6202b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240906-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240920-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240906.2.0",
+                    "release": "40.20240920.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4df0d3741f4d411768927d61b87c9402f18bfca2dbc41f8cbcac5feaa37ca739"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1c776c46ca2d8cab79e0cb06a7d17846fea580d6f677000d730707f14d9f5dd5"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-09-16T21:49:18Z"
+    "last-modified": "2024-09-24T16:05:23Z"
   },
   "releases": [
     {
@@ -119,9 +119,6 @@
     {
       "version": "40.20240906.1.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -131,8 +128,16 @@
       "version": "41.20240916.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1726578000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "41.20240922.1.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1440,
+          "start_epoch": 1727197200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-09-10T23:15:34Z"
+    "last-modified": "2024-09-24T16:05:19Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240808.3.0",
+      "version": "40.20240825.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240825.3.0",
+      "version": "40.20240906.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1726023600,
+          "duration_minutes": 1440,
+          "start_epoch": 1727197200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-09-10T23:15:34Z"
+    "last-modified": "2024-09-24T16:05:21Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20240825.2.0",
+      "version": "40.20240906.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20240906.2.0",
+      "version": "40.20240920.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1726023600,
+          "duration_minutes": 1440,
+          "start_epoch": 1727197200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).