### PR TITLE
Roll out stable 40.20241019.3.0, testing 41.20241027.2.0, next 41.20241027.1.0

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,6 +1,10 @@
 releases:
-  41.20241024.1.0:
+  41.20241027.1.0:
     issues: []
+  41.20241024.1.0:
+    issues:
+      - text: "ship podman 5.2.5 for CVE-2024-9675, CVE-2024-9676"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1821"
   41.20241020.1.0:
     issues:
       - text: "kdump fails with composeFS enabled"
@@ -37,6 +41,8 @@ releases:
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1718"
       - text: "systemd v256: nodes utilizing cgroups v1 will fail to boot"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1715#issuecomment-2331986149"
+      - text: "updates alternatives don't work"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/677"
   40.20240906.1.0:
     issues:
       - text: "New Package Request: pciutils"

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,6 @@
 releases:
+  40.20241019.3.0:
+    issues: []
   40.20241006.3.0:
     issues:
       - text: "`/boot/efi` is `unlabeled_t` since version 40.20240504.3.0"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,24 @@
 releases:
+  41.20241027.2.0:
+    issues:
+      - text: "Rebase onto Fedora 41"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1695"
+      - text: "Complete composefs integration in Fedora CoreOS"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1718"
+      - text: "gcp: support c3 metal instance types"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1794"
+      - text: "ship podman 5.2.5 for CVE-2024-9675, CVE-2024-9676"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1821"
+      - text: "hanging `journalctl --list-boots` stops boot"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1641"
+      - text: "dropping some firmware packages that provide Wi-Fi firmware"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1575"
+      - text: "systemd v256: nodes utilizing cgroups v1 will fail to boot"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1715#issuecomment-2331986149"
+      - text: "Crash on IDPF (new Intel driver)"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1797"
+      - text: "updates alternatives don't work"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/677"
   40.20241019.2.0:
     issues: []
   40.20241006.2.1:

--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-10-26T01:47:59Z",
+        "last-modified": "2024-10-29T16:07:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "28c8daf0af0b27c4f723e49bec1235f3f57c9e6c9e199499782cd059923ea81b",
-                                "uncompressed-sha256": "685557631b8df5369534c170ca4c8436969b203ecd4a34b7549d3b651de46744"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "695337b0d0c04fdf8b78817262c1306524490174adb502c764535cb9d324cdd5",
+                                "uncompressed-sha256": "baf9273ae3fae1dc4c38a62dcb5f05cee927a8831798d4641598ed04491879a9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "69c7d8ba7f10b8457152ee21d175bd2c68662af3484ffc68b75ed1c5b78a425b",
-                                "uncompressed-sha256": "eb1c1b0b30e36525e81b3d68f3b0fab0232b8b991cff3e4ccdea42b8859b631d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ec54f019f5c729fd75ffe543660cff2e77c6ad2e7263500ef21637698875ae17",
+                                "uncompressed-sha256": "98fe67825c2fb44689bd4fb078d57843b918cbf84be175d69a22b659f4888ac2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "38d8c87715d1f2e6071eec07bef004beea973c6e0a46bd8ae38c26bb7af9eb2e",
-                                "uncompressed-sha256": "0833ea39c3205ecd632c76db2efc204c892dd1e2f4ddb8e1851529e2d4db68e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "58f6f8f829d3b3b8be6c0f31ae0823aacb44f7a0c0e7e7d03c022c26ea8964d1",
+                                "uncompressed-sha256": "e46a8b0486b044d98acbfb077ff4113f81e60a4206706bf9bcfc5bcc312444f4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "b46b57d5c6ba83eac182fe7557eaacaf73144c3956eb2dbdb0b497e9959384f6",
-                                "uncompressed-sha256": "d7083df31d906e8833a04f0241b73b78f52bdc51cf0ea177ade34c5e2fe59ee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0ce847b4c09bb972d1c7d99305a910d45523dc623596faa645cab6f251f28725",
+                                "uncompressed-sha256": "68600fcc4cdae13719f2eee36af73d4f8bdc096add8a86b4a38ee4c338fd1da5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "61d2f9612132944a70d7f9842735464221ac7efab9ec03752590a3b3e859ef49",
-                                "uncompressed-sha256": "331a61c022dd02fe0e3fc6c8f77a50d055eb32a1a5f47e2ae36f342264d7a417"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ca1c134678333bc011ca9f981a3df837f10bb665d31283090d77adad50e03087",
+                                "uncompressed-sha256": "9abc839ed80722571fa1fc2907353b7719cb0e48735ae678971cfc46ccc6e82d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2c4b813f43720bf4830f837caccdc531c8e13bd9a70e373a691cbfc9e55490d6",
-                                "uncompressed-sha256": "950915a24574a01bdc69656a3c6f53b29b3d255b33770c1e119f0e5139f15354"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "11b69fcc1d738c64f46b07b0e7035969b85ae4fad6c54728e49f621d57c01ecc",
+                                "uncompressed-sha256": "b81c7c4dc03d4eb4bf9d1f78070767b0727e179d07805078db1e41378ac6710c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live.aarch64.iso.sig",
-                                "sha256": "3721a57271d47551732b06200e968c72f35fc17899bfced0db627d3c0264d930"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live.aarch64.iso.sig",
+                                "sha256": "9286056bdd4dffecac31bdd32eb1eb9bd5923846a47dbdea17c73ac1f649361c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live-kernel-aarch64.sig",
-                                "sha256": "f7a7c3b20e3021128b0b7b7133618952dcae45b55a75dba81ebc513884ee47b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-kernel-aarch64.sig",
+                                "sha256": "b7593504d57829cb34817c4bca93d6ae8feb923a46518fea4e6ea02d91e89c5a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0418c27def45ecae2986b1eb518d3f986bf33d3a15a9cb7c3087ef2832cf1d77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "70eb853b15d200a87736d84e212a58e6704d62f227b6212689a0b81c9db5eb50"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ad77f5c2c160f44416bffaa80913938bb54d7a2d7a53bd45343f8a77fa0bd76c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6a400c05b5426f5b6606b1e85b5b932b7e399f86d39842b1b60c11912d292e97"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "e769a92d2b0b5897d4397059c0da457986b794ed14e713aa6aad634d64c9f8a6",
-                                "uncompressed-sha256": "42cfe1b8b5c2c0fd09311d94a5e12a855bbf859e432c0170e9f07daa1c600291"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "46e92583daf2738c8b587b24a56c7bc1691a98a1f38e7fa6fefc2cd4d7c7612c",
+                                "uncompressed-sha256": "717853d35916edb93ebdd2f75d5f3f3d6c4eea1e5c08d1df3411d0c4e22ea526"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f71801d1ee8a1cf6f2cf5309aad478c5a448ba4b672369664b4d7e60768d4f25",
-                                "uncompressed-sha256": "35545d556678fe95f7953c7f46b06e31674183eed39d0479835a58664be51490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4cc321d3bc94ac58806a2e2bf13de3b717969ede67fce289fe2c7cf604f10bf3",
+                                "uncompressed-sha256": "3cf228d19a93b088a863ff6b1346ecb2b2f21307a470acb6df9d63e38f7fd713"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/aarch64/fedora-coreos-41.20241024.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1a277507bc8a09862f7e646a28d9ea5ac17ff8b64eaa34938ad94da08f958d9f",
-                                "uncompressed-sha256": "6d3082b92417ad1f6ae8de24e953475f7a3d7a5f44e2eefcc4ece30e99a78caf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ac76144df558e84c6c7034007bc39707e855adcf9dda998a11e292d4614f80ca",
+                                "uncompressed-sha256": "8b2615c87b45490bb36b5bc3792f35b7b222c58c2d7b68e49e5bead6fe9d1ea6"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-01097549d293da267"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0052c4a9ce764de60"
                         },
                         "ap-east-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-03f519d0b210144f9"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0c23a460c7a325d8f"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0d3b3acbe29fac8de"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0653ed7eceff299ca"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0325a1483642bec7b"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-00f7223a9764da663"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-04dff539ca7221578"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-02be959086dc501de"
                         },
                         "ap-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0b163f9264c08420b"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-047bb167f0bc3dc3f"
                         },
                         "ap-south-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-04b3c3958aaeefec2"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-010823ec0cfb7e4ce"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0fceec742c614e30f"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0d91a0b5b6ed39bbb"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-08d7d7bfcd5ea05f7"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-096e07bac59d1bf17"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-02844f567fe8ebfb9"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0fbfd5b5e418cfa97"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-09302c03cdf4e00ef"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-069e815bb8707f774"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0e342db5683042b7c"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-026500fd7ee72bb5f"
                         },
                         "ca-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-041c0499cc3a78499"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-03d6494a87a68917b"
                         },
                         "ca-west-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0f609308c2909e660"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0deaa1d0cd45548d0"
                         },
                         "eu-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0e6013884e87faff9"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-01f4d241daa2a4c88"
                         },
                         "eu-central-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0995851f1f0b940a4"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0610b7c50505a5577"
                         },
                         "eu-north-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-00b97732419859f4d"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-07798c27c5ad88900"
                         },
                         "eu-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0e41ddfb35489e6d8"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0c74912d80008f239"
                         },
                         "eu-south-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0cc73eff9554626a7"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-06e196587a8493e89"
                         },
                         "eu-west-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0f35ee3d551518d0c"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0bc720a26c15bae8c"
                         },
                         "eu-west-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0a822c3ce1b268bdd"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0e02b9c093c683c79"
                         },
                         "eu-west-3": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-021786be5c6293c24"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-058eb2255d647d67b"
                         },
                         "il-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0bf1b36e8c3ed2d2c"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0cd4230cf9c39d231"
                         },
                         "me-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-06d5403cdd5c2b70f"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0771896a038d820db"
                         },
                         "me-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0ca078dbf09798a8e"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0ebf2fd48cc8c951a"
                         },
                         "sa-east-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-04e373d05993613b2"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-04e2a7fde931ec528"
                         },
                         "us-east-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0aa7c328ddb429266"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-03e519bf1d5dd75e3"
                         },
                         "us-east-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-082cbd3bf08992af0"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0a6860474ec2f61ae"
                         },
                         "us-west-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0f21564689acdebcc"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-02ee1efdf02f543e2"
                         },
                         "us-west-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-011680053d9d7b99c"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-054e75cb2fa2d9d35"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20241024-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241027-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "e2c269590493da382fb9a8856337a528a073e2983f5de07f52acf12a6a869c00",
