### PR TITLE
Roll out stable 40.20241006.3.0, testing 40.20241019.2.0, next 41.20241020.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-10-08T20:38:33Z",
+        "last-modified": "2024-10-22T15:52:40Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a68440de6bf8b995595ac17289d5d08679bb342103f96aaef575f7849a7b4921",
-                                "uncompressed-sha256": "1932c9dd4839b3983d4a6e4386566f740b9bee60f6facbe74b492bd14859bade"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "50bba7a27798549442901c3089c7049a79051d88d97488188322508e966bf28c",
+                                "uncompressed-sha256": "a644431a305d4bfa75bc4f257d2b3010ce90cfeef21d7a85055efd1eb4d3b9eb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3862d5a34f8877b6bd80aa701393446a445799d72a20edc60bfc4092c264fd90",
-                                "uncompressed-sha256": "2c9cf917acf03cecc669a21395243798fe8baec8702875b12be7ffeb1835be54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4cc3ede220f35410d95fe016b707f3b4d1b572f14a35210f6a45910e6e9079bf",
+                                "uncompressed-sha256": "54af4ce35d25d3a8c73bdc79548b0e354bfc2f1eb76bd3a1e0b58f4653ac051b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "73340865f74939fcdbcce80dbb580074c5907dcd1db65b48f4e93d7c907f9a2b",
-                                "uncompressed-sha256": "d7310c013963a23a94a47357004d8aed10b13bbd3c06703826affb03822afc04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c8d5f107ae115f841b2dec3954a9b8fa34470e6b5004f9c062811ac603aaeea6",
+                                "uncompressed-sha256": "d80edb619c9290066e6154a92a7595e2aa4e4addd19e583993b1c590de254814"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "784ee7ea51b2b9664b2450dbac059a01580bcd9b1045336e79202fd511dcef6b",
-                                "uncompressed-sha256": "a409d4a3ef2236dbfd4c178f48a271116f80fabb24374c2a0f57fef078edec2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "9ecb9c485698f8c20ee94d4d175f4fb055034a0e1a249d848b0d6fb2625b58b4",
+                                "uncompressed-sha256": "071274a348196a1388f81fa67b45056a34fa96aff29f6958a86a09d44da0b3df"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "6a112e3bdf04e4d696d7888ae0882ee94a8a00a3ccb3777f372453acda10e3b2",
-                                "uncompressed-sha256": "d40538ca57d656cbb52365a66d614f81265cb1e1d86be670c9074a11428e475e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1899863144d52728d3fe6fef9867406ee0b52d48b5cddb94c7c36898954408fb",
+                                "uncompressed-sha256": "0302a7092e9ea51739f49ed872b67ae4a31f532c5c9e20c0a3d56a816cb76e60"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "678f5cb573ebe86d2073dc3c62b8e392f6626df7847997642b7d631f4ee155ca",
-                                "uncompressed-sha256": "b97e1e4d34f63b6b6a263ea43b216bb8bc7a45dcd49672b208778f701937ddd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1e0c7e5609e543ab16fd920da4cec16117132c9529a121e7aa8b3fbefd8f2035",
+                                "uncompressed-sha256": "9bd9cccb4ce0f9ed1f9e61dbf828c5a84b55a1d1147d5803c01af0c87a2367e0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live.aarch64.iso.sig",
-                                "sha256": "51515a944c6d25eeb756229f9b9133c058b74975ddb354b63f9e63e42baee20d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live.aarch64.iso.sig",
+                                "sha256": "6f30ca5b19fdd3c51f5277c86c82997bfcdca285c381225f9afd3aff4207822a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-kernel-aarch64.sig",
-                                "sha256": "a1fd115e04bd3a61558501db9690b02c911f8b258c8f25c8cddbd513edd4fc93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live-kernel-aarch64.sig",
+                                "sha256": "87da2117a71ad090bf1aba13ef86915f9f7b058b238533c437613ae23e1e38bb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "a7760c20e90bfd787e6d597279e061af8ed6b5cff5a9dbdc130e1c7101240753"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "76fb1f5edb4f032f44fd909bc15302f75303c8dd18efcfd44d071eb3ac5aa199"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "fa24bd4af79c4c15af8cae6c3b0f0a5528f5fd4be4974382da97322d284446fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "49635c5f65895d71f97d0f21dbf78e60cf80eb3838eeecfa60637094e06cd34d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "981ea6ac0d7f57d2d019c06d5668c73aeeb5dd4203d94870e47e8e166fc45c09",
-                                "uncompressed-sha256": "a7e66f3a270c89f4efd76419af40f9675875a561c3818b2fedd6d9dac46a7f9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "06501697f3636682b53226783e2dfd8a4efed50d633a46dcb0d1be00ddd0d983",
+                                "uncompressed-sha256": "3a828de8c60141ba1c715bbe9d0c25ca4e017b689d3a09f273305ba91531b520"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7ff8312aefe30c859c184de36ba302aaa920462ed6656f7e65dee51f323faf4f",
-                                "uncompressed-sha256": "8fad7fe0dcf2719eacb84d90f338cee577d43ac3b45ea78c30586a8d05288178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "924b13691a64d8b66c90b289b6070b56c6b71c1c118efeb03aad19072d7e55a6",
+                                "uncompressed-sha256": "0b347b2cf75542c28e2c960191b7ca7b129a6419f3c7fb2840867ad100799cee"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/aarch64/fedora-coreos-41.20241006.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "fe15ce4faf978acfb73603c1bbb4fc19ae13bd1f44dfaf37ad45a789fcda6257",
-                                "uncompressed-sha256": "4475ef478b1c86f53c8cbc254add882d3d38c5cb4212c3ac3a8902025659c898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/aarch64/fedora-coreos-41.20241020.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1a80b76267a1b900198be3834f734cde7521998f5e66465445a77e57e8078ab0",
+                                "uncompressed-sha256": "ef4701bb80b5ca3e3c004edae382ced4df7fc14f83113b7d15591259816d4903"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0ca26f40f5156a8cf"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0faf22e16bc15b1dd"
                         },
                         "ap-east-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0de9145b87e7cfae3"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0c958bd6a27f8bb28"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0e42ef91c81651762"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0eba5d0668cf8ef8f"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-095da381937b587c9"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0c856371f33ce3422"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-089b1c1cc899acba1"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0facae71690e9dacc"
                         },
                         "ap-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-04e5875a886d0423c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0bd6ab5cc899b145d"
                         },
                         "ap-south-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0894ef0535f638898"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0108917668c68090e"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-09f30bea3a6d14b7b"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-06fa9ba90b2dfbef7"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-05c5b48239b688201"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-023cbfa980035305f"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0f78cf7423c94ad79"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-00756362a7523bf31"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0cafc328562ef28ad"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0c0942b07f58d6fb3"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-027f6a7e6e31caebb"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0103bbe5f5e0ffbbd"
                         },
                         "ca-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-04dbb41bca7478ad2"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-09ebfd0e0b66dd70b"
                         },
                         "ca-west-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0aecf7ea087d84634"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-00384acb8562be7e8"
                         },
                         "eu-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0bb250b7f2a44624c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0251a7768c3da3d3e"
                         },
                         "eu-central-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0a3a8fc383df0d37a"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0e2b531610b10a543"
                         },
                         "eu-north-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-057ce7c9aaace517c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-00566df647d6bcdb1"
                         },
                         "eu-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-026c8a8684894e58c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-069cbafdbfbff9ee1"
                         },
                         "eu-south-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-079e3558658205b35"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-059e12e5fc362d006"
                         },
                         "eu-west-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0034ca2e6348b6019"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0ed8ba6bd4a5d41ca"
                         },
                         "eu-west-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0c566768f9bfebd09"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-02582e4a1ec5e2d3a"
                         },
                         "eu-west-3": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-020de50ea04310bf6"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0803c5e977962137f"
                         },
                         "il-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0a006f9d20b25c8b3"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-081bcba87414ce81a"
                         },
                         "me-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-07d2c486a6c882c16"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0570e25ab14deeb08"
                         },
                         "me-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0f64b3a6c8b093881"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0bfc2c24236517d8c"
                         },
                         "sa-east-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-020471ac9ac58d136"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-07fcc4d13983b8591"
                         },
                         "us-east-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0ebecd3e50edc4e9a"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0c8baf78b4b622c06"
                         },
                         "us-east-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-07dcd318dfec328cd"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-00b386a45e2032bc3"
                         },
                         "us-west-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0c306626e82cfe2f0"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0f53fbdddac962629"
                         },
                         "us-west-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-08d8c479ff77f9900"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-01a9b5f0d68ab9ba7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20241006-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241020-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f062c4f626e36e6fcdb93cdd0cae491cc273c0af962872da53487636ce7438c9",
