### PR TITLE
Roll out stable 40.20240920.3.0, testing 40.20241006.2.1, next 41.20241006.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-09-24T16:05:22Z",
+        "last-modified": "2024-10-08T20:38:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "7248e26524e768c49642f7532687dabf93304bf886a7570d589397098a8ce56b",
-                                "uncompressed-sha256": "20d4ace4cad1a0579fdad7425801f42943cd3b21c3d6898f2eedb0a236d57c9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "a68440de6bf8b995595ac17289d5d08679bb342103f96aaef575f7849a7b4921",
+                                "uncompressed-sha256": "1932c9dd4839b3983d4a6e4386566f740b9bee60f6facbe74b492bd14859bade"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "266d1497e28e1b5477879d784edef37fa32e7eb392c7a6f7cac4f176f2dc268a",
-                                "uncompressed-sha256": "bbf5baaffe5532a25d2a720d53555cd894a49c6796bdfb7ff587c855299329e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3862d5a34f8877b6bd80aa701393446a445799d72a20edc60bfc4092c264fd90",
+                                "uncompressed-sha256": "2c9cf917acf03cecc669a21395243798fe8baec8702875b12be7ffeb1835be54"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "25bb80edf4e450741223c559d6c799129e6f366ab9f2c54fc6c3042ef7fbc3e5",
-                                "uncompressed-sha256": "b29710d4f3c1a9546fa0537f46b8be0aacc4f70a6a0af77ecaf81ceb7826c558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "73340865f74939fcdbcce80dbb580074c5907dcd1db65b48f4e93d7c907f9a2b",
+                                "uncompressed-sha256": "d7310c013963a23a94a47357004d8aed10b13bbd3c06703826affb03822afc04"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "659f514a66f00bc8ac2fe69c105984f339f0237c7e21a30caeb69e3424904fdc",
-                                "uncompressed-sha256": "6e969c73263a617bc7f9030e38067130e3fd9a186a7cdb73cc5c53e59e7a6203"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "784ee7ea51b2b9664b2450dbac059a01580bcd9b1045336e79202fd511dcef6b",
+                                "uncompressed-sha256": "a409d4a3ef2236dbfd4c178f48a271116f80fabb24374c2a0f57fef078edec2d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "9725c871fb83ddc336142e254dd9a35c8d4abf9b0429091c63f59bb474a55e30",
-                                "uncompressed-sha256": "d24ff98f987fbbf5504c68e0e37b0884c8ac4a50b9af38a7ee0b114906b704fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6a112e3bdf04e4d696d7888ae0882ee94a8a00a3ccb3777f372453acda10e3b2",
+                                "uncompressed-sha256": "d40538ca57d656cbb52365a66d614f81265cb1e1d86be670c9074a11428e475e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0a06952d315fe8767d456b35f8d6ca558fbe96e538d04ca56a6125c1f1d52ffe",
-                                "uncompressed-sha256": "1f984263f3df2eb616890fddfe27efac9cf85ea5d0b871387aa6be24d8a9e0ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "678f5cb573ebe86d2073dc3c62b8e392f6626df7847997642b7d631f4ee155ca",
+                                "uncompressed-sha256": "b97e1e4d34f63b6b6a263ea43b216bb8bc7a45dcd49672b208778f701937ddd9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live.aarch64.iso.sig",
-                                "sha256": "940873676a9be3c04fdbf1d0fea467fdd2fa1943676f34a07cbb8aee20fa2147"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live.aarch64.iso.sig",
+                                "sha256": "51515a944c6d25eeb756229f9b9133c058b74975ddb354b63f9e63e42baee20d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-kernel-aarch64.sig",
-                                "sha256": "6c3f4ae2f25e9d8b5d9d005eb4376102d21a19cbdb8d9fd96ef43f17b106b9e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-kernel-aarch64.sig",
+                                "sha256": "a1fd115e04bd3a61558501db9690b02c911f8b258c8f25c8cddbd513edd4fc93"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5d369b7c5b2c079473c9bf4b34e7f13b40bafc0abb714414aa74890e59bb72d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "a7760c20e90bfd787e6d597279e061af8ed6b5cff5a9dbdc130e1c7101240753"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3b31cb63b703992e40552a53cace97d35b9deb873225bfb9e22d133313015462"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "fa24bd4af79c4c15af8cae6c3b0f0a5528f5fd4be4974382da97322d284446fe"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "6cc099c3a427a3c9add5b445b2fc9fa40386c15fc5a0e46499e105919c4ec326",
-                                "uncompressed-sha256": "23ee9cdf3ea6f7fc6f310b7e0a01a4f39757a2d03e8d19f2271b9d181afee5a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "981ea6ac0d7f57d2d019c06d5668c73aeeb5dd4203d94870e47e8e166fc45c09",
+                                "uncompressed-sha256": "a7e66f3a270c89f4efd76419af40f9675875a561c3818b2fedd6d9dac46a7f9c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "478db23129e194f2eae730a6659b7a1fb76149f791cb8d98cb61b95d4d437962",
-                                "uncompressed-sha256": "b9707a266ca45f191ac11073e21b9e5535cddf5c7d164e475effce5d2bbbee7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7ff8312aefe30c859c184de36ba302aaa920462ed6656f7e65dee51f323faf4f",
+                                "uncompressed-sha256": "8fad7fe0dcf2719eacb84d90f338cee577d43ac3b45ea78c30586a8d05288178"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/aarch64/fedora-coreos-41.20240922.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5fd19b84b5dc6cef51066e289c0fccad5402ab8bc225ae4bfbb3aaf64c8253da",
-                                "uncompressed-sha256": "2d93693f60ecf34e8d41bc294089a979809b8ee4607f41200e280ada5c037fe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "fe15ce4faf978acfb73603c1bbb4fc19ae13bd1f44dfaf37ad45a789fcda6257",
+                                "uncompressed-sha256": "4475ef478b1c86f53c8cbc254add882d3d38c5cb4212c3ac3a8902025659c898"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0ebf6bb8533a3ce3a"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0ca26f40f5156a8cf"
                         },
                         "ap-east-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0aac3ef91bc881a98"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0de9145b87e7cfae3"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-01465aa3f0acbf225"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0e42ef91c81651762"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0bb2401e168c72194"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-095da381937b587c9"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-012da51892cfa2e5a"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-089b1c1cc899acba1"
                         },
                         "ap-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-033912701c4133646"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-04e5875a886d0423c"
                         },
                         "ap-south-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-05d6710843c5afc71"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0894ef0535f638898"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-06ebaa3a0beaab21d"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-09f30bea3a6d14b7b"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0402a015d4311afc2"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-05c5b48239b688201"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-092e468c7944fb03e"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0f78cf7423c94ad79"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0cff666aae133a339"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0cafc328562ef28ad"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-09c9cde6e1883ffca"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-027f6a7e6e31caebb"
                         },
                         "ca-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0ca84ea30ec3c9637"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-04dbb41bca7478ad2"
                         },
                         "ca-west-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0007cdf44fb41d7ef"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0aecf7ea087d84634"
                         },
                         "eu-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0ca395256f6175ca3"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0bb250b7f2a44624c"
                         },
                         "eu-central-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0d8275a0ac0dcbfc5"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0a3a8fc383df0d37a"
                         },
                         "eu-north-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-068ab0c9b4b8991be"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-057ce7c9aaace517c"
                         },
                         "eu-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-014821fc4c91ef71c"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-026c8a8684894e58c"
                         },
                         "eu-south-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-09e7c4942abb92ab6"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-079e3558658205b35"
                         },
                         "eu-west-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-077b9102e7601871a"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0034ca2e6348b6019"
                         },
                         "eu-west-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-08b3f4fa36ec11af6"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0c566768f9bfebd09"
                         },
                         "eu-west-3": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0d2208c3018a04ac7"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-020de50ea04310bf6"
                         },
                         "il-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0c8bcec7601a1902f"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0a006f9d20b25c8b3"
                         },
                         "me-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-07921d7593ea03596"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-07d2c486a6c882c16"
                         },
                         "me-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0ea8a433afc2fd9c5"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0f64b3a6c8b093881"
                         },
                         "sa-east-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-091e32f03b529e787"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-020471ac9ac58d136"
                         },
                         "us-east-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-05c7f9a99a2287c70"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0ebecd3e50edc4e9a"
                         },
                         "us-east-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0dc4e87d0780c83de"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-07dcd318dfec328cd"
                         },
                         "us-west-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0dbcf7d531d38e967"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0c306626e82cfe2f0"
                         },
                         "us-west-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0d25f07533dc4c18d"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-08d8c479ff77f9900"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20240922-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241006-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "debf1609ca3c3c0eee9048fc5f8eaf0d972ced1863b1ab90ae284cbf76be0448",