-                                "uncompressed-sha256": "13669352c8572d8006a2a8d572bf11ad78e5fa562b7400b723d0566c860cc7ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0cd948c280087de7d9aa3735b8ac2c47fc9f513202f77931cf2e2c8cf16e020f",
+                                "uncompressed-sha256": "8eaf947e507d88e3cef44c7182d31bca19784258dddb24ed4d0d2cb887bd058d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live.ppc64le.iso.sig",
-                                "sha256": "a4d88ff81db219bac54a7bb4bd2ea9c5c17778cff30992bc92bab5bfd00f8ea2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live.ppc64le.iso.sig",
+                                "sha256": "f6b7c2cb1fc089a769ff93befc55be36ccb795786266344711558ae1258ea6c5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "eca627adbe42437cacea169beeb4c3c12a5cfbca1a6b1ba5218d28139d2143c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "5c3a59742a992e2778dd5f06757cb90f5e616525b56f2e1ea07ce2831cb56b5b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "380e6e523dfd5497cb67c09930b3d77e1db31ae2d1d2b02ddb912eaf5da99231"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "4dd25352ace4466e29ee92c21fd60baacc90a5459edc417f02441312611eaa87"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3ad410148b4dd0e82db63aff1ea1ad5068c370a3a63e6e9b7b28d934db7c59d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "2c863c237a2a87622afd4a621f0c47245291f30ffb4c34b3b84dce97beedf498"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6155607ae6f15ead64b7c37bfbd962290d77728b44e8dddd0583324ebaec5da2",
-                                "uncompressed-sha256": "8e7b6991fb76159b66c9f34497e13f2463f4812d282062725787fb1495774420"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "567f43a2968ccac240db429722f5b2d65b98acc733ae2c8498a33c9c41582d01",
+                                "uncompressed-sha256": "ff96dcf1810beef9d2e5cca4642a65b1422720e657efcdd9efc9173058d0b807"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "bbd9fb9d3c58dfbb9a9fd53072b353a0b1e9a9b375adad994f513eb4e4606177",
-                                "uncompressed-sha256": "362aa0e4b8356af36963899a423601e1c039a489dad31bc77e62728ae7defe10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e5a133988d70b1cdfba005525dfedf8d1b9e4ca1a5674c00927cc5dbb2fa65db",
+                                "uncompressed-sha256": "a145b81ca30278af4c02add057c3f357e55b0681ba806f8dfdfe5676d796ce59"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "74c3dd95d7afce08e7cef547ee751e092f0d51126956bd9230d73c629193eff9",
-                                "uncompressed-sha256": "c46417ed76f1e2774e19ff8c49a511b2a699d3b566cbc5b35fc42288af29332d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "660e704b35b0b3693410127af85b2b8a459e608b4d4fe0dfa5613542fbbba336",
+                                "uncompressed-sha256": "80e789dc514c3633ba4051d149691f089897cc1ebce076e305db5ed35deab63a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/ppc64le/fedora-coreos-41.20241024.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5c74b8382791ec4d65a4f7307456a6773d7e8b8286a79afef29b17513ac7846a",
-                                "uncompressed-sha256": "0fcc13309b483146be209b5e7f93397090e9712e9058be92cb8980f0a32c292b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e748b50e38008689538e6fe0652f7b79a41f395c331cc7a60eed661e783f34b1",
+                                "uncompressed-sha256": "373058b8ec0c3c3621c7f390bf9b71795f1b13ef12affa45f5a29f3ea2de9db9"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0426d3c20b867eb87fdf6b3dff6d022f996424b3fa518067ae153157c53b30e7",
-                                "uncompressed-sha256": "1bca71981aa720c6a5a4559ce4396c0e5b04086cb97b2de930d979c3bc35e9fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "aee24f73b89d5b24ba6cfdf8200fd2aec7c5c2d47873876b8caded2d4eb6a35a",
+                                "uncompressed-sha256": "7967e960c0bc65471f246cf118888d95bcc6f10b073c1b502b4c2c611b3ca0d5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5fd4b558923d06b3cce3ca7f933aa453532b296e00b2ffc85bc18a9cf75d62ef",
-                                "uncompressed-sha256": "b876720aac7d2bc4794eda2bb136cea5835f7fdcaee0c5ab184bb6c6e87cb8b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "60e841b9b34f12aa2064a6e355bec34628a02f84b5ab650dbfe5ac1b739ce0e4",
+                                "uncompressed-sha256": "ea6c8ffe5fb1765027e6dc8de2f9b42e0331fc66cef25c0eaa2c4fecc1f3c9e5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live.s390x.iso.sig",
-                                "sha256": "aaab87e221615ede5d2360edd382226f1cdd0bde599b1eeb147dfe1dbbbf6588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live.s390x.iso.sig",
+                                "sha256": "cddd875cb8b885c5aad291646428b1db6504b69d43c645fbd82ff3cd2973cbb6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live-kernel-s390x.sig",
-                                "sha256": "592c85c2294b7e154d9be8b704ad30cba4a910dbddd0213c486c692918b616e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-kernel-s390x.sig",
+                                "sha256": "e470d5ee058c8bc9439d44e3338f569b76012d7f588b31e5fe5073bb9ad3b770"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7e8b132f5369d1430fee5183614d799b05e5181a84671396005af7f74ea69167"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ada1833467239217d990f271730942b5376ad15a611a975189f829f6de7623c2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5c05b6c69070affe5b78e6d37d929a1fbf301495d296697c07cb857f9335b08c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "139d5f9c1275cd2efacb3a6c487570dcc2e8e328ecf081852dbbc84ed715279e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "aa0e46dcd1ff30fc5c9906acfdbaebbc645e4e43139ec3d9edb499f23e3a5947",
-                                "uncompressed-sha256": "988e1cfc37f52b0afaf6c5539187bfde38eab749993516865aec4a110e9112d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "2ae9478f9c561ff8141ecf3616c3019fda97498c96deb18ef9855b8ab09974ca",
+                                "uncompressed-sha256": "0de528da7113d0352bbed19d22d2fbc763796285f139d061c22a247f46f0df18"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "45ad06a9e9d78af83280c0f247c809bd643c1f497cc76ebd1921b55c490ebdb4",
-                                "uncompressed-sha256": "8a38a28b255e7230bac26a636def913e0bc92813aaf14244c3638ab11a349c74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "80d5b822cc83d64bcc07c4aef9a09f6ca7b7e1802ea485b30477e9e644a4172e",
+                                "uncompressed-sha256": "36917de7a56cb06b1953c43cac5864a2128d1da86158312640df9cbd65e9e05e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/s390x/fedora-coreos-41.20241024.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5d78d9f49ed23604bdcac94dd42b842fa0208ec43df7f644ce4240ce60acba6f",
-                                "uncompressed-sha256": "7be9dc8982b951cbda4fa2c21e0d6a4cac8844e4f9585cd198b2101110deeea4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9ecff791204a5f2021949635215fdfcecfe33b65bc49f5616dde3f5331d7a6c4",
+                                "uncompressed-sha256": "570b2492dbf5fc4fd1f46e64874fc2a83e83716117d26872829e8c0fafd6910e"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e4dee8eb9bcc671651948c2f0682cf7fb5b06c3253adf916ce7a2de9fa38490e",
-                                "uncompressed-sha256": "dd27467289b48b14a984e3477b553b0eda5608b150dcbe0601c191cbd20f4e35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cd692cb82506dca1390782c52af435595f1e6c89a8f72cd98ef038e244e0ee97",
+                                "uncompressed-sha256": "10a75207a552d0c67ab28f5981b8a900b8670d1bde5498b6e6ded89a1dcd901b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "69411d5a4950bdfd0b0d0752fbf01d1ead5f228660e6812a7220d96950706793",
-                                "uncompressed-sha256": "afcc20d540aa30a5581571b5c27924cf798717455bc57d4fe92d69e86e87dfcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8303477fddc9f89fc2a977c3d4ad6888c3683e2ed75398688a67a727cc5ede76",
+                                "uncompressed-sha256": "e2ff240be747f287166490a626e6c6f6abcad86e6665ca91580a0c4966d36b90"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5e9af881986609cf60f1f94817dfbb99d26036cfc2b79c0c7f1a40a5941ac42c",
-                                "uncompressed-sha256": "483bf38f93be7e738e13a76a884146df37b1216b8201f464641f801c40a5c4d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cc624e722af04292d78641e5927612d0ead94a3297b227571e76774167534f46",
+                                "uncompressed-sha256": "5954f333590b7bc6b76fc1590d4fe94a75c5b10ac1ee050a97f3902fcf4dee0b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "57428c41e37cc128b60d2b4d0727a886fac990f2cf5c53260a2c2e13d62b6f0a",
-                                "uncompressed-sha256": "cb37ffe47daa95c54647b3d790caeb7bcae7019144ab9923388949a7a4c23a81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "eabc2d0ccc186bf8704fe19eb9ea221e2349aae4f65cf8eb59aa766e5697c88c",
+                                "uncompressed-sha256": "00f463bbf0ef774fdc420910154fc3fe4a006ec623a36ace1210c246f069b64b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e9bb36eb7103f6051e9e4dccf649c9a931827430009e737bb22692cfa03738c3",
-                                "uncompressed-sha256": "eaf7ead18b8383571b36c5f852859edee9e2a4af29e43cc7718a812142636fa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "93d25988e6133ae28138f2a213ae3f0f2fa31826c4e86c053ee5c2e9bfb5fe3b",
+                                "uncompressed-sha256": "e2e5ecfb7f38749d630078c649c1971c5607c94acd23a2e3c2bdbc5d1473ad33"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c4badcd896ec57920ae204df43153699c871b1fcd4ced0e26177cd3f744e3e30",
-                                "uncompressed-sha256": "8f88be2dc5755c99f5dee61ea6851b0e04afec15ab5c591a21598965e9afa51d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "378f2017d94d3a19ff899d43dc46c769f4bffdc8f5b5a21ad3afd09f77d7046b",
+                                "uncompressed-sha256": "35ebb8319f7a5fb0b34ea919851298bef8e1a18dd17f2ed5917ecea5f902106b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3e1a8f728be2bdbc7a051bc7cc31df3e61995ff0895fb834a1f9e15f836d1235",
-                                "uncompressed-sha256": "70971bc50d6fc0028a361d0b2249531aff5774765093920bc08c3537982d6f87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "732bd8e6bb13dc2382386051a2321609b183c587ef194e8ac0b3baf2cfced13d",
+                                "uncompressed-sha256": "0ee8854b457b72381255707cb89cc266d39ecb61368610b786d4967784b1a597"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ac0ab31bce58b51a86f400c8e73a4a72ed0a2e40453f41cf4b699957d6b7bc20",
-                                "uncompressed-sha256": "633a868d718d3ab0ab3544c645d64666be01c82f734633fcce7aea6c108fc67c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2cb91fa7b472f8d434d814f18659013117db0fa8838fd0d2d07bd80a82c63064",
+                                "uncompressed-sha256": "45a7b288e29055f32de314cd8e27ae7b917ee9888c9bd52028c5c430db52aca5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d820e58525ba9e3df7718e07675192c9455832a235060aa718d13fac2afe268b",
-                                "uncompressed-sha256": "7f93e63db1922746c362d0e939f71f3b53b9e25268813d4ae4877a5c21f280c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "61c5c880329d469f1f47bc0cb19442953b1702724666010ed09f661e9d2109b5",
+                                "uncompressed-sha256": "9434cd5699bedfe1633726bd7b2c10c120b4fa19c0f7874e51a37a19d36c89b6"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7cb64f397d34b9402179347c2f30c164090ba61f4e58775c3fbe0e134e9762aa",
-                                "uncompressed-sha256": "d9641813516a15cf1aecedc742d544f769d73107b5a39a5a0ec6fa58d7eb6c12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3abd17813efdc097f951bd6149d5da82c8551fc2435aea2763f7ccb1dd76d8d9",
+                                "uncompressed-sha256": "78c457ff1838266628db9d7bf4fb4cd0719772f5a8f75875c9515af8b1f8038b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e2a37cd3aa0698baa395b841feb8e2184fa3ae72a55bd44bda9ee74ee9dc89ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "56e1e1ee0cf63f5d33c811269a16b4bae0affd2b0c80bf025cd733a0f1aea85e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7c8a3e4767075299f6b2eb5cb977a155ec6bdbecab3a1b357e62873fdf95ae0f",
-                                "uncompressed-sha256": "c3c5382383cc5e799d49d6dc317f47de6b7a32c014dbc5a083b2a07027ac9fa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3f498f8fa5c159d37b47d7369ce4a90dcb661be757ee85616614af99f6ebb4a1",
+                                "uncompressed-sha256": "391b61318f8de5fe96c78f6559cc6abe16b9d8e2fed9ddc2ed6a4f3644358b42"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live.x86_64.iso.sig",
-                                "sha256": "9f5181af230228e00d2bef5595e4beb781b1c1c3a9b06c0a42bd741102b154e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live.x86_64.iso.sig",
+                                "sha256": "c487964c53243c49272709b58d79afc47e130b8a95fda56f72569771914f9bfd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live-kernel-x86_64.sig",
-                                "sha256": "5f5457bd9d68d9e1c6443c16b6c416be9531f3bca4754a30f5cfdf8038ce01a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-kernel-x86_64.sig",
+                                "sha256": "4a8f189eb2dddfca6495f5e951a0099882e1453e9f6629ad4d961f99428e12c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "faeb2178d3f525e46977139a4755a806e84f8ca5a50780fc2b35f23f8685f4d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "393bbad4ac42ecd31db1bcde8e94b032e3544bd61b881ec6014384a1b8d86341"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a284f329c48238ba5dbadd2ad9fc0d1574d2c08f42aeeafd1ef54c419713e49d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "73e7d4079eb40ba4bea09e264d0e4670fd70545ab9b0354e818ae45bcb816244"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a7bb9977f4d73b012370313b29696e6665a71c99cd1466f11aea11377217fdcc",
-                                "uncompressed-sha256": "7a51ddfd10bcf275abeba79ff1d8367bf41e7776eb6f844efc45fdaf3a954b86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f9fff745521ee0ba15c83f8bd8257bb38807e8778aba2681fb8cb93e0c620e20",
+                                "uncompressed-sha256": "55c64a53641b68b474b0a726bce93495f55c21349b8e401e14815e37711ea6e3"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "01b22e1152153bfb97bea62dcef1d856236ada9dff773d8f6b5997acd7f41871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9dcc80749cda6dc0a75f8399f1ede8c929a38146eed9742b04683365ed83dd27"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "db014361a91ade49bbb5a908aa9e208260f8098282b57ada455e155500311b4e",
-                                "uncompressed-sha256": "bacb12ffb887a0ea03a858e7dcaea229a19baacf7dd01b27ad167ba4181cc1f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8ee41430934ec3f07c115c015f952c99a67be6eeb506aa44f41bcb8c4a3c97bf",
+                                "uncompressed-sha256": "267c4073f869628e7c1fea1a9e0d279ba7dae902049a6a2acbe18d0e18b476a3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5b85d8d2f4387be5bf402f1a083249f8f29ed2fbd0e5b2f1be258f49978d9a20",
-                                "uncompressed-sha256": "cf590ce099d44ad40ca35cb5845e41dc4af00af3d0d594163eed7874d00e1e38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8b418b7ad18a26c31ad91b52f5155305da143c7bb0624d6619f8f0a709ebb421",
+                                "uncompressed-sha256": "0ce6c0072c4ab562dad1d1f47e9eee9f4bdf8aac7ea30a177742f670290c4961"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "646771b13829ff550101d43290b12fe47229c035405222620b454df4b536b428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b2ed1a4db2242e328d9248ab22338d11e7d378209cf2d8c64cda13ab0119fbfa"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "d6778bd6c1f25a0c78920a8e6172563b820fef583ed9a786f30269d279e0ad11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "8009fac73ed72edc4cd0a39ca9b9f08377cc1f7fd65d5fb3d1b5a5ffd5fa367b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241024.1.0/x86_64/fedora-coreos-41.20241024.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a7b7b213ab5e3023d12f65375527b61806257d2b4f02cdf88f7510f04aaad1ec",
-                                "uncompressed-sha256": "c928d39ca46e55b9d4acbc27dbfcb4ab786151580e7d136d8fd185dfea3c90ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a989d9d4b191c1cd395542e032872cbef7e6506817557d8fef3e5ac2b5b995dd",
+                                "uncompressed-sha256": "16ec2c1308a5fe797a0444a9e874a0f9a5b6ba258dfb0048ef205208d0d4643b"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0671f49a7fe6dbcb1"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-022f2520cb31c6b0f"
                         },
                         "ap-east-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0dc41b81a3c6f63c8"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0b92a3fa47667bb4f"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-097e430da03a8b4ff"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0a5304a75700faf77"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-04b86bee0ba217603"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0e0d44570a550e900"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-02e7eed20189cc96f"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0832e6ae897193108"
                         },
                         "ap-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0abfefb91c11561ae"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0a2d42193d9e06913"
                         },
                         "ap-south-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0cc7135fb14476e0e"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-09a4a484f39726d38"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-08dc94c0e27b919cd"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0adfca117292f6215"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-00c2e69b2df19265b"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0fc04373eadeda8a4"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-004d46de47cb222c9"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-00afefd6e63dbbaa4"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0f075e7141bfe05a8"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0a7d277ffd27810b0"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-060f1a78e12cd3aa2"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-048f8e1b8c36b1076"
                         },
                         "ca-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0e5393508e47b072c"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-025554c4c3bdf0449"
                         },
                         "ca-west-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-03be558e64c2fbb7a"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0ab50aa6b90862a9d"
                         },
                         "eu-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0f6bb11b5315e2ee4"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-044f7e5a111f9e2c4"
                         },
                         "eu-central-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0285bfd9ec46815aa"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-03845d7021ac7ac0c"
                         },
                         "eu-north-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-08e3537303f041736"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-013b696d73916eaee"
                         },
                         "eu-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0df5a46d7f546c735"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0bd9031cd2456fc0a"
                         },
                         "eu-south-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0fd2643bb671eb480"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0d5db36f3ca9a6107"
                         },
                         "eu-west-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-04f76af18bd0cac8a"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-019408d38e9406a8c"
                         },
                         "eu-west-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-07fa0012d6be87732"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0e9bda5530495c105"
                         },
                         "eu-west-3": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-09d6d4011ebdc09b8"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0291dd86f2bf073b2"
                         },
                         "il-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0ebbf2a0fdd3bd3bc"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0f109379977debbfa"
                         },
                         "me-central-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0c0fbad85ccd0dd8a"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0901a6d6fd6e05667"
                         },
                         "me-south-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-02feef9c1579e5f95"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0bb9ff0a893fbd016"
                         },
                         "sa-east-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0da62441ed0243aef"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0b5ac1d26a9b4a2b9"
                         },
                         "us-east-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0b74da3a2b7c0acf7"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-069e702aef921d353"
                         },
                         "us-east-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-0181b2b0dde8917a0"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-05c3be060514aa2f6"
                         },
                         "us-west-1": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-048da394055f8e40f"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0df83060f8d088b7e"
                         },
                         "us-west-2": {
-                            "release": "41.20241024.1.0",
-                            "image": "ami-09b0825e7d65a445d"
+                            "release": "41.20241027.1.0",
+                            "image": "ami-0c20b79262f439ff6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20241024-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241027-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241024.1.0",
+                    "release": "41.20241027.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f4814b78f54b4b6dae0a92ffc132d2126c8fe89d6f52dd273dfccdb9b8291840"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d60dbaac9b620ede6275f7a93f32583ae7bb0b3dc81800aa527fafb566ef3e0d"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-10-22T15:52:38Z",
+        "last-modified": "2024-10-29T16:07:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "736a102035eb400090e9e3740a4259462058a3a94f1bed6e411b38cfc87f395e",
-                                "uncompressed-sha256": "e6967351a1da2b7520ea3e6d8f0a8f9bb96848ebd866c6ca1b22d155484e25c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "8bd0e85a5c886ab44ffbbab273b2df21c590d03efe0e62a1dc2c2eb00c4340d1",
+                                "uncompressed-sha256": "6e1799a0526f317b14db3ac21c2f8ccc1bf81d356d9e4c80236d497900a5bb0d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ed4515fe80a2afa305dd2fa371dc671dd46efa11ecb4e002ed28b7fe8e047b69",
-                                "uncompressed-sha256": "49f21e23cdcc32dfbcae02cc8ffb70724497101df789c0e5aceb54ae290865a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "7e7f9f4fd281a80bc29dc4535ac8f916347b4614587135c1a735a0624f9cf6dc",
+                                "uncompressed-sha256": "6c7c999e63431dd2f463db1c1550e3ca3ded26b727eb72d4959251473557bea0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a77182bb99f0148ea1f87e6dd7b240e0d948dd6f3c7ae196522b68e41b57fba1",
-                                "uncompressed-sha256": "2a484b3ab342faa2928a89bc7dcb9911c83213d6dafe2c8a4bea0425494f02ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1c5501f79e0aa7c736813ee5543bf3551233681420d5a9db2cbeb56077f875d9",
+                                "uncompressed-sha256": "d914336303e91d2b97435d85398f8b4d8798ef2ba1a80779d9474e6bf15feef3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3e5fbe44b1e2240e6af4b6238e71b86941bbed85f4d852fdd735dee1d65cc52d",
-                                "uncompressed-sha256": "2e2c4f72e73f290268e7a332e9979f9f1bba964cc25df80ccc0bdc882bf175ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0322ef3901f3d6bdd61b9c5e6933cea3eb80f0ccaff327505961beee4ebea159",
+                                "uncompressed-sha256": "e8e291019c2528f0405af7e08a54e8646f717d2608cd4cc13b6659c50a42f78e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "f1ae441a91266cbef06c1ac0953c688bcbcefe2037e5e3c9765ec93b899f9ffa",
-                                "uncompressed-sha256": "02aea640fbf02860dea024e25efc05030fd8b62c0f957b2e05695fe8b16cf8b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d2708280833caf1d6156195d896b8614c3e4f045b139886987d6394be32ecafe",
+                                "uncompressed-sha256": "b765eb58c4777b24523610bcca6f0dc4af7c3c345d7ab593b9bb0b84b0401d46"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c2af6bb592cb5f8f909f0cad34e3573a2d97b1665a0af570b578a17cff06fd3b",
-                                "uncompressed-sha256": "59f0af9d19b6bc68f69e4591875e8abb51a75cf7a2286ac3201eae87e846a734"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8052cb0a615319b99206401ec361bc65779ef4286f5563625abf7bd671f4741c",
+                                "uncompressed-sha256": "3df44e626a1219f8f8abb7e3cff550bc3e1162aef4acb3acd770ae7d8be56924"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live.aarch64.iso.sig",
-                                "sha256": "0c347bf796a24d90d5b46767d048affba608c9822d087408fefab215b4fa4546"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live.aarch64.iso.sig",
+                                "sha256": "c5b5e916ee147d5e812f841374b84c8843de3da4f1b6694a64f6d23d6f7e70db"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-kernel-aarch64.sig",
-                                "sha256": "838dd6346c11f890fa63f4e9465cae414932f5cabb65d78a3d3f8d6c05c716dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-kernel-aarch64.sig",
+                                "sha256": "6c0b0b237412921c48ff83fa5f787463479c4ae539a77c647ee25f27608546b7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1df6f29d1ed9924a5a29c54185548132b8c587b60a9f237d971d3f5b2fbd0d74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "23e3e32ddeb231ff63c644873244d75338099d9e1eec25d70bab90871c9a2ccf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a3d28e71ed7c45585af81ebb8969930606df04018e6e273faad017b0c51b93a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "376cee3253531639142541668863d1c8086c06cb4cd33642846dbe1b0e7dd2cf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "bf1003de0b462cdab517727fbc27ce47a5979f1005a1b9231563b5f8fdc3e34d",
-                                "uncompressed-sha256": "8c276f9d0a016170813e4bfb6fbb7e6952fd8cb1c30b687942f750fe024e163e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "98747123f81ff1c21bb82b7ca2d49a406b3a1e7bb3f6a8537494eee0433ffc54",
+                                "uncompressed-sha256": "c0063caaf48a1751e8a7157b8d12be056d83ec1ca26f647b213818fb00011097"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "20d7e2c94960805a9c57f4223e3ac2bc06b14adfd49b1db7ed9da30ab26f33a0",
-                                "uncompressed-sha256": "a361060f7091f1d8fc3d7c9cb12996dc071e03f73c3cc390d838a06d8573ab8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "03604a6c1ad717f6f0a8c09f07f58d88c8989ebf5cdf25a974a77103c8f50733",
+                                "uncompressed-sha256": "49aef8901185ce30eb39bb13e80c27bf52b733bfd95ad1af90f1aa59fa304320"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/aarch64/fedora-coreos-40.20241006.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "edce3175df5a1a89564db5428b7127877c699062b0d7c1763310f2deeaa38f76",
-                                "uncompressed-sha256": "26effc869bdba42c0088590190fdad9bf478887f60503c8fde1c6ecc54d95519"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "692cc0ca76a3165b292a27ab716068788b66444d3f197cbacb41f2e6157c8c45",
+                                "uncompressed-sha256": "74b51876dd2c1e6d800fdb3ea7ba4b4220c521acbae6aa9219eb75c25cee40df"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-03c5b0aed382255c2"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0c98d8de9caf23380"
                         },
                         "ap-east-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0f12d75ed096821fb"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0771aced057a8eea5"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-018cda2526cc78e9a"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-08438e3afa7ad557e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-03f2b30b4055bdef4"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-00d4a2351eecee7d2"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-02770c3d0c4dfbbf9"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-00231bc37a2f23617"
                         },
                         "ap-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0ca1f000ffd398889"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0dc792c7ebdde8b0c"
                         },
                         "ap-south-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-01ecf04bfb6872900"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0b78acb9e408d0999"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0a3024ecd6c728ecb"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-067ad6ddba7bcc2ae"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-00da4412599e8a9c4"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0e33df29657755758"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-090a554735fa4817f"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-071228d6de97b6618"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0b93e5c3aad4febbb"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0b9502d9c5537fc35"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-043f5253074220aca"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0d9a63b8cb452cfc3"
                         },
                         "ca-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-07856c6b31f77c510"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-063e930a18c96d141"
                         },
                         "ca-west-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-000f50987a4897dab"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-090614a38b8f1bb03"
                         },
                         "eu-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-077e860b4ac6416ff"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-03d7abf2ff00c9a39"
                         },
                         "eu-central-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-01dbf442e9a0eadee"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-05650cbf4cc67f006"
                         },
                         "eu-north-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-027d5cdc1ee969446"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-09cf4aca18801baf0"
                         },
                         "eu-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0ca7256c62bdded66"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0663821a91fb486b8"
                         },
                         "eu-south-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0febc192757e45009"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0229032834cf7cdef"
                         },
                         "eu-west-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0ab3da251a289c713"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0b331918c7d8cba86"
                         },
                         "eu-west-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-03cb4e455922b96ea"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0550e109f95fad9cd"
                         },
                         "eu-west-3": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-00746c9f08e785620"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0f629a198d4465fd5"
                         },
                         "il-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-040f0d86385fe5948"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0192a00cf2fbeedd3"
                         },
                         "me-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0a669356e3f1b726b"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-049843d2430045ee0"
                         },
                         "me-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0fe913429266b3290"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0cf52992567807cff"
                         },
                         "sa-east-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0848edf99f9601e50"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-08d57aade92b345dc"
                         },
                         "us-east-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0ce2bbe93e90dfa0e"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-07ee160bba3bf6138"
                         },
                         "us-east-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-02b2a157442b83c43"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-064f39f3d427627a8"
                         },
                         "us-west-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0670547fdc38e8cd8"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-033793052cefc36c4"
                         },
                         "us-west-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0a6f2bc110b300370"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-09e942c71d289e3cb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20241006-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-40-20241019-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b15ed82eb823ca3bdb8fcace76056005c0e305e349daa247629077fca71d0d55",