-                                "uncompressed-sha256": "7d5b9861544f0c34c19f7b5b33253dad3859f5874a1243d4edf6824468a1c0bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "d0d7fbe44f9e31710d48ca11a31bcd6beefd5c575dee6473b07f779ad267a60c",
+                                "uncompressed-sha256": "34a38124deb1b5f132a887e24ce5647b7cbc7232f5bd0a72bed329bd81e2ee4f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live.ppc64le.iso.sig",
-                                "sha256": "394e62ec521da6b33cfab12d602c9e1dac1f07e0b96f8912fea7e6c49c4e1a07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live.ppc64le.iso.sig",
+                                "sha256": "b21919de8a054121a231bf5827dbc045c0aa7f5fe6e83c3bc4725919608fc4ef"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "87b07e8411aa19f076b00e957940878e052fcf40859de0d741e99e8d78afa85d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "5f3a276d35af566572fe82361a095f6ec25d27b1c7d97eb94576f0f3c2828791"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "79ee13f0b800ed433761ea6adb27d93b6873fe27dc63dc9acb574f9033685962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c275bcc31cc0c0a8b296d962485a0961d9210a22f9f36f5e3bda8776450be615"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "376f2b9d9114789d4893dd5ac62509fb80276079fd3c6530d9102d795fa5b01e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "befc1891a1d6e1bca68197fe4ccbb1e37f29f79aa39292c5f196db5d70688cc1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "36f85349b396aab64dba46b7442b4d0fdeb81ebb429d03f3dcab2999e2b59607",
-                                "uncompressed-sha256": "6a8b6003a663ca2e0762df814e914faae3e25f02e2ce6a32c2d244b9e8cd0dd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "299c7a6302bb51f5992645b3d5da5be48d3d4fe6f7e2abe3e2f24c04abb22960",
+                                "uncompressed-sha256": "018a00e31159f790c07231599ccc318bed488179ae0c30eb12c73ab3a26eaf5e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "4fdfec52becc74cf27363b081b6fcac2990650cc3b6b2a195bc92f3b637a6127",
-                                "uncompressed-sha256": "bdeadf6909b68121577566f398b6f41e61d94540cb4d9910d48b8e267cc7ac9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "06375158caeec88616c26a82be8189d63841dd021e65a173aca8b600be7893bd",
+                                "uncompressed-sha256": "99abb1bd69f85cfe1ba937d7aac044cdc25ecc0d23d2d66fc0a7c38e62f5438e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "de451dfffe91affdad8d55e414096e727be81064fb5d3d7b18921d69e7a2ab51",
-                                "uncompressed-sha256": "0805e3c8fd2b4ac338addae49fc432a6bc565e888c36e02850e64df015eaf83d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ab10e1825d905eef382fb385be87ce516c013bb1c36b60038aa0d795b2686319",
+                                "uncompressed-sha256": "0dc173a9c9c3b15b906ef61a57edf3e903c9fc6de2b1c7ac5ea4a2af842d8ec3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/ppc64le/fedora-coreos-41.20241006.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9a3dfe19f831375e3a4b646dc9fc272e2f80df2f55a32016e75ebaa141fe4011",
-                                "uncompressed-sha256": "3ff08f79c1273089437d2787374fa4b5f9a979e7312bc8cb91391337a43ede14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/ppc64le/fedora-coreos-41.20241020.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4ab98fedccbc692d217f290157996ae2a4cd1ba702816458d22565d7f96a1aad",
+                                "uncompressed-sha256": "1f30391f7b0362399b500c584d1bcf83781fb3a3b0e5461c29f994077e1beb9c"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "05076170df8ba2114d61ae7b503f4dabb670ac4726830c922876f8262fa8c29a",
-                                "uncompressed-sha256": "8ca31456731422576b99dc1121bbfa5cb17ab602e80688ee83016b9777d239cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "637b814b57bcda5dabfb8722f863ae63dbf265d8ec45c3e4db30775e5dde6e8f",
+                                "uncompressed-sha256": "16274391030f3a43d449b8e783d6a8dec7bc548653afef406d59d052d9577083"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8583481bd4b24267ea7fd76ed0e11ee5093bd207eeaa460bec40543d46f32e39",
-                                "uncompressed-sha256": "899446bf7b56e6822a62b1862dbe3613ef7bf5c0ede204584fec824c5f3326ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ff942cdc44734021c8b65051ed0ae509dbb3f310c52ec9e09a53f72b979fb933",
+                                "uncompressed-sha256": "5b5a4f95b6f457912eb91a96a59af38c8c2da42e950f5384ebf13cdaab165bcb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live.s390x.iso.sig",
-                                "sha256": "109128dae18185deee5b6891e915821ec18885ff2e43e27241cda83a29186898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live.s390x.iso.sig",
+                                "sha256": "de06ea05a673a4934a4196aebf6224beabc993ab78a93b1d7ce8611d34b3cd6e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-kernel-s390x.sig",
-                                "sha256": "5c7b64eb7a1722a2524ed68f93f97de1a060e35ac1a6cb705bda1ebdf99545a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live-kernel-s390x.sig",
+                                "sha256": "3f55e94864afeb9a99ca2d5c8cac8fdf917500b6e7346ac7da7c7712b2f9ead4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "f6b42402ae5f22956ef2bf8d8bd67d2c89c9d6c9eb10efcb8d7d61578e602f0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "2f9d3ff948254e5c68ffcf136f0a63bf9f5f08186d02215525a570b1e5fce25f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "b36da1a84f1f0c1cd0d456091b04eaa59d1c71b3c23b8f289a61cd6efe3f312a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "beef0c6471ff1cfc3e28a00afe21057206cb5ac505c63f19d94e0edf46c17ba4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "26d2ed383474ebf2f568304827ab91839457a07349d56cb4948e800692177098",
-                                "uncompressed-sha256": "0a440749b92c67ac7439eaeab39003ae8f703b02deb0d3354edeca355a465752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "bcc45d96354f5fcba541fad22502f693530eefb9032cd4c95b2dfd1d4ebd6e34",
+                                "uncompressed-sha256": "be82169f92d23328509aef735af4510dc529b55d52484b5b2b76774cfdba95be"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "95becbc02ed7a614b55f1e78ba9e500f8c06fcc51ce7bbc9781bc9abd31df79e",
-                                "uncompressed-sha256": "c550ca5c4fbef50e0232df458db4f7f403d8d91ddc17370caa1bd450bb5a86ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "83d431da88ef64f036cbe1551c4df3af67ed816e2df17dbc1ea926592e2d5324",
+                                "uncompressed-sha256": "fdf723229be60a198b2e38e7928ddc8241ac07ac120e0dd0934e9c1a811ed71a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/s390x/fedora-coreos-41.20241006.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "da4ef7eb29d4e28cb8d8d62b8bfceb7e5170c2bfce5e3775da366b5e982dd2e7",
-                                "uncompressed-sha256": "9d475158b9b2e737c5776bd4fffb0b372cf43ced91aa752ec592f7980a05cca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/s390x/fedora-coreos-41.20241020.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "fd863e8d4d334d7025d6c1a94adffcd3069ce67e3362fe1006a17e08e144ffc5",
+                                "uncompressed-sha256": "19c04500a8ea3d12ced937603e38f0dc98c402a9b4e62134a9e22adef2285613"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "178f6773fb677d5fc2445ae624e8a9949b7ae0220ad39e7d4f9290271ca73d80",
-                                "uncompressed-sha256": "8d249e8f8f5d80fad13488a4cce60f5d076cca5145174387af549d9084764450"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "136fd4e752c9ff1e3f479672f926327d5987179d55f3bbbb37c0392e0a0a6f63",
+                                "uncompressed-sha256": "c77c95b4ea605e1915d793c0516c0ec9769ad7482bbacc6cfd77fde31d5b97f6"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3a24a7bbe6679615569db350a1353fabcf98e420afd33e04aab973ad996f4f4d",
-                                "uncompressed-sha256": "04b4dc57524fc42e6ef0a0289f48a167d80a8643bc52fa74733e7b21996623b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "eefe98cc8ed1313939e99b740dbe2c96991da0d41a4b1bbf6f6407faa30c39a9",
+                                "uncompressed-sha256": "3c10d124d593aae3d6932acb87d0fb825c5625ed3a6cb4044c6d5b58f2094a11"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a2df4bbfe0b4c2e5d9ee8c0ecf43be6353b3b5ec5100d0a7c82b2e0103971bb3",
-                                "uncompressed-sha256": "6381d3e744b83316f338f2300f06de0d8b9ed5eebf81c2c91bf228f131f28f67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9951d47fbd42add0db8212639c6bcc353dd51199f8270e76cc95b74b82fa54a2",
+                                "uncompressed-sha256": "c93173a0a8bfdd18ee64daf317ce254a81a6c865a7595ee398500b861ca47ae6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "27b698999fb154d6fbe6fd6a88ee9895800da521d1d68c8432ba8758f19b0cb2",
-                                "uncompressed-sha256": "be4710ef03de14723a256d914131190407061f390ff13ae23c2c9c009b9fb786"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5bda6be798117c9253487ed700f756791599ebbcafc7dfb223e01261221f38f8",
+                                "uncompressed-sha256": "a77a60189f3ed35848b0390c22ae49444f121389ef13a7019b90bc4ebc9ccffc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0c81ee932ba32d92016f3f84fcd028651b92b824931153cb1c253e836f5db80a",
-                                "uncompressed-sha256": "0d8e9659d8328d911d92239feca6000d617d4d9c44cc14b67c0cb09df9d89caa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f9fa75bee498d4a571977559a787a1b192bfe1f782ca3e1b3d1eb280fac2c231",
+                                "uncompressed-sha256": "80fe8e10dd7ede53a93b18d9bf6426fabb81e11c288baa2915fe8965510c2d5f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bafadd14290cf7795dc1ce6e0d2d10a5d1f0871e51385d438a501568a042b579",
-                                "uncompressed-sha256": "7be6a4872ceccaebd180fc78d9226201a10eb92ba881fc4af21c70ec6793ae88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2ba8fb188600188066ed41c5fda3ba9daf259daf789c29f562c7619463be60ed",
+                                "uncompressed-sha256": "3b4fa24036c817b0aea9ae3cb8864a9b57c29312e06e75f40a40809e08895972"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f24a5e4c1c3fd4dde51584781367602b0952d1ed4cc6f8c7e8aa2ff6192f2559",
-                                "uncompressed-sha256": "dda72d6413c786822b223afae7cae3a2153ff904d60a752a6d0473ffb7266de8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "9cd6e3efc1c5df785f41b9013ec9462ba1a6360439ce50a24bbc043fdbefa2ee",
+                                "uncompressed-sha256": "41ef023dd99b4a34e1e1cee04ade7b3ef648348183e028e2026c711fb2525ee2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7299eb118b8c5891d6cb9f6b89c7a9d2b19ce5d5dc7be5f5a05404b2e791f393",
-                                "uncompressed-sha256": "6094f7e344d362e0d462ba942f3c78dfce7e1965439c2b82f8c2f66de0ba8992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "24c44fdcee5b31b333733e915861b8407bc0832870ef1a837b97229043c41991",
+                                "uncompressed-sha256": "9326824ff2b9e60ce3865355267089803108fd0df41f59aa84dc2dc35aa8e4e6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "a0b3add4df0ce19a475dea1c78c469787eda764cda33cc0465739ef6ea7918cd",
-                                "uncompressed-sha256": "b065d19eef7da69f9e63d1522622a5ce0c834657a2df412957d7c6ccebdab485"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6b91f6e4ecf1bd59c130a3f6217a5ed5256df08b715dc39181cd22a3c12ef85e",
+                                "uncompressed-sha256": "c649c3445f4feceb61a26fd81d9a18ec872a5e2cc88206baa59404dee137d4cf"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0b0bffeceda63db714d9d5179a44a2f94c95e101eda1baf8ebbcb6a9c2e29caa",
-                                "uncompressed-sha256": "4d30a2a5b2190510639289c41bb7d57dc0b69eb1dcb3605292f5c8015dd69ce7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "28ddd4b8b40d61bc9a9c74e84024ea56f6e0a4f4e4b8fc7e10c4673fbdb23608",
+                                "uncompressed-sha256": "856cc755c776a52193ce86ef8753d3348ed96774bf2ffc865fa0b8df110e5981"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "95d7a7826c9446af029280797ef399f4dc588b6d53394e3be2bfddfe34ba62cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "1286f230ad338490ee026283b2d315f8769dbc5707bbd79affab71f19fc9ef8e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ef61a0e8ee4b48d6b1b7bf4cc37b8eb5feb9fab470f3639e966467efca7216a7",
-                                "uncompressed-sha256": "a7d7be8d7885c7551057f5fd9274fa50f39b5378ee3bb03d043f29f475248ca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "128f8300f21b06436556001766f50ab6c4feb8a81d24a15d0c809c1ae7e567d8",
+                                "uncompressed-sha256": "2402b1f9c2d585ac36757316d90aaefb63f3abf16aacf2e7962f5cad7b243a48"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live.x86_64.iso.sig",
-                                "sha256": "39c8e86aefd40d2a3e0f5c4b5d2344ff40497384e603e3f749bdabfa9173dd77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live.x86_64.iso.sig",
+                                "sha256": "801588679dda33fbaa35c0fecb39a06e2e8db5a07a1d555e895d217aba15452f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-kernel-x86_64.sig",
-                                "sha256": "934843069bf87177967fce88d639065274aed6f533274ba4f8fc40639e64dc98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live-kernel-x86_64.sig",
+                                "sha256": "86d10893be4557256ea45c93d3a579bece585c6d9608fb7765ac61718f067d63"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "82436682e554b46a43e7e7add3908e6bca77f0e8a0f1361e06b0895c3b64906d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "dc5d03ab31ac10215673ba6cd2f8c8aa821a58474cf7370b56295d843d0fddaa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "cd890971e6ccd9e1d55207eabf699a91faacf65deacfa893ea52acfa94b6c14e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7cd4d03559eecd46e9253e0ccb702729a2393484232aa2a6882eadd315a34b83"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d7408ee7e39bc1f1c97aedc16816a6a32638753298e8dc62a4a52ecc63526b6a",
-                                "uncompressed-sha256": "e6fa61b187a6c09256e792df75c85e70c8c5685f3d6acfec5ecbd0f0c1c61820"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8177eef3fa8c79eb65498149b544df5fa31c0309e39e72f26ffe5d96874ccad2",
+                                "uncompressed-sha256": "c50012432730ca0fb84851d1cb180951c76568bfd6e23d7ac80c7a5ffd22ff8b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "80c046b9c1546ace6539dc5c628fc9bdf8a0712066c1aee6aea813294c61afcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4043e64c2a3302d7f835a9ba727baa112a3150cee499c8e9477651ce5832d45a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e0c0fe0b7acd965bcc3a7f7ed32e085b0dc0e83e7fc691fd3d80cdc80def862c",
-                                "uncompressed-sha256": "c0fa5822103c15e2ea0777bda365f477ee0cb9955c6af704db6a022131bb186d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bc4c0bb0ada2d1ff58bc830ac5f43664ad7fd37e5566656ac0a88c6a7bac5c50",
+                                "uncompressed-sha256": "49ba2331ee8fc99076be2e21c5cb5eaeba17a56be3799f44b035f7796e803d55"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0a90ae8a1034639924ff971048c0c4059a909271057be33aa941f98d8c5c0b05",
-                                "uncompressed-sha256": "31c8fb34dc69e562ea3e32018ab7f6caa596f0550bc6c92efde5b0ecd7bcec9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6fff18d5673051daf883ad24bd123c7c4cc9a434a6f6aabbd1d85957b73ca711",
+                                "uncompressed-sha256": "150d4aa619bf5f4a1bfaf4c3f1b4d7d37c26520fc40ca9a4576b7ecd314be571"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "f1069afeecc22ce00425ff85191c1735a50a6f46d7c96a7e6d2ed7d7a1440b80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "08edf6592cb6821abf7e78d0374fae345a9688a22f8263460b30ab10b60c5872"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "5ebd2334e77f744585100ebda7a2f1ddf0d9af7c899e96436444753713e61b87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "3e50030c7e9e401025057862a56871661168b39eaf36c00366f9488681e6a1ca"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241006.1.1/x86_64/fedora-coreos-41.20241006.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "abfbacfb6706f3b6adf4277f25a9c41a15b01bc09b905a6de72c2e76d479e56d",
-                                "uncompressed-sha256": "4d056eedab9e4352bb677f08cffcd5c1c65b35d815b94c9c261318f0ffbe9c4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241020.1.0/x86_64/fedora-coreos-41.20241020.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9cf62223a877cf50fd3ff0290f525c7f35391550cb35ff0e317e331c97c4f47e",
+                                "uncompressed-sha256": "738a4a6f9a5e0a8a6f2b4186889cdf04a42261e6be0265bb057794cb96d2fc66"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-06a79b8111ae0e08f"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0a78b843c338f3f57"
                         },
                         "ap-east-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-07d1bf9fae5ff9625"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0af84e7a13145e62b"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-037980ac5f9f28169"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0ac63911eaef9601c"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-03234cb01ecfe972c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0a2ee0f419cf57dee"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-01613a219fd9e585d"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0b03871cb882e188c"
                         },
                         "ap-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0e7a897394afc7241"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0a74e334b2a7dfbab"
                         },
                         "ap-south-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-04bb6392f25ac8121"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-08f9e27c45fa67c85"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-025aa9c94aca91e8a"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-00d9c9b8e0504399f"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0ebaadc03cf1cf21c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-05703968cdea7baac"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-03ab9fa6a47991464"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-064e48f9b2eb103f0"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0d30582c1ac3d5a79"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-025e178bc397527c6"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0998f4642075e833f"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0780a6ff9a2665fe0"
                         },
                         "ca-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0c76184bfd5bf1272"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0ec492ea6a3b21634"
                         },
                         "ca-west-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-013c00fee12db9427"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-005d53fc5b84172e6"
                         },
                         "eu-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0033b1d26ddff446d"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0093a6da8de87aad9"
                         },
                         "eu-central-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-03b3c39243227a501"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-02ba8787f60eddb0b"
                         },
                         "eu-north-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0d539eaf80a1db4c5"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-073b69e6970a11bb8"
                         },
                         "eu-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0f144a81dbce8a7ec"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-013fbc571fb96cebf"
                         },
                         "eu-south-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-07ea9daa7ed361964"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-093e52ac803ba0703"
                         },
                         "eu-west-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0e707e462f537b7ab"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-005c26bc014e72eaf"
                         },
                         "eu-west-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-015e0612bd866c1df"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-07b83296006a407c2"
                         },
                         "eu-west-3": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0afc91b8711421d02"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0cbaf2a8c1055c4e7"
                         },
                         "il-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-09fede9c7c5be7f0c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-08e051cca760cc329"
                         },
                         "me-central-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-092202a7d23f424a0"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0147fdc5d9b820399"
                         },
                         "me-south-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-03bc9ff3b77b6e506"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0fbbef67c2a240ad3"
                         },
                         "sa-east-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-01847403fa7a7e878"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0ab89aa067033a08c"
                         },
                         "us-east-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-072300fdb4465173c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0a3bfcaeb9ae3ce6b"
                         },
                         "us-east-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-047c62664167b6d53"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0030f09a14fb617d4"
                         },
                         "us-west-1": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0fc68f2581e14afb2"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-0a66dfb5b118dce82"
                         },
                         "us-west-2": {
-                            "release": "41.20241006.1.1",
-                            "image": "ami-0baf14657f8c0990c"
+                            "release": "41.20241020.1.0",
+                            "image": "ami-042b568a11d43ac5c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20241006-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241020-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241006.1.1",
+                    "release": "41.20241020.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8884b8a173b85cf0e748221fd29f73a2e96d567a06b7146a1f3728d267f87d5e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:defafa34db0f3867a853ff42c6faf55c13391f6a660b9a1692e34a307542e05c"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-10-08T20:38:29Z",
+        "last-modified": "2024-10-22T15:52:38Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "6451aedfa665c2e41864201d3cfcde35fe86a69db174f91d56e150ef0e3cb533",
-                                "uncompressed-sha256": "d60edc289f167c92ecfca937f8976034b0b3f505e8250a9f24f51ea7bf35f41a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "736a102035eb400090e9e3740a4259462058a3a94f1bed6e411b38cfc87f395e",
+                                "uncompressed-sha256": "e6967351a1da2b7520ea3e6d8f0a8f9bb96848ebd866c6ca1b22d155484e25c6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a181c0d55e78a03baa159d732d299323785c9e3aab8b52ff9b7eca6b8d45e1e6",
-                                "uncompressed-sha256": "7f668e7791bff73308f645b55006a577713af1cade9c35311568e4f5ebb098cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ed4515fe80a2afa305dd2fa371dc671dd46efa11ecb4e002ed28b7fe8e047b69",
+                                "uncompressed-sha256": "49f21e23cdcc32dfbcae02cc8ffb70724497101df789c0e5aceb54ae290865a1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "12fccd69e33a26e2a65a60e0a741767e47a68cd098bb1b0120fcacff05fa1f94",
-                                "uncompressed-sha256": "26e1848c07032f1d9ffc6744c63c1e5962eb5e9adf3afb2263a8fa47f4ef8e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a77182bb99f0148ea1f87e6dd7b240e0d948dd6f3c7ae196522b68e41b57fba1",
+                                "uncompressed-sha256": "2a484b3ab342faa2928a89bc7dcb9911c83213d6dafe2c8a4bea0425494f02ec"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a790b04b0f174348196d2e7676b6c5360ce8a0b470e3b3d8c2eae27f9cc6eb3e",
-                                "uncompressed-sha256": "fe7545c2bad5032c6afb70473d525d544e06510ca3eb62e3a9aaed770c323906"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3e5fbe44b1e2240e6af4b6238e71b86941bbed85f4d852fdd735dee1d65cc52d",
+                                "uncompressed-sha256": "2e2c4f72e73f290268e7a332e9979f9f1bba964cc25df80ccc0bdc882bf175ce"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "5131da22a2d78710872e824fce97cd39d49fc159aa1180e8a44553f5eac884ca",
-                                "uncompressed-sha256": "df5b8ec0d22f11cc96a738793d63092d88d26bf74dd88289eb6d73f722872701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "f1ae441a91266cbef06c1ac0953c688bcbcefe2037e5e3c9765ec93b899f9ffa",
+                                "uncompressed-sha256": "02aea640fbf02860dea024e25efc05030fd8b62c0f957b2e05695fe8b16cf8b9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ba417130e58ec931d43880cdc3a5291079587fa3c1a5f9aa2ec7220231279826",
-                                "uncompressed-sha256": "6693837eed4f69bc5510138866e56924ca24069ecda7ec5127f218335fac99e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c2af6bb592cb5f8f909f0cad34e3573a2d97b1665a0af570b578a17cff06fd3b",
+                                "uncompressed-sha256": "59f0af9d19b6bc68f69e4591875e8abb51a75cf7a2286ac3201eae87e846a734"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live.aarch64.iso.sig",
-                                "sha256": "fe6095e80b3b243fd0fceccb2957c608318a4d93726480f0bfe98e6da88876f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live.aarch64.iso.sig",
+                                "sha256": "0c347bf796a24d90d5b46767d048affba608c9822d087408fefab215b4fa4546"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-kernel-aarch64.sig",
-                                "sha256": "cba8ea5453c6dd2669ac9ae8c935e47bf5680a76bff0a4242fc6bd42f2479588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-kernel-aarch64.sig",
+                                "sha256": "838dd6346c11f890fa63f4e9465cae414932f5cabb65d78a3d3f8d6c05c716dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "5956e493448e5660f1539b7930fa4f56a6cbb0675cc57f0f296075fed6a4ea23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1df6f29d1ed9924a5a29c54185548132b8c587b60a9f237d971d3f5b2fbd0d74"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d43d36830b35a17003315c404a416e9b1578759f3346911bd53b81a003db6548"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a3d28e71ed7c45585af81ebb8969930606df04018e6e273faad017b0c51b93a7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3252c54b15d57d19b96f6ef66e560bc98f7c1d89fd3331428d5060fcacc59a59",
-                                "uncompressed-sha256": "9db2347b3f09d6a84966b9d3f8507d9c1cd397c987b7580e999ebf7e64377250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "bf1003de0b462cdab517727fbc27ce47a5979f1005a1b9231563b5f8fdc3e34d",
+                                "uncompressed-sha256": "8c276f9d0a016170813e4bfb6fbb7e6952fd8cb1c30b687942f750fe024e163e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1e845bff25e959e2236cc583bce069a5d7904b03e0a53b67613720e068ffea9c",
-                                "uncompressed-sha256": "0415a5715a1af0994ad3d52c783e9062a0d2d7dd09d9abcec1c1089fe915e610"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "20d7e2c94960805a9c57f4223e3ac2bc06b14adfd49b1db7ed9da30ab26f33a0",
+                                "uncompressed-sha256": "a361060f7091f1d8fc3d7c9cb12996dc071e03f73c3cc390d838a06d8573ab8d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/aarch64/fedora-coreos-40.20240920.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "eed10ffd7fe4784e7af4d5d4d32719f5b659c6491fa34c4c68ed5f14d2fd5cc0",
-                                "uncompressed-sha256": "350cc092254b32f62a13442fe0595a94db65c17e3683e18f68605eaff9dbf69f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "edce3175df5a1a89564db5428b7127877c699062b0d7c1763310f2deeaa38f76",
+                                "uncompressed-sha256": "26effc869bdba42c0088590190fdad9bf478887f60503c8fde1c6ecc54d95519"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0c3af71038efa6277"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-03c5b0aed382255c2"
                         },
                         "ap-east-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0af156bc942013e8e"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0f12d75ed096821fb"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0279b554742ec2a24"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-018cda2526cc78e9a"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-099d9210c99627420"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-03f2b30b4055bdef4"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-05c98eed303e300b8"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-02770c3d0c4dfbbf9"
                         },
                         "ap-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0e6dc5ce6be10575f"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0ca1f000ffd398889"
                         },
                         "ap-south-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0ebc7c4f3e3f35e86"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-01ecf04bfb6872900"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-08409899c9b1af387"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0a3024ecd6c728ecb"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-098926f4a964eb512"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-00da4412599e8a9c4"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0e63c9ac1c90bbef5"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-090a554735fa4817f"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-00c3659a9687ee1a2"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0b93e5c3aad4febbb"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-07f5311f1e063fbf1"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-043f5253074220aca"
                         },
                         "ca-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-037d19a1f2702bff9"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-07856c6b31f77c510"
                         },
                         "ca-west-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0085189badcbe3a86"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-000f50987a4897dab"
                         },
                         "eu-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-021235e0d65401f56"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-077e860b4ac6416ff"
                         },
                         "eu-central-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-03c98d7536cce0134"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-01dbf442e9a0eadee"
                         },
                         "eu-north-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0808606317ad473b9"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-027d5cdc1ee969446"
                         },
                         "eu-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-04e5ed993f3430ae6"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0ca7256c62bdded66"
                         },
                         "eu-south-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0940200bc0b7f5bbd"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0febc192757e45009"
                         },
                         "eu-west-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0d02758f3e5e9fffc"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0ab3da251a289c713"
                         },
                         "eu-west-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-09bc7d48073ab2e02"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-03cb4e455922b96ea"
                         },
                         "eu-west-3": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0d7d7a2bb36270407"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-00746c9f08e785620"
                         },
                         "il-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-070a8f095ec627dc8"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-040f0d86385fe5948"
                         },
                         "me-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-01bd9494973abbf34"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0a669356e3f1b726b"
                         },
                         "me-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0ca12cd19632463f2"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0fe913429266b3290"
                         },
                         "sa-east-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0a2d776b045795c20"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0848edf99f9601e50"
                         },
                         "us-east-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-038124e8fae000d51"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0ce2bbe93e90dfa0e"
                         },
                         "us-east-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0cc52afb05e9617ef"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-02b2a157442b83c43"
                         },
                         "us-west-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0cc8ab168ab5ae4d6"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0670547fdc38e8cd8"
                         },
                         "us-west-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0f24c8f6a99a74bea"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0a6f2bc110b300370"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20240920-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20241006-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "07e1aaa1e6905f005f5b580f5085ddc9708046088172de2631f653c7b3436ae3",