-                                "uncompressed-sha256": "2e35803bf4bfa5e729fe24b1881d50c0c00d68c5fd470c58db8be589a4f1a260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f062c4f626e36e6fcdb93cdd0cae491cc273c0af962872da53487636ce7438c9",
+                                "uncompressed-sha256": "7d5b9861544f0c34c19f7b5b33253dad3859f5874a1243d4edf6824468a1c0bb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live.ppc64le.iso.sig",
-                                "sha256": "1ccdc47a3459bb59737e41bec1f4e1bd513fdcdde084042f2c5df61f2c02fe79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live.ppc64le.iso.sig",
+                                "sha256": "394e62ec521da6b33cfab12d602c9e1dac1f07e0b96f8912fea7e6c49c4e1a07"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "259c2b1a34edf7d970afe1064733568edbee009acaa26a1c36e2fb215069c485"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-kernel-ppc64le.sig",
+                                "sha256": "87b07e8411aa19f076b00e957940878e052fcf40859de0d741e99e8d78afa85d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "fe19a67c2d13fedc4b12cb080daab9c46f785079e0b1e14e7de37bb1b0f3f7ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "79ee13f0b800ed433761ea6adb27d93b6873fe27dc63dc9acb574f9033685962"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3492eff39b963c4050ed783be21d93ff35273203663b3df5f4ccae80760b4462"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "376f2b9d9114789d4893dd5ac62509fb80276079fd3c6530d9102d795fa5b01e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6596e3ed17aa8930ee350399b7e57f5a24ce8f34d79cac8efab9902f82d24c5b",
-                                "uncompressed-sha256": "bc0294e6442858a989ff7629da65fc4bb50dc70207ec4a903e92e63929cc352f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "36f85349b396aab64dba46b7442b4d0fdeb81ebb429d03f3dcab2999e2b59607",
+                                "uncompressed-sha256": "6a8b6003a663ca2e0762df814e914faae3e25f02e2ce6a32c2d244b9e8cd0dd8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9f14d2414d013c2c98ea09fa8c17dbd21a07512dc5cedfc939807754438013b7",
-                                "uncompressed-sha256": "bafd39c18892d6e20a5c992de40a89f0fd79b9c7b1caf8d0f4527fbecb741e7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "4fdfec52becc74cf27363b081b6fcac2990650cc3b6b2a195bc92f3b637a6127",
+                                "uncompressed-sha256": "bdeadf6909b68121577566f398b6f41e61d94540cb4d9910d48b8e267cc7ac9b"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "09ab5bf5c0a199ecd960c8e5a425b635e8c90e14a97dc509865a9bd50cb5e433",
-                                "uncompressed-sha256": "a9d0efa0217abfbeacae73b8061bf274d79d6c1bc2c6ca306bbd2cb99a39b0a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "de451dfffe91affdad8d55e414096e727be81064fb5d3d7b18921d69e7a2ab51",
+                                "uncompressed-sha256": "0805e3c8fd2b4ac338addae49fc432a6bc565e888c36e02850e64df015eaf83d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/ppc64le/fedora-coreos-41.20240922.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4e54d0d8015d05124ec8ba624cf35664c9e615252359fc6e91b0d49b347104d2",
-                                "uncompressed-sha256": "550ea4d9514ff2caabfb06ad9b82c9009ebca6dec5e0faf5ff20166ba941d553"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9a3dfe19f831375e3a4b646dc9fc272e2f80df2f55a32016e75ebaa141fe4011",
+                                "uncompressed-sha256": "3ff08f79c1273089437d2787374fa4b5f9a979e7312bc8cb91391337a43ede14"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "84999441e638be5dee074ad0f832f0ac9a2c29df68e06d490161aae3eb29130a",
-                                "uncompressed-sha256": "516a2e06f5a1996905400a770fc393e7762d38e54e943afa5a8eec4b1b808b21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "05076170df8ba2114d61ae7b503f4dabb670ac4726830c922876f8262fa8c29a",
+                                "uncompressed-sha256": "8ca31456731422576b99dc1121bbfa5cb17ab602e80688ee83016b9777d239cc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8eefec34e16085226d3ae6165a11f2ce14b32514b06b9cc1eb553c5256009822",
-                                "uncompressed-sha256": "2b9911a74f85fd1d1f324b39b6e72935d65f72f1d721bbca25f7860bad8df7e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8583481bd4b24267ea7fd76ed0e11ee5093bd207eeaa460bec40543d46f32e39",
+                                "uncompressed-sha256": "899446bf7b56e6822a62b1862dbe3613ef7bf5c0ede204584fec824c5f3326ac"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live.s390x.iso.sig",
-                                "sha256": "ecfe560ba193f9ac961b8434f234ad7e8c6c1bdb5d32cb672c945fb033d8dcb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live.s390x.iso.sig",
+                                "sha256": "109128dae18185deee5b6891e915821ec18885ff2e43e27241cda83a29186898"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-kernel-s390x.sig",
-                                "sha256": "09f274db80438b62d9c77176d411f7fb0e49702512a35af09a6b9a1eb6b0c856"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-kernel-s390x.sig",
+                                "sha256": "5c7b64eb7a1722a2524ed68f93f97de1a060e35ac1a6cb705bda1ebdf99545a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4e0079699934cc0ad16bf75d10697812db214749a3a914510a0c2203aa16e977"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "f6b42402ae5f22956ef2bf8d8bd67d2c89c9d6c9eb10efcb8d7d61578e602f0a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9a80f4f94d3fb102425adc672dc1c38302e8c4973aa5f4a481f9ef4a1d33b948"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "b36da1a84f1f0c1cd0d456091b04eaa59d1c71b3c23b8f289a61cd6efe3f312a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1d4b6aff80e1c0ffb2f6225dbd6a3998274c2d163dac2c419b795f0a4979db64",
-                                "uncompressed-sha256": "5a877a4f9f26dc7aa1e453245e55baad6a58328fd7ddbe778508c280b380cc93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "26d2ed383474ebf2f568304827ab91839457a07349d56cb4948e800692177098",
+                                "uncompressed-sha256": "0a440749b92c67ac7439eaeab39003ae8f703b02deb0d3354edeca355a465752"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "33e7bb044a27f06a91c565e65ee77288148a62d4c0ebf2f2200a3709dfc79d7f",
-                                "uncompressed-sha256": "dd289a74f3b915f94dd59e1685440944fad5402bf997eda61cd17088ddce7ce6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "95becbc02ed7a614b55f1e78ba9e500f8c06fcc51ce7bbc9781bc9abd31df79e",
+                                "uncompressed-sha256": "c550ca5c4fbef50e0232df458db4f7f403d8d91ddc17370caa1bd450bb5a86ff"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/s390x/fedora-coreos-41.20240922.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b4ed31433c71a9d7d7cdaa4f3086ab837b0615e4407f08965dacbbd405a0c5ac",
-                                "uncompressed-sha256": "6fda029c65e49e0b519790af788f8c991c6c01ded07866afcdf4bcd0f2e0adbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "da4ef7eb29d4e28cb8d8d62b8bfceb7e5170c2bfce5e3775da366b5e982dd2e7",
+                                "uncompressed-sha256": "9d475158b9b2e737c5776bd4fffb0b372cf43ced91aa752ec592f7980a05cca0"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "78bb24fe035a768264c348e95a88abb2086db5392dfa958895fda4982b040d7a",
-                                "uncompressed-sha256": "a90521a1e117dbbf1588b2e7faa2b3e31e50ba03e1cbdabaf4a23afe0133e32d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "178f6773fb677d5fc2445ae624e8a9949b7ae0220ad39e7d4f9290271ca73d80",
+                                "uncompressed-sha256": "8d249e8f8f5d80fad13488a4cce60f5d076cca5145174387af549d9084764450"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "22b1f576921e7511b6c3348178d3f4a6cd1aab202bae0edbc87e6d0fb26be6d5",
-                                "uncompressed-sha256": "a45c16285a20f08bb89af60e4ca93cc64b0be09b329c892ae7e438888959f65f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3a24a7bbe6679615569db350a1353fabcf98e420afd33e04aab973ad996f4f4d",
+                                "uncompressed-sha256": "04b4dc57524fc42e6ef0a0289f48a167d80a8643bc52fa74733e7b21996623b0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "747bbf89c773b8d9613732f96ae224f00a838c9f2e53b561bea64f31e8a736a1",
-                                "uncompressed-sha256": "9b36b4600803d210e03366267d6fce772bfd869bf0202c11da3e631566b7a878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a2df4bbfe0b4c2e5d9ee8c0ecf43be6353b3b5ec5100d0a7c82b2e0103971bb3",
+                                "uncompressed-sha256": "6381d3e744b83316f338f2300f06de0d8b9ed5eebf81c2c91bf228f131f28f67"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0f8da9641dd1e2f6a728faf68377ed44dd04e46c6a15890f486ea4afdaa201c7",
-                                "uncompressed-sha256": "a3d797beb723ec57a2fb2467522830be093f73bee6da9add2e0b77d85ab65f4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "27b698999fb154d6fbe6fd6a88ee9895800da521d1d68c8432ba8758f19b0cb2",
+                                "uncompressed-sha256": "be4710ef03de14723a256d914131190407061f390ff13ae23c2c9c009b9fb786"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5a165bb1f2e00675b16b945643a2023748808e4d2cdb4cef52aee3cb770a2ed7",
-                                "uncompressed-sha256": "b51bb852d500bc0968acb1e4bf6ef6a8323865063e8bb0233d1dae1046787247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0c81ee932ba32d92016f3f84fcd028651b92b824931153cb1c253e836f5db80a",
+                                "uncompressed-sha256": "0d8e9659d8328d911d92239feca6000d617d4d9c44cc14b67c0cb09df9d89caa"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "eb443f7f33c6347033f36b845a319db862d47aeddbafafad7e941c2abe257fa9",
-                                "uncompressed-sha256": "5a679fc19cb7b2304f8aac7ac14744a6ed76f24a071cf8ec7fe33be2db53b519"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bafadd14290cf7795dc1ce6e0d2d10a5d1f0871e51385d438a501568a042b579",
+                                "uncompressed-sha256": "7be6a4872ceccaebd180fc78d9226201a10eb92ba881fc4af21c70ec6793ae88"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "513d9dc934b6d78fd89c32da4b072e51a64c891d48a1a1448ae49ee93829cfc6",
-                                "uncompressed-sha256": "986125a5062f50a3226e2fb44c1ed754fb680d03dde13cea24cefa98dcb110d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f24a5e4c1c3fd4dde51584781367602b0952d1ed4cc6f8c7e8aa2ff6192f2559",
+                                "uncompressed-sha256": "dda72d6413c786822b223afae7cae3a2153ff904d60a752a6d0473ffb7266de8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f2feef5cbc52ce58ccb866eaa2d357a2ed91824d2e7bfdc9c80466cb2c1811fb",
-                                "uncompressed-sha256": "8efce421a7f4e93fbd65955e6990dac5459b3e848fe1f34a21c0d3a5e4840068"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7299eb118b8c5891d6cb9f6b89c7a9d2b19ce5d5dc7be5f5a05404b2e791f393",
+                                "uncompressed-sha256": "6094f7e344d362e0d462ba942f3c78dfce7e1965439c2b82f8c2f66de0ba8992"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "689342f8863886e776d72b50c6f0383832670bf3fc0ab6411dc492e14f61a488",
-                                "uncompressed-sha256": "522dcb68177215766d207cce8fbe7ed0a999c7dabc0b0b078d4a514a8bfb5933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "a0b3add4df0ce19a475dea1c78c469787eda764cda33cc0465739ef6ea7918cd",
+                                "uncompressed-sha256": "b065d19eef7da69f9e63d1522622a5ce0c834657a2df412957d7c6ccebdab485"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c101cd276390e53afcea7b2bc833c81505bdc914b1626561d2d9508ac4bd656e",
-                                "uncompressed-sha256": "7f6ae36b2005981e678517e60a96a03d4a13958ecd7b6a3c2464705c73c804cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0b0bffeceda63db714d9d5179a44a2f94c95e101eda1baf8ebbcb6a9c2e29caa",
+                                "uncompressed-sha256": "4d30a2a5b2190510639289c41bb7d57dc0b69eb1dcb3605292f5c8015dd69ce7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "64b71d594720cbd0b4e9090c3c28fbca990f9d5b9d1cdc7eb71c0dc49b72ca42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "95d7a7826c9446af029280797ef399f4dc588b6d53394e3be2bfddfe34ba62cd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "38abb96a1cdc389e9105d3d9adf689afcc45b2d989b92b218f3cb9b6824ee999",
-                                "uncompressed-sha256": "9a8bf1a92a3fb2d4f4daf515d1241032d17112dce55585d0ba1012271259a2c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ef61a0e8ee4b48d6b1b7bf4cc37b8eb5feb9fab470f3639e966467efca7216a7",
+                                "uncompressed-sha256": "a7d7be8d7885c7551057f5fd9274fa50f39b5378ee3bb03d043f29f475248ca6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live.x86_64.iso.sig",
-                                "sha256": "0a466bedbed970be9133283e3ad19c4a8a42e13bdbb30e177bc22c06089a57a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live.x86_64.iso.sig",
+                                "sha256": "39c8e86aefd40d2a3e0f5c4b5d2344ff40497384e603e3f749bdabfa9173dd77"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-kernel-x86_64.sig",
-                                "sha256": "2dd814d42d3922d8d788c89b7da814733fd405d5e77c2dbe485883b76f014fde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-kernel-x86_64.sig",
+                                "sha256": "934843069bf87177967fce88d639065274aed6f533274ba4f8fc40639e64dc98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0a3b58de522d486c09884a0daf528257f07ef0e764e1a3066b16cb2c8ce7daaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "82436682e554b46a43e7e7add3908e6bca77f0e8a0f1361e06b0895c3b64906d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a6fe993fb5e0f4f67c0e7b80f4f6dfbe559299fe522393bd97673fab676eaa82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "cd890971e6ccd9e1d55207eabf699a91faacf65deacfa893ea52acfa94b6c14e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "38059896aa5f78e8760b6a24f56fa637131c20f8c083156089f5b74d2980109a",
-                                "uncompressed-sha256": "ba5fa34b8302929f4cb940bb250d6c7b69a9f60b9eaa799e2f918cb329612276"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "d7408ee7e39bc1f1c97aedc16816a6a32638753298e8dc62a4a52ecc63526b6a",
+                                "uncompressed-sha256": "e6fa61b187a6c09256e792df75c85e70c8c5685f3d6acfec5ecbd0f0c1c61820"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "acbd79fecfbffd08b225d9ed038c0aace93e61aae67272b27498efdea0f8ccff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "80c046b9c1546ace6539dc5c628fc9bdf8a0712066c1aee6aea813294c61afcb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "672cfe6a78ad64cabef41036d420fd1c43ac1af9af076214147a99a5e137f3c9",
-                                "uncompressed-sha256": "19bf931753e85bb05f91ea930a0ad1bdf47a0630842090a2e6aa077fb085064c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e0c0fe0b7acd965bcc3a7f7ed32e085b0dc0e83e7fc691fd3d80cdc80def862c",
+                                "uncompressed-sha256": "c0fa5822103c15e2ea0777bda365f477ee0cb9955c6af704db6a022131bb186d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a93e46feef1486d4c19267a8cb89ef667dcd4e459acd605d1a6c4672b28bc8cf",
-                                "uncompressed-sha256": "f41c5309ba771d91840f556c5823d8e4905eeea5f632e1c6f12ca31c85ebe66b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0a90ae8a1034639924ff971048c0c4059a909271057be33aa941f98d8c5c0b05",
+                                "uncompressed-sha256": "31c8fb34dc69e562ea3e32018ab7f6caa596f0550bc6c92efde5b0ecd7bcec9e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "aaa51d8c1cea55289b68d99d940d3e21695bb6eb396c039b5b9ae495da667ed8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "f1069afeecc22ce00425ff85191c1735a50a6f46d7c96a7e6d2ed7d7a1440b80"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "e7bafe56cdeef5e9697d7c90ee889df45bec134f2e09e497207bfd85f0e9f6ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "5ebd2334e77f744585100ebda7a2f1ddf0d9af7c899e96436444753713e61b87"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20240922.1.0/x86_64/fedora-coreos-41.20240922.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "28e59715789e6c262c2c9aec025cc9b6a6f360ce3cc7f88a7d1bc5b5abb1e647",
-                                "uncompressed-sha256": "b8ff676cb5f8fb9692f1c1724a76a2bfc4dfca13ae31f122321663fb60004f95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "abfbacfb6706f3b6adf4277f25a9c41a15b01bc09b905a6de72c2e76d479e56d",
+                                "uncompressed-sha256": "4d056eedab9e4352bb677f08cffcd5c1c65b35d815b94c9c261318f0ffbe9c4a"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-03413207118873959"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-06a79b8111ae0e08f"
                         },
                         "ap-east-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0c3dc01569d7a13eb"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-07d1bf9fae5ff9625"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0d15dd34f1462ddbd"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-037980ac5f9f28169"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-053ac2e065f20f981"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-03234cb01ecfe972c"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0053da683f29a0357"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-01613a219fd9e585d"
                         },
                         "ap-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0565519881c5d4ab3"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0e7a897394afc7241"
                         },
                         "ap-south-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-091a5597d3aed8146"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-04bb6392f25ac8121"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-02d32c185b448202a"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-025aa9c94aca91e8a"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0bfbaf727ef7d2699"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0ebaadc03cf1cf21c"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-029ccbaa287f12429"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-03ab9fa6a47991464"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-028e8464c9f6771bb"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0d30582c1ac3d5a79"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-08cd3cf37a70250f8"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0998f4642075e833f"
                         },
                         "ca-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-00adf269935143522"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0c76184bfd5bf1272"
                         },
                         "ca-west-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0330d88a773e6147b"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-013c00fee12db9427"
                         },
                         "eu-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0c706433ae8e46340"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0033b1d26ddff446d"
                         },
                         "eu-central-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0340d2e99794441aa"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-03b3c39243227a501"
                         },
                         "eu-north-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0533701ddaf7702ee"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0d539eaf80a1db4c5"
                         },
                         "eu-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-02b5aec6ff96ab49a"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0f144a81dbce8a7ec"
                         },
                         "eu-south-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-060b3ccc240c10a38"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-07ea9daa7ed361964"
                         },
                         "eu-west-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0cb452c03b90d1434"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0e707e462f537b7ab"
                         },
                         "eu-west-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0703b9b02c5e28cf0"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-015e0612bd866c1df"
                         },
                         "eu-west-3": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-039f5e77766d3dc06"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0afc91b8711421d02"
                         },
                         "il-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0e8cbc12180411568"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-09fede9c7c5be7f0c"
                         },
                         "me-central-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-05518a863e56fb0a1"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-092202a7d23f424a0"
                         },
                         "me-south-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0e7bf507de10d0ba5"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-03bc9ff3b77b6e506"
                         },
                         "sa-east-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0892969c85ae7fd3c"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-01847403fa7a7e878"
                         },
                         "us-east-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0b49c88632d791ce4"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-072300fdb4465173c"
                         },
                         "us-east-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0d1d369d0f60191d8"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-047c62664167b6d53"
                         },
                         "us-west-1": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-0c189991dd5a43974"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0fc68f2581e14afb2"
                         },
                         "us-west-2": {
-                            "release": "41.20240922.1.0",
-                            "image": "ami-02df4f09c62395dd2"
+                            "release": "41.20241006.1.1",
+                            "image": "ami-0baf14657f8c0990c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20240922-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241006-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20240922.1.0",
+                    "release": "41.20241006.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:dbd7f136d1d243d30477d3a22c3a76dd57a1033e595078f66bb03c01030235b7"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8884b8a173b85cf0e748221fd29f73a2e96d567a06b7146a1f3728d267f87d5e"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-09-24T16:05:18Z",
+        "last-modified": "2024-10-08T20:38:29Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "c2b08ff68dfe5c4efbf9948aee899e712dc3dbf5f691459a0bfc3c7758e6fbdb",
-                                "uncompressed-sha256": "b32c5059fa0a8a95593373562e0791f55b7591b76e136616c95a11963e451711"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "6451aedfa665c2e41864201d3cfcde35fe86a69db174f91d56e150ef0e3cb533",
+                                "uncompressed-sha256": "d60edc289f167c92ecfca937f8976034b0b3f505e8250a9f24f51ea7bf35f41a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4516b917f3bfd147d0490fab68008691bdb3be2f118908bbd3fb976990b2440b",
-                                "uncompressed-sha256": "08f03b0c87b4742b805d79ed39e0393fbc0ab7e807440704cd262b2bca7acae4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a181c0d55e78a03baa159d732d299323785c9e3aab8b52ff9b7eca6b8d45e1e6",
+                                "uncompressed-sha256": "7f668e7791bff73308f645b55006a577713af1cade9c35311568e4f5ebb098cb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "65c6079c246928ea21019fb9d3675ac7f021c9af18b28e1ad779761ea36b7d2f",
-                                "uncompressed-sha256": "04008d24166a09d9b76e5adfa334a3acbfb57e735dd4115f375f2a197ac63595"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "12fccd69e33a26e2a65a60e0a741767e47a68cd098bb1b0120fcacff05fa1f94",
+                                "uncompressed-sha256": "26e1848c07032f1d9ffc6744c63c1e5962eb5e9adf3afb2263a8fa47f4ef8e79"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ba5d9cfed85a89d5ad292900f1c2cb5c0fbbdfd2b37cd2e3a366868f36c8d09b",
-                                "uncompressed-sha256": "3ce9bda64d65e3c5493a1b203e0254bf7474b45a39bcd2d909668725ba2be88c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a790b04b0f174348196d2e7676b6c5360ce8a0b470e3b3d8c2eae27f9cc6eb3e",
+                                "uncompressed-sha256": "fe7545c2bad5032c6afb70473d525d544e06510ca3eb62e3a9aaed770c323906"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "3e93c16d17ea1a438b429aeeba4afce302882710210c4502428d058c9d146a20",
-                                "uncompressed-sha256": "4dd8b2b3eb0f7d91ff4f8fcf779dfe4155958f4758011f0decc7b52be3a6d25c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "5131da22a2d78710872e824fce97cd39d49fc159aa1180e8a44553f5eac884ca",
+                                "uncompressed-sha256": "df5b8ec0d22f11cc96a738793d63092d88d26bf74dd88289eb6d73f722872701"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "22d79995fc1d404db4f8707c2237da8bdd00f84f0dfbacee9e12c4e96e33d8ac",
-                                "uncompressed-sha256": "11eb939f562a9edce8ccf91b5386a35d8e75d24abb9e4ee7ff8a211a47011245"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ba417130e58ec931d43880cdc3a5291079587fa3c1a5f9aa2ec7220231279826",
+                                "uncompressed-sha256": "6693837eed4f69bc5510138866e56924ca24069ecda7ec5127f218335fac99e1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live.aarch64.iso.sig",
-                                "sha256": "c3a8ee006a235738ebbecbab27f3f7f5d844c62eea9b709b4e5ffe8a44cea64d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live.aarch64.iso.sig",
+                                "sha256": "fe6095e80b3b243fd0fceccb2957c608318a4d93726480f0bfe98e6da88876f0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-kernel-aarch64.sig",
-                                "sha256": "09855c0c691c8d13f8a7216bc45366ba83f627884c35c755fab01e4da0c19761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-kernel-aarch64.sig",
+                                "sha256": "cba8ea5453c6dd2669ac9ae8c935e47bf5680a76bff0a4242fc6bd42f2479588"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "84099bccac8db7b2988df11452c15958258afed7a11e2c5c5f7d199fb5d71a55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "5956e493448e5660f1539b7930fa4f56a6cbb0675cc57f0f296075fed6a4ea23"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "0d97a52c530a6bf945201b347bbf86a5eebdad52652a6554b74b9a805f611f9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d43d36830b35a17003315c404a416e9b1578759f3346911bd53b81a003db6548"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0978c82d4370e3f857f83586c10df99b3ad460ca6b4df2623aab0b45991ac624",
-                                "uncompressed-sha256": "30d0fe57daa85d6f34c1b07ce29aed63438eb726083bffcfd65570b9ccbf9909"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3252c54b15d57d19b96f6ef66e560bc98f7c1d89fd3331428d5060fcacc59a59",
+                                "uncompressed-sha256": "9db2347b3f09d6a84966b9d3f8507d9c1cd397c987b7580e999ebf7e64377250"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8b187e7bb8acf18a160f0bc6bef2508c5feaac266ecbfd39e46c3a3b2a39a989",
-                                "uncompressed-sha256": "f093b66fc06a7d2f071de1a9ba8cd86202f10e1b81fa119f2d11dca9ed4876f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1e845bff25e959e2236cc583bce069a5d7904b03e0a53b67613720e068ffea9c",
+                                "uncompressed-sha256": "0415a5715a1af0994ad3d52c783e9062a0d2d7dd09d9abcec1c1089fe915e610"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/aarch64/fedora-coreos-40.20240906.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0beea26fd9baef60971fb83eb9ddf8b4c1991448540a5d6bf2fd91a64758d9fa",
-                                "uncompressed-sha256": "784ee26c47d5c3f38cfd300959a840ec12eb4081faf5e684cc8a79532f1e6819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "eed10ffd7fe4784e7af4d5d4d32719f5b659c6491fa34c4c68ed5f14d2fd5cc0",
+                                "uncompressed-sha256": "350cc092254b32f62a13442fe0595a94db65c17e3683e18f68605eaff9dbf69f"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-077b4143ea359c29a"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0c3af71038efa6277"
                         },
                         "ap-east-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0c9f5f057e438e9f9"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0af156bc942013e8e"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0537abcaa56968e2a"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0279b554742ec2a24"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-08482af66511a9213"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-099d9210c99627420"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-03658d7e88ce8f0b2"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-05c98eed303e300b8"
                         },
                         "ap-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0d667356c019a3653"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0e6dc5ce6be10575f"
                         },
                         "ap-south-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0ec213b1dfb61ed0c"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0ebc7c4f3e3f35e86"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0565f3a673305cf44"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-08409899c9b1af387"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-07532db9fa4ae3b3a"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-098926f4a964eb512"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-01331a4c96262bc90"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0e63c9ac1c90bbef5"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-01421b6f8663d5229"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-00c3659a9687ee1a2"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0dbb2cf8b189675a7"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-07f5311f1e063fbf1"
                         },
                         "ca-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-01208def3a07175c7"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-037d19a1f2702bff9"
                         },
                         "ca-west-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0003dca6558ce8d38"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0085189badcbe3a86"
                         },
                         "eu-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-03a7d31b82f8ade77"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-021235e0d65401f56"
                         },
                         "eu-central-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0201c27a9992f3a23"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-03c98d7536cce0134"
                         },
                         "eu-north-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-02ba66daf850bfc87"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0808606317ad473b9"
                         },
                         "eu-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-02aedb2e4caaf07ae"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-04e5ed993f3430ae6"
                         },
                         "eu-south-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-09e096fc6c0bbcb38"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0940200bc0b7f5bbd"
                         },
                         "eu-west-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-06fd9c6efdd622978"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0d02758f3e5e9fffc"
                         },
                         "eu-west-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-04c5ae4870417e0cb"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-09bc7d48073ab2e02"
                         },
                         "eu-west-3": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0cfc640372e90532d"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0d7d7a2bb36270407"
                         },
                         "il-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-01e1f50020ce35abf"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-070a8f095ec627dc8"
                         },
                         "me-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0e1fd5f6c4138a720"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-01bd9494973abbf34"
                         },
                         "me-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0f5518c40c325c0d3"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0ca12cd19632463f2"
                         },
                         "sa-east-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-02030af2f45192e70"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0a2d776b045795c20"
                         },
                         "us-east-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0f3330aaf83197342"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-038124e8fae000d51"
                         },
                         "us-east-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-092a236d1507291ee"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0cc52afb05e9617ef"
                         },
                         "us-west-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-06a7886f87e4931ff"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0cc8ab168ab5ae4d6"
                         },
                         "us-west-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-074536ad21a0590e5"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0f24c8f6a99a74bea"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240906-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20240920-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5f649696a9203a5f2ea367dd298d95660cd873d1e6ceba295d1fe9be64b9f37b",