-                                "uncompressed-sha256": "a4b5ea81daca253b69c2852ac50ec549366ae61d2d16c65cd7b39cde6d53ded5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c2c4d319426337c14d95b2b63e4ea3efe2daf34071eb836a7dd7625dbf404ce2",
+                                "uncompressed-sha256": "d5801bdb8a1df43149dbe8291a6058ca599c5bac43167b0b5c5ff0865ad48d84"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live.ppc64le.iso.sig",
-                                "sha256": "d4ed456761548574cbb6f023df3e268c864f516f6615e94d9ae6a43c4ebe4ace"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live.ppc64le.iso.sig",
+                                "sha256": "ece35d250a90a61d561fe8f7cef8df05dd0ddebfdf3db200a7228fe0d64bed68"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "461a1ad51bd0749c2c8792f8f8de14843b53be357ecfdf1ead4f1e8ce6ecbe53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "c3e753b8c82592436727b0cc0717a55d5909fcd3c5ae3b4db7a36082ac5fd6c5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "62b99f86b2def475f04f25d03bcfccc7eb6b1220e5d1665f700beae33b63a978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "fd6687fdee323963f2908cc79c4f3e69829093e4921a796d91b55019be5b2d2f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "dfc8ace662f218b3c4beb18a61414d55bbf300604e81bd2ab3d7f661986b79bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9c7d4d067ff9355573a686bd96df7d8b6cbc95e72caf44a508eb2b14448ea551"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a1f2f133ed316b8b3f79e830a87800e7dcaff8d96a9596908b1cd1aa3b3c755f",
-                                "uncompressed-sha256": "fa22430da5cf21e86c232f9fd5c5e22987ee8f33b6cacaaea3c64a51420c0c24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "175417fa2a14521fe956c1d43fe0115afa0b9c0f4764c5c7719b46cb0a3f94ae",
+                                "uncompressed-sha256": "9ccb36bfb24db9c6180e6a8e44cc8711d64245a48c19f8ae1bc1a8df9135ffbc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "5a941b5ea720003e1246fcf5eaec3c0aa41319dd5f98763307febaa32f0b5926",
-                                "uncompressed-sha256": "afc4ddf4d434e0c7604ea506679ccb46a90c33a3f688e28f4a62e3a936e23550"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "04736ddf98b5ee779ab470988b10a4aa9a902bf4ab38dafe5992e9036591b32c",
+                                "uncompressed-sha256": "3e4da458cf817f75731c7b1dd0b173aa209a68f3bb68b1421d088b9657dd5abf"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4de9ef885a3017b55f61fb549b2e7c24516b16dc14f74547f1f5a2c6b51f7833",
-                                "uncompressed-sha256": "e8fbe8fc49daa563f193b7e07934a28a9e3e9c743655754d13c3e7933a3e4098"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "711d40e0a18065e861407fc3324ef729d21d172b8c6b07f08670c15e313bb695",
+                                "uncompressed-sha256": "e919a7e9b26250cd6d1f036af5d4014e6895cf0b447af529c7e84d385c0de7e0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/ppc64le/fedora-coreos-40.20241006.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "599220419dc4b84bb08d242da164e2ed0d4091fda9a2d45e7f3d9dbebba19861",
-                                "uncompressed-sha256": "fb9b2beb3dc6b335706c9dccfe0e14766ca7068f95425503b1a680859c70919d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f68bdccc3314d6968ad370514a6a97ad171c35767dba8f0b4081118fffedda6e",
+                                "uncompressed-sha256": "17d9708a446c78c845d09f57adff0ef01aa8606714d8579accd9d1dcf1e42cb4"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a02f0b39746707adf4aba37b639d470e39ce95cb92916f3feb5e2b96955fdae7",
-                                "uncompressed-sha256": "ff99448b9cfb8f4ae615a99a9bad6023536dc608ae6efa15c44e866601ba269a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "de99ee4846bb99a4d081fc9d3f09150cd2b71ad38c5f95f7d46b63612cc38071",
+                                "uncompressed-sha256": "4cdfdf137616ad3f30bd88bb7566db7996f8bdee4f6f54582e95a0fcd52d594c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "cf30d39d2c52f5f1c3c6f9aa5283d785eb8b7a1700f39ae808e4521e5197ec11",
-                                "uncompressed-sha256": "3f075f05a8a88a650f0560b8c28301d433d89ea7683d3e1e5c86a8ae3bde25ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "bb0f248fb21951d961e74e5568fa4ebe3919a1669a04940697013d847b8ff2b2",
+                                "uncompressed-sha256": "103c0b345671f9c35d766a4f7fb782f76a4a015f4aabb0ef9d2dfd25fbc90f76"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live.s390x.iso.sig",
-                                "sha256": "74ba0d3a93a063a9897fb212c7cffbc5f7f044dce94ca459d7830faf456e13f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live.s390x.iso.sig",
+                                "sha256": "e2838fbfd2ae5b020befc9e08553a0c649ab9884e6f3bbf561cff37c028e84d9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-kernel-s390x.sig",
-                                "sha256": "56ec902518e8bd6d9668f0a572a3774296d0a0776530cfef51553eeda0eadc57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-kernel-s390x.sig",
+                                "sha256": "ef6d3d73ddf9b5f77f46cc5e2ebfce15488e1e9a714b94855d7764dedd4b6ec9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "065a48ac1f370e5af6bbf064102153b4a2c658f8402e346c7bd643aecd027573"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "bfdc6e2fb7c2772738d8f27c4007f0f38629ef95200fd7ee6c3bdc8a31b98906"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9a1eccca5cdcb6c2a8d02b9c1af609bd783f26a10df22441ef5875c0cc0fa59e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c8141bd0477c09249075d05149637e42a7fcc354ad87eeedaf5ed52ce6a9613b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "024ffb2e5ebf3ede23761e8441d9a48d802a6b2372272dfef013706e5ee6bdd2",
-                                "uncompressed-sha256": "cb059a1393d621b43fe237c9a47adef9c36dbed0c941f4429020c68469019845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "476706d47401f76674ddfc34fdf6ccd46348bd3dc9d7dd13aac9cc9ac6af7585",
+                                "uncompressed-sha256": "cc3f4588f715252d9b45909571af58b19e475eb2ff6bab9db55e4306230a70fa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b39eee5f69b8a3854c31f6878a488add97d32737a9dce3a442f369c20ee620ab",
-                                "uncompressed-sha256": "1e2bacee1664e1c102b7d0c591f7d33032994c5e4f73e04796acad3ac38cbc5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ac5055f6719ffd66dc785161d68977192b824437eece02de5509736df4179ab8",
+                                "uncompressed-sha256": "72c35d1f646c0765fdcd909f46b1db302e206df1b5a743f3e10c872173a2082c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/s390x/fedora-coreos-40.20241006.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5f74090ed95123141e3beaacea0057cca50dff0d091bde7a91da5fe516797264",
-                                "uncompressed-sha256": "41fe14f8a387cef18d1d64c6d09315a51930bfc737bfc5e9e5e5df146bb8d014"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ff01d2354737c93b4dbf294f4ae85f9d506aace5f8e7d2bae76e5d94633105c0",
+                                "uncompressed-sha256": "c6d5269ce23b68e98899aa6164c3ae8f4a1573545348168e08ab7503b895dd41"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "772a1edac0a2494d7ff6eede2bb633bae920378a3ecca7045a904c87c2a54cac",
-                                "uncompressed-sha256": "78348daf69fecb9b9e33d74dd35b1eeb93dab307f77457543c163e23dd08426f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4383e8779b1186e52da08cee2dc737b9124a38795a82f397ed5ffb61f9090058",
+                                "uncompressed-sha256": "295fc33b65903e4958e02741317c0bbea5e21980fb6f6f2f9d40df23edd557c1"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "84c058ea8d3b6100d12904f9c02ba384b0a519cac4e5a0b98644d9e5f29566db",
-                                "uncompressed-sha256": "b839ef64e43be90687fd2e876ef284145852733ed46e22f4d3b52255e6777976"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "1d86d7e10b062211c96bb71e406d155bcfd91e0a15e89d9eb6caf64594705053",
+                                "uncompressed-sha256": "5832624a68c494ae41f76fd86e712e0d40e1c7a4b84c0de586edd18d28519f05"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "57c7a4f425a499d9a39349736eb00dd14d99c183cd6559a3d18e39d9444926b7",
-                                "uncompressed-sha256": "eeab339c41c8388a1fa3b6b54e037da3370541f463f106e327e8001e995f91a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ac8e93dbf213b62d37d92d7111e6ce9cefbb8e66637fe28874dea363c597ae93",
+                                "uncompressed-sha256": "c0d8e95be849deb0d31e12bf0934ee298711ffeff00e09cf1686ac0693f5ece9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8a1a654ddc5dfb9c8592c735b4c3ec0f1bb58fb1a5acbaee49fe00745876f71f",
-                                "uncompressed-sha256": "7016516632d1b0fb03d21c3f1a375929060ba31434d8d2c8f83dae78ad966962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8bb05e8de44aab58a5ddc6bc2becdae9d0f7ca16836326cb2a5130bc0d23f317",
+                                "uncompressed-sha256": "4e27ed10b33818c1231009980c98a2372893d0bca5d8f73cc3b899911bcc9bc2"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "cf79331a4e559954e8d88987ee2b2e3fb18c0b4b1804a72519cdabafc95c7e8d",
-                                "uncompressed-sha256": "e0a142fe898008f413232442266105e4687f07f03245f2101fc44d174658f7c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d6b6e97814688c419ade95eadd59d7993327dc9496ae058da411c7fa451fe19e",
+                                "uncompressed-sha256": "68459f199f8787d17bff5bfe0e4dedcd45b96f4940bd59f95685a56c631225bf"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a24a9b9ce7a8646e688fe20240e5601ac405ae5c8e6573e8ebfb313e804b94cd",
-                                "uncompressed-sha256": "6cca80321f3acbc9358a00e1806a201a6c2f8b303263a144ffcb5c214844afbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4db60e73d943fd543d5f9094588342d76483140e01f89510e64baeedbc1f2fb1",
+                                "uncompressed-sha256": "7923d41689eae0857d951544226b864489267b99ca8f156978c242068300cd12"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d485af2154a233b9277c07c4a6dc2f5263b52af77ed89f3d3e58fdeb7565d04f",
-                                "uncompressed-sha256": "dffc37fcb13b7c6e2928a51ba9501691ccb806a6f377af4b9e06d7314bbf423c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4c4fc4be5c6846763476c5e46a1d77255cfbdcf87afe77817f50d599aa61bbe8",
+                                "uncompressed-sha256": "9d3508cdab015430fc295c6dca7186aecf00b18f6eac1ff1aa991b06fed84408"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "de2e34d35965ecfdf4dbaff305463f9f384a2199f1413b3e511a9c872eb21745",
-                                "uncompressed-sha256": "bc83817e96f4f3ebb59e4594d503bb39005660e8962b8f86faaaaa82b06dd835"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e0cc4c6a74ab10e7bdb26b7a0149292788a18c97f5c232de5d8c050ddecd2a66",
+                                "uncompressed-sha256": "87a57cdecca91f8573ad6e119671c3c78ff0713af18e0d9b6b4c7fb88e698b95"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "8418f7de63fcac95030327c5e6bf2ec42b9c872968fd7de0a02d8a1c8e07a232",
-                                "uncompressed-sha256": "5d8885943d857440fc3e77b6044a5aefbced5c220ed18019c6b11444d527b50f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e939f4574d8c88c5ad62e4716b7af7bf2d72152ed84a9662808243f9af108a32",
+                                "uncompressed-sha256": "5a5651ac6f9ce271047e9b17eef06e57d64a337d5d678ff17564faeed68303b3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "14cf28e793eea8eafcfd49be93447a9eaea84569acf8145e41734e32dc5d6e10",
-                                "uncompressed-sha256": "b103103b334ad2e93bdbd972609c35af5e806a8a2efcde1cc51602e4866c0af0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a422e8f7740625b3744681c99b2190e0b30b19103d36a7633c0f8edb357e12ed",
+                                "uncompressed-sha256": "c5728a85650a946691b73b332b73914493300cbe6f7576e916b96cdabb806509"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "41c1c04f1fb4ad8c7688fd1c45f1a34ad004734298d98d9c6f8ac70e0d20a2bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "0ab04ef2f0a852bae37cb7f834ffac5ce4e7eed00eb1ec7d3e8eb6d0736793b0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2493ad76ae7229831a67f45f4b59189d9170161b00c3a228d18912c7845a2099",
-                                "uncompressed-sha256": "72a6c00b9a8ad35ba064d77a630386f13962cc82a458fde95b8276217dc21e0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6e82d31844ce91189e371baf072771dfba51c61e6a55101ec2ef75781b70ce4e",
+                                "uncompressed-sha256": "7a07bf26fff1ba37cb2f457411efb9a8f72ed89a4975e36ce963ec69ecc336df"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live.x86_64.iso.sig",
-                                "sha256": "848cfd974ead6d5f6a910ce601353acca6900cdf050fa074d8730c2fcc670f6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live.x86_64.iso.sig",
+                                "sha256": "f4ac09328ac019a62f71b7939d12734401af1ff57dfc090310b0ed1b255b2a98"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-kernel-x86_64.sig",
-                                "sha256": "14eb3096084edc15e6fe8676c269a0e43e0b0e102b49e9d7cbc8a1e29cbaaf3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-kernel-x86_64.sig",
+                                "sha256": "cd069acfe4dc025d51cd716de66211d55ca2facf32808f9ae5aa2f66097a513c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "b0fbe31d91a51e0e03e7d7aed1b5e4331e228f82a0661cc0f0c57cf18c9a94df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "d9790ccece83e15b2e938de8feb14a6606ab305974131787736f6e4236eaeb33"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0717c4c2471240e75b3c8878d2bc336e4c11d5931fe011f62c8b32af45f0697b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8cb090b2c164bf4575d26d38f6fa993a3c54147acea8d9700e413da753d05435"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7f886b8606b52de598f0486637a9086fad15686a69fac711f8d11efd630c8c66",
-                                "uncompressed-sha256": "8c2df55ba004ef596a8e79598d1f0fc6f3c407af884201ee46d062f6eb575187"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "bd9b522421a5d0c805aa521638c449ac326b4b9015e90022e58d3e71d5ddb085",
+                                "uncompressed-sha256": "a36e372228cebcfdd455cd21aa1794a6756463502beffd23c80eaddbc3ce7f36"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e9cbabdd8da797318a4c82100bc71f1d9897d27d408536151b44ab00744fa78e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "867668b06d93197852fac15f2b3b7920faf40899b1b7e7b49fcadb20ef36259c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "80a12083f2341ac96407c186759c0b24296e87e81c9ad86bb078846b89521977",
-                                "uncompressed-sha256": "f69cdb344f828818b89984b19db1910ddde286c1d5637846f5768f2f32ac0aa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c02ce0d103c0ddd4683578d6dc44153b60cf7c05e207fcd10e4712312b33afb3",
+                                "uncompressed-sha256": "d35df9407bd88cf4682ae4da33c5ddeac41a6cb60a5baef4ff09779144c7681e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e4a76340870afbab72528c78e7d1bfa455a22b5db3e9724e947a209684016ee2",
-                                "uncompressed-sha256": "1c5e8c951312cf7037d94afdf9590c9a6ac684fc46883c47978cc77a85fad9de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "022eb0c53da4d83d00a6a95cf3bd1690fda1e556925b2232ae321ed32c1e94ae",
+                                "uncompressed-sha256": "2a63677935adf7b081a73319fab74e6bb843610c3eb50d1ae1e53de379c573ef"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0b4279ebb3b553e67fb8625b8a7cdd9692e3aa6855ab95bb97efb898af107012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f868a6495aaf9943dbb5c748730aeee990c81df65280bcf7ec8fbdc917d8f017"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "51e3fd21ea4af10465c20766e5a70bcc7622177ab3c323eeb9f0dc9d6651cf98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "34c0bdbcaed97a8100151298492a6e337e49af3607a978918a68d5aac32f2554"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241006.3.0/x86_64/fedora-coreos-40.20241006.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "adb55f64b6be3624a539baa4a45fc0b24aa92cacd69a2c1691b08858239184b3",
-                                "uncompressed-sha256": "72c2a156b64f90ff17fefa7c7cd7ec655b0a257f063d7914023b78ac6c51827d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a576401079bf933bfd44b75ac40c712947cfd026004bc940f722a022976ec911",
+                                "uncompressed-sha256": "16490ba7712a43e550ae02f95ae874d828d16c5693f17016e60eb3eee41d4075"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0398c582dbaa30f00"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-09e70997bebe86110"
                         },
                         "ap-east-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-08e7541ac8a86fb7a"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-01c76958d6783ff64"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-023419d25c88f78eb"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-04fda739af23c3d52"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0656ead118f2823ab"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-05c4263871218a187"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0722f40d45c7fedfb"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-00d7488903d50b23e"
                         },
                         "ap-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0e6c535ad2d517fc5"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-056787c2f91d34a4e"
                         },
                         "ap-south-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-09118528e56d28ef8"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0160184ddf241c42f"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0c7b8808241c907c2"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-043457bfc64cc409f"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-078df141472c694a8"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-072901c8e2ec43e1f"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0d31b8aaa34e3140a"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0583988d157e5f6c9"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-079e13621237617c3"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0abd6dff54f8cdbb5"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-059670515c24305c3"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-09de185856794438e"
                         },
                         "ca-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-04147639570320222"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0cbda5d8a6dfedaaa"
                         },
                         "ca-west-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0006b3e5e5fcbf35b"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-00b46a887960ffe4f"
                         },
                         "eu-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0a7832ba050b6a094"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-07e2ccb46b627b686"
                         },
                         "eu-central-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0d6f317703c18081e"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0200903b9bc73d116"
                         },
                         "eu-north-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0135bdc7e2c4593fd"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0ac6db9928c2061c6"
                         },
                         "eu-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-070d4cb4aab156e1d"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-042b4796dc83c3e1e"
                         },
                         "eu-south-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-083b0be27727ff8f0"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-094e1536891ef294a"
                         },
                         "eu-west-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-02021fe8ef872cf70"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-048bdbc041cff8ef6"
                         },
                         "eu-west-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-038215962691e48ea"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0c16aea531460cb44"
                         },
                         "eu-west-3": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-08b93e2eda176fa1e"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0339433037dd3b9c3"
                         },
                         "il-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-01badd74c53b8523f"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-02f7baebbe7864c1c"
                         },
                         "me-central-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0215b24b51a2475a2"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0c05a4d6844947bad"
                         },
                         "me-south-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-03f43941e5fc1a65d"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0a3422f256f9a3a07"
                         },
                         "sa-east-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0c59e28410656d7df"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0bcdfcf44344492db"
                         },
                         "us-east-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-088cc31744bf5dbfb"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0b8ded38c9da07b13"
                         },
                         "us-east-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-0588a2c27bf267a62"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0dcb90d7b83356230"
                         },
                         "us-west-1": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-03fdfe95ac83887ed"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-0963883196cbc2a0d"
                         },
                         "us-west-2": {
-                            "release": "40.20241006.3.0",
-                            "image": "ami-080ac35a4604386d4"
+                            "release": "40.20241019.3.0",
+                            "image": "ami-045bc915191be70ff"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20241006-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-40-20241019-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20241006.3.0",
+                    "release": "40.20241019.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cc8c31d467ba5d9eb1c57053ab8b2b934ec459024a7c405dcd870fc4f799c6ea"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:aa9f9d12f8a1659004036f5adba02abe6b8d8c0951e181496c4e6d3e349a6552"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-10-22T15:52:39Z",
+        "last-modified": "2024-10-29T16:07:02Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "7234fe86261d48c7c3a35ea21b63a927dd7097913d141565f23c07d80b5a42b4",
-                                "uncompressed-sha256": "115d802512400eeca3cf0c63348cc657d693b6cf0343d26aa801276f081b4e95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "4be9375a0ea714411fe85bef25b051552400311504318aada36e4c77fecdda8b",
+                                "uncompressed-sha256": "d96523012a645c11b329103f8d6fb0434aac2f20ff45f02c6393c948b8266864"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "355eda2dfe44b2c4528e5e36e98711d392c2ba66f4b5632ac04b83bc4f09dfb0",
-                                "uncompressed-sha256": "9c043c7457e5aa728bd3476498993e42dddec7fc7791ebdf597379c3e94e7491"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fc11a208922a2db30a38e7c7851b6b8dc80bb198dc82999718f6fb1fecf3fc13",
+                                "uncompressed-sha256": "82cd69f60235b9fe19bf15875d15c85ada5bbeb70758a7708e2f6711a996478d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a3e089c5d321411ae71a2e0a0afedb832bdb74d3c50a14ed8e6c7dfcb606fcb2",
-                                "uncompressed-sha256": "c813f1fe921adb33792a1352a849182a94f919bf0d3f1a153c4907baac8e6daa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "070b2e4eb96b62d382cd4cbf85a398035e0ee6848e0cf42ac22d735271d68d2f",
+                                "uncompressed-sha256": "fba7872b341e19a77ae622811c6c78c37be71d7d1fda22fd88de035017ca339c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1130a8ba9cf42beea478ff68d8f88cf33ca63f3078c442299f6636bed35f78bf",
-                                "uncompressed-sha256": "0cbd4d077713621282404b02ace6162b16538fd901cf1c3b73af95cbb4377fed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "b8d4df90ac115a4ab9c7ddf8f8af0b9d8e0a2d504d625b4074b1f431a48099be",
+                                "uncompressed-sha256": "e59b704a6cd22a479c2e534be73342399e3145b76606ed26f09c20578125bda6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "e2ed409412c62acbb583a6c61e73eb3d926bc2f7b4153e5de7f799e0bfc512fd",
-                                "uncompressed-sha256": "7f454e003ddcd6678a2c99991fec696a50d68bc2e8c6fff6ed349dd6f2000ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "3b3b255de228846336eef8afb643e8e027286005e6cfdd24805418901880789e",
+                                "uncompressed-sha256": "fcb7c3ac60282fe53519e85244a91b1dce6cba5e9db0e45a946cac03cde34b36"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f36733a2f0c91674516c459daddf0fa98c16f5fafbce95424621c3e4dede02c6",
-                                "uncompressed-sha256": "33596373f655285c53d967df01dfa8e5263d8bc3bb4b660a8ec8cc5eceb95dc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8411ccf019ecb06b33ca869fd9c31323c8baa1185546e9a460880e67ecf45557",
+                                "uncompressed-sha256": "a03b08ef5f144a5234f8e3f3a178658fdf2177d770d2e3b1175b5662815cfb64"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live.aarch64.iso.sig",
-                                "sha256": "98cf7b93902278d80943217011baea1a8fab4b4c1e3fe32ae96dda3595b6ab4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live.aarch64.iso.sig",
+                                "sha256": "cd19bffb6549b15263902160ddee6718972352e1bae78c2e4ab47e60fbd36c7f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-kernel-aarch64.sig",
-                                "sha256": "6c0b0b237412921c48ff83fa5f787463479c4ae539a77c647ee25f27608546b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-kernel-aarch64.sig",
+                                "sha256": "b7593504d57829cb34817c4bca93d6ae8feb923a46518fea4e6ea02d91e89c5a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c0f24353d81243c7a0e548484e8263ebe0c310207b3cf9cefe2752eabd583fbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "61168063bbfad5e0118af856a2901071d8ee69a74e17b9569b75416973d006f6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "428da49ec721e6e3fde320d8d29996590171fd42c965d7105856713950eb7d05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6683c65943bd3df5a10a2484b5b35c5d083abd56c1be0304e8f2fc4586fa0708"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "e5e2efcefb9f0749d04c87b79afbb84946fa176322e2bcb2b079beba2ae6738f",
-                                "uncompressed-sha256": "468bf883f840b1e585656237c43f0cd54fb94e5343fb8eb3d1ef2ce0f7594b5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "30e945737d0c28630337cbce7beba4fe0603c5a1f7103ccaf45a6c5281fa953a",
+                                "uncompressed-sha256": "db740e15f2517a9704919b0a5ec59b4d62769cdc134941aeaa3b5493b8d5fb57"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3eef7d9063723781c36c6786f451be294b90c43122b75b330b7557710016a628",
-                                "uncompressed-sha256": "2938165460d63fd6ad1edb4a3b7364a1c82973173b74b647473f206283b59034"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5391fdf94bcc1b6970bf5200cc8c8d901b51ff04cd8106baa21e9c9225cd002c",
+                                "uncompressed-sha256": "e91a4a2a2b0deb79482f357b283f8a2f779503a8d807da1c644da90cd13b6502"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/aarch64/fedora-coreos-40.20241019.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "60874ad906e8f62f9b57a22c940df76cccd13b7203605d01343683c1f441dc3f",
-                                "uncompressed-sha256": "21901f93ecd749e39a0592d747a4d8cd17ae7b6149df00c6afe2faebb284b09d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0c73b74a87cd33f6d0930a8d23acea1805c5d92a7084d38e736cfa87126d1e1c",
+                                "uncompressed-sha256": "7002fcaebdd0c97540b0ef10fc1139a08cdd51fe7db2f4ec20175a22df16e4aa"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0dd5765116860d084"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-01df8650d4ba8d03b"
                         },
                         "ap-east-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-00d7f623130f58324"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0be0f636252b5d000"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0f0664753cec67ebc"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0b7b3cc50a0279bb1"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-05101bd17a8079322"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-043d729073b861246"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0f627260ae3370335"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-036eec653a5b57db5"
                         },
                         "ap-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-04067dae6bb39ac75"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0d9ea773cf5ff532f"
                         },
                         "ap-south-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0df27264a80bd4103"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0ab41f7ba47136824"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-01ddd4420a1b0b549"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-00256f26d67ddd586"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0eafc8a8b732e4ecd"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-04a9eab4f5b0d15c2"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-05e97536c045c2ad6"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-02fd8b4c89aea2ae4"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-03941c8ab0ecacf2d"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-037c0f3233709eafc"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0048b05f18c40f355"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-027b928570d472195"
                         },
                         "ca-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-09f0bfc163f3b8a61"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0234002af4c4ae677"
                         },
                         "ca-west-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0a0a00ac3f0cb4028"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-09367e56ded3943e5"
                         },
                         "eu-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0e67ea9e77af1d9ec"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0a182ea10b0f8c1d5"
                         },
                         "eu-central-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-00fc79e9a5d156efa"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0051abb40a91ff688"
                         },
                         "eu-north-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-044d955fb69d7488c"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0e4758cc7d5c92356"
                         },
                         "eu-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-082dedfe507ef670f"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-08088dbe7cb7c7037"
                         },
                         "eu-south-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-09cf3879b6887f910"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0b53961153fdae90b"
                         },
                         "eu-west-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0c079b25134c810a4"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-074f728ce87ae439e"
                         },
                         "eu-west-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0eafa00b39ed86bab"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-07a7b6b5bf0d5c606"
                         },
                         "eu-west-3": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-01884f7edf50a0667"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-08e9eff13ed006b52"
                         },
                         "il-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-02dcfdaeb1fe0aa96"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-061369e10dd53b1fb"
                         },
                         "me-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0a1fd3cf3bc5c693a"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-033a9e86b7c4d43c3"
                         },
                         "me-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0fed8ef6510f2a075"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-08b9571d0e3ae15c1"
                         },
                         "sa-east-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0f904a0ee32377b6d"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0e29bff5214a5a3ef"
                         },
                         "us-east-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-00bb042a23f7f3750"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-09f3b21c59a7a33bd"
                         },
                         "us-east-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0dcd127e2a7d74972"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-096a6d2194c062a71"
                         },
                         "us-west-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0d7a455adbaf47fa6"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0c64918b27206f031"
                         },
                         "us-west-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-00d0c415318abfbae"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0ae31a5838ef6d39d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-40-20241019-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241027-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "01f0128e235c6cebc40687236f0e67d7450e39e379fe2dc91970d99f380eb6c3",
