### PR TITLE
Upgrade release note to notify users of cgroup v1 no longer working

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -25,6 +25,8 @@ releases:
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1641"
       - text: "Complete composefs integration in Fedora CoreOS"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1718"
+      - text: "systemd v256: nodes utilizing cgroups v1 will fail to boot"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1715#issuecomment-2331986149"
   40.20240906.1.0:
     issues:
       - text: "New Package Request: pciutils"


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/1714#issuecomment-2426654196

Propose a release note notifying users that cgroup v1 will no longer boot by default due to systemd 256.