-                                "uncompressed-sha256": "c110e35cefc6ef2a68d49502d6edbbe2d3bad12dbcb3283b1fabf80162030e76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b15ed82eb823ca3bdb8fcace76056005c0e305e349daa247629077fca71d0d55",
+                                "uncompressed-sha256": "a4b5ea81daca253b69c2852ac50ec549366ae61d2d16c65cd7b39cde6d53ded5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live.ppc64le.iso.sig",
-                                "sha256": "cf39a8e51e91813d44579f8a007992bc717a3326c37e6153014d65434a53e68a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live.ppc64le.iso.sig",
+                                "sha256": "d4ed456761548574cbb6f023df3e268c864f516f6615e94d9ae6a43c4ebe4ace"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "d46ee1013aaaf5ae268dec58b8ccf27d1691db19a770c5ace38f1ea9b6fc3244"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "461a1ad51bd0749c2c8792f8f8de14843b53be357ecfdf1ead4f1e8ce6ecbe53"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "3091ea593b5e805d4e0d3a884e2fcb5c9a799aaa0190d7ee21f0a2599db71ada"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "62b99f86b2def475f04f25d03bcfccc7eb6b1220e5d1665f700beae33b63a978"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "89ad28ed1ae94894c5ac6dd59dfd9bcf84778c5574bb174b7ceb2a60e5d148a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "dfc8ace662f218b3c4beb18a61414d55bbf300604e81bd2ab3d7f661986b79bd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "cfb097a3af4eaa50483896f92068117d160eaac71514972636f34f2f62f38b81",
-                                "uncompressed-sha256": "89184045eb92c353ba970f571e974e89178d9a5c7ac5281f5cec9a02b6d21edc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a1f2f133ed316b8b3f79e830a87800e7dcaff8d96a9596908b1cd1aa3b3c755f",
+                                "uncompressed-sha256": "fa22430da5cf21e86c232f9fd5c5e22987ee8f33b6cacaaea3c64a51420c0c24"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1a9f41e4516beca81efdee524858057d73d3be0777d9697fb7816366b59a37b8",
-                                "uncompressed-sha256": "768f1243a2c4a932aab9f1645a0a418e179b1a4af59ac8e082dbeb3120f1e514"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "5a941b5ea720003e1246fcf5eaec3c0aa41319dd5f98763307febaa32f0b5926",
+                                "uncompressed-sha256": "afc4ddf4d434e0c7604ea506679ccb46a90c33a3f688e28f4a62e3a936e23550"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "84aad8288a4cef63095c3df1c9083cc675d42dfe280f346d4cf0a68ccdfe1794",
-                                "uncompressed-sha256": "61c9149641ee41c37313c6b621acc5e1c040105d15eee25ade4c3fa47ef82d31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "4de9ef885a3017b55f61fb549b2e7c24516b16dc14f74547f1f5a2c6b51f7833",
+                                "uncompressed-sha256": "e8fbe8fc49daa563f193b7e07934a28a9e3e9c743655754d13c3e7933a3e4098"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/ppc64le/fedora-coreos-40.20240920.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "0c4bf7bb561c0865df1af297a4653312ef1ce652cf0ae70ab43dfbe6703b9dd8",
-                                "uncompressed-sha256": "fd0ff4680f1921de652b95f66b72214470d8f04c0ccb6764bd78e3454b32dd0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "599220419dc4b84bb08d242da164e2ed0d4091fda9a2d45e7f3d9dbebba19861",
+                                "uncompressed-sha256": "fb9b2beb3dc6b335706c9dccfe0e14766ca7068f95425503b1a680859c70919d"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d8215ffb042429cd2578ee22bbd39f8dd1fa5cd313f62fbe3c4952602b47f6bd",
-                                "uncompressed-sha256": "c9dfd37f77a321ebce40ed6240a34132f12efa5ecbb5ed0f591c5651ba4adda1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a02f0b39746707adf4aba37b639d470e39ce95cb92916f3feb5e2b96955fdae7",
+                                "uncompressed-sha256": "ff99448b9cfb8f4ae615a99a9bad6023536dc608ae6efa15c44e866601ba269a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "733844ce5efd729d9b98735ff151b77f2cb1d1ded7f73b7eb5b03e0330927b60",
-                                "uncompressed-sha256": "93d261df6e4f0571db6ce02cce6f256bc5de2f15438d2b7bae4a23cc5580ca93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "cf30d39d2c52f5f1c3c6f9aa5283d785eb8b7a1700f39ae808e4521e5197ec11",
+                                "uncompressed-sha256": "3f075f05a8a88a650f0560b8c28301d433d89ea7683d3e1e5c86a8ae3bde25ca"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live.s390x.iso.sig",
-                                "sha256": "eae4324a8fd1471be40e4cf0dc07e62335e1c349348506e44459177aee0171e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live.s390x.iso.sig",
+                                "sha256": "74ba0d3a93a063a9897fb212c7cffbc5f7f044dce94ca459d7830faf456e13f8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-kernel-s390x.sig",
-                                "sha256": "319c73cd5ddfc00b861941bb7a2bf5b7cb04c2b728dc42e9c6095672f2169448"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-kernel-s390x.sig",
+                                "sha256": "56ec902518e8bd6d9668f0a572a3774296d0a0776530cfef51553eeda0eadc57"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7cfa22f167ab6f3c047cbdb325d9f5fc869fb3164d1880312077f023239632f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "065a48ac1f370e5af6bbf064102153b4a2c658f8402e346c7bd643aecd027573"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "addaae58f86fff8262f8f3bd9233c1030235722a09419c9cf67e6ed095329125"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9a1eccca5cdcb6c2a8d02b9c1af609bd783f26a10df22441ef5875c0cc0fa59e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "94b7b32f6dddec93918e137775443e501650e2ef298127614d600405dba0b86d",
-                                "uncompressed-sha256": "92c0161ba76e2dd90ac5eaefb445ea653febe4f03a7ace76c771216cab0e3da8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "024ffb2e5ebf3ede23761e8441d9a48d802a6b2372272dfef013706e5ee6bdd2",
+                                "uncompressed-sha256": "cb059a1393d621b43fe237c9a47adef9c36dbed0c941f4429020c68469019845"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0469cfedebe2551fc790b132575f526ca488963c04eaca994883631a6340a5eb",
-                                "uncompressed-sha256": "7feddd215ddd583df96d824844ee4971b8d935585b05a07c1bc254ebb6a1ebe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b39eee5f69b8a3854c31f6878a488add97d32737a9dce3a442f369c20ee620ab",
+                                "uncompressed-sha256": "1e2bacee1664e1c102b7d0c591f7d33032994c5e4f73e04796acad3ac38cbc5c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/s390x/fedora-coreos-40.20240920.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "43bfc8f6e1e84f8ed087e395109d972d229f1e240a83f7b8ad9557413aa54e44",
-                                "uncompressed-sha256": "c84313fc0350d4d66e8e049b5af85f4a0f3c8ae14107642f258b8b14fbcca02a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5f74090ed95123141e3beaacea0057cca50dff0d091bde7a91da5fe516797264",
+                                "uncompressed-sha256": "41fe14f8a387cef18d1d64c6d09315a51930bfc737bfc5e9e5e5df146bb8d014"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "845503eaae5bb734e5a3658a64ae3f46f764572fb8e2279b9ee942ee68c51e09",
-                                "uncompressed-sha256": "2607d25c65c042c4f1d50bb1a212bd99af8d7984c88057e0efc80dfe7cdbf1fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "772a1edac0a2494d7ff6eede2bb633bae920378a3ecca7045a904c87c2a54cac",
+                                "uncompressed-sha256": "78348daf69fecb9b9e33d74dd35b1eeb93dab307f77457543c163e23dd08426f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "894055b746444c03343308d03e8c03f579e0b4100d833da0e5548fbf8415e312",
-                                "uncompressed-sha256": "e3078f39e4a44c1c789676b15bf302df7adf20f5af8bd99b20d1313129230a48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "84c058ea8d3b6100d12904f9c02ba384b0a519cac4e5a0b98644d9e5f29566db",
+                                "uncompressed-sha256": "b839ef64e43be90687fd2e876ef284145852733ed46e22f4d3b52255e6777976"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2105ef3656220579b2fe81cb5d57dd6a53b8a0425e93e8a87bd8753630e168b1",
-                                "uncompressed-sha256": "b836c7734a029623d58b6d75557a040faa071ca7d451df85b002b554204f70ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "57c7a4f425a499d9a39349736eb00dd14d99c183cd6559a3d18e39d9444926b7",
+                                "uncompressed-sha256": "eeab339c41c8388a1fa3b6b54e037da3370541f463f106e327e8001e995f91a2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5566f8d4683ade51e6c0ce6a845c56d2cc7863cf828e5d03ecf88cfa08c26df1",
-                                "uncompressed-sha256": "afcb72eb7d420fd662446915e92454b0c88f95c476560aa9b030293b199cc8e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8a1a654ddc5dfb9c8592c735b4c3ec0f1bb58fb1a5acbaee49fe00745876f71f",
+                                "uncompressed-sha256": "7016516632d1b0fb03d21c3f1a375929060ba31434d8d2c8f83dae78ad966962"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a961ed6f101f315c99e4f0b3d4b9f505ad0061681537be16e152d641e96c73f3",
-                                "uncompressed-sha256": "8b8a1d87c8fa8b896fbbfa7297e8d76d73a17862df8d3ddbf6106ab8351bc652"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cf79331a4e559954e8d88987ee2b2e3fb18c0b4b1804a72519cdabafc95c7e8d",
+                                "uncompressed-sha256": "e0a142fe898008f413232442266105e4687f07f03245f2101fc44d174658f7c3"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7c2f393546661ee2a15e90f0c874f7f37129694d2c6f365bb3feb3c5337159df",
-                                "uncompressed-sha256": "c96ccae7e1d52ea9767c39c142faeb605354e06527ce4ba024350fa52236a304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a24a9b9ce7a8646e688fe20240e5601ac405ae5c8e6573e8ebfb313e804b94cd",
+                                "uncompressed-sha256": "6cca80321f3acbc9358a00e1806a201a6c2f8b303263a144ffcb5c214844afbe"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2f91e984275f821d450a7cf89904715ed7380c7bdf94a5a1086399edf6dc037b",
-                                "uncompressed-sha256": "89af5b8f21971a6b8bec7a3374729b16904b43a4b1b8e12c32506adda4deb72f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d485af2154a233b9277c07c4a6dc2f5263b52af77ed89f3d3e58fdeb7565d04f",
+                                "uncompressed-sha256": "dffc37fcb13b7c6e2928a51ba9501691ccb806a6f377af4b9e06d7314bbf423c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "af4a3111d0fc00417e9d16888e2063068097a049ca048789a16b1f8c8b184347",
-                                "uncompressed-sha256": "d4a424c539684bfc379bd0633950446489c4b8f16d7aebafddb4c5b8a2364943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "de2e34d35965ecfdf4dbaff305463f9f384a2199f1413b3e511a9c872eb21745",
+                                "uncompressed-sha256": "bc83817e96f4f3ebb59e4594d503bb39005660e8962b8f86faaaaa82b06dd835"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "992b867387b3fa8b8c34d187f69b23d00594f01becf9d881ce4c5d3fe3c0a3a3",
-                                "uncompressed-sha256": "2de2035f20a354cbd83cba3279501d750d606e33063d87219afb858a7c13e05b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "8418f7de63fcac95030327c5e6bf2ec42b9c872968fd7de0a02d8a1c8e07a232",
+                                "uncompressed-sha256": "5d8885943d857440fc3e77b6044a5aefbced5c220ed18019c6b11444d527b50f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "536b9cf5ed9900faa878df4430ac7aa66ccdc7a339c48838f6b631c7e87adf3d",
-                                "uncompressed-sha256": "077cdf685feb91891c95bf6b90ea70dcc01c7914b31ac4140b271c2aa3c2a8a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "14cf28e793eea8eafcfd49be93447a9eaea84569acf8145e41734e32dc5d6e10",
+                                "uncompressed-sha256": "b103103b334ad2e93bdbd972609c35af5e806a8a2efcde1cc51602e4866c0af0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ec5805a85928bde572fa7b99d7338cced86f683f4ca6e9041b3473625f494cae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "41c1c04f1fb4ad8c7688fd1c45f1a34ad004734298d98d9c6f8ac70e0d20a2bf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "48467ab744cdf670f6448de5bd6cc4dd1a5ea2cc6f668a558294da8b48d1be2f",
-                                "uncompressed-sha256": "bc839f50b96f88dd7bcc84aebdaaef87a75642ce01abcde07d6471b422362dc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2493ad76ae7229831a67f45f4b59189d9170161b00c3a228d18912c7845a2099",
+                                "uncompressed-sha256": "72a6c00b9a8ad35ba064d77a630386f13962cc82a458fde95b8276217dc21e0c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live.x86_64.iso.sig",
-                                "sha256": "3ec348f6d4a17604455f35291892bae5a8b6603d9aa281d95d44c9a9867fe22e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live.x86_64.iso.sig",
+                                "sha256": "848cfd974ead6d5f6a910ce601353acca6900cdf050fa074d8730c2fcc670f6d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-kernel-x86_64.sig",
-                                "sha256": "76cae19de14b3957eaa9056a349a0fabe446dc668a437cd89a258952f515eb78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-kernel-x86_64.sig",
+                                "sha256": "14eb3096084edc15e6fe8676c269a0e43e0b0e102b49e9d7cbc8a1e29cbaaf3d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d8cb02db9c44f51f038d529159634ca5afd52868f9fc5c4a3869c3be5160c595"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "b0fbe31d91a51e0e03e7d7aed1b5e4331e228f82a0661cc0f0c57cf18c9a94df"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "81c2793524dba973af3667c711f0f290ae529d8cfe6592de7c9b0e29b5bd3c9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0717c4c2471240e75b3c8878d2bc336e4c11d5931fe011f62c8b32af45f0697b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c8d710f412aec85c737c6ec307050f332b9e3f2f34649bf673815a4da3dde74a",
-                                "uncompressed-sha256": "aa734b8b54cac3bfd69b7d8bf97974c0550c1611ab7fd42ee6e403fc7634db31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7f886b8606b52de598f0486637a9086fad15686a69fac711f8d11efd630c8c66",
+                                "uncompressed-sha256": "8c2df55ba004ef596a8e79598d1f0fc6f3c407af884201ee46d062f6eb575187"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c99916885e30b9acedfe5443868d88942eb22be69518c53f2b02e60009bf3439"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e9cbabdd8da797318a4c82100bc71f1d9897d27d408536151b44ab00744fa78e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2f2e4283866118abf913ef055017f74a93635709ce24ea9c42eb597aff1c7809",
-                                "uncompressed-sha256": "547ab50af0d51fca21abb5c07a636a2453892c4d185c69aec3942b4dde48ab6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "80a12083f2341ac96407c186759c0b24296e87e81c9ad86bb078846b89521977",
+                                "uncompressed-sha256": "f69cdb344f828818b89984b19db1910ddde286c1d5637846f5768f2f32ac0aa0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d4bc5e908e864f413fe59e8b29a418eeee379b970ccc67619cfb7015ece4e3d7",
-                                "uncompressed-sha256": "28480163deaa05e8db5d6a61d00b26a56aa80ee258e18a67f8d030aef55169af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e4a76340870afbab72528c78e7d1bfa455a22b5db3e9724e947a209684016ee2",
+                                "uncompressed-sha256": "1c5e8c951312cf7037d94afdf9590c9a6ac684fc46883c47978cc77a85fad9de"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f11472c3af9abd21e599e550e086c440a118bf09ada022571dc9022dcabd48fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0b4279ebb3b553e67fb8625b8a7cdd9692e3aa6855ab95bb97efb898af107012"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "cdf68ae11e9c8df087460124bcba5d031e4ecdcfdb2fadf8451d8530f016b19a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "51e3fd21ea4af10465c20766e5a70bcc7622177ab3c323eeb9f0dc9d6651cf98"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20240920.3.0/x86_64/fedora-coreos-40.20240920.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a7ba3ce2c65db17d47287decaf1bef78370d086528ec466e1da0fd0967e47e83",
-                                "uncompressed-sha256": "2d836edbd5faf2aa8580b9aa8dddae506ea93b2a43892ab3d6d31c45fbc57a02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "adb55f64b6be3624a539baa4a45fc0b24aa92cacd69a2c1691b08858239184b3",
+                                "uncompressed-sha256": "72c2a156b64f90ff17fefa7c7cd7ec655b0a257f063d7914023b78ac6c51827d"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-01282f8517613ee5e"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0398c582dbaa30f00"
                         },
                         "ap-east-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0ef302e319ec21ec9"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-08e7541ac8a86fb7a"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-00e7ba8ff91372e00"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-023419d25c88f78eb"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0ed0fd3f02fcbad38"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0656ead118f2823ab"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-002ed9f55e6fc360f"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0722f40d45c7fedfb"
                         },
                         "ap-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-09ee77b05b99c0d83"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0e6c535ad2d517fc5"
                         },
                         "ap-south-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-01448808619d1545c"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-09118528e56d28ef8"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-05fd115e46c7826e8"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0c7b8808241c907c2"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-08914b491605829b0"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-078df141472c694a8"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0fc685ded0960844d"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0d31b8aaa34e3140a"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-08a8ff37ef24c9eeb"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-079e13621237617c3"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0c2f506b8b34ec5ad"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-059670515c24305c3"
                         },
                         "ca-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0222c71b9d49ac7d1"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-04147639570320222"
                         },
                         "ca-west-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-06cd7ea27cb1c0575"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0006b3e5e5fcbf35b"
                         },
                         "eu-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0dcdd5ce0c395eca7"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0a7832ba050b6a094"
                         },
                         "eu-central-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-09ddbe7799a020c0e"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0d6f317703c18081e"
                         },
                         "eu-north-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-04d07ac91f6d6283c"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0135bdc7e2c4593fd"
                         },
                         "eu-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0b782c36c17e03a5a"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-070d4cb4aab156e1d"
                         },
                         "eu-south-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-060ff3314beb24829"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-083b0be27727ff8f0"
                         },
                         "eu-west-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-07bbdfa91138b7c59"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-02021fe8ef872cf70"
                         },
                         "eu-west-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-069f0ec584fe23d27"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-038215962691e48ea"
                         },
                         "eu-west-3": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0aeb51dc46c7262da"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-08b93e2eda176fa1e"
                         },
                         "il-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-084c65e2ec4ec5097"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-01badd74c53b8523f"
                         },
                         "me-central-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-096996786b441d610"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0215b24b51a2475a2"
                         },
                         "me-south-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-03f2eb3904bc0b8b5"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-03f43941e5fc1a65d"
                         },
                         "sa-east-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0f5c834e13f649a22"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0c59e28410656d7df"
                         },
                         "us-east-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0f4fbdaa2eb59b980"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-088cc31744bf5dbfb"
                         },
                         "us-east-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-04702a67f30a05c0c"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-0588a2c27bf267a62"
                         },
                         "us-west-1": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0862dbdcb419e26a3"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-03fdfe95ac83887ed"
                         },
                         "us-west-2": {
-                            "release": "40.20240920.3.0",
-                            "image": "ami-0df7916c7a3870eb3"
+                            "release": "40.20241006.3.0",
+                            "image": "ami-080ac35a4604386d4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20240920-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20241006-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20240920.3.0",
+                    "release": "40.20241006.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:842cb9bd5b2ed23bd048a3cf14893ddfa331d6ed4d4edec6158558f0b0983608"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cc8c31d467ba5d9eb1c57053ab8b2b934ec459024a7c405dcd870fc4f799c6ea"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-10-08T20:38:31Z",
+        "last-modified": "2024-10-22T15:52:39Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "9318f3fe80959139217cdb1cdb1093111f3c7376ca38bdbda1ec4db21892620b",
-                                "uncompressed-sha256": "38ba41c944dc8a8562d24d60e7eff8cf09ea4282d6dc5acadb6c0e8e1a2564b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "7234fe86261d48c7c3a35ea21b63a927dd7097913d141565f23c07d80b5a42b4",
+                                "uncompressed-sha256": "115d802512400eeca3cf0c63348cc657d693b6cf0343d26aa801276f081b4e95"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "993735bfe3f4ac6f6da4b998eea364ab38e7bb1ff40f7eaddb4843a70c10f2f9",
-                                "uncompressed-sha256": "3f5e95988c19aa7f0668aeeae6ce9b0b510d42b83e54b1f89725eda620749d62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "355eda2dfe44b2c4528e5e36e98711d392c2ba66f4b5632ac04b83bc4f09dfb0",
+                                "uncompressed-sha256": "9c043c7457e5aa728bd3476498993e42dddec7fc7791ebdf597379c3e94e7491"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a48b6d2a035acf646e0ad31b6da80aea9a85eb203b05d9f6dfabf8c3d0e43ed8",
-                                "uncompressed-sha256": "f5fc2fd7d680df7e403c3100c48c625e1f15a13fdb98e3e49e2db4875335ea8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a3e089c5d321411ae71a2e0a0afedb832bdb74d3c50a14ed8e6c7dfcb606fcb2",
+                                "uncompressed-sha256": "c813f1fe921adb33792a1352a849182a94f919bf0d3f1a153c4907baac8e6daa"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0d1d3e23022969b9d90cd38cb5918e7f2eae841a3de09e20adbc37e015235073",
-                                "uncompressed-sha256": "2489208c2884a35e2b9d2e89f619d0514951d0393e0aea58e12da9fac616e13a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "1130a8ba9cf42beea478ff68d8f88cf33ca63f3078c442299f6636bed35f78bf",
+                                "uncompressed-sha256": "0cbd4d077713621282404b02ace6162b16538fd901cf1c3b73af95cbb4377fed"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "6f76ad9600c3866084658bac27562dd0583a9c328e2a37e88b88718f0ce7485d",
-                                "uncompressed-sha256": "aaac81651a45eeb6dc12092497261efd33cc9cc6455f14408b899b5733bf5aa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "e2ed409412c62acbb583a6c61e73eb3d926bc2f7b4153e5de7f799e0bfc512fd",
+                                "uncompressed-sha256": "7f454e003ddcd6678a2c99991fec696a50d68bc2e8c6fff6ed349dd6f2000ab4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "08bfc274c3be26d9f3338ce8b3d698c7764ce178875c1a5cf9d99781643c16b9",
-                                "uncompressed-sha256": "0b5d7f3514999449b6f09f9b7238e4b371ac30100cfa8a4fa5660bbfa7875c2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f36733a2f0c91674516c459daddf0fa98c16f5fafbce95424621c3e4dede02c6",
+                                "uncompressed-sha256": "33596373f655285c53d967df01dfa8e5263d8bc3bb4b660a8ec8cc5eceb95dc6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live.aarch64.iso.sig",
-                                "sha256": "c78e0e499d34e53001168ed9774fdd0fec32dfa9645544c2290287c1beefde1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live.aarch64.iso.sig",
+                                "sha256": "98cf7b93902278d80943217011baea1a8fab4b4c1e3fe32ae96dda3595b6ab4b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-kernel-aarch64.sig",
-                                "sha256": "838dd6346c11f890fa63f4e9465cae414932f5cabb65d78a3d3f8d6c05c716dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-kernel-aarch64.sig",
+                                "sha256": "6c0b0b237412921c48ff83fa5f787463479c4ae539a77c647ee25f27608546b7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "b44759b3b5fb7d211bbbef3c26d6ec850629010aa126e374017e84c6a06e9e99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c0f24353d81243c7a0e548484e8263ebe0c310207b3cf9cefe2752eabd583fbb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "496d1912125d87dcbf6c1e50323dab79ad237b7cb055b9f15dce1af0be313fd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "428da49ec721e6e3fde320d8d29996590171fd42c965d7105856713950eb7d05"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "82c25c5cba61ee08d61071947076439394298490efe71a6271f4074fe84545fc",
-                                "uncompressed-sha256": "296945e75f242c5eecf99af78d030f064ae37a1077c79114b05990c4b67bf977"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e5e2efcefb9f0749d04c87b79afbb84946fa176322e2bcb2b079beba2ae6738f",
+                                "uncompressed-sha256": "468bf883f840b1e585656237c43f0cd54fb94e5343fb8eb3d1ef2ce0f7594b5c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fa55ce8191e6c3150da4c50c6a06a51d3200fbd8716a6930e5f9bff2c2f7678d",
-                                "uncompressed-sha256": "a5b7a010feb9958b200d3b64e36e90936db25c4f3aded43200240510655274ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3eef7d9063723781c36c6786f451be294b90c43122b75b330b7557710016a628",
+                                "uncompressed-sha256": "2938165460d63fd6ad1edb4a3b7364a1c82973173b74b647473f206283b59034"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/aarch64/fedora-coreos-40.20241006.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5dab5840c3b783c9701235f551bcbe9df06e8580d1e8db2e1ea54c704748ce9b",
-                                "uncompressed-sha256": "c3e5195d5bbfb01f5944ec6c5a5b4cf22115a3fca1f03577745432cc88a6a1df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "60874ad906e8f62f9b57a22c940df76cccd13b7203605d01343683c1f441dc3f",
+                                "uncompressed-sha256": "21901f93ecd749e39a0592d747a4d8cd17ae7b6149df00c6afe2faebb284b09d"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07d1efde3c98e055f"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0dd5765116860d084"
                         },
                         "ap-east-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0ab115299eb223562"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-00d7f623130f58324"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0aff22b83906365b4"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0f0664753cec67ebc"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-03651eced89da0358"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-05101bd17a8079322"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-09590cd6534ca5226"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0f627260ae3370335"
                         },
                         "ap-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-055d7046c65c11cf0"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-04067dae6bb39ac75"
                         },
                         "ap-south-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0e2b23ddf45d41f7d"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0df27264a80bd4103"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0a175378a2725145f"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-01ddd4420a1b0b549"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07d2d27746efce893"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0eafc8a8b732e4ecd"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0d19c473616e0e490"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-05e97536c045c2ad6"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-05728e1dd3899feaa"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-03941c8ab0ecacf2d"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-013653dd5c0e8559e"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0048b05f18c40f355"
                         },
                         "ca-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0e5da636d8aa44327"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-09f0bfc163f3b8a61"
                         },
                         "ca-west-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0f24959913b3db469"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0a0a00ac3f0cb4028"
                         },
                         "eu-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-09cf423a12e376dff"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0e67ea9e77af1d9ec"
                         },
                         "eu-central-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-036c3af4669e0e5d0"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-00fc79e9a5d156efa"
                         },
                         "eu-north-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-00902b818028f138b"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-044d955fb69d7488c"
                         },
                         "eu-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-02aa09a0478f15ddb"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-082dedfe507ef670f"
                         },
                         "eu-south-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07fd114e3358eb85b"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-09cf3879b6887f910"
                         },
                         "eu-west-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07fc21ae2bd656755"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0c079b25134c810a4"
                         },
                         "eu-west-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0d6629ca6b35b8f7e"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0eafa00b39ed86bab"
                         },
                         "eu-west-3": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-05a3df60cd726cccb"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-01884f7edf50a0667"
                         },
                         "il-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0fcb065318db34911"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-02dcfdaeb1fe0aa96"
                         },
                         "me-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-02a2444058309b7af"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0a1fd3cf3bc5c693a"
                         },
                         "me-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07531ab115f602029"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0fed8ef6510f2a075"
                         },
                         "sa-east-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0cf520f359b332665"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0f904a0ee32377b6d"
                         },
                         "us-east-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-00b161bef25c76171"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-00bb042a23f7f3750"
                         },
                         "us-east-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0a9c28d6a0be1773b"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0dcd127e2a7d74972"
                         },
                         "us-west-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07006302c3a564f6f"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0d7a455adbaf47fa6"
                         },
                         "us-west-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0dcba6f042542ccaa"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-00d0c415318abfbae"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20241006-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-40-20241019-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a2746457dfaf6663ec670bd102430465c59a4f973f0a9eaab418f2184e413571",