-                                "uncompressed-sha256": "dc8f597b68930352d5556ceb0382fd9bef42de8deb6dcdb863c4f4cc7703954b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "07e1aaa1e6905f005f5b580f5085ddc9708046088172de2631f653c7b3436ae3",
+                                "uncompressed-sha256": "c110e35cefc6ef2a68d49502d6edbbe2d3bad12dbcb3283b1fabf80162030e76"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live.ppc64le.iso.sig",
-                                "sha256": "c785925a45b28558cb5c32eb92c0968e658a3bc8368034125475cb69f406eb98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live.ppc64le.iso.sig",
+                                "sha256": "cf39a8e51e91813d44579f8a007992bc717a3326c37e6153014d65434a53e68a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "8f74ba2c9942315b677986a78ce529d61aa5edddce2c6675b0d797cba280eecd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "d46ee1013aaaf5ae268dec58b8ccf27d1691db19a770c5ace38f1ea9b6fc3244"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "85b331eb5381afc3589b98bf8a969f4138f0efecbd4f6f0f074a90d0d8b68194"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "3091ea593b5e805d4e0d3a884e2fcb5c9a799aaa0190d7ee21f0a2599db71ada"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "86d5b992e0a21ae2cf6177c71478fb054638aca87b6d9ccdb51e49eb20fc8c00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "89ad28ed1ae94894c5ac6dd59dfd9bcf84778c5574bb174b7ceb2a60e5d148a4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "9af286c1b237174131f6a2b41bb20c34fb9cdfc5c14709f1c03fa1435647c691",
-                                "uncompressed-sha256": "31ecf7aefebed8f815db343c0dc16fa816f8d4fbb887c70dd38d00d3bbe8f010"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "cfb097a3af4eaa50483896f92068117d160eaac71514972636f34f2f62f38b81",
+                                "uncompressed-sha256": "89184045eb92c353ba970f571e974e89178d9a5c7ac5281f5cec9a02b6d21edc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2d038e27b927e889232b8a56b9d218e52b3a6a5e34d1a42f57569647bb89b284",
-                                "uncompressed-sha256": "bcd6dec8c5c16a9f13d4e15e7330068fc0d2c4e54a8d4c3efaf91ddab0604b8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1a9f41e4516beca81efdee524858057d73d3be0777d9697fb7816366b59a37b8",
+                                "uncompressed-sha256": "768f1243a2c4a932aab9f1645a0a418e179b1a4af59ac8e082dbeb3120f1e514"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0b0e306e3fa7aa9b9a035802f43466b69e4873894b4b94e2bf5788af31abbfd6",
-                                "uncompressed-sha256": "7155c464286e8ec98b82a0f4b2e186d2896ee921a3541f26b992f9f0f666547e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "84aad8288a4cef63095c3df1c9083cc675d42dfe280f346d4cf0a68ccdfe1794",
+                                "uncompressed-sha256": "61c9149641ee41c37313c6b621acc5e1c040105d15eee25ade4c3fa47ef82d31"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/ppc64le/fedora-coreos-40.20240906.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2259c4a368d1293419b9a9567ddba25d1461ecf0227cab1f09100dcacb039321",
-                                "uncompressed-sha256": "a5da0d133a0e0e4ea8ec58a704842fd8c16959a474000f20981daba64febb4ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "0c4bf7bb561c0865df1af297a4653312ef1ce652cf0ae70ab43dfbe6703b9dd8",
+                                "uncompressed-sha256": "fd0ff4680f1921de652b95f66b72214470d8f04c0ccb6764bd78e3454b32dd0f"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a5d0522a4d8147335dee35b424a795a6e625db13c746e49b9b35e859d302e976",
-                                "uncompressed-sha256": "9580664095bd9e9251d324a1c393dbd90c4d91e7458b9307a8fc7f7eebb5a3c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d8215ffb042429cd2578ee22bbd39f8dd1fa5cd313f62fbe3c4952602b47f6bd",
+                                "uncompressed-sha256": "c9dfd37f77a321ebce40ed6240a34132f12efa5ecbb5ed0f591c5651ba4adda1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "dea5d1d286687bb50c4f1f1f3544877d245f833a38562d939bb979af0e070d53",
-                                "uncompressed-sha256": "532466859de4cf99d385e6a576c797630853faf04d13abce15b8336789e25040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "733844ce5efd729d9b98735ff151b77f2cb1d1ded7f73b7eb5b03e0330927b60",
+                                "uncompressed-sha256": "93d261df6e4f0571db6ce02cce6f256bc5de2f15438d2b7bae4a23cc5580ca93"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live.s390x.iso.sig",
-                                "sha256": "8a59b891930993395158fa83ce5021841233352b0a5b20e1c91e9039794d9bd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live.s390x.iso.sig",
+                                "sha256": "eae4324a8fd1471be40e4cf0dc07e62335e1c349348506e44459177aee0171e4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-kernel-s390x.sig",
-                                "sha256": "94e52beccbd2c3840e93c4dc5f078767f617bd350534460fb4fefaa40d8f6130"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-kernel-s390x.sig",
+                                "sha256": "319c73cd5ddfc00b861941bb7a2bf5b7cb04c2b728dc42e9c6095672f2169448"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c0f5c928da0696839c6c9dbc2d29e60ef10a472fd0d17f48b83a8fe90519202e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7cfa22f167ab6f3c047cbdb325d9f5fc869fb3164d1880312077f023239632f0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9823bbb24929ded6a28a8be3dfc41cbd5a65771b8a043da09eb2bd09e71b3734"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "addaae58f86fff8262f8f3bd9233c1030235722a09419c9cf67e6ed095329125"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "283d9dbba0a9a23d5653f959394ebd9d482c7571cf41b983089b39451473f14b",
-                                "uncompressed-sha256": "05a6b8b26a7e8aecc2d792b540dd2e277612e0d1f741b56e2af06f3dd9b203d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "94b7b32f6dddec93918e137775443e501650e2ef298127614d600405dba0b86d",
+                                "uncompressed-sha256": "92c0161ba76e2dd90ac5eaefb445ea653febe4f03a7ace76c771216cab0e3da8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c3e486f02e46f8a9173761280ad9d9a9f4748d68a094e2ea01f79bb497dfec6d",
-                                "uncompressed-sha256": "27233a2f053c1744393512564d17f924fe6ce58d1f0f7062f3bfd0c7ff8bf16f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0469cfedebe2551fc790b132575f526ca488963c04eaca994883631a6340a5eb",
+                                "uncompressed-sha256": "7feddd215ddd583df96d824844ee4971b8d935585b05a07c1bc254ebb6a1ebe8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/s390x/fedora-coreos-40.20240906.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "58b4e9d0ec6b90b33169985930939dc3e672beb51787a003de6246d05335e91b",
-                                "uncompressed-sha256": "f7982a6a7347178e7aef326fd4ef73c48dddbb85161dc2fafed86e7a066a465c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "43bfc8f6e1e84f8ed087e395109d972d229f1e240a83f7b8ad9557413aa54e44",
+                                "uncompressed-sha256": "c84313fc0350d4d66e8e049b5af85f4a0f3c8ae14107642f258b8b14fbcca02a"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "149fea70f06a3d57d741aaeb3170045b6fd4e4afc6fbad5a1d5c42b1aec9ccfa",
-                                "uncompressed-sha256": "ea8392d958a1aefbaa07422a83d365963172de4488181a58ad6113b0b194b321"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "845503eaae5bb734e5a3658a64ae3f46f764572fb8e2279b9ee942ee68c51e09",
+                                "uncompressed-sha256": "2607d25c65c042c4f1d50bb1a212bd99af8d7984c88057e0efc80dfe7cdbf1fd"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f0f2fa53d414522ba36e2d300183c68e8993cecc65ae79d287b7bb6a76e9b172",
-                                "uncompressed-sha256": "67a85c79adc0d63822d21444129fd5cc536e25a86a5b0a1ff2c64bf13c8c4b10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "894055b746444c03343308d03e8c03f579e0b4100d833da0e5548fbf8415e312",
+                                "uncompressed-sha256": "e3078f39e4a44c1c789676b15bf302df7adf20f5af8bd99b20d1313129230a48"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2d2f357781fc4148a9e3e0d4b63335a892e76a5fead9a1bd9fb62b54c87f516c",
-                                "uncompressed-sha256": "582b94eba72160ae9222d9b9d407010d5800a1733447bb996bcd458839053eca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2105ef3656220579b2fe81cb5d57dd6a53b8a0425e93e8a87bd8753630e168b1",
+                                "uncompressed-sha256": "b836c7734a029623d58b6d75557a040faa071ca7d451df85b002b554204f70ae"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "54d94a9c4e523db8c3726f9f7310ed95521e42a8b832d73c92c30767ed1a6ac5",
-                                "uncompressed-sha256": "7ca6d68cd5af97fc2b989a7be94a4bece98312f4c9fb567749799dfa768d9662"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5566f8d4683ade51e6c0ce6a845c56d2cc7863cf828e5d03ecf88cfa08c26df1",
+                                "uncompressed-sha256": "afcb72eb7d420fd662446915e92454b0c88f95c476560aa9b030293b199cc8e0"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "451e76aeca80fb40be4fe62227cb5214b22991aa76ed4b3b9659b9238dc57b5c",
-                                "uncompressed-sha256": "1227ff3eb56ed3015453a407775db7a45daaba0c8882733b4eeff7baa38b4e4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a961ed6f101f315c99e4f0b3d4b9f505ad0061681537be16e152d641e96c73f3",
+                                "uncompressed-sha256": "8b8a1d87c8fa8b896fbbfa7297e8d76d73a17862df8d3ddbf6106ab8351bc652"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2564673f536fd8bc4cefdfda37fdc0ab6d3e851437426cce281202abc2644899",
-                                "uncompressed-sha256": "5d90e85a4d9350a1865be7df7966d2b8d14bd3164bc1706f9e3d04f7ea52d62c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7c2f393546661ee2a15e90f0c874f7f37129694d2c6f365bb3feb3c5337159df",
+                                "uncompressed-sha256": "c96ccae7e1d52ea9767c39c142faeb605354e06527ce4ba024350fa52236a304"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2e6ec7a69d68dcd5dc15665b9f93e734a08d9ea2f085aec4b65839a5e96016fa",
-                                "uncompressed-sha256": "aa00f294b5d9047c764409793f2947e87e71ba32cc5a099d317ab7be639c67fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2f91e984275f821d450a7cf89904715ed7380c7bdf94a5a1086399edf6dc037b",
+                                "uncompressed-sha256": "89af5b8f21971a6b8bec7a3374729b16904b43a4b1b8e12c32506adda4deb72f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7b50bb25f57a1efe8242fc3ccaa560f2bd1b26535d6fdf620e3d8caa104db62b",
-                                "uncompressed-sha256": "a6dbe2246922200a2d5dd45c61619d23a3c84d9b17785f7d0949cd405ab50751"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "af4a3111d0fc00417e9d16888e2063068097a049ca048789a16b1f8c8b184347",
+                                "uncompressed-sha256": "d4a424c539684bfc379bd0633950446489c4b8f16d7aebafddb4c5b8a2364943"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "647f85ad90c9c66899f681363f4c36118cc1d2335aa44cdc598394381c3e6d71",
-                                "uncompressed-sha256": "59f19e8cd51124a28cec30484817eca781068d9596ebb8f2e24ec2e2259a20ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "992b867387b3fa8b8c34d187f69b23d00594f01becf9d881ce4c5d3fe3c0a3a3",
+                                "uncompressed-sha256": "2de2035f20a354cbd83cba3279501d750d606e33063d87219afb858a7c13e05b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0b14a5fb09ae9872cd3f73966c703280e68583ae9e3f2c3016622d4077e20ff1",
-                                "uncompressed-sha256": "2ff49029aa698466cee07626956fc6bb19749d84fc9ba342c093a5ac66c9f45e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "536b9cf5ed9900faa878df4430ac7aa66ccdc7a339c48838f6b631c7e87adf3d",
+                                "uncompressed-sha256": "077cdf685feb91891c95bf6b90ea70dcc01c7914b31ac4140b271c2aa3c2a8a6"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "eafa26d5c1a224c6b6873e00a4b5edaf686b489ed6e58b52f7ff4f15d3e85baa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ec5805a85928bde572fa7b99d7338cced86f683f4ca6e9041b3473625f494cae"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b7353221ee88c4131d223b1e464ea0253e3c3f9e189eb68c47a3d1eb93933f63",
-                                "uncompressed-sha256": "8ad2fef33b17c235b33eb6454b6047f29a6ecd6378b559cac383a062b013f089"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "48467ab744cdf670f6448de5bd6cc4dd1a5ea2cc6f668a558294da8b48d1be2f",
+                                "uncompressed-sha256": "bc839f50b96f88dd7bcc84aebdaaef87a75642ce01abcde07d6471b422362dc8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live.x86_64.iso.sig",
-                                "sha256": "5760135309cfcb2cb0ada13b65ac9b086ff85f485bb1a0ec72be1ee5033107d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live.x86_64.iso.sig",
+                                "sha256": "3ec348f6d4a17604455f35291892bae5a8b6603d9aa281d95d44c9a9867fe22e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-kernel-x86_64.sig",
-                                "sha256": "f99eabaaf7523e47b50b1e14c5fae53432c9de2d0fc842bf6af2d7926f9cec01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-kernel-x86_64.sig",
+                                "sha256": "76cae19de14b3957eaa9056a349a0fabe446dc668a437cd89a258952f515eb78"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9e97669dcac6ff79ba79c77f6f929df8fd5fc49f8762a7184f6274b1fc1aec1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d8cb02db9c44f51f038d529159634ca5afd52868f9fc5c4a3869c3be5160c595"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1ddbad6a98540217f35ded7b0f0324a5877a4e4b93c1f8af01913b505062c08b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "81c2793524dba973af3667c711f0f290ae529d8cfe6592de7c9b0e29b5bd3c9c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f35e8b91457450f2e6df95ea7a3bcc374278d5f4e46b305efd941c34f1b60853",
-                                "uncompressed-sha256": "f30a7ab9f1a93014f87d7cb627952ca7dbe98e6bb96ce914c4b1e14fdb6b856c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c8d710f412aec85c737c6ec307050f332b9e3f2f34649bf673815a4da3dde74a",
+                                "uncompressed-sha256": "aa734b8b54cac3bfd69b7d8bf97974c0550c1611ab7fd42ee6e403fc7634db31"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "849fdd38a3c5b6b5672208dd130c41e48e94a78bd26d1bdd8e902130737a2a1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c99916885e30b9acedfe5443868d88942eb22be69518c53f2b02e60009bf3439"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e00730191df38cdee9cf8a13d49d0a0244f71fc4e9f82741b88cca50e3531176",
-                                "uncompressed-sha256": "c8f15ee63a844d605f8bcdeaaea9b7d0fb518f3e7d3f4c59e8cb67459119c183"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2f2e4283866118abf913ef055017f74a93635709ce24ea9c42eb597aff1c7809",
+                                "uncompressed-sha256": "547ab50af0d51fca21abb5c07a636a2453892c4d185c69aec3942b4dde48ab6d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "94d371b8b8ff878b1812690a7b0e0eede964fa2a05e178f5ca2f3537543f37cf",
-                                "uncompressed-sha256": "da378a384bff509850766e01405e9d665ab29362309d13ddcaf7b0a7a2ce299d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d4bc5e908e864f413fe59e8b29a418eeee379b970ccc67619cfb7015ece4e3d7",
+                                "uncompressed-sha256": "28480163deaa05e8db5d6a61d00b26a56aa80ee258e18a67f8d030aef55169af"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "614502890cd0a30164b9f17f15e335965fc224d251d5e766ce9a5588086cd450"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f11472c3af9abd21e599e550e086c440a118bf09ada022571dc9022dcabd48fe"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "61530b9617fd66f1e32185c171eca0e125431822077279c57a675c629d307a7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "cdf68ae11e9c8df087460124bcba5d031e4ecdcfdb2fadf8451d8530f016b19a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240906.3.0/x86_64/fedora-coreos-40.20240906.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c282a7550145562c846dbf70db1b4c8192b36c0692d682823052de5c13c2070e",
-                                "uncompressed-sha256": "32632f4748e8a6a5999a037fbacabdca2e7dacfa6c69eb42dcc59f2517ad24bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a7ba3ce2c65db17d47287decaf1bef78370d086528ec466e1da0fd0967e47e83",
+                                "uncompressed-sha256": "2d836edbd5faf2aa8580b9aa8dddae506ea93b2a43892ab3d6d31c45fbc57a02"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-04b70cb2b62c5c3f8"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-01282f8517613ee5e"
                         },
                         "ap-east-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-026a481e116e57331"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0ef302e319ec21ec9"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-042858d4462ac0f7c"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-00e7ba8ff91372e00"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0dc6d231737e2932e"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0ed0fd3f02fcbad38"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0fdc989a7d6715970"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-002ed9f55e6fc360f"
                         },
                         "ap-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0842b0f4e9dd56633"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-09ee77b05b99c0d83"
                         },
                         "ap-south-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-019acf3d2ee391bf1"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-01448808619d1545c"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0d84d2ed79d4237f0"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-05fd115e46c7826e8"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-06b9a3be40b76fdb2"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-08914b491605829b0"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-00684823413e31102"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0fc685ded0960844d"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-010a834c242442380"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-08a8ff37ef24c9eeb"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0d369dc8384734946"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0c2f506b8b34ec5ad"
                         },
                         "ca-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-085ad2bf09286eb7c"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0222c71b9d49ac7d1"
                         },
                         "ca-west-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0b6cc0ce67954f629"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-06cd7ea27cb1c0575"
                         },
                         "eu-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0424389e9756d216a"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0dcdd5ce0c395eca7"
                         },
                         "eu-central-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0d1482e2ecd9f3a83"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-09ddbe7799a020c0e"
                         },
                         "eu-north-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0e1a8ac2b1ffc1e55"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-04d07ac91f6d6283c"
                         },
                         "eu-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-073c3a2e45ddb8342"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0b782c36c17e03a5a"
                         },
                         "eu-south-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-07648e884c1e323df"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-060ff3314beb24829"
                         },
                         "eu-west-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0a5e4999ec9e1ad06"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-07bbdfa91138b7c59"
                         },
                         "eu-west-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0766833335f4ab1dd"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-069f0ec584fe23d27"
                         },
                         "eu-west-3": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0de2ffb91afa508bd"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0aeb51dc46c7262da"
                         },
                         "il-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0e097c477167e4017"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-084c65e2ec4ec5097"
                         },
                         "me-central-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0aaf48076f7a7f129"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-096996786b441d610"
                         },
                         "me-south-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0c346576e8e02aa60"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-03f2eb3904bc0b8b5"
                         },
                         "sa-east-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0f8c812c92064bd63"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0f5c834e13f649a22"
                         },
                         "us-east-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-0be1e1842ff557eb0"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0f4fbdaa2eb59b980"
                         },
                         "us-east-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-031249216d2ff012c"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-04702a67f30a05c0c"
                         },
                         "us-west-1": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-05a60c140bde387d1"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0862dbdcb419e26a3"
                         },
                         "us-west-2": {
-                            "release": "40.20240906.3.0",
-                            "image": "ami-05af79112a5ccb661"
+                            "release": "40.20240920.3.0",
+                            "image": "ami-0df7916c7a3870eb3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240906-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20240920-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240906.3.0",
+                    "release": "40.20240920.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:36611de43a2d00b724e90855d05e5ce67fd443345d91437711cc73d3d3e99d13"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:842cb9bd5b2ed23bd048a3cf14893ddfa331d6ed4d4edec6158558f0b0983608"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-09-24T16:05:20Z",
+        "last-modified": "2024-10-08T20:38:31Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "4d62233247081a9444f419e09b23bcc9a99da8ab8f7737b1a06d819a485a2ebf",
-                                "uncompressed-sha256": "ec3fe25ba033aeb5b3d92c5d8f5b4dff49d32f155e5321915348cf7924667c9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "9318f3fe80959139217cdb1cdb1093111f3c7376ca38bdbda1ec4db21892620b",
+                                "uncompressed-sha256": "38ba41c944dc8a8562d24d60e7eff8cf09ea4282d6dc5acadb6c0e8e1a2564b4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "041b0e7842b7baf23e463d652e8409ca531851a13d7d2d3232975704fcf33a8e",
-                                "uncompressed-sha256": "751d134ca26852bce0fa798c7eeba3eb6544bb0cb4a4b808116bc58e39c3e00f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "993735bfe3f4ac6f6da4b998eea364ab38e7bb1ff40f7eaddb4843a70c10f2f9",
+                                "uncompressed-sha256": "3f5e95988c19aa7f0668aeeae6ce9b0b510d42b83e54b1f89725eda620749d62"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9d8d3f81865a2d4dd5da1807ca11642dbf44559cb1f8a9bc688248008f6d1e2e",
-                                "uncompressed-sha256": "d4bb44f187d8a7c29ce482a37f604ce8c44e23ade6bbb181e64cd1dac0a0f4bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a48b6d2a035acf646e0ad31b6da80aea9a85eb203b05d9f6dfabf8c3d0e43ed8",
+                                "uncompressed-sha256": "f5fc2fd7d680df7e403c3100c48c625e1f15a13fdb98e3e49e2db4875335ea8a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d368f471a61d15c8d2e246b641912829d958e96fe06a927492af14e9dc8d62b3",
-                                "uncompressed-sha256": "e733dfd451d2e19e8116e1d203722d345df2acf1cee63b25c88fbc5d12436859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0d1d3e23022969b9d90cd38cb5918e7f2eae841a3de09e20adbc37e015235073",
+                                "uncompressed-sha256": "2489208c2884a35e2b9d2e89f619d0514951d0393e0aea58e12da9fac616e13a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "c31715f2e7abb9f41b2899badb2818dd22ac07e83036e737ded79e37dadd6018",
-                                "uncompressed-sha256": "4036c349324082b794972ec81019b00eebd3fea0c65d0c5757e452590675dd92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6f76ad9600c3866084658bac27562dd0583a9c328e2a37e88b88718f0ce7485d",
+                                "uncompressed-sha256": "aaac81651a45eeb6dc12092497261efd33cc9cc6455f14408b899b5733bf5aa6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c45b68968f05c0ef0bd0bda13ca29e113ecb82e609e5b945ba6a2b85e05ddc42",
-                                "uncompressed-sha256": "075aff28e0c5bd966976f65ec2ba4045e07d5c4706d4c55e37d2b88a1803d58f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "08bfc274c3be26d9f3338ce8b3d698c7764ce178875c1a5cf9d99781643c16b9",
+                                "uncompressed-sha256": "0b5d7f3514999449b6f09f9b7238e4b371ac30100cfa8a4fa5660bbfa7875c2b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live.aarch64.iso.sig",
-                                "sha256": "8df48c92341c998eb2a4daa21737e70314221da42c847866ef7ea9111da0444c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live.aarch64.iso.sig",
+                                "sha256": "c78e0e499d34e53001168ed9774fdd0fec32dfa9645544c2290287c1beefde1e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-kernel-aarch64.sig",
-                                "sha256": "cba8ea5453c6dd2669ac9ae8c935e47bf5680a76bff0a4242fc6bd42f2479588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-kernel-aarch64.sig",
+                                "sha256": "838dd6346c11f890fa63f4e9465cae414932f5cabb65d78a3d3f8d6c05c716dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5be0a9ff617a4b6aad47eec0fbb351a3769adece0dcb24840efd1c3486e05a46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "b44759b3b5fb7d211bbbef3c26d6ec850629010aa126e374017e84c6a06e9e99"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d949426a424f400867b93d8abda8ff4b6622f6aa8f406ad85efc9bcaf4ef71e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "496d1912125d87dcbf6c1e50323dab79ad237b7cb055b9f15dce1af0be313fd1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "0bd07ab7e830e71dbd5c238f00fa8a89f66a6ff6d601bfa59fe13bd8e13a884a",
-                                "uncompressed-sha256": "0fab9f88a76ca146186923a570f43c97a2e505149e7f03b965d20b1abdeb855c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "82c25c5cba61ee08d61071947076439394298490efe71a6271f4074fe84545fc",
+                                "uncompressed-sha256": "296945e75f242c5eecf99af78d030f064ae37a1077c79114b05990c4b67bf977"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2b899edbecec8d95355031f2685eb6f8237d8c55a6554d62f32ea6ed440af56d",
-                                "uncompressed-sha256": "fb60279ca41fb8fdad95009847c1fd54f45d198a9443826d6d3d280f19447b6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "fa55ce8191e6c3150da4c50c6a06a51d3200fbd8716a6930e5f9bff2c2f7678d",
+                                "uncompressed-sha256": "a5b7a010feb9958b200d3b64e36e90936db25c4f3aded43200240510655274ab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/aarch64/fedora-coreos-40.20240920.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "41725c6d3976969d5cf22f68b8c41689dce42ee3a41b317a8aa38bf9cf7db793",
-                                "uncompressed-sha256": "81116e0b9712a5cc7e6a76e02877da5bf17905d1a8fc2c3d4dfd780a6b7e2be5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5dab5840c3b783c9701235f551bcbe9df06e8580d1e8db2e1ea54c704748ce9b",
+                                "uncompressed-sha256": "c3e5195d5bbfb01f5944ec6c5a5b4cf22115a3fca1f03577745432cc88a6a1df"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-01c99a6095272f77a"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07d1efde3c98e055f"
                         },
                         "ap-east-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-07e0ac2a28cbc3833"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0ab115299eb223562"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0aed18f7930518983"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0aff22b83906365b4"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0dde046be8efc4734"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-03651eced89da0358"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0386d4f2ff06fa919"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-09590cd6534ca5226"
                         },
                         "ap-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0f925ced27e59d51a"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-055d7046c65c11cf0"
                         },
                         "ap-south-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-090d3f4c5eb5b160c"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0e2b23ddf45d41f7d"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0b4fe1eb3e9b15d91"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0a175378a2725145f"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-026827c4ee378eb40"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07d2d27746efce893"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0f01b4beee667129a"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0d19c473616e0e490"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0edf606fbe1fa2895"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-05728e1dd3899feaa"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0b711ae7580834c9e"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-013653dd5c0e8559e"
                         },
                         "ca-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-00ef2529f7c2c234a"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0e5da636d8aa44327"
                         },
                         "ca-west-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-03807602a550479bf"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0f24959913b3db469"
                         },
                         "eu-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0145f58ca3fa4a3a7"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-09cf423a12e376dff"
                         },
                         "eu-central-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0fedb07b8898bceb1"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-036c3af4669e0e5d0"
                         },
                         "eu-north-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0e86e1c97bf14f583"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-00902b818028f138b"
                         },
                         "eu-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0d087bbb964f512b0"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-02aa09a0478f15ddb"
                         },
                         "eu-south-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0c42c282f061bebb4"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07fd114e3358eb85b"
                         },
                         "eu-west-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-08c1721bd9a0da0f3"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07fc21ae2bd656755"
                         },
                         "eu-west-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0cf3771533c97abaf"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0d6629ca6b35b8f7e"
                         },
                         "eu-west-3": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-029a50e0105f13c3d"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-05a3df60cd726cccb"
                         },
                         "il-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0a44b4cf74a531226"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0fcb065318db34911"
                         },
                         "me-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0806983b1625ac42e"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-02a2444058309b7af"
                         },
                         "me-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-051c4f2c3c1341dc9"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07531ab115f602029"
                         },
                         "sa-east-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-00b899c22825e04bf"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0cf520f359b332665"
                         },
                         "us-east-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-07847e982520399d8"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-00b161bef25c76171"
                         },
                         "us-east-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-07f7e53d773a496f0"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0a9c28d6a0be1773b"
                         },
                         "us-west-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-09b838d4c84639de3"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07006302c3a564f6f"
                         },
                         "us-west-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-055d491c9ae1bf33a"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0dcba6f042542ccaa"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20240920-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20241006-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "7155e94013c99922c8d47f124e4117def49e8c07ae3e036aa99e553b268f326d",