-                                "uncompressed-sha256": "f2a885b7ec9d43ab53d1cbcf381a986332de26907fd4647e3b9ce69ef62aa4a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6297b8ed82dd170c65666b1c9ec666c7746abff4168f551aecae2c7572eaa44b",
+                                "uncompressed-sha256": "47ed5a2830110efedfdfbc981a6f306d800acf54d5acff03a164b98bdec18865"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live.ppc64le.iso.sig",
-                                "sha256": "22f532e88f0250f22caa4d235da501cb1a1885e6559079ac5ebe44156ffd7e0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live.ppc64le.iso.sig",
+                                "sha256": "acc7874e8623b71355ddcb5def563dde52956b916ef40a8e6901cbb1c2df7892"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "c3e753b8c82592436727b0cc0717a55d5909fcd3c5ae3b4db7a36082ac5fd6c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "5c3a59742a992e2778dd5f06757cb90f5e616525b56f2e1ea07ce2831cb56b5b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ec57506638202b52e9740dc8870a1fdc218be043a4a12cf6f21d87bdf619a4db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9dd9a64259e1f1c82113c560e5d4c7b85e94916c07ab5e2f882a432895de395b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "6a979b32f984b71902c49d08f5299c5e70ab970b5bce7c5f38afc77869dae40f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "7d603f9895d9cf3c5d0ef05f8dd861d372b3a292b504592421b48aeb779d359f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b46bb5b1872cf8cad5be3580bd3201f8847ef13a545fded31e75d71932eff8df",
-                                "uncompressed-sha256": "3de02fe4f9281c9d6e6dfcd37b2b6adb1b7d3f2369616c327075a660d9429d40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a33cc03f42621a0a2ca7af482a42f04d23e4b34b44c4f2a0e61246076ee47a88",
+                                "uncompressed-sha256": "12062a3d959cffeb6cbb0a2002d0a6f17abb4fd962bf6d0eff955a00cb3daf0d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "41c05b57243b64414b1f50ab8708c37d455471ae57a810d2d2f0dccd2b398552",
-                                "uncompressed-sha256": "727822f90eeebeead7225bded358e5020deb22f3ff12f943a8ca9cface93fb72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1eeb085418265b3b0a76003989f3cbe7456ff5a717fa7b5af81a833121b296f6",
+                                "uncompressed-sha256": "505bef82e5cfb04efbe379bbcacf61951f5099dc833953ce6d74eb737bb2e3ff"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ab85bf96c522a882d43563564731f3b23af91b4154f20dd8e97443f1776b3b23",
-                                "uncompressed-sha256": "2aec97f45f4ed084a0f87d5b37d002558be5b83dfa3df568825e8a6b64e2d257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "28f7ca15f92a882a1ea4bdb1a63d988f2769f7bfe65f7e1698b2469899ae386c",
+                                "uncompressed-sha256": "fce7be1297ce58e8a4b434b7e79820e99690ee66b8a5ef2071708bb0fe22e191"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/ppc64le/fedora-coreos-40.20241019.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "aeea5d13a3e4ce1db4acbaed60ab539f1cd5bbffa99f153c035c01a996e0502a",
-                                "uncompressed-sha256": "8c267efe414f6424cb6b7e00f3aa4dc504948bfcc66232688853e1b588772639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7db747f4b67b95fdde134920d379bddd11b69fd54009d0c92887674f93bc5d7a",
+                                "uncompressed-sha256": "235cd79aee99821770eb1366303a11d0a6fca06c29e247b4e321808aed756f4b"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a0959acee0e0ac12e7e6af74200563caf9ca4f5c4654d7fbab2c0bc76b24da66",
-                                "uncompressed-sha256": "661a24495228d9932e1f2969b04a492721160bb9069e4a7dd17b91b26e8fb27f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d05c533e5ce65474a52161e24bda32b1bc4cffeeced1dbf4630da9c17e019441",
+                                "uncompressed-sha256": "92fea5bd56a9433108766eb054ccdca9aa6097189cc1dc2ae0bc9e170ccabde1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b5745efa90b2821a60dd84bf0610da6190bf260aeaa59d67b6527b709de51d25",
-                                "uncompressed-sha256": "86a7f0352ac97733b3c46fb146fe2327b38b0752c32eaf4443f1e48e70fd8b76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "42bc762375d3ed7073d8050ba0062cad256ed23eb2447ac64952e91368f031f4",
+                                "uncompressed-sha256": "f9d47033969be42762f90c498fb27e70850e27351f685a05d86bd4f3b93a3b36"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live.s390x.iso.sig",
-                                "sha256": "172f7af99389c3e7310d4206c95654fd5dbced6bc255c5b777667878d5868909"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live.s390x.iso.sig",
+                                "sha256": "bc4f7296c277a398aaa268ba7ac960af9641ded325996acee6943ab2a5099917"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-kernel-s390x.sig",
-                                "sha256": "ef6d3d73ddf9b5f77f46cc5e2ebfce15488e1e9a714b94855d7764dedd4b6ec9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-kernel-s390x.sig",
+                                "sha256": "e470d5ee058c8bc9439d44e3338f569b76012d7f588b31e5fe5073bb9ad3b770"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "acf53c413ea8fdb8101e809d3ccc9a0e56490ab28f4dcbf15d388657767cb9db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c036e81245f99d3efb94ecbea3fda6d96ac62e93fe67aa2bbd6626b76967243a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "3046d02fd654705cc4a02a02f9ac84340da39d18b0814ab698ec57f97b6255be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "03240b4b25d53274377f71f02c080473a309536cb2b94e9265358ea7ee952bc2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "5d1d5ff7ad7c7107fb02eed9192d15f99040c11d528ea30f986ec69028f44a45",
-                                "uncompressed-sha256": "3d831687fa6508e9482d35176fcf31323fb24778f2e2bdab72b59c72e31c6ef7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "ea06a6562ebe0f459c49b6316d61b4ac0e0a42b0ba1b9995d4eff248260b76aa",
+                                "uncompressed-sha256": "0a5e877292eae91dc28f7da8dc050d9bb0ea14fef1cf52527962eecec6965373"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0348a7c8519800ef4c9a624d64f1454bfcca0f9891a71ca3a3b631d9b9065e56",
-                                "uncompressed-sha256": "a377338ae22233af302dfb5bca60b565b0a94e38ec3a0fa907969fde1a205715"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ea8a30ac17183eb974ab4b3d883bb9b40c03223508480252f633331e38bc7f3d",
+                                "uncompressed-sha256": "38a0f6b86e28ebdfdbd959b901635ed0cc07c486a2ae34e39429854a2b16ae29"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/s390x/fedora-coreos-40.20241019.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4fab7baafcd5c6c2930ce84d37cd1cb0b0b4b8f789f6b35ae13c0dc138f47cbd",
-                                "uncompressed-sha256": "da3a843a6b183e572b21fbb97a619874e27a9a03bcff143cc69b18ecbbecdbd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7fca0c289031613d2c09d6e10f5163a51da95e258d41e90d922d2b26fe0c6743",
+                                "uncompressed-sha256": "8fbbcac5b097ac51c6b839716056655288227cd12c0351eca5dcf8ce018c9585"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "89d4bb7cbd52e6483eeb12d3d97c86490d863a25d29ef2b03b90fa0b2fc38426",
-                                "uncompressed-sha256": "f4256029a0d41266151537795cebd01a69b451b348ec55332246fc3f1cce17b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "dbf3c11b63b4fd85071deef3a5e60e296e79401d5ea9d1974e64e9f820582c6c",
+                                "uncompressed-sha256": "82643864efabfe8fb7de04803ed50579ae8221cd104b625533d02f5882ed3847"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3be87f614631f8230635a1fca6061d1cfb24963db0741a72c87db7ecfe3e5451",
-                                "uncompressed-sha256": "7a5c1835326683b4a6bb0f7ae2f5c7c52650bf5a7d5793801bfc4174e7c6e7d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "daa68ca3a9f0680db53205841931715c9ee0cae6ba2946cfb203d63a0b39790c",
+                                "uncompressed-sha256": "1c0365e031f35f08e2077df8bb76b1cbbb6bbc61f0fa76f341b698f51119524c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ad44df072b9d5d569d12805674f993d6254212739b50237dc35acdbad897600b",
-                                "uncompressed-sha256": "8223ef26939dc5782fcbb49f21745880e612e21171aa311b9a6c4def320e647d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2a411c704c67604c49ff58ecf2fef6cf4ce0eda8c2bebd05169db9ebe2071a5a",
+                                "uncompressed-sha256": "29c69856d482dc5287e3d0d071e6c74a42641befa2b3f5f33bd94397bb257c3f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "09c813389d6e153d7bd4456367be3fe03732f0d993f49a8dd9b66d9405eea1f3",
-                                "uncompressed-sha256": "dd0de32930d43673ea451ab1416ae74cfea8f8a1f56f0f5346e4efaa1ab868e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6d4713611654c6d43b9d24d7cf253d342e2c5d2588b62a93d84578252abd1451",
+                                "uncompressed-sha256": "46220f605e53539d1ad285b743e68c42dffc2072c415cef2a4ad12e34fd95de7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2a87c9c2d5cadfd141c097aefa7794bd2cc2e69c01aa1092db24fbcbedab3426",
-                                "uncompressed-sha256": "e1e3609f38515a3cd23fd3dbdfe4db6436213bf72b233bcab31fdcd85d8d9ea1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d1d5ffbf0ee6b8e5f72988448d126144dc21e27e0991e4f33f80b8c5b6a83054",
+                                "uncompressed-sha256": "8ed3279a337d6e3a737d37cbfeec2c1930a39e056af05d00cc75946b77e81d97"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1fc21ad760fcf1a59b615194b2c367061db5af23c398940649d38a47e30e5852",
-                                "uncompressed-sha256": "53ae1c679e66271e2b7355ce0ac1d621c61d5ae10ecdc2b1b628914bfacacf8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "00a9e22aed9ee8759292cd56cba1c75bd340211325e5206ae3a45ca7d5a369c9",
+                                "uncompressed-sha256": "1c718b4b4fb131546ab73c2266c011dd40f2c47a9fa2bc0754f44fac0cf7d7cf"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "41bddb5b4717f42d795d5601fc4f8523fb41d81959496fd9109f2b97366b4ee9",
-                                "uncompressed-sha256": "db65bfa29953b6d3ad98d4ab97117cbdc8182f5433a4e3bf40497f9098b354b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3ee5541562e4cccc62b1ea1e358bce472e999cd88ce162779bcedef5b4730d88",
+                                "uncompressed-sha256": "a07bf5d0c23c72bc2bfd2cbacdc94ee8566dad8824e3bca5237f660a361dc978"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "18acc3feec76047f8b04af5a4b0fab1013088e5e99963e6f6a0770d0acd31898",
-                                "uncompressed-sha256": "11305e499cbb64fc644a97d541a3c2c97f3108785084bc90eeb14926dfea9b95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "fe9f7f28946ea2a54aaf42fa19f79114e7c2d6539de5749d43af13cbcab59c38",
+                                "uncompressed-sha256": "c01f94a4a836e3434364560a2265b3c16be03ebae41bd27e2bc412e0bb987dc6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ac8a695f7799b3eb75bf3814cde1a7ff331cc7f54ce5cae3adeb3a24f3ffee4a",
-                                "uncompressed-sha256": "de840b61619a991ca71367289d502234a96eaad59f18119ece7faa50e0d757ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "f36bbddb32d7ae2fffc4ad856ebcdb79e0915b08905a00e77c3d79cc1194ee85",
+                                "uncompressed-sha256": "08e8f3ab5133c9fc7d733bd1be96d20256c2d15b88648f83994bb40565e48c53"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3d51c5032dad6e6ee41b187054faf724532649e57ec9ef685aa068545f6ee7e6",
-                                "uncompressed-sha256": "d97ea4d4adb029eb43a0a8300f3ecd661279f8d95db6732be048fa66e9c66912"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cb2d8d8c24c12ff1c3bd43bcc5a956b925f32472449dae8c8b1c7611517ae38f",
+                                "uncompressed-sha256": "5eb4bbfd3a1e54cb6c1b6cd9db321f8b6a7442ce30a43255356f0d723aef76a2"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "821f4b64d43cf95cc292e35fa687c218e31d915b670c9a21ab8ca744f5d3f55d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "70c1f181da3dc0a3ba0bebfa26a254fbe120df2d8d52a92b5d6de5d4dfe38c6b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a1fcc97ddc5599e8e52abadcdad8832470f27b856bf03e20a9f4a260e92f7d44",
-                                "uncompressed-sha256": "f6c95ce692d09f0c4e27e617393fae3c2d719b8e84107db082660adc53631ad7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cd0e39ee2b9fe464d60b3f8f6a215c4f8fc853bc5f066b14072456d90f7aa59e",
+                                "uncompressed-sha256": "c2e3eaec9d0f23ad83570a6bbab9127fb00667cb4c35c471823396ee2a931e56"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live.x86_64.iso.sig",
-                                "sha256": "17cc6b2a4eab73e69ce836ec6c8a928b051da4501292f3428ac4ec81d8ecd8b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live.x86_64.iso.sig",
+                                "sha256": "d12fe6922e6e3b7559920addd49045e7e873ccac2af93421840bb6f29d70ae52"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-kernel-x86_64.sig",
-                                "sha256": "cd069acfe4dc025d51cd716de66211d55ca2facf32808f9ae5aa2f66097a513c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-kernel-x86_64.sig",
+                                "sha256": "4a8f189eb2dddfca6495f5e951a0099882e1453e9f6629ad4d961f99428e12c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "5b19d68f4caca11046bd8edf8bd910b3414c2c6d87077cfc82f67ddafa95106c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c9e06b63e89259c07b7daba0055f29372d2a34cf9b70f37aba40b4a71762ea1b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "7678c47111a0252341480c22477bc86a8091c649c19b739bbb449047e1bedd7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f57211ed9886329abdae7e0361c7315b0a59420135ef84c93f09e499f795f511"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f5abf2c9b3ebeb9b1e8f3388ffa6a395d60d084d29ba5f68f029f745c99e4b3f",
-                                "uncompressed-sha256": "e8457da3364b0ad67a9e5c30833b6b03eaea908ca171c720b5e9a3b7573b867e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "92b30c714ec3f48f2ec32ee37b5a27be6831cd8ed4de9857a151ab9718824f02",
+                                "uncompressed-sha256": "c913df8448da0c262c7fcba55cff28e43825c40a4ba97737559ee63fc7644516"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "52c7b3171eea6188be4289179fe855677778f4fe05f8edccf3cccb48a15c79d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e214e1dd9041ad57ff6d14c43e1b0167ef953bd0c364f72654ce2cf72b4fb0b1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4a028ff4b6d91f82adfe55ddfcd50167ca3700f06ebf0e52075cc96ce7e841c2",
-                                "uncompressed-sha256": "9850781d601b10044005933434ade50fa7ee2d884dd006c4244b64c3db0469af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0d3021e94a5bddafbfe538c74460597268879729788db659b0609b928112585b",
+                                "uncompressed-sha256": "1bbe777f3ed37d77448ab176d4a2d4cc74ccf822f1e9e3e178f0d38d26ab0363"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9b64132233769418162d341846ef8088f7e1225ff224353a8aadca61391eed51",
-                                "uncompressed-sha256": "ea3b52f1c1cbda4b3c82f07f74a7f560a1b9d730261c85018d8fc9fc376b42eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ce95bf8e63e4523a61956fa25a451602b97d55a7afbdfc50be044fceb9aea578",
+                                "uncompressed-sha256": "e608d0940339fe63f1b8169da3afec5465e70fdb443800112679dbbb6e118ecf"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b9074fe63beaf4ac62a638a170150f7edaddc3e085d37530cbf9219a109e448b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d1088ef59dac2c8e0663be17ad4ffeda0b477839a24ba0fc665f0ba971706427"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "d388caafb846ac6c054ee04c79996405039040895e0ef38d6f31dde1518da242"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "6c85e585a2c365491a09cf1022986a4c13d42412131b9853cc26b798486cd5c7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/40.20241019.2.0/x86_64/fedora-coreos-40.20241019.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3a5805473e36cb60393d68dfc1f9a53b6315407f30149c9db931d767e95e8566",
-                                "uncompressed-sha256": "53a293c5b53af06cf82251edba9b687d129439df9ecdf50173a9ff6c47e4a831"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "438586eb598fd6451be04e5db58199a87579f2e2eafd6fef1311b7618233850d",
+                                "uncompressed-sha256": "c142d97bc187188d6bbcb4ce296358ccb060b77c6e03b636c975705e465c0195"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0041e17d4b7956e2f"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0b81e8b321b7ae0f8"
                         },
                         "ap-east-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-066d5027b26835b68"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0d664f8319e4c03fc"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0ffe5b912d59820d2"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0ec2b6594fe740435"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-069be786896c02d1c"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-01a50c8fa29a48bc3"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0bd16b3d39ac796cd"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-01edc9fc217d56b0e"
                         },
                         "ap-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-004fe13fb51ba693f"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-021e1bd0d70e61b4e"
                         },
                         "ap-south-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-03c38423d109d4b45"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0ea83a2b7b53d4e72"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0bbd57c73041125f9"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-00afd806a5642bbf1"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-01377aae6a32b5926"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0a1dbade908855474"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-02c7b4357dc28d36c"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0b592a9ebbfcfabf8"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0dd2dead030a3074c"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0083963cb099eb767"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-08d7806287ab48aeb"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0a12719bf996331a8"
                         },
                         "ca-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-04bca18b280beffad"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-083790e730fb5ae61"
                         },
                         "ca-west-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-03a110c0aa16f716f"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-01a630bc0ce01db93"
                         },
                         "eu-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0e5a1bd281cf1e25a"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0795b50a863dd2031"
                         },
                         "eu-central-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-06927998867761669"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0ba0853721e9120e7"
                         },
                         "eu-north-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0bdca4071f28f80a7"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-056950cc4296ffef9"
                         },
                         "eu-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-00a0723031307ca9a"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-070c7f7d8b84e41d6"
                         },
                         "eu-south-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-003eb3a9394a05f74"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0394fa699237e0293"
                         },
                         "eu-west-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0d3951761b4e73357"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0f5d5d2d508dd9b04"
                         },
                         "eu-west-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-057848a46e763f672"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-048526c56aa224bde"
                         },
                         "eu-west-3": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0534332dc041a0d21"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0f057aa6447a5b904"
                         },
                         "il-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0aa0b1b2a1ffa557b"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-08286d464109eb0dd"
                         },
                         "me-central-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-051094065c9b4738d"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-04a65957f3387dac5"
                         },
                         "me-south-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0b1819c914de9dd25"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0543521b65b24911c"
                         },
                         "sa-east-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0372cfec0cdf4db9e"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-01604a586ce250775"
                         },
                         "us-east-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0e3ab6b784ee55450"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-013251ac3beb178ec"
                         },
                         "us-east-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-022637cecdfe5cfa8"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-05a7df9532a4e404e"
                         },
                         "us-west-1": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-086f2f46a11c11377"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0637c63fec52f5126"
                         },
                         "us-west-2": {
-                            "release": "40.20241019.2.0",
-                            "image": "ami-0976264971fe724b7"
+                            "release": "41.20241027.2.0",
+                            "image": "ami-0b5b22b783bd9ba7d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-40-20241019-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241027-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20241019.2.0",
+                    "release": "41.20241027.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2f6e503972245cff10544a5c90dc535ac083748136678c5eec9b74f604115afa"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bf4745bb0b8e205845c8d210bf62fa62f8bb17fc1097c3a58bb9b8bb0983acda"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-10-26T01:48:00Z"
+    "last-modified": "2024-10-29T16:07:04Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20241020.1.0",
+      "version": "41.20241024.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20241024.1.0",
+      "version": "41.20241027.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1729951200,
+          "start_epoch": 1730219400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-10-22T15:52:39Z"
+    "last-modified": "2024-10-29T16:07:02Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20240920.3.0",
+      "version": "40.20241006.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20241006.3.0",
+      "version": "40.20241019.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1729612800,
+          "start_epoch": 1730219400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -129,6 +129,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-10-22T15:52:40Z"
+    "last-modified": "2024-10-29T16:07:03Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "40.20241006.2.1",
+      "version": "40.20241019.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "40.20241019.2.0",
+      "version": "41.20241027.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1729612800,
+          "start_epoch": 1730219400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).