-                                "uncompressed-sha256": "ee1cd682035bcc5920c5ece2ab101b19caf2fab1563399ffa923b28a8125cc14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "01f0128e235c6cebc40687236f0e67d7450e39e379fe2dc91970d99f380eb6c3",
+                                "uncompressed-sha256": "f2a885b7ec9d43ab53d1cbcf381a986332de26907fd4647e3b9ce69ef62aa4a1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live.ppc64le.iso.sig",
-                                "sha256": "8a7c69c1d0c4a48acaf0837d4fd6cd27a0a6186437cbd11dfbada5b81c76cfc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live.ppc64le.iso.sig",
+                                "sha256": "22f532e88f0250f22caa4d235da501cb1a1885e6559079ac5ebe44156ffd7e0a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-kernel-ppc64le.sig",
-                                "sha256": "461a1ad51bd0749c2c8792f8f8de14843b53be357ecfdf1ead4f1e8ce6ecbe53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "c3e753b8c82592436727b0cc0717a55d5909fcd3c5ae3b4db7a36082ac5fd6c5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "dac5332044d67eafc41521e2f82c11c2328d6b8fe95392aedf7085b8bfa52a8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ec57506638202b52e9740dc8870a1fdc218be043a4a12cf6f21d87bdf619a4db"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "10eb1a34def3ec81be29830878da3623fe0941aff924ebe6831c7e51d9c8590e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "6a979b32f984b71902c49d08f5299c5e70ab970b5bce7c5f38afc77869dae40f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "0a6c2c66e3c89f39193df8d1dda8d9fc36e8ef7cece119c1ecb9c3d59d20d1ab",
-                                "uncompressed-sha256": "70dccf9087616a33e0f8d6fba221018db3fb33aa7a2e6be787adb9a8e04e8dd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b46bb5b1872cf8cad5be3580bd3201f8847ef13a545fded31e75d71932eff8df",
+                                "uncompressed-sha256": "3de02fe4f9281c9d6e6dfcd37b2b6adb1b7d3f2369616c327075a660d9429d40"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "ce1391903de342cfbc5966bce395c11f6772f88a833967f123a956c7e63bba94",
-                                "uncompressed-sha256": "e5cec49ee59742c8e25100a510eb56726b7c953677ba579852846602d2a9c3b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "41c05b57243b64414b1f50ab8708c37d455471ae57a810d2d2f0dccd2b398552",
+                                "uncompressed-sha256": "727822f90eeebeead7225bded358e5020deb22f3ff12f943a8ca9cface93fb72"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ab150016e1d8ff8f222b51f4fc34445c0c491d80ea24e56fd0b2cb284d62c0d8",
-                                "uncompressed-sha256": "1ac86c8970b1185ab20c8fc7dfed4b41491972fdc2012ce93de5d2cd2918b545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ab85bf96c522a882d43563564731f3b23af91b4154f20dd8e97443f1776b3b23",
+                                "uncompressed-sha256": "2aec97f45f4ed084a0f87d5b37d002558be5b83dfa3df568825e8a6b64e2d257"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/ppc64le/fedora-coreos-40.20241006.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "6cdc517b9a22d99ef8853d1ec2ad02b14e1e171b877f64de410a217c4a650be0",
-                                "uncompressed-sha256": "f0609107cc17282f84da0493b297885a8815cde236c53bfed1202f832e15a266"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "aeea5d13a3e4ce1db4acbaed60ab539f1cd5bbffa99f153c035c01a996e0502a",
+                                "uncompressed-sha256": "8c267efe414f6424cb6b7e00f3aa4dc504948bfcc66232688853e1b588772639"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7120d6448d9eedb58569c6fcd60f4e5e55959e97b738603fcbb870f310f817d9",
-                                "uncompressed-sha256": "755ad04eb2a30a6e97fd7873239089b13b29f2e98fac101fb209f8384e4c2688"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a0959acee0e0ac12e7e6af74200563caf9ca4f5c4654d7fbab2c0bc76b24da66",
+                                "uncompressed-sha256": "661a24495228d9932e1f2969b04a492721160bb9069e4a7dd17b91b26e8fb27f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3786a3d012a02d1eb9129a0cc3b92f596b2de721d38edc8b9f08f9398316a8de",
-                                "uncompressed-sha256": "5df25c678c27860451a03c61d27bb1b15d340b3e85d5f84896ad35d2f8e77868"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b5745efa90b2821a60dd84bf0610da6190bf260aeaa59d67b6527b709de51d25",
+                                "uncompressed-sha256": "86a7f0352ac97733b3c46fb146fe2327b38b0752c32eaf4443f1e48e70fd8b76"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live.s390x.iso.sig",
-                                "sha256": "a52ed2b7b52e3775d13ba09ea7d2caa6387996e84aa3e1072450ca6906b73203"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live.s390x.iso.sig",
+                                "sha256": "172f7af99389c3e7310d4206c95654fd5dbced6bc255c5b777667878d5868909"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-kernel-s390x.sig",
-                                "sha256": "56ec902518e8bd6d9668f0a572a3774296d0a0776530cfef51553eeda0eadc57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-kernel-s390x.sig",
+                                "sha256": "ef6d3d73ddf9b5f77f46cc5e2ebfce15488e1e9a714b94855d7764dedd4b6ec9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "248a81654dd93a31815da6e3a3d8f557df9728407f9619b561431684ffb55748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "acf53c413ea8fdb8101e809d3ccc9a0e56490ab28f4dcbf15d388657767cb9db"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "016741ff63d5a8269e927c86f920a4693af6035bbfacbb0f9b40e66223e54646"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "3046d02fd654705cc4a02a02f9ac84340da39d18b0814ab698ec57f97b6255be"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "dbba54edff9509736755393ef2afba936bf65c4af174290a9f3024d56b68d193",
-                                "uncompressed-sha256": "5dae09b4526058b5b0d4f74bf7f0db947fa65af22d0db79cb9c8730b5b00efad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "5d1d5ff7ad7c7107fb02eed9192d15f99040c11d528ea30f986ec69028f44a45",
+                                "uncompressed-sha256": "3d831687fa6508e9482d35176fcf31323fb24778f2e2bdab72b59c72e31c6ef7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a885242f3960674d54b9c507249aa62c57f835e9cf6c77e6d760ccd2be199802",
-                                "uncompressed-sha256": "daf32a210343e85098d7f99c4d1a58b70d5b4677cedd85be1a76e72646291256"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0348a7c8519800ef4c9a624d64f1454bfcca0f9891a71ca3a3b631d9b9065e56",
+                                "uncompressed-sha256": "a377338ae22233af302dfb5bca60b565b0a94e38ec3a0fa907969fde1a205715"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/s390x/fedora-coreos-40.20241006.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9ddbbd33bc9bdaf43dbc5a065ef81b04c57c52535fc2c9412502841d75c14665",
-                                "uncompressed-sha256": "5f1cb7b638d7b34b4871839010e7a02cb868dbf463795eef66d4b16b6c82bfcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4fab7baafcd5c6c2930ce84d37cd1cb0b0b4b8f789f6b35ae13c0dc138f47cbd",
+                                "uncompressed-sha256": "da3a843a6b183e572b21fbb97a619874e27a9a03bcff143cc69b18ecbbecdbd5"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cf9e5867210bdd7c1262726f0c33575202f77e4fd94631fa5cd41d7aa1b2df61",
-                                "uncompressed-sha256": "88faa26b38c8290f50a6f447d41206e1c0324758501474fc0187434e64dcc6d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "89d4bb7cbd52e6483eeb12d3d97c86490d863a25d29ef2b03b90fa0b2fc38426",
+                                "uncompressed-sha256": "f4256029a0d41266151537795cebd01a69b451b348ec55332246fc3f1cce17b4"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8aec6ad8472a62fa3ee8afb86db0229933cc8a3099825713974be18d5c8de4cd",
-                                "uncompressed-sha256": "fb3c0b333a11e1ee7ee79a1ecb1e5c57b489f3ca64273207df4830fc2e38cb33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3be87f614631f8230635a1fca6061d1cfb24963db0741a72c87db7ecfe3e5451",
+                                "uncompressed-sha256": "7a5c1835326683b4a6bb0f7ae2f5c7c52650bf5a7d5793801bfc4174e7c6e7d7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2eb81601059546b1765c15e3e79e32a3ddc0e0ebc86745ed92414b322c594911",
-                                "uncompressed-sha256": "8902c244b4f3570c9fd96a79ffb324cbbc4c2de78e25b05ee6fffff09c3dea64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ad44df072b9d5d569d12805674f993d6254212739b50237dc35acdbad897600b",
+                                "uncompressed-sha256": "8223ef26939dc5782fcbb49f21745880e612e21171aa311b9a6c4def320e647d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "adcdb4a9e0e2274d3ab6a6a336fa2acedd11a4fde853c8a34a2c21e0bc20aac6",
-                                "uncompressed-sha256": "69e31de67b6dab1b34675e1fdfc62620e6be08c112fa712a68c628acfcff7608"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "09c813389d6e153d7bd4456367be3fe03732f0d993f49a8dd9b66d9405eea1f3",
+                                "uncompressed-sha256": "dd0de32930d43673ea451ab1416ae74cfea8f8a1f56f0f5346e4efaa1ab868e6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b813f9ed1a8c8e499543168230d75af188f4533f39f3f59c82caace9dc912de1",
-                                "uncompressed-sha256": "3c6b93d02bd055d419af05c0776eac249957c72becd170797b0e1414b0dae2d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2a87c9c2d5cadfd141c097aefa7794bd2cc2e69c01aa1092db24fbcbedab3426",
+                                "uncompressed-sha256": "e1e3609f38515a3cd23fd3dbdfe4db6436213bf72b233bcab31fdcd85d8d9ea1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "36a86b82637ba577f6208bacfbe31b9a5e00cd2122ac036d2d3f53ab53da5537",
-                                "uncompressed-sha256": "d30d551bf34ac115190c799e99cd6cc0ba202ebb8156e97ef671ce80387e8159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1fc21ad760fcf1a59b615194b2c367061db5af23c398940649d38a47e30e5852",
+                                "uncompressed-sha256": "53ae1c679e66271e2b7355ce0ac1d621c61d5ae10ecdc2b1b628914bfacacf8e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1623764e1124f645dd9387ed1f00c2bab9dec3fe2dbd7ceb4451b58cc63974db",
-                                "uncompressed-sha256": "e0943c7f0670434f2cae37a1b888a7eac1e124ba478153103a06489525c95f8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "41bddb5b4717f42d795d5601fc4f8523fb41d81959496fd9109f2b97366b4ee9",
+                                "uncompressed-sha256": "db65bfa29953b6d3ad98d4ab97117cbdc8182f5433a4e3bf40497f9098b354b3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ae783ccf4cf2c19e63095dd3b2ea5de198bdc69a6fd6abf17853951c5a478c4f",
-                                "uncompressed-sha256": "ba115ba1de464f3236a8d934bbea3d44e3971c35cba23184c699e72ea94c68ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "18acc3feec76047f8b04af5a4b0fab1013088e5e99963e6f6a0770d0acd31898",
+                                "uncompressed-sha256": "11305e499cbb64fc644a97d541a3c2c97f3108785084bc90eeb14926dfea9b95"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "4d63ef499f1ba7395918c59ce4deec9dafbe6b543e47ab401ac53a9babfc2193",
-                                "uncompressed-sha256": "5f466a5382cf96e0e6bc6b679a46a9198211c54df59a937b57907b61446b5c0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "ac8a695f7799b3eb75bf3814cde1a7ff331cc7f54ce5cae3adeb3a24f3ffee4a",
+                                "uncompressed-sha256": "de840b61619a991ca71367289d502234a96eaad59f18119ece7faa50e0d757ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "684a98c1c7696e6472d920e9bb9561653efb3da0e8460b8411ad942c395a2474",
-                                "uncompressed-sha256": "00a2665fa3678032615d1faccfccc8bf80986b345f1c92cfb7af49bc72e51500"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3d51c5032dad6e6ee41b187054faf724532649e57ec9ef685aa068545f6ee7e6",
+                                "uncompressed-sha256": "d97ea4d4adb029eb43a0a8300f3ecd661279f8d95db6732be048fa66e9c66912"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ed0c441b250693520cb5c0a1fcea61ed3348db10b41df4699e082e3f621be75e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "821f4b64d43cf95cc292e35fa687c218e31d915b670c9a21ab8ca744f5d3f55d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "446bca461008100b30d19aec51b0c14d06db6c46722279a23a37dfa725438d84",
-                                "uncompressed-sha256": "6687c9eab25a4b1c1c86de516b78762fb661a76b02e98cfed7178d2a83aa2b63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a1fcc97ddc5599e8e52abadcdad8832470f27b856bf03e20a9f4a260e92f7d44",
+                                "uncompressed-sha256": "f6c95ce692d09f0c4e27e617393fae3c2d719b8e84107db082660adc53631ad7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live.x86_64.iso.sig",
-                                "sha256": "853403e0b5ce5d1833285a4c176a3b91f00862efc57fdf001ec762f3aa7a100b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live.x86_64.iso.sig",
+                                "sha256": "17cc6b2a4eab73e69ce836ec6c8a928b051da4501292f3428ac4ec81d8ecd8b3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-kernel-x86_64.sig",
-                                "sha256": "14eb3096084edc15e6fe8676c269a0e43e0b0e102b49e9d7cbc8a1e29cbaaf3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-kernel-x86_64.sig",
+                                "sha256": "cd069acfe4dc025d51cd716de66211d55ca2facf32808f9ae5aa2f66097a513c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "26041dbcfb68280ba2b23ca01dd9c480bc452b7cb872d492444535cce31b43e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "5b19d68f4caca11046bd8edf8bd910b3414c2c6d87077cfc82f67ddafa95106c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b3b59463ab74a64d614c13f2ddac21322078e55b195760a82357fda7ca91285d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "7678c47111a0252341480c22477bc86a8091c649c19b739bbb449047e1bedd7b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "3b4c747731cbfd04f2892a6b9ff791c65bf0243b814500271d87fd6bc036cc74",
-                                "uncompressed-sha256": "e46250cec91dda0043b1c50984ffa3aefb8cd6876629f6d46610fdee9c5fa183"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f5abf2c9b3ebeb9b1e8f3388ffa6a395d60d084d29ba5f68f029f745c99e4b3f",
+                                "uncompressed-sha256": "e8457da3364b0ad67a9e5c30833b6b03eaea908ca171c720b5e9a3b7573b867e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6002007347e18bc59160276a4eeb199dc50ce67c774aa131cd4142d24deca5e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "52c7b3171eea6188be4289179fe855677778f4fe05f8edccf3cccb48a15c79d7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "259c2e856d8f894e7d856bcbc7ef5077320b34adfd2f09534c6c247bf6ea8697",
-                                "uncompressed-sha256": "a9c0cff09740d4dff372c71a0d0ca2846d4d4b701fa15c2e890f65a5de4e924b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4a028ff4b6d91f82adfe55ddfcd50167ca3700f06ebf0e52075cc96ce7e841c2",
+                                "uncompressed-sha256": "9850781d601b10044005933434ade50fa7ee2d884dd006c4244b64c3db0469af"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1fca9769333f1fd604903285c6ae9875bb9a2ec211b029b8229b43364f35a37b",
-                                "uncompressed-sha256": "b2fcb8f08abc8271495b720c0db006787af3d5d48972815f0bbbd91cefd450e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9b64132233769418162d341846ef8088f7e1225ff224353a8aadca61391eed51",
+                                "uncompressed-sha256": "ea3b52f1c1cbda4b3c82f07f74a7f560a1b9d730261c85018d8fc9fc376b42eb"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "407b79d5381efbb71be18ccb29cd47d1b453b070a99e5c98b33b5d2ed00fee72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b9074fe63beaf4ac62a638a170150f7edaddc3e085d37530cbf9219a109e448b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "3e1c4ddb014b62c37f8c4d8ad04d6d51f0e958b2b398a232337b02eb8eee8017"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "d388caafb846ac6c054ee04c79996405039040895e0ef38d6f31dde1518da242"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241006.2.1/x86_64/fedora-coreos-40.20241006.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7c009fa435ee8d88eaf225a1d99f8c15a442f35497abc6a7424418b0e4797101",
-                                "uncompressed-sha256": "d628ffec322c0dc26108f0a1804fb63a8b0db902731ed20e64c038f1a5a461f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3a5805473e36cb60393d68dfc1f9a53b6315407f30149c9db931d767e95e8566",
+                                "uncompressed-sha256": "53a293c5b53af06cf82251edba9b687d129439df9ecdf50173a9ff6c47e4a831"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-01d5c9ade93ef299c"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0041e17d4b7956e2f"
                         },
                         "ap-east-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-05cb354c2a7ff49da"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-066d5027b26835b68"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0b949aa5f37f6a516"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0ffe5b912d59820d2"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0c611f24be69e2b3c"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-069be786896c02d1c"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0310107487b915a44"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0bd16b3d39ac796cd"
                         },
                         "ap-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-01dea4db47d372091"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-004fe13fb51ba693f"
                         },
                         "ap-south-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0337e04918f43d46d"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-03c38423d109d4b45"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0513e771bdadb8374"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0bbd57c73041125f9"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-00e4fdf678f2e4ad9"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-01377aae6a32b5926"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-011ebfb2dfaee9a2c"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-02c7b4357dc28d36c"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-08c81c2f0a2a12e22"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0dd2dead030a3074c"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-02c122afaf7c58c41"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-08d7806287ab48aeb"
                         },
                         "ca-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0ba662aa8acf22c48"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-04bca18b280beffad"
                         },
                         "ca-west-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0cac5856713bad8f7"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-03a110c0aa16f716f"
                         },
                         "eu-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-06faa89dcd685d8d7"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0e5a1bd281cf1e25a"
                         },
                         "eu-central-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-02af21c7afbfd05ab"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-06927998867761669"
                         },
                         "eu-north-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0dd41bc23860cb435"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0bdca4071f28f80a7"
                         },
                         "eu-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0bf4d478aa98a7fef"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-00a0723031307ca9a"
                         },
                         "eu-south-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0100f86ea6a5e4c17"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-003eb3a9394a05f74"
                         },
                         "eu-west-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-07dceb9ea2d16db4e"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0d3951761b4e73357"
                         },
                         "eu-west-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-05e6133782808d3b3"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-057848a46e763f672"
                         },
                         "eu-west-3": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0ce448079bd3fa2a6"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0534332dc041a0d21"
                         },
                         "il-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0f256e4946fbf31d3"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0aa0b1b2a1ffa557b"
                         },
                         "me-central-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0589ec3a1f24f4a44"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-051094065c9b4738d"
                         },
                         "me-south-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-092768cc0768da9e6"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0b1819c914de9dd25"
                         },
                         "sa-east-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0b080569008dd8d00"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0372cfec0cdf4db9e"
                         },
                         "us-east-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-0a85588fa6f6ddb7a"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0e3ab6b784ee55450"
                         },
                         "us-east-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-04ab5bb372196b257"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-022637cecdfe5cfa8"
                         },
                         "us-west-1": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-04fdbeaa3a5bed76a"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-086f2f46a11c11377"
                         },
                         "us-west-2": {
-                            "release": "40.20241006.2.1",
-                            "image": "ami-00bc4904931d9edf8"
+                            "release": "40.20241019.2.0",
+                            "image": "ami-0976264971fe724b7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20241006-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-40-20241019-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20241006.2.1",
+                    "release": "40.20241019.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ffef50a8647bc54ad055c4cbbebec81185b4fe91873decdee529d69d757ee46b"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2f6e503972245cff10544a5c90dc535ac083748136678c5eec9b74f604115afa"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-10-08T20:38:33Z"
+    "last-modified": "2024-10-22T15:52:41Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20240922.1.0",
+      "version": "41.20241006.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20241006.1.1",
+      "version": "41.20241020.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1728482400,
+          "start_epoch": 1729612800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-10-08T20:38:30Z"
+    "last-modified": "2024-10-22T15:52:39Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240906.3.0",
+      "version": "40.20240920.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20240920.3.0",
+      "version": "40.20241006.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1728482400,
+          "start_epoch": 1729612800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-10-08T20:38:32Z"
+    "last-modified": "2024-10-22T15:52:40Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20240920.2.0",
+      "version": "40.20241006.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20241006.2.1",
+      "version": "40.20241019.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1728482400,
+          "start_epoch": 1729612800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).