-                                "uncompressed-sha256": "17cc0ef44684224880ac39b924d12aa2bb7b5aad20f4417e71198ae36090a7ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a2746457dfaf6663ec670bd102430465c59a4f973f0a9eaab418f2184e413571",
+                                "uncompressed-sha256": "ee1cd682035bcc5920c5ece2ab101b19caf2fab1563399ffa923b28a8125cc14"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live.ppc64le.iso.sig",
-                                "sha256": "c14066f967f7a564d42bc9107aab2a55f26cd13f869368dc776f3fba476536da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live.ppc64le.iso.sig",
+                                "sha256": "8a7c69c1d0c4a48acaf0837d4fd6cd27a0a6186437cbd11dfbada5b81c76cfc1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "d46ee1013aaaf5ae268dec58b8ccf27d1691db19a770c5ace38f1ea9b6fc3244"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-kernel-ppc64le.sig",
+                                "sha256": "461a1ad51bd0749c2c8792f8f8de14843b53be357ecfdf1ead4f1e8ce6ecbe53"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "8785a1685f58b5594ea4a6ee5eb164a1d08b3f6a9c27afea1ec51d59dc2ab401"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "dac5332044d67eafc41521e2f82c11c2328d6b8fe95392aedf7085b8bfa52a8f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b4693f06e597b561241fab8dc8ac8cfc364a7d084f73f4483a61bccf3346dd8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "10eb1a34def3ec81be29830878da3623fe0941aff924ebe6831c7e51d9c8590e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "58623a9cc7d0de0e521cb56d1e02c23d820cc6082f8044737676264c9cde0b78",
-                                "uncompressed-sha256": "92a5b27574cec67d3dfd4bfe3dd3ff68f760acac0d55b1db8f37c5d6f4a60a26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0a6c2c66e3c89f39193df8d1dda8d9fc36e8ef7cece119c1ecb9c3d59d20d1ab",
+                                "uncompressed-sha256": "70dccf9087616a33e0f8d6fba221018db3fb33aa7a2e6be787adb9a8e04e8dd2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "47d7fc76ea9c46e73b06b356f8da009c92fefb9a0c1d6add15988e50dbd75926",
-                                "uncompressed-sha256": "c467482e04c5e0c6f3f0751a38b528d4f18d4e9ed8e595afaac5edf4a7cfaeec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ce1391903de342cfbc5966bce395c11f6772f88a833967f123a956c7e63bba94",
+                                "uncompressed-sha256": "e5cec49ee59742c8e25100a510eb56726b7c953677ba579852846602d2a9c3b9"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0809b79be534a2c516aca6bbd1ab568ca6358aa7d77cbdae7033491259435fda",
-                                "uncompressed-sha256": "7206749addc27ac9d4fd311d299142fc8bf2387e83ca82c8283f2ade2e5e0992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ab150016e1d8ff8f222b51f4fc34445c0c491d80ea24e56fd0b2cb284d62c0d8",
+                                "uncompressed-sha256": "1ac86c8970b1185ab20c8fc7dfed4b41491972fdc2012ce93de5d2cd2918b545"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/ppc64le/fedora-coreos-40.20240920.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "ad8b5746f414c27f8839332ac8bea072a117168a2922159e98709e3d5673bc81",
-                                "uncompressed-sha256": "a052dc23658dfd3a5c12eda0f8f968e16705692035f14577c916069ccd9c7c7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "6cdc517b9a22d99ef8853d1ec2ad02b14e1e171b877f64de410a217c4a650be0",
+                                "uncompressed-sha256": "f0609107cc17282f84da0493b297885a8815cde236c53bfed1202f832e15a266"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d0b2c1234877dd3e739fcdc9b3abe16091c446de8dba203173d63a85ec63eccb",
-                                "uncompressed-sha256": "6460d207c638a1134c4effa04fa25f16ae52e391be9d715895d58840cb394146"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7120d6448d9eedb58569c6fcd60f4e5e55959e97b738603fcbb870f310f817d9",
+                                "uncompressed-sha256": "755ad04eb2a30a6e97fd7873239089b13b29f2e98fac101fb209f8384e4c2688"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7e9dbcdfb98ef4694335c3b3804bb4e844f556c43b7678d905e6ffa01a47e52b",
-                                "uncompressed-sha256": "bbedd880f3d0f848964dac299a1045d75adb4de95fdc3fd1abdde64f14533882"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3786a3d012a02d1eb9129a0cc3b92f596b2de721d38edc8b9f08f9398316a8de",
+                                "uncompressed-sha256": "5df25c678c27860451a03c61d27bb1b15d340b3e85d5f84896ad35d2f8e77868"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live.s390x.iso.sig",
-                                "sha256": "a794eebb5054fb7d69e88ad634ee4c2de35c67695468cc3d9507292f15cde103"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live.s390x.iso.sig",
+                                "sha256": "a52ed2b7b52e3775d13ba09ea7d2caa6387996e84aa3e1072450ca6906b73203"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-kernel-s390x.sig",
-                                "sha256": "319c73cd5ddfc00b861941bb7a2bf5b7cb04c2b728dc42e9c6095672f2169448"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-kernel-s390x.sig",
+                                "sha256": "56ec902518e8bd6d9668f0a572a3774296d0a0776530cfef51553eeda0eadc57"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "2046ee532b9461e17177e9c637661abe286813a172b0696433dbba02b6fc9a87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "248a81654dd93a31815da6e3a3d8f557df9728407f9619b561431684ffb55748"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ffde5500cc754f452951856f30eab964255b2442f94d22551943220726bc6fa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "016741ff63d5a8269e927c86f920a4693af6035bbfacbb0f9b40e66223e54646"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "c62db88e3fc6b2d12954ab615b8e1dcee821c63cf5991af4e28bed2626cf9f72",
-                                "uncompressed-sha256": "8a2ca3a18808ea557020130e15c1378b191f783af4a44a635723b2540f64795f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "dbba54edff9509736755393ef2afba936bf65c4af174290a9f3024d56b68d193",
+                                "uncompressed-sha256": "5dae09b4526058b5b0d4f74bf7f0db947fa65af22d0db79cb9c8730b5b00efad"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "581bc2118e698ee1e787d8cd0ec691dd78a269ff08c77b8d85ca4c1ba10952d3",
-                                "uncompressed-sha256": "117181b49a89b5eeeb5c4f419bd787ee0a74d1edb03f7ac765b418387207517c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a885242f3960674d54b9c507249aa62c57f835e9cf6c77e6d760ccd2be199802",
+                                "uncompressed-sha256": "daf32a210343e85098d7f99c4d1a58b70d5b4677cedd85be1a76e72646291256"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/s390x/fedora-coreos-40.20240920.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3aec7b993a935327cd201de170795d4cab896aaa5856bde845a1c5b33305ade7",
-                                "uncompressed-sha256": "713185f64088ade27e276850b42503af5f0ae4d6d76adce2574c60dafe24e125"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9ddbbd33bc9bdaf43dbc5a065ef81b04c57c52535fc2c9412502841d75c14665",
+                                "uncompressed-sha256": "5f1cb7b638d7b34b4871839010e7a02cb868dbf463795eef66d4b16b6c82bfcc"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d223b44a3779bc4accd3e2b3a9354fa3f75cce1ea371e3a40a30a41ff39172f6",
-                                "uncompressed-sha256": "367434412870cb804f01e7547fb71212f08e0140995b262b3596c1c167123e1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cf9e5867210bdd7c1262726f0c33575202f77e4fd94631fa5cd41d7aa1b2df61",
+                                "uncompressed-sha256": "88faa26b38c8290f50a6f447d41206e1c0324758501474fc0187434e64dcc6d1"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "cd07e852ecfdc475cc8be531af07d2d6577adbebf61fb30bdb5f298da86c2178",
-                                "uncompressed-sha256": "2f6af2a0431f579a3827cf74e121bd91bfe58f0e267ae19410c4279158135707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8aec6ad8472a62fa3ee8afb86db0229933cc8a3099825713974be18d5c8de4cd",
+                                "uncompressed-sha256": "fb3c0b333a11e1ee7ee79a1ecb1e5c57b489f3ca64273207df4830fc2e38cb33"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "33c58d7860d155b716e1b06378e93fab26c99c19af731422ad9972c62edd0520",
-                                "uncompressed-sha256": "e6b4e157b772c99914626d018859a22d063ebc85488eb4a16221c7bb51b08cd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2eb81601059546b1765c15e3e79e32a3ddc0e0ebc86745ed92414b322c594911",
+                                "uncompressed-sha256": "8902c244b4f3570c9fd96a79ffb324cbbc4c2de78e25b05ee6fffff09c3dea64"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0d30acce04de1c310f13279ddd1f7136538cc2b4bd4336db381e28142a98a64c",
-                                "uncompressed-sha256": "2d8cdb4fbe7c1a75bc330ea8be23623d83ea1a483eb686130dacf239f002f22a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "adcdb4a9e0e2274d3ab6a6a336fa2acedd11a4fde853c8a34a2c21e0bc20aac6",
+                                "uncompressed-sha256": "69e31de67b6dab1b34675e1fdfc62620e6be08c112fa712a68c628acfcff7608"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "bcd6e83ae4b8dc890ffbe1f4d6aec392154e3a5aa96c6c0cab2588ecab39eafc",
-                                "uncompressed-sha256": "c861ec6074f27765bb9730602890c87bf8ed4133feded0b2e5f13a1c1be58bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b813f9ed1a8c8e499543168230d75af188f4533f39f3f59c82caace9dc912de1",
+                                "uncompressed-sha256": "3c6b93d02bd055d419af05c0776eac249957c72becd170797b0e1414b0dae2d0"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "88ee04db542c869b0acbae3de8d32be00e3d06b5cb5b131474b760a48476d076",
-                                "uncompressed-sha256": "5e57448c50cf2d1326c783abd31e70ac402efebc0e0d1bb9c64943b895d14a1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "36a86b82637ba577f6208bacfbe31b9a5e00cd2122ac036d2d3f53ab53da5537",
+                                "uncompressed-sha256": "d30d551bf34ac115190c799e99cd6cc0ba202ebb8156e97ef671ce80387e8159"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "149eb632c820555609988b6897457d63b4c14e52888632ebb48841aaf2331ffe",
-                                "uncompressed-sha256": "ca3f3cd3927880249989f63e08718d322c9d935dc901765a6d428c7888bc51d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1623764e1124f645dd9387ed1f00c2bab9dec3fe2dbd7ceb4451b58cc63974db",
+                                "uncompressed-sha256": "e0943c7f0670434f2cae37a1b888a7eac1e124ba478153103a06489525c95f8e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0d2f721a14fe2090889ff6c0e2a128498880162c469d5a7a30450a767a9159dd",
-                                "uncompressed-sha256": "43371e0be41bead793a45271d1bb051eafdbd894aeadb485bbbe56e67d0afaed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ae783ccf4cf2c19e63095dd3b2ea5de198bdc69a6fd6abf17853951c5a478c4f",
+                                "uncompressed-sha256": "ba115ba1de464f3236a8d934bbea3d44e3971c35cba23184c699e72ea94c68ad"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "6f698dd2351458430915302165d3ee9ddf68e72ce1ca0c880b69a4d9a33a0a24",
-                                "uncompressed-sha256": "a5d676568e4e7479936bcbd155b23f2701d39b7663dd02e3562c940183e8eaeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4d63ef499f1ba7395918c59ce4deec9dafbe6b543e47ab401ac53a9babfc2193",
+                                "uncompressed-sha256": "5f466a5382cf96e0e6bc6b679a46a9198211c54df59a937b57907b61446b5c0b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "09835d4c04897128ebe00fc6f68025a8b618caa28b607b628c91be126e09925b",
-                                "uncompressed-sha256": "1c944031cca971b4dc9af7d43210f9c84f0b58508e7dad7d65f075e49bf15379"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "684a98c1c7696e6472d920e9bb9561653efb3da0e8460b8411ad942c395a2474",
+                                "uncompressed-sha256": "00a2665fa3678032615d1faccfccc8bf80986b345f1c92cfb7af49bc72e51500"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "218e0a8588e2a1c4483dcba466688a7183de7b1644d74e5b95269a72e007121b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ed0c441b250693520cb5c0a1fcea61ed3348db10b41df4699e082e3f621be75e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8f404cc3e94880350024d11aea0d0658f85ddff5001478394afc031538bbbbef",
-                                "uncompressed-sha256": "9518a08724b8f85bf5ac0f6e7b1929f9a62f55aa86ae19363fbdd2112be7e1bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "446bca461008100b30d19aec51b0c14d06db6c46722279a23a37dfa725438d84",
+                                "uncompressed-sha256": "6687c9eab25a4b1c1c86de516b78762fb661a76b02e98cfed7178d2a83aa2b63"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live.x86_64.iso.sig",
-                                "sha256": "163a46c39596d816768f587dd0eb3067d9b2d99bcea5e194cffe496309eb1fbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live.x86_64.iso.sig",
+                                "sha256": "853403e0b5ce5d1833285a4c176a3b91f00862efc57fdf001ec762f3aa7a100b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-kernel-x86_64.sig",
-                                "sha256": "76cae19de14b3957eaa9056a349a0fabe446dc668a437cd89a258952f515eb78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-kernel-x86_64.sig",
+                                "sha256": "14eb3096084edc15e6fe8676c269a0e43e0b0e102b49e9d7cbc8a1e29cbaaf3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c9a64d863456585f04e067306bd93710f500665dda7fb8aea5dfc955843d63dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "26041dbcfb68280ba2b23ca01dd9c480bc452b7cb872d492444535cce31b43e6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c8d0d7a6f79445a19d9d6765ee4f3f4c06871a6e0ded0b628e1eb22b659b6444"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b3b59463ab74a64d614c13f2ddac21322078e55b195760a82357fda7ca91285d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b41f057b0e783398f9360878383a77664ebd2ed4ed11559ddb949c33e75a95bb",
-                                "uncompressed-sha256": "b62ee000b16647643da7df50bc122516de4d4871a13d1c2f6caf9fb53fdc8072"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "3b4c747731cbfd04f2892a6b9ff791c65bf0243b814500271d87fd6bc036cc74",
+                                "uncompressed-sha256": "e46250cec91dda0043b1c50984ffa3aefb8cd6876629f6d46610fdee9c5fa183"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8bb2a256a04276b671d0958750962415279402c3da14712c3b3ec2ea9b7d4424"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6002007347e18bc59160276a4eeb199dc50ce67c774aa131cd4142d24deca5e4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d2db03cc0a5fb09bc456ef311b9ca54f358c94c9a796b6d2128b1d3aad0bfcce",
-                                "uncompressed-sha256": "73010fd4c7916aa55632f067fe49ab31122d21149fc398b9e445af94c7059e4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "259c2e856d8f894e7d856bcbc7ef5077320b34adfd2f09534c6c247bf6ea8697",
+                                "uncompressed-sha256": "a9c0cff09740d4dff372c71a0d0ca2846d4d4b701fa15c2e890f65a5de4e924b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8d23d66088c654049866349048e3bcc65669d4adc8366179e7e66b983df661c8",
-                                "uncompressed-sha256": "cbf34098e4acf76e7be2f701ac910ae67a29580ae6e32b6ab3b358618d847972"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1fca9769333f1fd604903285c6ae9875bb9a2ec211b029b8229b43364f35a37b",
+                                "uncompressed-sha256": "b2fcb8f08abc8271495b720c0db006787af3d5d48972815f0bbbd91cefd450e0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0945ed4130fa5823dad2aad6b1698186a26ba7f6201020dfa3737b99a7a4b66f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "407b79d5381efbb71be18ccb29cd47d1b453b070a99e5c98b33b5d2ed00fee72"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "866a4f5286c7094572168b8a8f0f2fb22f25c6cd7110c750a59520880e5ea14f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "3e1c4ddb014b62c37f8c4d8ad04d6d51f0e958b2b398a232337b02eb8eee8017"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20240920.2.0/x86_64/fedora-coreos-40.20240920.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9a75343efab5bf46e71e258e66f942307fb0e0359709cfad197d1e4b216a54e8",
-                                "uncompressed-sha256": "fbb4a80d523a120806c9fdf24dac52428df803aa0329ef04b81e82e44df56822"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7c009fa435ee8d88eaf225a1d99f8c15a442f35497abc6a7424418b0e4797101",
+                                "uncompressed-sha256": "d628ffec322c0dc26108f0a1804fb63a8b0db902731ed20e64c038f1a5a461f4"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-08c7136e0183ef4fa"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-01d5c9ade93ef299c"
                         },
                         "ap-east-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-04edb204556b8f21c"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-05cb354c2a7ff49da"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-03f7f041c541d6089"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0b949aa5f37f6a516"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0b35cc9e33d108f85"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0c611f24be69e2b3c"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0b40ee87e15afc571"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0310107487b915a44"
                         },
                         "ap-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0de2af8bf465a7d05"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-01dea4db47d372091"
                         },
                         "ap-south-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0747fc99c1541df43"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0337e04918f43d46d"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-06a37ebf086909708"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0513e771bdadb8374"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-06be7a3c2efd6ce30"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-00e4fdf678f2e4ad9"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-095f4cebbcc3c21de"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-011ebfb2dfaee9a2c"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-07f28549d9cab6d37"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-08c81c2f0a2a12e22"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-09aad191d05b007c0"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-02c122afaf7c58c41"
                         },
                         "ca-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-04e6ebb6004fd3423"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0ba662aa8acf22c48"
                         },
                         "ca-west-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-09f0073acf103034e"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0cac5856713bad8f7"
                         },
                         "eu-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0cc97707e3c1f71ee"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-06faa89dcd685d8d7"
                         },
                         "eu-central-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0f281ea2b6e2eeeb3"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-02af21c7afbfd05ab"
                         },
                         "eu-north-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-03448d8ef47f7c9f7"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0dd41bc23860cb435"
                         },
                         "eu-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0368d5e6d732451cf"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0bf4d478aa98a7fef"
                         },
                         "eu-south-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-005bcc7be14a5e28e"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0100f86ea6a5e4c17"
                         },
                         "eu-west-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0dcc1bbbc14ed5e1e"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-07dceb9ea2d16db4e"
                         },
                         "eu-west-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-07a5c2046bc8eb1ac"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-05e6133782808d3b3"
                         },
                         "eu-west-3": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-023691fe4b94608ab"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0ce448079bd3fa2a6"
                         },
                         "il-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-082a732027ef5aed5"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0f256e4946fbf31d3"
                         },
                         "me-central-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-06e27f9b5d5272f63"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0589ec3a1f24f4a44"
                         },
                         "me-south-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-037f078b11eaad7df"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-092768cc0768da9e6"
                         },
                         "sa-east-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0963bc449f7e62d03"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0b080569008dd8d00"
                         },
                         "us-east-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0073aa7222fd661e6"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-0a85588fa6f6ddb7a"
                         },
                         "us-east-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-05136eaf0b0615e57"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-04ab5bb372196b257"
                         },
                         "us-west-1": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-0820d6aae3729fa87"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-04fdbeaa3a5bed76a"
                         },
                         "us-west-2": {
-                            "release": "40.20240920.2.0",
-                            "image": "ami-06c26c60938f6202b"
+                            "release": "40.20241006.2.1",
+                            "image": "ami-00bc4904931d9edf8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20240920-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20241006-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240920.2.0",
+                    "release": "40.20241006.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1c776c46ca2d8cab79e0cb06a7d17846fea580d6f677000d730707f14d9f5dd5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ffef50a8647bc54ad055c4cbbebec81185b4fe91873decdee529d69d757ee46b"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-09-24T16:05:23Z"
+    "last-modified": "2024-10-08T20:38:33Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20240916.1.0",
+      "version": "41.20240922.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20240922.1.0",
+      "version": "41.20241006.1.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1727197200,
+          "duration_minutes": 2880,
+          "start_epoch": 1728482400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-09-24T16:05:19Z"
+    "last-modified": "2024-10-08T20:38:30Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240825.3.0",
+      "version": "40.20240906.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240906.3.0",
+      "version": "40.20240920.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1727197200,
+          "duration_minutes": 2880,
+          "start_epoch": 1728482400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-09-24T16:05:21Z"
+    "last-modified": "2024-10-08T20:38:32Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20240906.2.0",
+      "version": "40.20240920.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20240920.2.0",
+      "version": "40.20241006.2.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1727197200,
+          "duration_minutes": 2880,
+          "start_epoch": 1728482400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).